### PR TITLE
chore(claude): migrate dev workflow infra from DocumentBuddy

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -1,0 +1,43 @@
+---
+name: code-reviewer
+description: Reviews code changes for Clean Code, security, and consistency with project patterns
+tools: Read, Grep, Glob, Bash(git diff:*), Bash(git log:*)
+model: sonnet
+---
+
+You are a senior React/TypeScript-style JavaScript code reviewer for Nalanda, an interactive CS learning platform that runs entirely in the browser.
+
+## Your Review Checklist
+
+### Correctness
+- No null/undefined dereferences; check optional chaining where needed
+- React hooks follow Rules of Hooks (top-level only, no conditionals)
+- Effects have correct dependency arrays — no stale closures, no infinite loops
+- No race conditions in async code (cleanup on unmount, AbortController where applicable)
+- Error boundaries or try/catch around WASM and browser-API failure points
+
+### Clean Code
+- Functions do one thing, named by what they do
+- Components are small and focused — one concern per file
+- Max 2 levels of nesting in JS — early returns preferred
+- No dead code, no commented-out code, no premature abstractions
+- Tailwind classes are reasonable in length; extract a component if a class list becomes unmanageable
+
+### React/Vite specifics
+- No direct DOM manipulation outside refs
+- Keys on lists are stable and unique (not array indexes for dynamic lists)
+- Memoization (`useMemo`/`useCallback`/`memo`) only when there is a measured reason
+- No top-level side effects in modules (everything runs inside the component or a hook)
+- Heavy widgets (CodeMirror, WASM) are loaded on demand when possible
+
+### Consistency
+- Follows existing patterns in the codebase (check similar files)
+- Imports ordered and grouped (external → internal → relative)
+- File and folder naming matches existing conventions
+
+## Output
+Report issues as:
+- **file:line** — description
+- **Severity**: critical / warning / suggestion
+
+Be concise. If it's clean, say so in one line.

--- a/.claude/agents/test-analyzer.md
+++ b/.claude/agents/test-analyzer.md
@@ -1,0 +1,36 @@
+---
+name: test-analyzer
+description: Analyzes smoke test coverage, lint health, and testing patterns
+tools: Read, Grep, Glob, Bash(npm run lint:*), Bash(node:*)
+model: sonnet
+---
+
+You are a frontend testing specialist for Nalanda.
+
+Nalanda uses puppeteer-based smoke tests (`smoke-test-*.mjs` at the repo root) instead of a unit-test framework. Treat the smoke tests as the primary safety net and the lint as the secondary one.
+
+## Your Analysis Tasks
+
+### 1. Smoke-test coverage
+- Each main widget and route should have at least one smoke test that loads the page and asserts core behavior
+- Identify pages/widgets without a corresponding smoke test
+- Identify error paths or edge cases that are never exercised (empty state, error state, large inputs)
+
+### 2. Smoke-test quality
+- Tests are self-contained (start from a known URL, do not depend on external state)
+- Tests assert on observable behavior (DOM content, network calls), not on implementation details
+- Selectors are stable (prefer `data-testid` or semantic queries over brittle CSS paths)
+- Tests do not leak processes (browser closed on success and on failure)
+- Screenshot artifacts are named consistently and not committed unless meant as fixtures
+
+### 3. Lint health
+- Run `npm run lint` and report results
+- Flag rules that have been disabled inline (`// eslint-disable*`) and assess whether the disable is justified
+- Flag tests or code with `console.log` debug noise
+
+## Output
+- **Uncovered areas**: list of widgets/pages/routes without smoke tests
+- **Quality issues**: specific files and lines that need improvement
+- **Health**: lint pass/fail and any flagged disables
+
+Be specific with file paths and line numbers.

--- a/.claude/hooks/notify.sh
+++ b/.claude/hooks/notify.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Notification hook: macOS notification when Claude needs input.
+osascript -e 'display notification "Claude Code needs your input" with title "Nalanda" sound name "Ping"' 2>/dev/null
+exit 0

--- a/.claude/hooks/protect-files.sh
+++ b/.claude/hooks/protect-files.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# PreToolUse hook: block edits to sensitive or generated files.
+# Exit code 2 = block the tool call with reason in stderr.
+
+INPUT=$(cat)
+# Extract file_path without jq (not installed on host)
+FILE_PATH=$(echo "$INPUT" | grep -o '"file_path"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"file_path"[[:space:]]*:[[:space:]]*"//;s/"$//')
+
+if [[ -z "$FILE_PATH" ]]; then
+  exit 0
+fi
+
+BASENAME=$(basename "$FILE_PATH")
+
+# Protected file patterns
+case "$BASENAME" in
+  .env|.env.*|package-lock.json|yarn.lock|pnpm-lock.yaml)
+    echo "Blocked: $BASENAME is a protected file. Ask the user before modifying it." >&2
+    exit 2
+    ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,51 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/protect-files.sh"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/notify.sh",
+            "async": true
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git status:*)",
+      "Bash(git branch:*)",
+      "Bash(git fetch:*)",
+      "Bash(git pull:*)",
+      "Bash(git push:*)",
+      "Bash(git mv:*)",
+      "Bash(git worktree:*)",
+      "Bash(npm install:*)",
+      "Bash(npm run:*)",
+      "Bash(node:*)",
+      "Bash(npx:*)",
+      "WebSearch"
+    ],
+    "deny": [
+      "Bash(rm -rf:*)",
+      "Bash(git push --force:*)",
+      "Bash(git reset --hard:*)"
+    ]
+  }
+}

