### PR TITLE
docs: version initial ADRs (0001-0003)

### DIFF
--- a/docs/decisions/0001-introduce-go-backend.md
+++ b/docs/decisions/0001-introduce-go-backend.md
@@ -1,0 +1,52 @@
+# ADR-0001: Introduce Go backend; abandon 100%-static principle
+
+**Status:** Accepted
+**Date:** 2026-05-20
+**Decision-makers:** Miguel Rodriguez (project owner)
+
+## Context
+
+The current SPEC.md describes Nalanda as a 100%-static site deployable to GitHub Pages, with all execution (C++/Python via WASM) happening in the browser. This was appropriate for the POC of widgets validation.
+
+The platform is now expanding to include:
+- User accounts and authentication.
+- Live class sessions with sync between professor and students.
+- Tasks with submissions and grading.
+- Multi-course, multi-professor administration.
+- Course inheritance/forking semantics.
+
+None of these can be implemented as a purely static frontend. A backend service is required.
+
+## Decision
+
+Introduce a backend service written in **Go**, abandoning the "100%-static" boundary from the original SPEC.
+
+Stack:
+- Runtime/framework: `net/http` + `github.com/go-chi/chi` (minimalist router).
+- SQL: `sqlc` (generates type-safe Go from SQL queries, no runtime overhead).
+- Migrations: `goose` (or `golang-migrate` — final choice in E1 spec).
+- Database: PostgreSQL (Docker locally, Neon free tier in production).
+- Contracts with frontend: OpenAPI 3 + `oapi-codegen` for code generation (TS types + Go handlers from a single source).
+
+## Alternatives considered
+
+- **Node + Hono** (initial recommendation): same language as frontend, smaller learning curve. Rejected because Go offers lower RAM (256MB vs 512MB+ Node baseline), single binary deployment, and native goroutines for SSE broadcasting.
+- **Bun + Elysia**: faster but library ecosystem is less mature.
+- **Stay 100% static + use a hosted backend-as-a-service** (Firebase, Supabase): rejected because of vendor lock-in and per-user-style costs that grow with scale.
+
+## Consequences
+
+**Positive**:
+- Memory-efficient deploys (Go binaries ~10-20MB, fit comfortably in Fly.io free tier).
+- Goroutine-based concurrency is well-suited to SSE/long-lived connection workloads.
+- Strong typing reaches end-to-end via OpenAPI codegen.
+
+**Negative**:
+- Frontend (TS/JS) and backend (Go) speak different languages → shared contracts require codegen step (ADR-003 covers this in `packages/shared-contracts/`).
+- The "100%-static" property is lost — frontend now has a runtime dependency on the backend for auth, sessions, submissions.
+- Material content (`/courses/...`) remains servable as static (per ADR-0002 domain separation) — the "static fallback" UX is still achievable when backend is unreachable.
+
+## References
+
+- Plan file: `/Users/so77id/.claude/plans/quiero-hacer-muchos-specs-typed-stonebraker.md` (decisions G, G', H).
+- Free-tier rationale: minimize-backend-cost feedback memory.

--- a/docs/decisions/0002-material-vs-administration-domain-separation.md
+++ b/docs/decisions/0002-material-vs-administration-domain-separation.md
@@ -1,0 +1,63 @@
+# ADR-0002: Course Material domain is separated from Course Administration domain
+
+**Status:** Accepted
+**Date:** 2026-05-20
+**Decision-makers:** Miguel Rodriguez
+
+## Context
+
+A course in Nalanda has two conceptually distinct aspects that have been entangled in many similar platforms (Moodle, Canvas, etc.):
+- Its **material**: the chapters, sections, MDX content, embedded widgets, slide markers — the textbook itself.
+- Its **administration**: enrollments, live class sessions, submissions, progress per student, events.
+
+If these are entangled in code, several desirable properties become impossible or expensive:
+- Public read-only access to course material (a "visitor" mode for prospective students, public textbook, search-engine-indexed previews) requires that material can be served without auth, enrollment, or per-user state.
+- CDN caching of content (fast page loads, edge serving) requires that responses are not per-user.
+- Specs for content authoring should not be entangled with specs for grading.
+
+## Decision
+
+**Treat Course Material and Course Administration as separate domains** throughout the system:
+
+### Material Domain
+- **What lives here**: courses, course_versions, sections (text, MDX, widgets), slide markers, assets (images, PDFs).
+- **Characteristics**: static, read-heavy, no per-user state, potentially public.
+- **API surface**: `/api/content/...`. Cacheable. May or may not require auth (future visitor mode possible).
+- **Frontend routes**: `/courses/<slug>/learn/...`. Could be made public.
+- **Storage** (phase 1): MDX files in repo, bundled by Vite. (Phase 2+: TBD per O' decision.)
+- **Cache strategy**: aggressive CDN/edge cache, invalidation on deploy.
+
+### Administration Domain
+- **What lives here**: users, enrollments, sessions, submissions, progress, session_events, tasks.
+- **Characteristics**: dynamic, per-user state, write-balanced, private.
+- **API surface**: `/api/admin/...`, `/api/sessions/...`, `/api/submissions/...`. Requires auth + role/enrollment check on every request.
+- **Frontend routes**: `/courses/<slug>/study/...`, `/sessions/<code>`, `/teacher/...`, `/admin/...`.
+- **Storage**: PostgreSQL (Postgres + sqlc).
+- **Cache strategy**: no shared cache; response per-user.
+
+### Cross-domain rules
+- Administration tables MAY foreign-key to Material entities (e.g., `enrollments.course_version_id`, `sessions.current_section_id`).
+- Material tables MUST NOT reference Administration entities. The Material domain has zero awareness of who's using it.
+- Specs are scoped to one domain. A spec about content authoring lives in the Material domain; a spec about session sync lives in Administration. If a spec needs both, it's typically too large and should be split.
+
+## Alternatives considered
+
+- **Single domain (the default for naive ed-tech platforms)**: everything in one set of tables, one API surface, one set of routes. Simpler short-term, but blocks future visitor mode and forces auth on content reads forever.
+- **Microservices (a separate "content service" and "admin service")**: same logical separation but with network/process boundary. Overkill for our scale; we get the conceptual separation without the operational complexity.
+
+## Consequences
+
+**Positive**:
+- Visitor mode (public textbook) becomes a feature we can add without architectural surgery — just remove the auth middleware from `/api/content/...` and `/courses/<slug>/learn/...`.
+- CDN caching of content is straightforward.
+- Specs stay focused — content specs don't drag in submission tracking, and vice versa.
+- Mental model is clean: "is this about *what's in the book* or *who's doing what*?"
+
+**Negative**:
+- Requires discipline to enforce — easy to accidentally let Administration leak into Material specs.
+- Slightly more route/endpoint structure to maintain.
+
+## References
+
+- Plan file: decision X (the most-important architectural decision per the planning conversation).
+- Memory: `feedback_domain_separation.md`.

--- a/docs/decisions/0003-java-runtime-cheerpj-with-pivot-path.md
+++ b/docs/decisions/0003-java-runtime-cheerpj-with-pivot-path.md
@@ -1,0 +1,58 @@
+# ADR-0003: Java runtime via CheerpJ in browser only, with documented pivot path to server-side
+
+**Status:** Accepted (pending license verification at E3/S3.1)
+**Date:** 2026-05-20
+**Decision-makers:** Miguel Rodriguez
+
+## Context
+
+The pilot course is "Estructuras de Datos en Java". The existing CodeEditor widget supports C++ (via `browsercc` + WASI) and Python (via Pyodide), both compiling and executing entirely in the browser. Java is the new requirement.
+
+Three architectural paths exist for running Java student code:
+
+1. **In-browser via CheerpJ 3.0** (Leaning Technologies): full JVM + std lib compiled to WebAssembly. ~20MB lazy-load. Free for educational/non-commercial use.
+2. **Server-side compilation in sandbox** (`javac` + `java` in container, what most online judges do): students POST code, backend compiles and runs, returns output. ~1-3s round-trip per execution. Backend complexity (JDK + sandbox + queueing).
+3. **Hybrid** (CheerpJ for interactive in-class use, server-side for canonical autograder validation).
+
+Other Java-to-browser tools (TeaVM, Bytecoder, GraalVM Native Image WASM) compile ahead-of-time and cannot compile *student* code at runtime — they're tools for *shipping* Java apps to the browser, not for *running arbitrary* Java code there. DoppioJVM is abandoned.
+
+## Decision
+
+**Use CheerpJ in the browser only, with NO server-side Java compilation.**
+
+This matches the existing `useRuntime` pattern (cpp.worker, python.worker) by adding a `java.worker` that lazy-loads CheerpJ.
+
+Acceptance gate at the E3/S3.1 spec:
+- **License verification**: CheerpJ's "free for non-commercial/educational use" must be confirmed to cover a Chilean university course context.
+- If license check **fails**, this ADR is superseded by a follow-up ADR introducing server-side Java compilation. The frontend interface (`useRuntime`, `<CodeEditor language="java">`) stays unchanged; only the worker implementation changes.
+
+## Alternatives considered
+
+- **Server-side compilation only**: license-free (OpenJDK) but adds latency, backend cost, and sandbox complexity. Not chosen for MVP because the educational UX is better when iterations are fast (CheerpJ once warm).
+- **Hybrid (in-browser + server validation)**: deferred — keeps complexity high upfront. We can add server-side validation later for tasks that count for grade if integrity matters, without changing the in-browser flow.
+
+## Consequences
+
+**Positive**:
+- Zero backend cost for Java execution (no compute on Fly.io free tier consumed by `javac`).
+- Fast iteration UX after first warm load (~5s warm-up, sub-second for subsequent runs).
+- Works offline once cached.
+- Same architectural pattern as existing C++/Python runtimes (no exception).
+
+**Negative**:
+- Initial bundle load is ~20MB (lazy, only when Java is selected; cached after first download).
+- **Autograder integrity risk**: a sufficiently motivated student can modify their local JS to fake passing outputs to the backend. For educational/practice context this is acceptable; for high-stakes grading (final exams), the hybrid mitigation (server-side re-run) is documented as the upgrade path.
+- License dependency on Leaning Technologies. If they change terms or sunset CheerpJ, we need to pivot to server-side. ADR documents this so the pivot is not a surprise.
+
+## Implementation notes
+
+- New files in E3/S3.2: `apps/frontend/src/widgets/code-editor/runtimes/java.js`, `java.worker.js`.
+- Lazy-load via dynamic import inside the worker.
+- Extend `LanguageContext` to include `'java'`.
+- Smoke test: `smoke-test-java.mjs` covers compile, run, stdin.
+- Phase B refactor (post-junio) introduces a `RemoteRuntime` abstraction so the same worker contract can be backed by either local WASM (CheerpJ) or remote HTTP (server-side fallback).
+
+## References
+
+- Plan file: decisions K (Java runtime) and L (worker pattern).
+- POC reference: `src/widgets/code-editor/runtimes/cpp.worker.js`, `python.worker.js`.


### PR DESCRIPTION
## Summary
Version the three architectural decision records drafted during the platform-architecture phase. The files have been sitting untracked in `docs/decisions/` locally; this PR just brings them under version control with no content changes.

## Contents
- **ADR-0001 — Introduce Go backend; abandon 100%-static principle**
  Establishes that the platform moves beyond the GitHub-Pages-only POC and adopts a Go backend (with shared OpenAPI contracts and IaC) to support enrollment, authentication, and live class features.
- **ADR-0002 — Course Material domain is separated from Course Administration domain**
  Records the boundary between the *material* domain (content authoring, widgets, presentation) and the *administration* domain (users, enrollments, sessions, billing) so the two can evolve and scale independently.
- **ADR-0003 — Java runtime via CheerpJ in browser only, with documented pivot path to server-side**
  Default Java execution is client-side via CheerpJ, contingent on license verification at S3.1 (Epic #13). A server-side fallback path is documented in case licensing or performance blocks the browser approach.

## References
- Parent epics: #11 (Foundation & Infra), #13 (Java Runtime), #14 (Backend & Auth)
- Workflow alignment: `CLAUDE.md` → `References → ADRs (docs/decisions/)`

## Test plan
- [ ] `ls docs/decisions/` shows the three files on `main` after merge.
- [ ] Markdown renders correctly on GitHub (headers, status block, sections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
