### PR TITLE
design: close sections 1-4 (D6-D18)

### DIFF
--- a/docs/design/2026-08-redesign.md
+++ b/docs/design/2026-08-redesign.md
@@ -27,8 +27,8 @@ Status: `pending` → `in discussion` → `closed`
 1. **Visión aspiracional & actores** — what Nalanda is in its final form, who uses it. — `closed`
 2. **Modelo de datos & usuarios** — how courses/users/progress are stored; roles; entities. — `closed` (detailed serialization/ID design lands at spec time)
 3. **Arquitectura de sistema** — frontend/backend split, stack, hosting. Revisits old ADR-0001 from zero. — `closed`
-4. **Componentes de contenido** — abstract containers, per-mode behavior (book/presentation/teacher/...), authoring standard, design-system catalog. — `in discussion`
-5. **Componentes conectados / sesiones en vivo** — sockets, professor↔student sync, shared code, remote presentation advance. — `pending`
+4. **Componentes de contenido** — abstract containers, per-mode behavior (book/presentation/teacher/...), authoring standard, design-system catalog. — `closed` (inventory populated at planning time)
+5. **Componentes conectados / sesiones en vivo** — sockets, professor↔student sync, shared code, remote presentation advance. — `in discussion`
 6. **Runtime de código (Java)** — execution engine decision. Old ADR-0003 as input. — `pending`
 7. **Sistema de creación de clases** — authoring pipeline/skill: presentation → Nalanda class. Waits for the clase-a-clase meeting outcome. — `pending`
 8. **Etapas & roadmap** — cut aspirational design into versions (v0.1 = minimum to start adding content); rewrite ADRs; open new issues. — `pending`