--- a/.claude/skills/capture-idea/SKILL.md
+++ b/.claude/skills/capture-idea/SKILL.md
@@ -1,0 +1,255 @@
+---
+name: capture-idea
+description: Capture a raw idea as a GitHub Discussion in the 💡 Ideas category of so77id/nalanda. Use when the user wants to save an idea for later without working on it now. Triggers on slash command `/capture-idea` or natural-language phrases such as "I have an idea", "save this idea", "tengo una idea", "anótame esto".
+---
+
+# capture-idea — Process A
+
+Capture a raw idea as a GitHub Discussion in the `💡 Ideas` category, without forcing the user to specify acceptance criteria or implementation detail. The goal is to preserve **context surrounding the idea** so the user can return to it later — not to produce a refined spec (that is Process B).
+
+## When to invoke
+
+- The user types `/capture-idea` (explicit).
+- The user uses natural-language triggers: "I have an idea", "save this idea", "anótame esto", "tengo una idea", "guárdame eso como idea", "para más adelante: ...". When detected, ask once: "Want me to save this as an idea?" before starting the flow.
+- Do **not** invoke when the user is asking to develop, refine, or implement something. Those are Processes B and C respectively.
+
+## Constants (from `docs/conventions.md`)
+
+```
+Repo:              so77id/nalanda
+Repo node ID:      R_kgDOSGlAqQ
+Ideas category ID: DIC_kwDOSGlAqc4C9bBm
+```
+
+If these IDs become stale (Project recreated, etc.), refresh `docs/conventions.md` first.
+
+## Conversational flow
+
+Total turns: 3 to 6, depending on whether duplicates exist and how clear the user's first description is.
+
+### Step 1 — Listen and gather context
+
+The user describes the idea with their own words. Read carefully. Identify:
+
+- **What** the idea is (the core proposition).
+- **Why now** (the trigger, what made them think of it).
+- **Where it applies** (subsystem, module, scenario).
+
+If any of those three are missing or unclear, ask **1 to 3 focused questions**. Limit to context you cannot derive — do not deepen the idea.
+
+**Good questions:**
+- "What made you think of this now?"
+- "Where in the codebase do you see this applying — a widget, the course content, the presentation mode?"
+- "Is there a specific scenario you have in mind?"
+
+**Bad questions (these belong in Process B, not here):**
+- "What are the acceptance criteria?"
+- "How would you implement this?"
+- "Should this be split into slices?"
+- "What is the priority?"
+
+If the description is already clear (what + why + where), skip directly to Step 2 without asking.
+
+### Step 2 — Detect duplicates
+
+Before drafting, query existing Discussions in `💡 Ideas` for matches. Use simple keyword matching against title and body.
+
+Run:
+
+```bash
+gh api graphql -f query='
+query {
+  repository(owner: "so77id", name: "nalanda") {
+    discussions(first: 100, categoryId: "DIC_kwDOSGlAqc4C9bBm", states: [OPEN]) {
+      nodes { number title body url }
+    }
+  }
+}'
+```
+
+Rank existing discussions by:
+1. Word overlap with proposed title.
+2. Word overlap with proposed body keywords.
+3. Same `area:*` label inferred for both.
+
+If you find 1+ matches with significant overlap (≥3 keywords or strong title similarity), **show top 3 to the user** and ask:
+
+> Found similar idea(s):
+> 1. #N — <title> (<url>)
+> 2. #M — <title>
+>
+> Options: (a) create new anyway, (b) add this as a comment to existing, (c) edit the existing body to consolidate.
+
+Wait for the user's choice before proceeding.
+
+If no matches, continue silently to Step 3.
+
+### Step 3 — Draft
+
+Build the Discussion content:
+
+**Title format:** `<verb>: <object>` in imperative, English, ≤80 chars.
+
+Examples:
+- `Add graph DS visualizer with BFS/DFS animations`
+- `Investigate Pyodide for in-browser Python execution`
+- `Fix CodeMirror line-tracker desync with visualizer`
+
+**Body template** (English, markdown):
+
+```markdown
+## Idea
+<one-paragraph summary of what the user proposes, in their own words but cleaned up>
+
+## Context
+<one-paragraph why-now: trigger, scenario, what motivated the idea>
+
+## Notes
+<optional: constraints, references to existing code, tradeoffs the user mentioned>
+```
+
+If `Notes` is empty, omit the section entirely.
+
+**Inferred labels:**
+- One `type:*` from {bug, feature, refactor, docs, chore} based on the idea's nature.
+- One or more `area:*` from {widgets, course, presentation, runtime, infra, docs} based on the modules touched.
+
+If you are unsure about a label, ask once: "I'd label this `type:feature` and `area:widgets` — does that fit?". If you are confident, do not ask.
+
+### Step 4 — Confirm with user
+
+Show the draft inline:
+
+```
+Title: <title>
+
+<body>
+
+Labels: type:<x>, area:<y>
+```
+
+Ask: "Save it like this?". The user replies with one of:
+- "yes" / "ok" / "go" → proceed to Step 5.
+- An edit ("change the title to..." / "drop the area label") → adjust and re-show.
+- "no" / "cancel" → abort and confirm.
+
+### Step 5 — Save
+
+Create the Discussion via GraphQL:
+
+```bash
+gh api graphql -f query='
+mutation($title: String!, $body: String!) {
+  createDiscussion(input: {
+    repositoryId: "R_kgDOSGlAqQ",
+    categoryId: "DIC_kwDOSGlAqc4C9bBm",
+    title: $title,
+    body: $body
+  }) {
+    discussion { id number url }
+  }
+}' -f title="<TITLE>" -f body="<BODY>"
+```
+
+Capture the returned `discussion.id` and `discussion.number`.
+
+Then add labels using `addLabelsToLabelable`. First fetch label IDs (cache them across captures within the same session):
+
+```bash
+gh api graphql -f query='
+query {
+  repository(owner: "so77id", name: "nalanda") {
+    labels(first: 30) { nodes { id name } }
+  }
+}'
+```
+
+Then attach the inferred labels:
+
+```bash
+gh api graphql -f query='
+mutation($labelable: ID!, $labels: [ID!]!) {
+  addLabelsToLabelable(input: { labelableId: $labelable, labelIds: $labels }) {
+    labelable { ... on Discussion { id labels(first: 5) { nodes { name } } } }
+  }
+}' -f labelable="<DISCUSSION_ID>" -F labels="<LABEL_IDS_ARRAY>"
+```
+
+If saving fails (network, auth, rate limit), report the error to the user with the draft preserved so they can retry.
+
+### Step 6 — Confirm save and close
+
+Tell the user:
+
+```
+Saved → #<N>: <title>
+URL: <url>
+```
+
+Then ask: "Another idea, or back to what we were doing?"
+
+If "another" → restart at Step 1.
+If "back" or anything else → return to the prior conversational context **without** restating it. Do not summarize the previous topic; the user remembers it.
+
+## Edge cases
+
+### Trivial idea (one sentence, low scope)
+
+Capture anyway. Consistency matters more than ceremony. The Discussion may be empty in `Notes` and have only `Idea` + `Context`. That is acceptable.
+
+### Existing match for the duplicate-detection options
+
+- **Option (b) "add as comment":** post a comment on the existing Discussion with the new content. Use `addDiscussionComment` mutation. Body of the comment should include `> Added on YYYY-MM-DD: ` prefix to mark when.
+- **Option (c) "edit existing":** use `updateDiscussion` mutation to replace the body. Preserve the original by appending a `## Update YYYY-MM-DD` section instead of overwriting.
+
+### User describes multiple ideas at once
+
+If the user packs 2+ distinct ideas into a single message, ask: "I see 2 ideas here — capture them separately or combine?". Default to separate if uncertain.
+
+### Idea references a specific code location
+
+If the user mentions a file or symbol (e.g., `src/widgets/code-editor/CodeEditor.jsx:120`), include it in `Notes` verbatim. Do not try to verify the line is still accurate — just preserve the reference.
+
+### User cancels mid-flow
+
+If the user says "cancel" or "skip" at any point, abort cleanly: confirm "Got it, not saving" and return to prior context.
+
+### `gh` command fails
+
+- **Auth error:** ask the user to run `gh auth login` or `gh auth status`.
+- **Network error:** retry once after a brief pause; if still failing, surface the error and ask the user to retry later.
+- **Rate limit:** report and pause; do not loop.
+
+## Output format reference
+
+A complete saved Discussion looks like:
+
+```
+Title: Add graph DS visualizer with BFS/DFS animations
+
+## Idea
+Build a new widget that visualizes graph traversal step by step.
+Reuses the visualizer scaffold but adds adjacency-list rendering
+and edge highlighting on each BFS/DFS frame.
+
+## Context
+The course already has stack, queue, and BST visualizers. The next
+chapter introduces graphs and there is no widget that covers it.
+
+## Notes
+- Reuse existing visualizer base in src/widgets/
+- Confirm framer-motion can animate edges performantly with N=50 nodes
+
+Labels: type:feature, area:widgets
+```
+
+## Operational quick reference
+
+| Action | Command |
+|---|---|
+| List discussions in Ideas | `gh api graphql -f query='...discussions(categoryId:"DIC_kwDOSGlAqc4C9bBm")...'` |
+| Create discussion | `gh api graphql -f query='mutation { createDiscussion(...) { ... } }'` |
+| Comment on discussion | `gh api graphql -f query='mutation { addDiscussionComment(...) { ... } }'` |
+| Update discussion | `gh api graphql -f query='mutation { updateDiscussion(...) { ... } }'` |
+| Add labels | `gh api graphql -f query='mutation { addLabelsToLabelable(...) { ... } }'` |
+| Fetch label IDs | `gh api graphql -f query='query { repository(...) { labels { nodes { id name } } } }'` |

