### PR TITLE
chore: archive old ADRs into proof-of-concept + record design decisions D1-D5

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ nalanda/
 ├── proof-of-concept/   Archived POC app + documented issues from the old roadmap
 ├── docs/
 │   ├── design/         Living redesign document (source of truth for what's next)
-│   ├── decisions/      ADRs
 │   ├── conventions.md  Workflow conventions (branches, commits, PRs, kanban)
 │   └── course-graph.md Course topology (deferred until platform v0.1)
 ├── .claude/            Agent workflow skills (capture-idea, refine-idea, groom-backlog, develop-task)

--- a/docs/design/2026-08-redesign.md
+++ b/docs/design/2026-08-redesign.md
@@ -18,6 +18,7 @@
 | M7 | Design approach: aspirational design first (the full software we want), then cut into staged minimal versions. No rush — no tasks created until design closes. | 2026-08-05 |
 | M8 | POC packaged into `proof-of-concept/` (code + archived issues). All open issues from the May roadmap documented there and closed. Repo clean: nothing open. | 2026-08-05 |
 | M9 | Implementation first steps (when design closes): define folder structure + services as a self-contained monorepo; import the necessary dev standards from DocumentBuddy (clean code, TDD, etc.). | 2026-08-05 |
+| M10 | Old ADRs 0001–0003 archived into `proof-of-concept/decisions/`. New ADRs will be produced by this redesign. | 2026-08-05 |
 
 ## Agenda (sections to design, in order)
 
@@ -84,4 +85,17 @@ types, persistent code in editors (a real work tool), LeetCode-style problem set
 with contests/leaderboards, forums — everything an online course carries.
 **For now**: the student is a spectator; features arrive incrementally.
 
-*(open — under discussion: data model derived from the above)*
+**Decisions closed in this section:**
+
+| # | Decision | Date |
+|---|---|---|
+| D1 | Early versions store content as **folders/files in git — no database**. The logical model, however, is designed DB-first from day one: stable `id` per content node (frontmatter); the folder layout is just the serialization. Moves/renames must not break links or (future) progress data. Detailed design pending. | 2026-08-05 |
+| D2 | **No login at all in the first versions.** Courses are fully public; authoring happens via git + skills. Auth is born together with the first server-backed feature that genuinely needs it. | 2026-08-05 |
+| D3 | A **Document** is the content unit: a complete "sección/presentación". A single source can render as book, as slides, or both — the content decides. | 2026-08-05 |
+| D4 | Course content is a **graph, not just a tree**: wiki-like navigation with cross-references between documents. On top of it lives an **index** — the ordered teaching path (based on how Miguel runs the class, dependency-aware). The system must support both; ideas iterate as the first course gets written. | 2026-08-05 |
+| D5 | **Hito 1 (first milestone)**: presentation synchronized professor→students (live class), plus some real content built with the components. From there, features grow clase a clase, driven by need. | 2026-08-05 |
+
+**Open in this section:**
+- Leaf/document *types* (lección, guía, evaluación…): homogeneous vs typed — how they
+  are administered, and what's in the first implementation vs later (P6, under discussion).
+- Detailed stable-ID + graph/index model design (D1/D4 follow-through).

--- a/proof-of-concept/README.md
+++ b/proof-of-concept/README.md
@@ -9,8 +9,9 @@ work — it is a reference archive of working code and already-written ideas.
 
 ```
 proof-of-concept/
-├── frontend/   The POC app (React 19 + Vite 7 + Tailwind 3) — still runnable
-└── issues/     All 33 issues open at archive time, exported as markdown (INDEX.md)
+├── frontend/    The POC app (React 19 + Vite 7 + Tailwind 3) — still runnable
+├── issues/      All 33 issues open at archive time, exported as markdown (INDEX.md)
+└── decisions/   ADRs 0001–0003 from the May 2026 planning cycle (archived)
 ```
 
 ## What the POC proved
@@ -41,6 +42,5 @@ detailed designs (content model, slide markers, CheerpJ runtime, Go backend, aut
 that remain useful as input for the redesign.
 
 Related material that stays active outside this folder:
-- `docs/decisions/` — ADRs 0001–0003 (may be rewritten by the redesign).
 - `docs/course-graph.md` — course topology (51 topics); deferred until platform v0.1.
 - GitHub Discussions 💡 Ideas — captured widget/feature ideas (still the live idea inbox).

--- a/proof-of-concept/decisions/0001-introduce-go-backend.md
+++ b/proof-of-concept/decisions/0001-introduce-go-backend.md
@@ -1,6 +1,6 @@
 # ADR-0001: Introduce Go backend; abandon 100%-static principle
 
-**Status:** Accepted
+**Status:** Archived 2026-08-05 — superseded by the from-zero redesign (`docs/design/2026-08-redesign.md`). Kept as reference.
 **Date:** 2026-05-20
 **Decision-makers:** Miguel Rodriguez (project owner)
 

--- a/proof-of-concept/decisions/0002-material-vs-administration-domain-separation.md
+++ b/proof-of-concept/decisions/0002-material-vs-administration-domain-separation.md
@@ -1,6 +1,6 @@
 # ADR-0002: Course Material domain is separated from Course Administration domain
 
-**Status:** Accepted
+**Status:** Archived 2026-08-05 — superseded by the from-zero redesign (`docs/design/2026-08-redesign.md`). Kept as reference.
 **Date:** 2026-05-20
 **Decision-makers:** Miguel Rodriguez
 

--- a/proof-of-concept/decisions/0003-java-runtime-cheerpj-with-pivot-path.md
+++ b/proof-of-concept/decisions/0003-java-runtime-cheerpj-with-pivot-path.md
@@ -1,6 +1,6 @@
 # ADR-0003: Java runtime via CheerpJ in browser only, with documented pivot path to server-side
 
-**Status:** Accepted (pending license verification at E3/S3.1)
+**Status:** Archived 2026-08-05 — superseded by the from-zero redesign (`docs/design/2026-08-redesign.md`). Kept as reference.
 **Date:** 2026-05-20
 **Decision-makers:** Miguel Rodriguez
 


### PR DESCRIPTION
## Summary
- Moves ADRs 0001–0003 to `proof-of-concept/decisions/` (status updated to *Archived*, kept as reference) — they belong to the discarded May 2026 planning cycle.
- Updates `docs/design/2026-08-redesign.md`: adds M10 and the first five closed design decisions (D1 folders-no-DB with DB-first logical model, D2 no-login early versions, D3 Document semantics, D4 graph+index content model, D5 hito 1 = synced presentation).
- Updates READMEs to the new layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjgYwMF75pzdJAxMXbQ1Lf