@@ -131,5 +131,22 @@ new app (assumed from POC; Miguel hasn't explicitly confirmed).
 **Section 3 status: CLOSED.**
 
 ### 4. Componentes de contenido
+
+**Decisions closed in this section:**
+
+| # | Decision | Date |
+|---|---|---|
+| D15 | **Modes v1: `book` and `presentation` only.** `presenter` (old "teacher" mode with private notes) is future. `book` = wiki-like reading. **Each document has its own presentation mode**: a slide-rendering of that same document with more/fewer/same things depending on the page's configuration. Every component must work and look right in both modes. | 2026-08-05 |
+| D16 | **Mode↔sync relationship is defined in section 5**, not here. In principle presentation mode inherently syncs when students join the cátedra; future syncs may cover other components or book mode. | 2026-08-05 |
+| D17 | **Component contract v1**: (1) explicit render per mode — no component may ignore a mode; (2) typed props schema (TS); (3) mandatory catalog entry (usage docs + when-to-use + live examples) — a PR adding a component without its catalog entry fails review; (4) reserved slot for an optional session-sync interface (designed in section 5); (5) client-side compute for any heavy work; (6) **feature-toggle props** — components expose props that enable/disable capabilities (e.g., IDE: editable vs copy-only, show/hide panels; applets likewise); (7) **abstract/composable components** exist — containers that render other components injected into them (e.g., "proyector" rendering structure applets; future: line-by-line code stepper with a synchronized drawing). Composition details at planning time, based on what the POC already implements. | 2026-08-05 |
+| D18 | **Catalog structure**: four families — *estructura*, *semánticos*, *interactivos*, *media* — editable as needed. The catalog is **self-governing**: each family is defined and explained (so it's obvious where a new component belongs); it documents how to add a new component, the documentation checklist, the review checklist verifying all required docs are present, and how to add a new rule to the catalog itself. | 2026-08-05 |
+
+**Deferred to planning time**: the concrete component inventory (extracted from real
+course material as classes get created — clase-a-clase method); composition/injection
+API details.
+
+**Section 4 status: CLOSED (design level).**
+
+### 5. Componentes conectados / sesiones en vivo
 
 *(open — under discussion)*

--- a/docs/design/2026-08-redesign.md
+++ b/docs/design/2026-08-redesign.md
@@ -26,8 +26,8 @@ Status: `pending` → `in discussion` → `closed`
 
 1. **Visión aspiracional & actores** — what Nalanda is in its final form, who uses it. — `closed`
 2. **Modelo de datos & usuarios** — how courses/users/progress are stored; roles; entities. — `closed` (detailed serialization/ID design lands at spec time)
-3. **Arquitectura de sistema** — frontend/backend split, stack, hosting. Revisits old ADR-0001 from zero. — `in discussion`
-4. **Componentes de contenido** — abstract containers, per-mode behavior (book/presentation/teacher/...), authoring standard, design-system catalog. — `pending`
+3. **Arquitectura de sistema** — frontend/backend split, stack, hosting. Revisits old ADR-0001 from zero. — `closed`
+4. **Componentes de contenido** — abstract containers, per-mode behavior (book/presentation/teacher/...), authoring standard, design-system catalog. — `in discussion`
 5. **Componentes conectados / sesiones en vivo** — sockets, professor↔student sync, shared code, remote presentation advance. — `pending`
 6. **Runtime de código (Java)** — execution engine decision. Old ADR-0003 as input. — `pending`
 7. **Sistema de creación de clases** — authoring pipeline/skill: presentation → Nalanda class. Waits for the clase-a-clase meeting outcome. — `pending`
@@ -111,5 +111,25 @@ hito 1 needs only a tiny event-relay server (no auth, no persistence); content =
 files in git rendered by a public static frontend; self-contained monorepo (M9);
 old ADR-0001 (Go + chi + sqlc + Postgres + OpenAPI) is reference input, re-decided
 from zero.
+
+**Decisions closed in this section:**
+
+| # | Decision | Date |
+|---|---|---|
+| D10 | **POC as quarry**: the new app is built from scratch; POC widgets/runtimes are ported piece by piece as content needs them, refactored to the new standards (and typed) as they enter. | 2026-08-05 |
+| D11 | **TypeScript** for all new frontend code. The style must be tightly defined and bounded — code style, writing format, folder layout — so agents don't improvise. As clean-architecture as practical. | 2026-08-05 |
+| D12 | **Backend in Go**, same rigor: clean code, patterns, and everything demanded of the TS side. Optimize for ease of development. | 2026-08-05 |
+| D13 | **DocumentBuddy-style developer experience** (extends M9): integration guides ("how to add a new X") for frontend AND backend; documentation practices exported from DocumentBuddy when it's re-read; how-to-document is defined here and embedded in the development flow. | 2026-08-05 |
+| D14 | **Hosting**: local-only for now. First deploy: something minimal — a VPS (university-provided or AWS free tier). Frontend stays on GitHub Pages. | 2026-08-05 |
+
+**Deferred to spec time**: sync protocol choice (WebSocket vs SSE) at hito-1 spec;
+monorepo folder structure at implementation start (M9); DB stack when phase B arrives.
+
+**Pending quick confirm**: React + Vite + Tailwind + framer-motion carry over to the
+new app (assumed from POC; Miguel hasn't explicitly confirmed).
+
+**Section 3 status: CLOSED.**
+
+### 4. Componentes de contenido
 
 *(open — under discussion)*

--- a/docs/design/2026-08-redesign.md
+++ b/docs/design/2026-08-redesign.md
@@ -24,9 +24,9 @@
 
 Status: `pending` → `in discussion` → `closed`
 
-1. **Visión aspiracional & actores** — what Nalanda is in its final form, who uses it. — `in discussion`
-2. **Modelo de datos & usuarios** — how courses/users/progress are stored; roles; entities. — `in discussion`
-3. **Arquitectura de sistema** — frontend/backend split, stack, hosting. Revisits old ADR-0001 from zero. — `pending`
+1. **Visión aspiracional & actores** — what Nalanda is in its final form, who uses it. — `closed`
+2. **Modelo de datos & usuarios** — how courses/users/progress are stored; roles; entities. — `closed` (detailed serialization/ID design lands at spec time)
+3. **Arquitectura de sistema** — frontend/backend split, stack, hosting. Revisits old ADR-0001 from zero. — `in discussion`
 4. **Componentes de contenido** — abstract containers, per-mode behavior (book/presentation/teacher/...), authoring standard, design-system catalog. — `pending`
 5. **Componentes conectados / sesiones en vivo** — sockets, professor↔student sync, shared code, remote presentation advance. — `pending`
 6. **Runtime de código (Java)** — execution engine decision. Old ADR-0003 as input. — `pending`
@@ -95,7 +95,21 @@ with contests/leaderboards, forums — everything an online course carries.
 | D4 | Course content is a **graph, not just a tree**: wiki-like navigation with cross-references between documents. On top of it lives an **index** — the ordered teaching path (based on how Miguel runs the class, dependency-aware). The system must support both; ideas iterate as the first course gets written. | 2026-08-05 |
 | D5 | **Hito 1 (first milestone)**: presentation synchronized professor→students (live class), plus some real content built with the components. From there, features grow clase a clase, driven by need. | 2026-08-05 |
 
-**Open in this section:**
-- Leaf/document *types* (lección, guía, evaluación…): homogeneous vs typed — how they
-  are administered, and what's in the first implementation vs later (P6, under discussion).
-- Detailed stable-ID + graph/index model design (D1/D4 follow-through).
+| D6 | **Documents are homogeneous** (no `type` field for now). What a document *is* emerges from its content and components. Typing may be introduced later if a feature needs it — migrate then. Rationale: object dependencies + structure should make a future editor easy; don't design types without real cases. | 2026-08-05 |
+| D7 | **Graph = curso, índice = recorrido.** Multiple recorridos over one graph are plausible futures (per-semester reorder, other professors, inheritance) — the design must make adding them easy, but **first implementations ship exactly one index per course**. | 2026-08-05 |
+| D8 | An index entry is a **topic, not a class session**. The index is the course *timeline* ("el clase a clase"): during a live class Miguel jumps topic → exercise → video → quiz → task → material → back, driving it manually. Timeline may differ per semester as it matures. *Future note*: "material" and "curso" may split — a curso pulling from several materiales. | 2026-08-05 |
+| D9 | **Hito 1 scope confirmed**: professor opens a session and gets a code; students join with the code, no login; server only relays events (professor's current position), no persistence; late joiners snap to current state. A student can **leave sync mode to explore freely** (wiki links + index) and return to sync. | 2026-08-05 |
+
+**Section 1–2 status: CLOSED.** Remaining fine-grained design (stable-ID scheme,
+folder serialization, index file format) happens at spec time for the corresponding
+implementation tasks.
+
+### 3. Arquitectura de sistema
+
+**Inputs/constraints already decided**: client-side compute philosophy (vision);
+hito 1 needs only a tiny event-relay server (no auth, no persistence); content =
+files in git rendered by a public static frontend; self-contained monorepo (M9);
+old ADR-0001 (Go + chi + sqlc + Postgres + OpenAPI) is reference input, re-decided
+from zero.
+
+*(open — under discussion)*


### PR DESCRIPTION
## Summary
- Section 1–2 closed: D6 homogeneous documents, D7 graph=curso/índice=recorrido (one index for now), D8 index entries are topics (course timeline), D9 hito 1 scope (session code, event relay, free-explore).
- Section 3 closed: D10 POC as quarry (port piece by piece), D11 TypeScript with tightly-bounded style, D12 Go backend with same rigor, D13 DocumentBuddy-style integration guides + documentation embedded in dev flow, D14 local-first hosting (VPS later, frontend on Pages).
- Section 4 (content components) now in discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjgYwMF75pzdJAxMXbQ1Lf