--- a/.claude/skills/develop-task/SKILL.md
+++ b/.claude/skills/develop-task/SKILL.md
@@ -1,0 +1,457 @@
+---
+name: develop-task
+description: Develop a GitHub Issue (WP) into a merged PR end-to-end. Setup worktree + branch, run full-auto TDD per slice, run the 4-tier pre-PR review, open a PR with the standard template. Triggers on `/develop-task <N>`, `/develop <N>`, or natural-language phrases like "let's develop #N", "vamos con #N", "implementemos la tarea #N".
+---
+
+# develop-task — Process C
+
+Take an issue from Backlog or Ready, develop it slice by slice via full-auto TDD-style verification, run the pre-PR review pipeline (4 tiers), and open a PR ready for the user's review and squash merge. The user keeps responsibility for manual verification, PR review, and merge.
+
+## When to invoke
+
+- The user types `/develop-task <N>` or `/develop <N>`.
+- The user says: "let's develop #N", "vamos con #N", "implementemos la tarea #N", "let's work on issue 42".
+- Do **not** invoke when the user wants to capture (Process A), refine (Process B), or groom (Process D).
+
+## Constants (from `docs/conventions.md`)
+
+```
+Repo:               so77id/nalanda
+Project number:     3
+Project ID:         PVT_kwHOAD5lg84BYOfH
+Status field ID:    PVTSSF_lAHOAD5lg84BYOfHzhTVzpo
+  Backlog     → 3876d811
+  Ready       → d471aa12
+  In Progress → 709335dd
+  Review      → 4bbf67b2
+  Done        → 374a7858
+Main worktree path: /Users/so77id/workspace/nalanda
+```
+
+## Phase 1 — Setup
+
+### 1.1 Verify and load the issue
+
+```bash
+gh issue view <N> --repo so77id/nalanda --json number,title,body,labels,state
+gh project item-list 3 --owner so77id --format json | grep '"number":<N>'
+```
+
+Confirm:
+- Issue is open.
+- Issue has at least one `type:*` label and one `area:*` label.
+- Issue is on the Project in column Backlog or Ready (or already In Progress if resuming).
+- Issue body contains `## Slices` section with `[ ]` checkboxes.
+
+If any check fails: report and ask the user (e.g., "issue lacks a type label, fix it first" or "this issue is in Done, did you mean a different one?").
+
+### 1.2 Move kanban → In Progress
+
+If issue is in Backlog or Ready:
+
+```bash
+gh project item-edit \
+  --project-id PVT_kwHOAD5lg84BYOfH \
+  --id <PROJECT_ITEM_ID> \
+  --field-id PVTSSF_lAHOAD5lg84BYOfHzhTVzpo \
+  --single-select-option-id 709335dd
+```
+
+### 1.3 Infer branch type
+
+Read the `type:*` label; the branch type is its value without the prefix:
+
+```
+type:bug      → fix
+type:feature  → feature
+type:refactor → refactor
+type:docs     → docs
+type:chore    → chore
+```
+
+Note: `type:bug` maps to `fix` per conventions, the rest pass through.
+
+Branch name: `<type>/issue-<N>-<slug>` where `<slug>` is kebab-case from the issue title (max ~5 words).
+
+### 1.4 context-engineering
+
+Per `docs/conventions.md`, **the issue body is the single source of truth for the WP** — it must contain the full spec, plan, and todo content inline. Verify this before going further:
+
+- The issue body should have a `## Original specification` (or equivalent) section with the complete spec content.
+- A `## Original plan` section with the complete plan content (when applicable).
+- A `## Original todo` section with the complete checklist (when applicable).
+
+If the body is just a summary with pointers to external files, **stop and report** — the issue was not refined per the convention. Ask the user whether to refine it now (re-running through Process B) or proceed knowing context is incomplete.
+
+Then invoke the context-engineering skill mentally:
+- Read root `CLAUDE.md`.
+- Read any subdir `CLAUDE.md` matching the issue's `area:*` label.
+- Read related ADRs in `docs/decisions/` (when present).
+- Read related code in the inferred area (use grep/glob to find components/widgets).
+- Skim adjacent open PRs and recently merged ones for shared context.
+
+### 1.5 Create worktree
+
+From the main worktree directory:
+
+```bash
+git fetch origin
+# Create a new branch off main and a worktree at ../nalanda-issue-<N> in one go.
+# This avoids the "main is already checked out" error that occurs with
+# `git worktree add <path> main` when main is checked out at the primary worktree.
+git worktree add -b <type>/issue-<N>-<slug> ../nalanda-issue-<N> main
+cd ../nalanda-issue-<N>
+npm install
+```
+
+`npm install` is needed because the worktree starts without `node_modules/` (it is gitignored).
+
+### 1.6 Comment on issue
+
+```bash
+gh issue comment <N> --repo so77id/nalanda --body "🚧 Started development.
+
+Branch: \`<type>/issue-<N>-<slug>\`
+Worktree: \`../nalanda-issue-<N>\`"
+```
+
+## Phase 2 — Slice loop (full-auto, test-first when applicable)
+
+For each unchecked `[ ]` slice in the issue body, in order:
+
+### 2.1 Announce
+
+Print: `Starting S<n>: <slice description>`.
+
+### 2.2 Test first (when applicable — red)
+
+Nalanda uses puppeteer smoke tests rather than a unit-test framework. If the slice introduces or changes a user-observable behavior:
+
+- Invoke `test-driven-development` skill.
+- Identify or create the smallest smoke test that asserts the slice's outcome (`smoke-test-<feature>.mjs`).
+- Run the relevant smoke test. Confirm RED.
+
+For internal refactors with no behavior change, skip this step — the existing smoke tests serve as regression guard.
+
+### 2.3 Implement (green)
+
+Invoke `incremental-implementation` skill:
+- Write the minimal implementation to satisfy the slice / test.
+- Run `npm run lint`. Fix lint errors before continuing.
+- Run the relevant smoke test (or the full smoke suite if multiple were touched). Confirm GREEN.
+- If any other smoke test breaks, the slice has unintended impact — pause and consult the user.
+
+### 2.4 Refactor (only if obvious)
+
+If the implementation has obvious cleanup (rename, extract small component/hook, remove duplication just introduced) and tests still pass, do it. Do not refactor adjacent code; that violates scope discipline.
+
+### 2.5 Commit
+
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+<type>(issue-<N>): S<n> <slice description>
+
+<optional body — only if the change has non-obvious context>
+
+Refs #<N>
+EOF
+)"
+```
+
+### 2.6 Mark slice as done
+
+Update the issue body via `gh issue edit --body-file` to flip `[ ] S<n>` to `[x] S<n>`.
+
+```bash
+# Fetch current body, modify, re-upload
+gh issue view <N> --repo so77id/nalanda --json body --jq '.body' > /tmp/issue-body.md
+# Programmatically flip the checkbox for S<n>
+sed -i '' "s/^- \[ \] S<n>:/- [x] S<n>:/" /tmp/issue-body.md
+gh issue edit <N> --repo so77id/nalanda --body-file /tmp/issue-body.md
+```
+
+### 2.7 Continue or break
+
+If more unchecked slices remain → next slice. If all done → Phase 3.
+
+### Exit conditions for the slice loop
+
+Pause and surface to the user when any of these occur:
+
+- Test cannot be made to fail after 2 attempts.
+- Implementation cannot reach green after multiple attempts (unclear root cause).
+- Suite breaks somewhere unrelated to the slice.
+- The slice turns out to be larger than estimated and should be split (propose `S<n>a` and `S<n>b` and update issue body).
+- A blocker appears (missing dependency, external change required).
+- Merge conflict with main.
+
+In all cases: comment the blocker on the issue with context, halt.
+
+## Phase 3 — Pre-PR review pipeline
+
+After the last slice is green, run all 4 tiers in order. Tiers 1-3 produce findings or block; Tier 4 is human-in-the-loop.
+
+### Tier 1 — Mechanical (blocking)
+
+Run from the worktree directory:
+
+```bash
+npm run lint
+npm run build
+# Run any smoke tests that cover changed areas
+node smoke-test-<area>.mjs
+```
+
+If any fail: fix and rerun. Failures here block PR.
+
+### Tier 2 — Code review (always run)
+
+Invoke `code-review-and-quality` (`review`) on the diff between `main` and the current branch. Produces findings across 5 axes (correctness, readability, architecture, security, performance).
+
+For each finding, ask the user: "Address now / defer / dismiss as not applicable?". For accepted fixes, generate a single review-fixes commit:
+
+```
+<type>(issue-<N>): review fixes
+
+- <bullet for each addressed finding>
+
+Refs #<N>
+```
+
+### Tier 3 — Conditional reviews (agent decides)
+
+Read the diff and propose **only the skills that the diff actually warrants**. Do not invoke any skill solely on label hints — judge from content. State your reasoning to the user before invoking.
+
+Heuristics (these are guides, not rules):
+
+| Skill | Invoke when the diff... |
+|---|---|
+| `security-and-hardening` | introduces or modifies code execution sandboxes, external data sources, or anything that takes user input and acts on it |
+| `performance-optimization` | adds work on render paths, modifies WASM execution, or affects animation loops; OR the issue mentions performance goals |
+| `code-simplification` / `simplify` | the diff contains complex blocks (>30 lines of new logic in a single function/component, deep nesting, repeated patterns) where simplification would aid readability |
+| `frontend-ui-engineering` | the diff introduces or significantly changes user-facing UI |
+| `deprecation-and-migration` | removes or replaces an existing public API or feature that other code depends on |
+
+Tell the user: "I propose running `<skill>` because <one-sentence reason>. Skip / proceed?".
+
+If invoked, treat findings the same as Tier 2.
+
+### Tier 4 — Documentation, AC, and manual gate (always run)
+
+#### 4.1 Documentation review (`documentation-and-adrs`)
+
+Invoke `documentation-and-adrs`. Identify which docs need updating based on the diff:
+
+| Trigger | Update |
+|---|---|
+| Architectural decision baked into the diff | New ADR in `docs/decisions/<NNN>-<title>.md` |
+| Pattern or convention changed globally | Root `CLAUDE.md` |
+| Pattern or convention changed in one area | Subdir `CLAUDE.md` (when those files exist) |
+| New "how to do X" pattern emerged | Section in the relevant subdir CLAUDE.md |
+| New domain term | `docs/glossary.md` (when it exists) |
+| Stack/setup changed | `README.md` |
+| SPEC implications | `SPEC.md` |
+
+For each identified doc, generate a draft and show to user. User approves, edits, or skips. After all are approved, commit:
+
+```
+docs(issue-<N>): <one-line summary of doc changes>
+
+- ADR-NNN: <title>
+- CLAUDE.md: <what changed>
+- ...
+
+Refs #<N>
+```
+
+#### 4.2 Acceptance criteria verification
+
+List each AC from the issue body and produce evidence per AC:
+
+```
+AC1: <text>
+  Evidence: commit <sha>, smoke test smoke-test-X.mjs, file src/path/file.jsx:line
+
+AC2: <text>
+  Evidence: <description>
+```
+
+If an AC has no clear evidence, halt and discuss with the user before proceeding.
+
+#### 4.3 Manual verification checklist
+
+Generate a manual checklist from the AC + slices for the user to run themselves:
+
+```
+Manual verification:
+  □ <AC1 reformulated as user action>
+  □ <AC2 ...>
+  □ Smoke check: run `npm run dev` and try <flow>
+```
+
+Wait for user to report "all pass" or list specific failures. If failures: loop back to slice loop or fixes.
+
+## Phase 4 — PR creation
+
+### 4.1 Push branch
+
+```bash
+git push -u origin <branch>
+```
+
+### 4.2 Create the PR
+
+Use `gh pr create` with the template from `docs/conventions.md`:
+
+```bash
+cat > /tmp/pr-body.md <<EOF
+**Closes #<N>**
+
+## Summary
+<1-3 bullets of what was done end-to-end>
+
+## Slices completed
+- [x] S1: <description>
+- [x] S2: <description>
+- ...
+
+## Acceptance criteria
+- [x] AC1 — <evidence>
+- [x] AC2 — <evidence>
+- ...
+
+## Tests
+- Added/changed smoke tests: <list>
+- All passing: ✓
+
+## Reviews run
+- Tier 2 (review): <X findings, Y addressed, Z deferred>
+- Tier 3: <skills invoked or "none">
+- Tier 4 (docs): <ADRs, CLAUDE.md updates, etc.>
+
+## Manual verification
+- ✓ <items>
+
+## Notes
+<observations, risks, links to created ADRs>
+EOF
+
+gh pr create \
+  --repo so77id/nalanda \
+  --base main \
+  --head <branch> \
+  --title "<type>: <short description matching issue title>" \
+  --body-file /tmp/pr-body.md
+```
+
+### 4.3 Move kanban → Review
+
+```bash
+gh project item-edit \
+  --project-id PVT_kwHOAD5lg84BYOfH \
+  --id <PROJECT_ITEM_ID> \
+  --field-id PVTSSF_lAHOAD5lg84BYOfHzhTVzpo \
+  --single-select-option-id 4bbf67b2
+```
+
+### 4.4 Comment on issue
+
+```bash
+gh issue comment <N> --repo so77id/nalanda --body "🔍 PR opened: #<PR_NUMBER>
+
+Ready for review and squash merge."
+```
+
+### 4.5 Hand back to user
+
+Tell the user:
+
+```
+PR ready: <pr-url>
+Issue: <issue-url> (now in Review)
+
+Your turn: review, run any final manual checks, then squash-merge.
+```
+
+## Phase 5 — Post-merge (only if user requests cleanup help)
+
+When the user confirms the PR was merged (or you detect closure via `gh pr view --json state`), do the cleanup:
+
+### 5.1 Verify state
+
+```bash
+gh pr view <PR_NUMBER> --json state,mergedAt
+gh issue view <N> --repo so77id/nalanda --json state
+```
+
+Both should be CLOSED / MERGED.
+
+### 5.2 Move kanban → Done
+
+The `Closes #<N>` in the PR body should auto-close the issue. If GitHub Actions or auto-close did not fire, do it manually:
+
+```bash
+gh project item-edit \
+  --project-id PVT_kwHOAD5lg84BYOfH \
+  --id <PROJECT_ITEM_ID> \
+  --field-id PVTSSF_lAHOAD5lg84BYOfHzhTVzpo \
+  --single-select-option-id 374a7858
+```
+
+### 5.3 Remove the worktree
+
+From the main worktree directory:
+
+```bash
+cd /Users/so77id/workspace/nalanda
+git worktree remove ../nalanda-issue-<N>
+```
+
+If the worktree has uncommitted changes (rare at this point), surface to user before forcing.
+
+## Edge cases
+
+### Resume an interrupted WP
+
+If the issue is already In Progress and a worktree+branch exist, do not recreate them. Cd to the existing worktree, identify the next unchecked slice, continue from Phase 2.
+
+### Multiple WPs in flight
+
+The user can have several issues In Progress in parallel, each in its own worktree. This skill operates on one issue at a time; if asked to switch, finish or pause the current one cleanly.
+
+### Slice discovers it needs to split
+
+During Phase 2, if a slice is too large, propose to the user:
+
+> S3 turned out to need two commits because <reason>. I propose:
+>   - S3a: <new description>
+>   - S3b: <new description>
+>
+> Update the issue body and continue?
+
+On approval, `gh issue edit` to update the slice list.
+
+### Diff is empty at PR time
+
+If the branch has no commits ahead of main (everything was a no-op), abort the PR and surface "nothing to ship".
+
+### `gh` failures
+
+- Auth → ask user to re-auth.
+- Rate limits → pause and retry once; surface if still failing.
+- Worktree exists already → cd into it, do not error.
+
+## Operational quick reference
+
+| Action | Command |
+|---|---|
+| View issue | `gh issue view <N> --repo so77id/nalanda --json number,title,body,labels,state` |
+| Edit issue body | `gh issue edit <N> --repo so77id/nalanda --body-file <file>` |
+| Comment on issue | `gh issue comment <N> --repo ... --body "..."` |
+| List project items | `gh project item-list 3 --owner so77id --format json` |
+| Move kanban column | `gh project item-edit --project-id ... --id ... --field-id ... --single-select-option-id ...` |
+| Create PR | `gh pr create --repo ... --base main --head <branch> --title "..." --body-file <file>` |
+| View PR state | `gh pr view <PR_NUMBER> --json state,mergedAt` |
+| Add worktree | `git worktree add ../nalanda-issue-<N> main` |
+| Remove worktree | `git worktree remove ../nalanda-issue-<N>` |

--- a/.claude/skills/groom-backlog/SKILL.md
+++ b/.claude/skills/groom-backlog/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: groom-backlog
+description: Promote issues from the Backlog column to Ready on the GitHub Project board for so77id/nalanda. Facilitates the mechanics — listing, grouping, filtering, selection, and movement — without recommending which issues to promote. Triggers on `/groom-backlog`, `/groom`, or natural-language phrases like "let's fill Ready", "review the backlog", "vamos a llenar Ready", "promovamos algo".
+---
+
+# groom-backlog — Process D
+
+List the Backlog and let the user pick which issues to promote to Ready. The agent's role is purely mechanical: fetch, present, move. It does **not** recommend, prioritize, or impose criteria — those decisions belong to the user.
+
+## When to invoke
+
+- The user types `/groom-backlog` or `/groom`.
+- The user says: "let's fill Ready", "promote some issues", "vamos a llenar Ready", "revisemos backlog", "groom the backlog".
+- Do **not** invoke when the user wants to capture (Process A), refine (Process B), or develop (Process C).
+
+## Constants (from `docs/conventions.md`)
+
+```
+Project number:    3
+Project ID:        PVT_kwHOAD5lg84BYOfH
+Status field ID:   PVTSSF_lAHOAD5lg84BYOfHzhTVzpo
+  Backlog     → 3876d811
+  Ready       → d471aa12
+  In Progress → 709335dd
+  Review      → 4bbf67b2
+  Done        → 374a7858
+```
+
+## Phase 1 — Fetch the Backlog
+
+```bash
+gh project item-list 3 --owner so77id --format json --limit 200
+```
+
+Filter the response to items with `status: "Backlog"`. For each item, capture:
+
+- Issue number
+- Title
+- Labels (especially `type:*` and `area:*`)
+- URL
+- Source (extract from issue body if present, e.g., "Discussion #N", "Audit ...")
+- Created date (or last updated)
+
+## Phase 2 — Present the list
+
+### Default: group by `type`
+
+Group items by the value of their `type:*` label. Within each group, list items oldest-first (so older issues are visible at the top).
+
+Format example:
+
+```
+Backlog (12 items)
+
+▸ refactor (5)
+  #42  Extract code-editor variants                  [discussion:#15] (3w)
+  #45  Decouple visualizer base from BST              (2w)
+  ...
+
+▸ feature (4)
+  #87  Add graph DS visualizer                        (1w)
+  ...
+
+▸ chore (2)
+  #103 Tighten ESLint config                          (4d)
+  #78  Re-record cover screenshots                    (5d)
+
+▸ docs (1)
+  #99  ADR for presentation-mode lifecycle            (3d)
+```
+
+Always show: count per group, total count, and the relative age in parentheses.
+
+### Alternative groupings (on request)
+
+The user can ask for other groupings. Honor verbatim:
+
+| Request | Grouping |
+|---|---|
+| "group by area" | Group by `area:*` label |
+| "group by source" | Group by source kind (discussion / audit / fresh / migration) |
+| "by age" | Flat list sorted oldest-first |
+| "by number" | Flat list sorted by issue number |
+
+### Filters (basic)
+
+The user can request basic filters; combine them with the current grouping:
+
+| Request | Filter |
+|---|---|
+| "only discussion items" | items where source mentions "Discussion" |
+| "only `area:widgets`" (or any area) | items with that area label |
+| "only `type:bug`" (or any type) | items with that type label |
+| "exclude chore" | omit items labeled `type:chore` |
+
+If the user asks for a filter the agent cannot apply mechanically, surface: "I cannot filter by <X> — what specific labels or fields should I match?".
+
+## Phase 3 — Selection
+
+The user picks items by:
+
+- **Issue number list**: "promote #42 #45 #51"
+- **Top N from a group**: "the top 3 from refactor", "first 2 by age"
+- **All of a category**: "all `area:widgets` to Ready"
+- **Description match**: "the one about graphs" — agent confirms by showing matched item
+
+If selection is ambiguous, agent shows candidates and asks for confirmation.
+
+## Phase 4 — Move to Ready
+
+For each selected item:
+
+```bash
+# Get the project item ID for the issue (already fetched in Phase 1; reuse).
+gh project item-edit \
+  --project-id PVT_kwHOAD5lg84BYOfH \
+  --id <PROJECT_ITEM_ID> \
+  --field-id PVTSSF_lAHOAD5lg84BYOfHzhTVzpo \
+  --single-select-option-id d471aa12
+```
+
+If a move fails (rate limit, transient error), report the failure with the issue number; continue with the rest. Do not silently skip.
+
+## Phase 5 — Confirm
+
+Tell the user:
+
+```
+Promoted to Ready:
+  #42 — Extract code-editor variants
+  #45 — Decouple visualizer base from BST
+  #51 — Fix CodeMirror desync
+
+Ready now contains 5 items:
+  (re-list Ready column briefly)
+```
+
+Then: "Anything else, or done?".
+
+## Auxiliary mechanics
+
+These are extensions of the same mechanical role.
+
+### Demote (Ready → Backlog)
+
+User says: "demote #N", "move #N back to Backlog".
+
+```bash
+gh project item-edit \
+  --project-id PVT_kwHOAD5lg84BYOfH \
+  --id <PROJECT_ITEM_ID> \
+  --field-id PVTSSF_lAHOAD5lg84BYOfHzhTVzpo \
+  --single-select-option-id 3876d811
+```
+
+### Reorder Ready
+
+GitHub Projects v2 supports item reordering via `gh api graphql` with `updateProjectV2ItemPosition` mutation. Use it on user request: "put #51 before #42".
+
+```bash
+gh api graphql -f query='
+mutation {
+  updateProjectV2ItemPosition(input: {
+    projectId: "PVT_kwHOAD5lg84BYOfH",
+    itemId: "<ITEM_ID>",
+    afterId: "<ITEM_ID_TO_PLACE_AFTER>"  # or null to put at top
+  }) {
+    items { totalCount }
+  }
+}'
+```
+
+### Inspect
+
+User says: "show me #N", "what's #N about?".
+
+```bash
+gh issue view <N> --repo so77id/nalanda
+```
+
+Show body inline so the user does not need to open the browser.
+
+### Bulk
+
+User says: "all `area:widgets` to Ready", "all discussion items to Ready".
+
+Apply the filter, list matching items for confirmation, then move all on user approval.
+
+## Edge cases
+
+### Backlog is empty
+
+Tell the user: "Backlog is empty. Capture or refine new ideas first.".
+
+### Ready already has many items
+
+By design (per `docs/conventions.md`), Ready has no hard limit. If Ready already has many items (say, >10), surface a friendly note: "Ready already has 11 items — sure you want more?". User decides; do not block.
+
+### Selection includes items already in Ready
+
+Detect duplicates and skip them with a note: "#42 is already in Ready, skipping.".
+
+### Issue number does not exist or is not on the board
+
+Surface: "#999 is not on the project board. Add it first via Process B (refine).".
+
+### Source field missing
+
+If an issue body has no `Source:` line, display source as `—` in the list. Do not block.
+
+## Operational quick reference
+
+| Action | Command |
+|---|---|
+| List items | `gh project item-list 3 --owner so77id --format json --limit 200` |
+| View issue | `gh issue view <N> --repo so77id/nalanda` |
+| Move column | `gh project item-edit --project-id ... --id ... --field-id ... --single-select-option-id ...` |
+| Reorder item | `gh api graphql -f query='mutation { updateProjectV2ItemPosition(...) { ... } }'` |
+| Search Backlog | `gh project item-list ... --format json` then filter by status and labels in agent |

--- a/.claude/skills/refine-idea/SKILL.md
+++ b/.claude/skills/refine-idea/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: refine-idea
+description: Refine an idea into a well-formed GitHub Issue (WP) in the Backlog column of so77id/nalanda. Use when the user wants to convert a Discussion, an audit finding, or a fresh idea into actionable work with spec, AC, and slices. Triggers on `/refine-idea`, `/create-task`, or natural-language phrases like "refine #N", "let's turn this into a WP", "vamos a refinar esta idea".
+---
+
+# refine-idea — Process B
+
+Convert a raw idea (Discussion / audit finding / fresh thought) into a well-formed GitHub Issue with spec, acceptance criteria, slices, and labels — placed in the Backlog column of the Project board. The output is the single source of truth for the WP.
+
+## When to invoke
+
+- The user types `/refine-idea`, `/refine-idea <discussion-number>`, or `/create-task`.
+- The user says: "refine idea #N", "turn this into a WP", "vamos a refinar la #N", "create a task from <audit-id>".
+- Do **not** invoke when the user wants to capture (Process A) or develop (Process C).
+
+## Constants (from `docs/conventions.md`)
+
+```
+Repo:               so77id/nalanda
+Repo node ID:       R_kgDOSGlAqQ
+Project number:     3
+Project ID:         PVT_kwHOAD5lg84BYOfH
+Status field ID:    PVTSSF_lAHOAD5lg84BYOfHzhTVzpo
+Backlog option ID:  3876d811
+Ideas category ID:  DIC_kwDOSGlAqc4C9bBm
+```
+
+## Conversational flow
+
+Total turns: 4 to 12, depending on idea clarity, conditional skills, and user iteration.
+
+### Step 1 — Determine source
+
+Identify where the idea comes from:
+
+- **Discussion**: user references `#N` and N is a Discussion number, OR you fetched it from `💡 Ideas` and the user picked one.
+  - Fetch with: `gh api graphql -f query='query { repository(...) { discussion(number: <N>) { title body labels(first:5){nodes{name}} url } } }'`
+- **Audit finding** (when audits exist under `docs/audits/`): read the relevant audit and locate the section.
+- **Fresh idea**: user describes something new in chat and wants it directly as a WP without first capturing it as a Discussion. Use the user's chat description as the seed.
+
+If the user is ambiguous (e.g., "let's refine this"), ask: "Refine idea from a Discussion (give me #N), an audit finding (give me ID), or fresh from this chat?".
+
+### Step 2 — Load context
+
+Invoke `context-engineering`:
+- Read root `CLAUDE.md` and any subdir `CLAUDE.md` matching the idea's apparent area.
+- Read related ADRs in `docs/decisions/` (when present).
+- Read related code areas if they are mentioned in the idea (filenames, components).
+- Skim recent issues for adjacent work (`gh issue list --state all --search '<keyword>' --limit 10`).
+
+### Step 3 — Idea-refine (conditional)
+
+Only invoke `idea-refine` if the idea is **vague**: lacks a clear problem statement, lacks a clear scope boundary, or proposes multiple competing approaches without committing to one. Be transparent: "this idea is broad — let me run idea-refine to surface alternatives" and the user can accept or skip.
+
+If the idea is already specific (most well-described Discussions), skip this step.
+
+### Step 4 — Spec (always)
+
+Invoke `spec` skill mentally — produce a Standard-depth spec (not light, not heavy) covering:
+
+- **Problem** — one paragraph: what is wrong / missing / desired, and why now.
+- **Goals** — bullet list of concrete outcomes.
+- **Non-goals** — bullet list of what is explicitly excluded from this WP.
+- **Design** — technical approach in plain language: components touched, key decisions, tradeoffs taken.
+
+Keep it ≤300 lines total. If the WP needs deeper spec, recommend creating an ADR alongside (Process C will produce it).
+
+Be conversational: draft the spec, show to user, let them edit.
+
+### Step 5 — Conditional skills
+
+Based on the spec, decide which skills apply and invoke them. Each is **optional** and you must justify why you invoke it:
+
+| Skill | Trigger heuristic |
+|---|---|
+| `api-and-interface-design` | Spec introduces or modifies a public component prop API, route contract, or module boundary |
+| `source-driven-development` | Spec depends on a library where API correctness matters (React, Vite, CodeMirror, framer-motion, WASI shim, etc.) |
+| `security-and-hardening` | Spec touches user-supplied code execution, external data sources, or sandboxing |
+| `performance-optimization` | Spec has performance goals, or affects hot paths (rendering, WASM execution, large lists) |
+| `deprecation-and-migration` | Spec removes or replaces existing functionality |
+| `frontend-ui-engineering` | Spec introduces or significantly changes user-facing UI |
+
+Tell the user: "I'll also run `<skill>` because <reason>". User can accept or skip.
+
+If the spec contains a non-trivial architectural decision, mark it for ADR creation in Process C (do not create the ADR here).
+
+### Step 6 — Plan (always)
+
+Invoke `plan` skill mentally — break the work into ordered slices:
+
+- Each slice = one commit (per `docs/conventions.md`).
+- Each slice has a single AC checkbox-able outcome.
+- Order by dependency.
+- Slice descriptions: `S<n>: <verb-led short description>`.
+
+Show the user the slice list before finalizing.
+
+### Step 7 — Draft the issue
+
+**MANDATORY:** the issue body must contain the **full, verbatim spec + plan + todo content** generated by the spec and plan skills (and any other artefact produced during refinement). Not summaries. Not links. Full content inline.
+
+The issue is the single source of truth — `develop-task` must have everything it needs in the body itself. If you find yourself writing "see `docs/X.md` for details" you are doing it wrong: inline the content, then optionally include a reference to the path.
+
+Body structure:
+
+1. **Header:** Type / Area / Source.
+2. **Structured summary:** Problem / Goals / Non-goals / Design / AC / Slices / Notes (per `docs/conventions.md`). This is the high-level scan-friendly view.
+3. **Full artefacts appended:** under `---` separators, sections `## Original specification`, `## Original plan`, `## Original todo` containing the **complete content** of each artefact.
+
+If a section's artefact does not exist (e.g., trivial WP with no separate plan doc), omit that section. Do not put placeholders or "TBD".
+
+Verify before creating: read your draft and confirm an agent could open this issue and execute the WP without ever opening another file (other than the codebase being modified).
+
+```markdown
+**Type:** <type without prefix>
+**Area:** <area without prefix; comma-separated if multiple>
+**Source:** Discussion #<N> | Audit YYYY-MM-DD §<id> | Fresh idea
+
+## Problem
+<one paragraph>
+
+## Goals
+- ...
+- ...
+
+## Non-goals
+- ...
+
+## Design
+<technical approach>
+
+## Acceptance criteria
+- [ ] AC1
+- [ ] AC2
+- ...
+
+## Slices
+- [ ] S1: <description>
+- [ ] S2: <description>
+- ...
+
+## Notes
+<dependencies, risks, references>
+```
+
+**Title format:** `<verb>: <object>` in imperative, English, ≤80 chars.
+
+**Labels:** one `type:*` plus one or more `area:*`.
+
+### Step 8 — Confirm with user
+
+Present the full draft inline. Ask: "Create the issue like this?". User can accept, edit any section, or cancel.
+
+### Step 9 — Create the issue
+
+Use `gh issue create` with `--body-file`:
+
+```bash
+# Write body to temp file
+cat > /tmp/issue-body.md <<'EOF'
+<the full body>
+EOF
+
+# Create issue
+gh issue create \
+  --repo so77id/nalanda \
+  --title "<TITLE>" \
+  --body-file /tmp/issue-body.md \
+  --label "type:<x>" --label "area:<y>"
+
+# Capture issue number from output
+```
+
+### Step 10 — Add to project Backlog
+
+Add the new issue to the Project, then set its Status to Backlog:
+
+```bash
+# Add issue to project
+gh project item-add 3 --owner so77id --url https://github.com/so77id/nalanda/issues/<N>
+# Output gives the item-id, e.g. PVTI_...
+
+# Set status to Backlog
+gh project item-edit \
+  --project-id PVT_kwHOAD5lg84BYOfH \
+  --id <ITEM_ID> \
+  --field-id PVTSSF_lAHOAD5lg84BYOfHzhTVzpo \
+  --single-select-option-id 3876d811
+```
+
+### Step 11 — Close source Discussion (if any)
+
+If the source was a Discussion, close it as Resolved with a comment linking the new issue:
+
+```bash
+# Add comment
+gh api graphql -f query='
+mutation {
+  addDiscussionComment(input: {
+    discussionId: "<DISCUSSION_ID>",
+    body: "Promoted to issue #<N>: https://github.com/so77id/nalanda/issues/<N>"
+  }) { comment { id } }
+}'
+
+# Close as Resolved
+gh api graphql -f query='
+mutation {
+  closeDiscussion(input: {
+    discussionId: "<DISCUSSION_ID>",
+    reason: RESOLVED
+  }) { discussion { closed closedAt } }
+}'
+```
+
+If the source was an audit, do not modify the audit doc (it remains a historical reference). The `Source:` field in the issue body is enough.
+
+### Step 12 — Confirm to user
+
+Tell the user:
+
+```
+Created → #<N>: <title>
+Project: Backlog
+URL: https://github.com/so77id/nalanda/issues/<N>
+```
+
+If a Discussion was closed: "Closed Discussion #<M> as Resolved with link to #<N>."
+
+Ask: "Refine another, or back to what we were doing?".
+
+## Edge cases
+
+### Idea is too small
+
+If the idea is genuinely a 1-line typo or trivial fix, suggest "yolo mode" instead (per `docs/conventions.md`): make the change directly, no issue, commit to main. Do not refine.
+
+### Idea is too big
+
+If the spec exceeds ~300 lines or has ≥10 slices with weak cohesion, propose splitting into multiple issues with a meta-issue linking them. Per `docs/conventions.md`, an Epic can be modeled as a parent issue with sub-issues — but for now we typically prefer multiple sibling issues with cross-references in `Notes`.
+
+### User wants to refine without spec/plan
+
+If the user explicitly says "skip the spec", produce a minimal issue: `Problem` + `AC` + `Slices` only. Honor it.
+
+### Audit reference not found
+
+If the user says "refine A99" and A99 does not exist in the audits, ask for clarification. Do not invent.
+
+### Duplicate of existing open issue
+
+Before Step 9, run `gh issue list --search "<title-keywords>" --state open` and check for near-duplicates. If found, surface to user with options: (a) create new anyway, (b) add comment to existing, (c) cancel.
+
+### `gh` failures
+
+- **Auth:** ask user to run `gh auth status` and `gh auth login` if needed.
+- **Project not found:** verify the IDs in `docs/conventions.md` are still valid.
+- **Issue created but project add failed:** the issue exists in main timeline, but is not on the kanban. Surface error and ask user to add manually or retry.
+
+## Operational quick reference
+
+| Action | Command |
+|---|---|
+| Fetch a Discussion | `gh api graphql -f query='query { repository(...) { discussion(number: <N>) { ... } } }'` |
+| Create an issue | `gh issue create --repo so77id/nalanda --title "..." --body-file ... --label ...` |
+| Add issue to project | `gh project item-add 3 --owner so77id --url <ISSUE_URL>` |
+| Set issue Status | `gh project item-edit --project-id PVT_kwHOAD5lg84BYOfH --id <ITEM_ID> --field-id PVTSSF_lAHOAD5lg84BYOfHzhTVzpo --single-select-option-id <OPTION_ID>` |
+| Comment on Discussion | `gh api graphql -f query='mutation { addDiscussionComment(...) { ... } }'` |
+| Close Discussion | `gh api graphql -f query='mutation { closeDiscussion(input: { discussionId: ..., reason: RESOLVED }) { ... } }'` |
+| Search issues | `gh issue list --search "<keywords>" --state all` |

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: review
+description: Code review of current changes. Checks Clean Code, security, edge cases, and test coverage.
+disable-model-invocation: true
+context: fork
+---
+
+# Code Review
+
+Review all uncommitted changes in this repository. Analyze each changed file for the following:
+
+## 1. Correctness
+- Does the code do what it claims?
+- Are there off-by-one errors, null/undefined risks, or unhandled error paths?
+- React hooks follow Rules of Hooks; effects have correct dependency arrays
+- Async cleanup on unmount (AbortController, subscriptions, timers)
+
+## 2. Clean Code
+- Functions and components doing one thing only?
+- Meaningful names (no abbreviations)?
+- Max 2 levels of indentation in JS?
+- No dead code or premature abstractions?
+
+## 3. Test / Smoke Quality
+- Is there a smoke test (or change to an existing one) for every new user-visible behavior?
+- Are edge cases covered (empty state, error state, large inputs)?
+- Are smoke-test selectors stable (`data-testid`, semantic queries — not brittle CSS paths)?
+- Are smoke tests self-contained (start from a known URL, no shared mutable state)?
+
+## 4. Security
+- No hardcoded secrets or credentials
+- No user-supplied strings passed to `eval`, `new Function`, or `dangerouslySetInnerHTML` without sanitization
+- WASM and browser-API failure points have error handling
+- External URLs and assets come from trusted sources
+
+## 5. Consistency
+- Follows existing patterns in the codebase
+- Imports ordered and grouped (external → internal → relative)
+- File and folder naming matches existing conventions
+- Tailwind class lists are reasonable; component extraction when they grow
+
+## Output Format
+For each issue found, report:
+- **File:Line** — description of the issue
+- **Severity**: critical / warning / suggestion
+- **Fix**: what to change
+
+If everything looks good, say so briefly.

--- a/.claude/skills/tdd/SKILL.md
+++ b/.claude/skills/tdd/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: tdd
+description: Execute a strict TDD cycle (Red-Green-Refactor) for a specific feature or behavior.
+disable-model-invocation: true
+argument-hint: "<description of what to implement>"
+---
+
+# TDD Cycle
+
+Implement `$ARGUMENTS` following strict Test-Driven Development. You MUST follow this exact order — no skipping steps.
+
+Nalanda uses puppeteer-based smoke tests at the repo root (`smoke-test-*.mjs`) instead of a unit-test framework. The "test" in each step below refers to one of those scripts.
+
+## Step 1 — Red (Failing Test)
+1. Understand the requirement from the arguments
+2. Identify (or create) the smallest smoke test that asserts the new behavior. Either add an assertion to an existing `smoke-test-<area>.mjs` or create a new `smoke-test-<feature>.mjs`
+3. Run the smoke test (`node smoke-test-<feature>.mjs`) — confirm it FAILS
+4. **STOP.** Do NOT write implementation yet. Show the user the failing test.
+
+## Step 2 — Green (Minimum Implementation)
+1. Write the MINIMUM code necessary to make the failing test pass
+2. No extra features, no "while I'm here" improvements
+3. Run the affected smoke test(s) — confirm they pass
+4. Run `npm run lint` — confirm lint is clean
+5. Show the user the implementation
+
+## Step 3 — Refactor
+1. Look for duplication, unclear names, or unnecessary complexity
+2. Refactor while keeping all tests green and lint clean
+3. Re-run the smoke test(s) after each refactor step
+4. Only refactor the code you just wrote — don't touch unrelated code
+
+## Rules
+- NEVER write implementation before the failing test exists
+- NEVER write more code than needed to pass the test
+- If multiple scenarios are needed, repeat the cycle for each one
+- If you discover edge cases, add them as NEW assertions or NEW smoke tests (new Red cycle)
+- Keep selectors in smoke tests stable (`data-testid` or semantic queries)

--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,10 @@
+# Node / build artifacts
+node_modules/
+dist/
+
+# Smoke test screenshots (regenerable artifacts)
+smoke-test-*.png
+
+# OS
+.DS_Store
+Thumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,6 @@ Thumbs.db
 # test artifacts (regenerated)
 smoke-test*.png
 
-# Claude Code local metadata
-.claude/
+# Claude Code local-only metadata (workflow files in .claude/ are tracked)
+.claude/settings.local.json
+.claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md — Nalanda
+
+## Description
+Interactive CS learning platform. A single browser-only site where theory, presentation, interactive data-structure visualizations, and live code execution coexist. MVP uses a single course ("Data Structures in C++") as a testbed for the core widgets.
+
+## Language
+All code, comments, variable names, commit messages, and documentation must be in English. User-facing content (course materials) may be in Spanish.
+
+## Stack
+- **Frontend**: React 19, Vite 7, TailwindCSS 3
+- **Code execution in browser**: WebAssembly via `@bjorn3/browser_wasi_shim` and `browsercc`
+- **Editor**: CodeMirror 6 (`@uiw/react-codemirror`, lang-cpp, lang-python)
+- **Animations**: framer-motion
+- **Icons**: lucide-react
+- **Lint**: ESLint 9
+- **Smoke tests**: puppeteer-core scripts (`smoke-test-*.mjs`)
+- **Deploy**: GitHub Pages (100% static)
+
+## Development commands
+```bash
+npm install            # Install dependencies
+npm run dev            # Vite dev server
+npm run build          # Production build to dist/
+npm run preview        # Preview the production build locally
+npm run lint           # ESLint
+node smoke-test-*.mjs  # Run individual smoke tests (puppeteer)
+```
+
+## Logging
+- Use `console.log/info/warn/error` in browser code; never leave debug logs in committed code
+- Never log secrets, tokens, or personal data
+- Prefer structured logging (`console.log({ component, event, data })`) when debugging cross-component flows
+
+## JS/React conventions (non-obvious)
+- Functional components only — no class components
+- Hooks must follow Rules of Hooks (top-level, no conditionals)
+- Components in `src/` follow a feature-first folder layout (widgets, course content, layout)
+- ESLint rules are enforced (`react/jsx-uses-vars` is on); fix lints rather than disabling rules
+- Keep components small — one concern per file. Extract shared logic into hooks
+- Tailwind classes inline; avoid creating CSS files unless necessary
+- Animations via framer-motion; do not introduce another animation lib
+
+## Development Workflow
+
+Four processes manage development. When a task arrives, identify the phase and invoke the corresponding skill:
+
+- **Capture an idea** (no work yet) → `capture-idea` skill (creates a Discussion in the `💡 Ideas` category)
+- **Refine an idea into a WP** → `refine-idea` skill (creates an Issue in Backlog with full body)
+- **Develop a WP into a PR** → `develop-task` skill (worktree + TDD slices + 4-tier review + PR)
+- **Promote items from Backlog to Ready** → `groom-backlog` skill
+
+Each skill encapsulates the full process. Read `.claude/skills/<name>/SKILL.md` for detail.
+
+### Hard rules
+
+- **All changes go through PRs** — never push directly to `main`.
+- **Squash merge** is mandatory for every PR (manual, by the user).
+- **One commit per slice**; the slice list is in the issue body as checkboxes.
+- **Test before commit**: lint passes AND smoke tests pass AND manual verification when applicable. Never commit untested code.
+- **Trivial fixes** (≤3 lines, no logic, negligible risk) may bypass the system — see `docs/conventions.md` "yolo mode".
+
+### References
+
+- Conventions (kanban columns, labels, branch naming, commits, PR template, worktree+`.env`): `docs/conventions.md`
+- ADRs (architectural decisions, when present): `docs/decisions/`
+- Spec: `SPEC.md`
+
+## Documentation
+- **README.md / SPEC.md**: Keep updated after architecture/feature changes.
+- **Conventions**: `docs/conventions.md` (workflow conventions referenced by the skills).
+- **Decisions**: `docs/decisions/` (ADRs, numbered sequentially) — created on demand.
+
+## Rules for Claude
+- Never modify `package.json` dependencies without discussing first
+- Never modify `vite.config.js`, `tailwind.config.js`, `postcss.config.js`, or `eslint.config.js` without user confirmation
+- Never modify `package-lock.json` directly — let `npm install` regenerate it
+- Never commit `node_modules/`, `dist/`, or `.env` files
+- For UI changes, run the dev server and verify in a browser before reporting the task done; smoke tests and lint verify code correctness, not feature correctness

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,187 @@
+# Conventions — Nalanda
+
+This document is the source of truth for development conventions: kanban columns, labels, branch naming, commit format, PR template, and worktree setup. The `.claude/skills/*` workflows reference this file by name.
+
+## Project board IDs
+
+**Setup required:** the user must create a GitHub Project for Nalanda with a Status field containing at least the columns below. Once created, fetch the IDs and fill in the placeholders.
+
+```
+Repo:               so77id/nalanda
+Repo node ID:       R_kgDOSGlAqQ
+Project number:     3
+Project ID:         PVT_kwHOAD5lg84BYOfH
+Status field ID:    PVTSSF_lAHOAD5lg84BYOfHzhTVzpo
+  Backlog     → 3876d811
+  Ready       → d471aa12
+  In Progress → 709335dd
+  Review      → 4bbf67b2
+  Done        → 374a7858
+Ideas category ID:  DIC_kwDOSGlAqc4C9bBm  # GitHub Discussions, 💡 Ideas category
+```
+
+How to fetch:
+
+```bash
+# Project + Status field
+gh api graphql -f query='
+query {
+  user(login: "so77id") {
+    projectV2(number: 3) {
+      id
+      field(name: "Status") {
+        ... on ProjectV2SingleSelectField {
+          id
+          options { id name }
+        }
+      }
+    }
+  }
+}'
+
+# Discussions Ideas category (requires Discussions enabled on the repo)
+gh api graphql -f query='
+query {
+  repository(owner: "so77id", name: "nalanda") {
+    discussionCategories(first: 10) { nodes { id name } }
+  }
+}'
+```
+
+## Kanban columns
+
+| Column      | Purpose                                                                 |
+|-------------|-------------------------------------------------------------------------|
+| Backlog     | Refined issues waiting to be promoted to Ready                          |
+| Ready       | Promoted issues — agent can pick the next one from here                 |
+| In Progress | Currently being developed in a worktree                                 |
+| Review      | PR open, awaiting user review and squash merge                          |
+| Done        | Closed and merged                                                       |
+
+## Labels
+
+Every issue gets:
+- One `type:*` label — `type:bug`, `type:feature`, `type:refactor`, `type:docs`, `type:chore`
+- One or more `area:*` labels — `area:widgets`, `area:course`, `area:presentation`, `area:runtime`, `area:infra`, `area:docs`
+
+Create them once with:
+
+```bash
+gh label create "type:feature"      --repo so77id/nalanda --color 0e8a16
+gh label create "type:bug"          --repo so77id/nalanda --color d73a4a
+gh label create "type:refactor"     --repo so77id/nalanda --color a2eeef
+gh label create "type:docs"         --repo so77id/nalanda --color 0075ca
+gh label create "type:chore"        --repo so77id/nalanda --color cccccc
+
+gh label create "area:widgets"      --repo so77id/nalanda --color fbca04
+gh label create "area:course"       --repo so77id/nalanda --color fbca04
+gh label create "area:presentation" --repo so77id/nalanda --color fbca04
+gh label create "area:runtime"      --repo so77id/nalanda --color fbca04
+gh label create "area:infra"        --repo so77id/nalanda --color fbca04
+gh label create "area:docs"         --repo so77id/nalanda --color fbca04
+```
+
+## Branch naming
+
+```
+<type>/issue-<N>-<slug>
+```
+
+- `<type>`: branch type derived from the `type:*` label. `type:bug → fix`, others pass through (`feature`, `refactor`, `docs`, `chore`).
+- `<N>`: issue number.
+- `<slug>`: kebab-case from the issue title, max ~5 words.
+
+Examples:
+- `feature/issue-42-graph-ds-visualizer`
+- `fix/issue-51-codemirror-line-tracker`
+- `refactor/issue-45-extract-visualizer-base`
+
+## Commit format
+
+One commit per slice. Every commit must leave lint clean and relevant smoke tests green.
+
+```
+<type>(issue-<N>): S<n> <slice description>
+
+<optional body — only if the change has non-obvious context>
+
+Refs #<N>
+```
+
+`<type>` matches the branch type. Example: `feature(issue-42): S1 add graph DS scaffold`.
+
+## PR template
+
+```
+**Closes #<N>**
+
+## Summary
+<1-3 bullets>
+
+## Slices completed
+- [x] S1: ...
+- [x] S2: ...
+
+## Acceptance criteria
+- [x] AC1 — evidence
+- [x] AC2 — evidence
+
+## Tests
+- Added/changed smoke tests: ...
+- All passing: ✓
+
+## Reviews run
+- Tier 2 (review): ...
+- Tier 3: ...
+- Tier 4 (docs): ...
+
+## Manual verification
+- ✓ ...
+
+## Notes
+...
+```
+
+PRs must be **squash-merged** manually by the user.
+
+## Worktrees
+
+Each WP is developed in its own worktree to allow parallel work:
+
+```bash
+git fetch origin
+git worktree add -b <type>/issue-<N>-<slug> ../nalanda-issue-<N> main
+cd ../nalanda-issue-<N>
+npm install
+```
+
+`npm install` is required because `node_modules/` is gitignored and not present in the new worktree.
+
+When the PR is merged, remove the worktree from the main directory:
+
+```bash
+cd /Users/so77id/workspace/nalanda
+git worktree remove ../nalanda-issue-<N>
+```
+
+## Yolo mode (trivial fixes)
+
+For changes that meet ALL of these criteria, the workflow above can be bypassed:
+
+- ≤3 lines changed
+- No new logic (typo, copy edit, dependency-free reorder)
+- Negligible risk (no chance of breaking existing behavior)
+- Lint passes
+- Trivially smoke-testable by visual inspection
+
+Commit directly to `main` with a clear message. Do not create an issue.
+
+## Issue body structure
+
+Every refined issue body must contain, in this order:
+
+1. **Header:** `**Type:** ...`, `**Area:** ...`, `**Source:** ...`
+2. **Structured summary:** Problem / Goals / Non-goals / Design / Acceptance criteria / Slices / Notes
+3. **Full artefacts appended:** `## Original specification`, `## Original plan`, `## Original todo` containing the complete content of any artefact produced during refinement
+
+The issue is the single source of truth for the WP. `develop-task` must have everything it needs in the body — no "see file X" references.


### PR DESCRIPTION
## Summary
- Migrate the 4-process workflow (capture-idea → refine-idea → develop-task → groom-backlog) and Claude support files from the sibling DocumentBuddy repo so Nalanda follows the same Claude-assisted development process.
- Keep only Claude-related infrastructure — Go/Docker/SQLite/CLP/Telegram/ISAPRE-specific bits were intentionally left behind.
- Set up the matching GitHub side: Discussions, Ideas category, type:*/area:* labels, and a new Project #3 with the 5-column Status field.

## What landed locally
- `CLAUDE.md` — stack (Vite/React/Tailwind/WASM) + workflow rules
- `.claude/settings.json` — PreToolUse + Notification hooks, allow/deny permissions
- `.claude/hooks/protect-files.sh` (blocks `.env`, `package-lock.json`, lockfiles)
- `.claude/hooks/notify.sh` (macOS notification "Nalanda")
- `.claude/agents/{code-reviewer, test-analyzer}.md` — adapted to React/JS + puppeteer smoke tests
- `.claude/skills/{capture-idea, refine-idea, develop-task, groom-backlog, review, tdd}/SKILL.md`
- `docs/conventions.md` — kanban, labels, branch naming, commit format, PR template, worktree workflow
- `.claudeignore` — `node_modules/`, `dist/`, screenshots
- `.gitignore` — narrow `.claude/` exclusion to `settings.local.json` and `worktrees/` only

## What landed on GitHub
- Discussions enabled; `💡 Ideas` category → `DIC_kwDOSGlAqc4C9bBm`
- 11 labels created: `type:{feature,bug,refactor,docs,chore}` + `area:{widgets,course,presentation,runtime,infra,docs}`
- Project **#3 "Nalanda"** → `PVT_kwHOAD5lg84BYOfH`
- Status field options:
  - Backlog `3876d811`
  - Ready `d471aa12`
  - In Progress `709335dd`
  - Review `4bbf67b2`
  - Done `374a7858`

## Not migrated (intentional)
- `gofmt.sh` (Go-specific)
- `rules/go-tests.md`, `rules/migrations.md` (Go/SQLite)
- `wp-session`/`wp-commit` skills (redundant with `develop-task`)
- DocumentBuddy domain rules (CLP integer, log/slog, ADR-017 provider stubs, ISAPRE/Telegram/Consalud)

## Test plan
- [ ] Pull the branch and confirm `.claude/` files are tracked, `.claude/settings.local.json` is ignored
- [ ] Try `/capture-idea` with a sample idea → confirms a Discussion is created in the `💡 Ideas` category
- [ ] Try `/refine-idea` against that Discussion → confirms a refined Issue appears in Project #3 Backlog with `type:*` and `area:*` labels
- [ ] Try `/groom` → confirms the Backlog is listed and an item can be promoted to Ready
- [ ] Verify the protect-files hook blocks an attempted edit of `.env` or `package-lock.json`
- [ ] `npm run lint` and `npm run build` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)