### PR TITLE
design: close section 8 — roadmap + ADRs 0001-0010 (design phase complete)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ presentation mode) and the discarded May 2026 roadmap are packaged under
 nalanda/
 ├── proof-of-concept/   Archived POC app + documented issues from the old roadmap
 ├── docs/
-│   ├── design/         Living redesign document (source of truth for what's next)
+│   ├── design/         Living redesign document (design narrative + roadmap)
+│   ├── decisions/      ADRs 0001–0010 — the living architectural decisions
 │   ├── conventions.md  Workflow conventions (branches, commits, PRs, kanban)
 │   └── course-graph.md Course topology (deferred until platform v0.1)
 ├── .claude/            Agent workflow skills (capture-idea, refine-idea, groom-backlog, develop-task)

--- a/docs/decisions/0001-client-side-compute-philosophy.md
+++ b/docs/decisions/0001-client-side-compute-philosophy.md
@@ -1,0 +1,40 @@
+# ADR-0001: Client-side compute philosophy
+
+**Status:** Accepted
+**Date:** 2026-08-05
+**Decision-makers:** Miguel Rodriguez
+**Source:** Redesign session (`docs/design/2026-08-redesign.md`, vision + D5/D9)
+
+## Context
+
+Nalanda's ambition is a live-class teaching platform that must stay cheap to run
+while serving potentially many students executing code, running visualizations, and
+following synchronized presentations. Server-side execution of student code (the
+online-judge model) scales cost linearly with usage.
+
+## Decision
+
+**Expensive computation runs in the user's browser; the server carries the minimum
+load possible.** This is a transversal principle, not a per-feature choice:
+
+- Code compilation/execution: in-browser via WASM toolchains (C++ `browsercc`+WASI
+  and Python/Pyodide proven in the POC; Java per ADR pending at its spec).
+- Visualizations and animations: pure frontend.
+- Live sessions: the server is a dumb event relay (see ADR-0008), never a renderer
+  or state machine for content.
+- Every future feature must justify any server-side compute it introduces.
+
+## Alternatives considered
+
+- **Server-side execution sandbox** (judge model): simpler client, but per-execution
+  cost, latency, and sandbox/queueing complexity. Rejected as default; may appear
+  later for narrow needs (e.g., high-stakes grading integrity).
+- **Hybrid by default**: complexity of both worlds without need at current scale.
+
+## Consequences
+
+- Hosting stays near-free (static frontend + tiny relay/auth backend).
+- First page load can be heavy for runtime downloads (WASM toolchains) — mitigated
+  by lazy loading and caching.
+- Client hardware becomes the performance floor; acceptable for a university course
+  context.

--- a/docs/decisions/0002-content-model-graph-index-stable-ids.md
+++ b/docs/decisions/0002-content-model-graph-index-stable-ids.md
@@ -1,0 +1,47 @@
+# ADR-0002: Content model — document graph + teaching index, stable ids, DB-first design
+
+**Status:** Accepted
+**Date:** 2026-08-05
+**Decision-makers:** Miguel Rodriguez
+**Source:** Redesign session (D1, D3, D4, D6, D7, D8)
+
+## Context
+
+A course is both a body of knowledge (navegable like a wiki) and a timeline (the
+order in which a professor teaches it, jumping between topics, exercises, quizzes
+and back). Content starts life as files in git but will migrate to a database when
+the platform gains an editor (vision phases A→B→C).
+
+## Decision
+
+- **Document**: the content unit — a complete "sección/presentación". One MDX source
+  can render as book, as slides, or both. Documents are **homogeneous** (no `type`
+  field); what a document *is* emerges from its content. Typing may be introduced
+  later by a real need.
+- **Graph**: documents cross-reference each other with wiki-style links by id
+  (`[[some-id]]`). The graph IS the set of documents plus their links; free
+  navigation is wiki navigation.
+- **Index**: a separate artifact per course — the ordered, nestable teaching path
+  ("el clase a clase"). Entries reference document ids; entries are *topics*, not
+  class sessions. Level names are configurable, not hardcoded. One index per course
+  for now; the design must make multiple recorridos over one graph easy to add
+  (future: per-semester reorders, other professors, course inheritance).
+- **Stable ids, DB-first**: every document carries a stable `id` (frontmatter). The
+  folder layout is merely the serialization of the logical model. Moves/renames must
+  never break links or future per-student data. This makes the git→DB migration a
+  storage swap, not a remodel.
+
+## Alternatives considered
+
+- **Tree-only model** (classic book chapters): simpler, but blocks wiki navigation
+  and multi-recorrido futures; rejected.
+- **Typed documents now**: designing types without real cases; deferred until a
+  feature needs them.
+- **Path-as-identity** (id = file path): breaks on every reorganization; rejected.
+
+## Consequences
+
+- Navigation, progress tracking, and sync all reference document ids — robust to
+  content reorganization.
+- The index file format and id scheme get detailed at v0.1 spec time.
+- Authoring tools (create-class skill, future editor) target a stable logical model.

--- a/docs/decisions/0003-mdx-document-format.md
+++ b/docs/decisions/0003-mdx-document-format.md
@@ -1,0 +1,47 @@
+# ADR-0003: MDX as the document format
+
+**Status:** Accepted
+**Date:** 2026-08-05
+**Decision-makers:** Miguel Rodriguez
+**Source:** Redesign session (D26; content requirements from D3/D15)
+
+## Context
+
+Documents must mix prose with interactive components (visualizers, code editors,
+exercises) in a single source that renders both as book pages and as slides. The
+format must be writable by humans, by authoring agents (create-class skill), and by
+a future in-platform AI editor.
+
+## Decision
+
+**MDX** is the document format: Markdown for prose, catalog React components inline
+where interaction is needed, YAML frontmatter for metadata (stable `id`, title, …),
+and `[[wiki-links]]` for cross-references (resolved by our pipeline).
+
+```mdx
+---
+id: bst-insercion
+title: Inserción en un BST
+---
+## La idea
+Para insertar comparamos con la raíz...
+
+<Visualizador estructura="bst" operacion="insert" valores={[50, 30, 70]} />
+
+Relacionado: [[busqueda-binaria]]
+```
+
+## Alternatives considered
+
+- **Plain Markdown + shortcodes**: weaker component embedding, custom parser burden.
+- **JSON/structured blocks** (Notion-style): editor-friendly but hostile to git
+  diffs, human authoring, and agents today; may be revisited at the DB/editor phase.
+- **HTML/JSX pages**: full power but loses prose ergonomics for course writing.
+
+## Consequences
+
+- Authoring is file-based and git-friendly (phase A) and remains parseable for the
+  DB migration (phase B) and editor (phase C).
+- Requires an MDX compile step in the frontend build (Vite plugin, ADR-0004).
+- Components available inside documents are exactly those registered by the catalog
+  (ADR-0010) — the authoring surface is controlled.

--- a/docs/decisions/0004-frontend-stack.md
+++ b/docs/decisions/0004-frontend-stack.md
@@ -1,0 +1,38 @@
+# ADR-0004: Frontend stack — React + TypeScript + Vite + Tailwind + framer-motion
+
+**Status:** Accepted
+**Date:** 2026-08-05
+**Decision-makers:** Miguel Rodriguez
+**Source:** Redesign session (D10, D11, D26)
+
+## Context
+
+The new app is built from scratch (the POC is a quarry: widgets get ported piece by
+piece as content needs them). The platform is component-based to its core — documents
+are literally built from components (ADR-0003). The frontend must deploy as a fully
+static site (GitHub Pages).
+
+## Decision
+
+- **React** — component model; POC widgets are React and port directly.
+- **TypeScript** — all new frontend code. Style is tightly bounded (ADR-0005).
+- **Vite** — dev server + static bundler (compiles TS/JSX/MDX; outputs static files
+  for Pages). Not a framework; no server rendering.
+- **Tailwind CSS** — styling as utility classes inside components; design-system
+  tokens (palette, spacing) defined in the catalog standard.
+- **framer-motion** — THE animation library. No other animation library may be added.
+
+## Alternatives considered
+
+- **Next.js**: adds a rendering server — contradicts static-frontend + minimal-server
+  (ADR-0001); rejected.
+- **Vue/Svelte**: no benefit worth discarding proven React widgets and the strongest
+  agent/ecosystem support.
+- **Plain CSS / CSS-in-JS**: style sprawl vs runtime cost; Tailwind keeps styles
+  colocated and constrained, which also limits agent improvisation.
+
+## Consequences
+
+- POC widgets get typed as they enter (porting cost paid per piece).
+- The static build remains deployable on GitHub Pages for free.
+- One animation idiom across every component keeps the catalog coherent.

--- a/docs/decisions/0005-dev-standards-bounded-style.md
+++ b/docs/decisions/0005-dev-standards-bounded-style.md
@@ -1,0 +1,40 @@
+# ADR-0005: Development standards — bounded style, TDD, DocumentBuddy-style guides
+
+**Status:** Accepted
+**Date:** 2026-08-05
+**Decision-makers:** Miguel Rodriguez
+**Source:** Redesign session (M9, D11, D12, D13)
+
+## Context
+
+Most code will be written by agents under Miguel's direction. Agents improvise when
+conventions are loose; a platform meant to grow for years needs the codebase to look
+like one person wrote it. DocumentBuddy proved a working formula: strict conventions
++ integration guides ("how to add a new X") + documentation embedded in the dev flow.
+
+## Decision
+
+- **Bounded style**: code style, writing format, and folder layout are explicitly
+  defined for TypeScript (frontend) and Go (backend) — as clean-architecture as
+  practical, favoring ease of development. Agents follow; they do not innovate.
+- **TDD**: test-first development is the default working mode (per the existing
+  `tdd`/`develop-task` skills).
+- **Integration guides**: for every extension point (new content component, new
+  session event type, new backend endpoint, new visualizer) a guide documents how to
+  add one, DocumentBuddy-style.
+- **Documentation in the flow**: how-to-document is defined once and enforced by
+  review — features aren't done until their docs exist. The necessary practices are
+  exported from DocumentBuddy when its docs are re-read at implementation start.
+
+## Alternatives considered
+
+- **Conventions-by-example only** (no written standard): drifts with every agent
+  session; rejected by experience.
+- **Heavyweight formal architecture** (full hexagonal, etc.): ceremony beyond the
+  project's size; "as clean as practical" is the bar.
+
+## Consequences
+
+- v0.1 foundation work includes writing the standards + guides skeleton before/along
+  the first feature code.
+- Reviews check documentation and catalog entries, not just code.

--- a/docs/decisions/0006-backend-go.md
+++ b/docs/decisions/0006-backend-go.md
@@ -1,0 +1,34 @@
+# ADR-0006: Backend in Go
+
+**Status:** Accepted
+**Date:** 2026-08-05
+**Decision-makers:** Miguel Rodriguez
+**Source:** Redesign session (D12; supersedes archived ADR (POC series) 0001)
+
+## Context
+
+The backend starts small — auth, a professors CRUD, and a session event relay
+(ADR-0008/0009) — and grows with the platform (progress, submissions, forums in the
+aspirational future). It must run cheaply on a minimal VPS and handle many
+long-lived socket connections (live classes) without drama.
+
+## Decision
+
+**Go** for the backend service, with the same rigor demanded of the frontend
+(ADR-0005): clean code, explicit patterns, bounded conventions, integration guides.
+Optimize for ease of development.
+
+## Alternatives considered
+
+- **Node/TypeScript**: one language across the monorepo and free type-sharing with
+  the client. Rejected: higher RAM baseline on a minimal VPS, weaker concurrency
+  story for many persistent connections; Miguel's conviction is Go. Event-type
+  contracts will be shared via schema instead (defined at spec time).
+- **Bun/Elysia and friends**: ecosystem maturity risk for a years-long project.
+
+## Consequences
+
+- Two languages in the monorepo → session event types and any future API contracts
+  need an explicit sharing mechanism (schema/codegen decided at spec time).
+- Single static binary deploys — fits the minimal-VPS hosting (D14).
+- Goroutines map naturally to the relay's fan-out (ADR-0008).

--- a/docs/decisions/0007-sqlite-first.md
+++ b/docs/decisions/0007-sqlite-first.md
@@ -1,0 +1,35 @@
+# ADR-0007: SQLite first, Postgres when genuinely needed
+
+**Status:** Accepted
+**Date:** 2026-08-05
+**Decision-makers:** Miguel Rodriguez
+**Source:** Redesign session (D19, D23)
+
+## Context
+
+The first database need is tiny: professor users (Miguel + friends & family via a
+CRUD) and auth records. Hosting is a minimal VPS (or local); operating a database
+service years before its scale arrives is pure cost. DocumentBuddy validated the
+SQLite-no-CGO pattern in production.
+
+## Decision
+
+**SQLite** as the database, running inside the production container with its file on
+a **persistent disk** so restarts survive. The Go repository layer is designed so
+that swapping to **Postgres** later is a localized change (repositories hide the
+engine; no SQLite-isms leak upward). The swap happens when a real need appears
+(multi-tenant scale, concurrent writers, managed backups).
+
+## Alternatives considered
+
+- **Postgres from day one** (the archived plan's choice): operational complexity and
+  either container orchestration or a paid/free-tier external service — all before
+  any real load exists. Rejected for now.
+- **Flat files/JSON**: no query/consistency story once sessions and progress arrive.
+
+## Consequences
+
+- Zero extra services to operate; backups = copying a file.
+- Deployment must mount/attach a persistent volume for the DB file.
+- Repository-layer discipline is mandatory (enforced via ADR-0005 standards) to keep
+  the Postgres path cheap.

--- a/docs/decisions/0008-session-event-envelope-relay.md
+++ b/docs/decisions/0008-session-event-envelope-relay.md
@@ -1,0 +1,44 @@
+# ADR-0008: Live sessions — dumb relay with a generic event envelope
+
+**Status:** Accepted
+**Date:** 2026-08-05
+**Decision-makers:** Miguel Rodriguez
+**Source:** Redesign session (D9, D20, D21, D22)
+
+## Context
+
+Hito 1's flagship feature: the professor teaches and students' browsers follow. The
+dream grows far beyond that (component-level sync, professor mirroring a student's
+session, live quizzes, raised hands), so the wire design must extend without
+rewriting the server — while the server itself stays minimal (ADR-0001).
+
+## Decision
+
+- All session traffic travels in a **generic envelope**: `{session, seq, type, payload}`.
+- The server is a **dumb relay**: it never inspects payloads; it fans events out to
+  session members and keeps only the last state in memory so late joiners snap to
+  current position. No persistence — a server restart ends live sessions.
+- **v1 implements exactly one event type** (`location`: current document, mode,
+  slide position) in one direction (professor → students). Following students see
+  what the professor sees across document jumps (wiki-wide). Students may detach to
+  explore freely and re-attach to sync.
+- Sockets (student↔server, professor↔server) are **bidirectional-capable**; future
+  features are new event types (component syncs, 1:1 mirror), not new architecture.
+- Session UX: professor opens a session (login required, ADR-0009) and gets a join
+  code; a slim persistent banner shows the code + connected-students counter and
+  later evolves into the professor toolbar.
+
+## Alternatives considered
+
+- **Typed server** (server understands each feature's events): every new sync needs
+  server work; violates the relay philosophy. Rejected.
+- **Peer-to-peer (WebRTC)**: no server fan-out cost, but NAT/scale complexity and no
+  authoritative late-join state. Rejected for v1.
+
+## Consequences
+
+- New sync features ship mostly as frontend + a new event type.
+- Transport choice (WebSocket vs SSE+POST), exact message schema, and reconnection
+  semantics are decided at the hito-1 spec.
+- Component contract reserves an optional sync interface (ADR-0010) declaring which
+  event types a component emits/consumes.

--- a/docs/decisions/0009-professor-only-auth.md
+++ b/docs/decisions/0009-professor-only-auth.md
@@ -1,0 +1,39 @@
+# ADR-0009: Professor-only authentication via Google OAuth
+
+**Status:** Accepted
+**Date:** 2026-08-05
+**Decision-makers:** Miguel Rodriguez
+**Source:** Redesign session (D2, D19)
+
+## Context
+
+The guiding rule: auth is born with the first server feature that genuinely needs
+it. That feature is opening live sessions (ADR-0008) — without a gate, anyone could
+open "the parallel cátedra". Meanwhile course *reading* must stay public (no student
+accounts exist yet; the interim rule keeps content open to everyone).
+
+## Decision
+
+- A **basic user system** ships with the backend: **Google OAuth** login, user table
+  (SQLite, ADR-0007), and a user administrator.
+- **Only professor logins exist.** Miguel's user arrives via **seeds**; a professors
+  CRUD manages friends & family accounts, curated by Miguel.
+- Logged-in professors see the **administration section** and the **open session**
+  action. Nothing else on the site requires login.
+- Students remain anonymous spectators: they read publicly and join sessions with a
+  code — no accounts. Student identity (OAuth, university-API validation) is a
+  separate future decision.
+
+## Alternatives considered
+
+- **No auth + shared secret link** for opening sessions: 5-line solution, but Miguel
+  chose to plant the real user system now — it is the seed of the professor role,
+  admin area, and future account features.
+- **Full user system with students**: far ahead of need; rejected for now.
+
+## Consequences
+
+- The backend gains DB + OAuth flow earlier than a pure relay would need — accepted
+  as the first deliberate step toward the platform's administration domain.
+- Course content remains cacheable/public (no per-user content responses).
+- Google is the only identity provider for now.

--- a/docs/decisions/0010-component-contract-catalog.md
+++ b/docs/decisions/0010-component-contract-catalog.md
@@ -1,0 +1,58 @@
+# ADR-0010: Component contract and self-governing catalog
+
+**Status:** Accepted
+**Date:** 2026-08-05
+**Decision-makers:** Miguel Rodriguez
+**Source:** Redesign session (D15, D16, D17, D18, D29)
+
+## Context
+
+Documents are built from components (ADR-0003); authors include agents and, one day,
+a course editor with custom components. Without a hard contract and a living
+catalog, every component invents its own behavior and the "one system" feel dies.
+
+## Decision
+
+**Render modes (v1)**: `book` (wiki-like reading) and `presentation` (the same
+document as slides — each page configures what appears in each). `presenter` (private
+notes/controls) is future. Sync is a navigation state layered on top, not a render
+mode (relationship detailed with ADR-0008 at spec time).
+
+**Every catalog component must satisfy the contract:**
+1. **Explicit render per mode** — no component may ignore a mode (even if the answer
+   is "I don't appear").
+2. **Typed props schema** (TypeScript) — the public contract.
+3. **Mandatory catalog entry** — usage docs, when-to-use, live examples. A PR adding
+   a component without its catalog entry fails review.
+4. **Reserved optional sync interface** — which session event types it emits/consumes
+   (ADR-0008); designed per component when needed.
+5. **Client-side compute** (ADR-0001) for any heavy work.
+6. **Feature-toggle props** — capabilities switch on/off per instance (e.g., editor:
+   editable vs copy-only; panels shown/hidden).
+7. **Composition** — abstract components may receive/render injected components
+   (e.g., a "proyector" rendering structure applets; future line-by-line code stepper
+   with synchronized drawing).
+
+**Catalog**: a live route (`/catalog`) organized in four editable families —
+*estructura*, *semánticos*, *interactivos*, *media*. It is **self-governing**: each
+family is defined and explained; the catalog documents how to add a component, the
+documentation checklist, the review checklist, and how to change the catalog's own
+rules. It serves humans and authoring agents alike.
+
+**Inventory is emergent**: no fixed component list — components are added and evolved
+as real classes need them, always through the catalog process.
+
+## Alternatives considered
+
+- **Storybook** (off-the-shelf catalog): heavier dependency; the catalog IS product
+  surface here (authors browse it), not just a dev tool. A custom route stays in
+  full control. May be revisited if maintenance cost grows.
+- **Free-form components** (no contract): the POC's approach; breaks down the moment
+  multiple modes and authors exist.
+
+## Consequences
+
+- Adding a component has fixed overhead (docs + checklists) — deliberate: the
+  catalog is the product's grammar and the future editor's palette.
+- Mode behavior is testable per component (contract point 1 gives concrete cases).
+- The catalog route ships in v0.1 and grows forever.

--- a/docs/design/2026-08-redesign.md
+++ b/docs/design/2026-08-redesign.md
@@ -31,7 +31,7 @@ Status: `pending` → `in discussion` → `closed`
 5. **Componentes conectados / sesiones en vivo** — sockets, professor↔student sync, shared code, remote presentation advance. — `closed` (fine detail at hito-1 spec)
 6. **Runtime de código (Java)** — execution engine decision. Old ADR-0003 as input. — `closed-deferred`
 7. **Sistema de creación de clases** — authoring pipeline/skill: presentation → Nalanda class. — `closed` (concept level)
-8. **Etapas & roadmap** — cut aspirational design into versions (v0.1 = minimum to start adding content); rewrite ADRs; open new issues. — `in discussion`
+8. **Etapas & roadmap** — cut aspirational design into versions (v0.1 = minimum to start adding content); rewrite ADRs; open new issues. — `closed`
 
 ## Section notes & decisions
 
@@ -183,3 +183,48 @@ details, session lifecycle.
 | # | Decision | Date |
 |---|---|---|
 | D23 | **SQLite first, Postgres when genuinely needed.** SQLite runs inside the production container alongside the app, its file on a persistent disk so restarts survive. The Go repository layer is designed so the swap to Postgres is localized. | 2026-08-05 |
+
+### 8. Etapas & roadmap
+
+| # | Decision | Date |
+|---|---|---|
+| D27 | **Version cut and order** (dependency-driven): v0.1 → v0.2 → v0.3 as below. Sync can wait until after the first class; executable code cannot — so "contenido vivo" precedes "la cátedra". | 2026-08-05 |
+| D28 | **Ten new ADRs** distill the design (list below); one decision per ADR — things go together only if they must. The design doc remains as historical narrative; ADRs are the living decisions. Old ADR series stays archived in `proof-of-concept/decisions/`. | 2026-08-05 |
+| D29 | **Component inventory is emergent** (per P27): no component is mandatory for v0.1 beyond the structural minimum. Components are discussed, added, evolved, and documented as real classes get built — each addition follows the catalog's how-to-add + checklists (D18). | 2026-08-05 |
+
+**The roadmap:**
+
+**v0.1 — "El esqueleto"** *(unlocks M6: content creation can start)*
+1. Foundation: monorepo structure + TS/React/Vite/Tailwind app scaffold, dev
+   standards imported from DocumentBuddy (code style, TDD, documentation practices,
+   integration guides), basic CI. (M9, D11, D13)
+2. Content model: MDX pipeline, documents with stable ids + frontmatter, `[[wiki-links]]`,
+   index file → TOC navigation + `book` mode rendering. (D1, D3, D4, D26)
+3. Presentation mode: same document rendered as slides; first structural components
+   (Slide, SectionBreak). (D15)
+4. Catalog: `/catalog` route with self-governance docs (families, how-to-add,
+   checklists), seeded with whatever components exist. (D18)
+5. Deploy: GitHub Pages.
+
+**v0.2 — "El contenido vivo"**
+6. Java runtime spec — CheerpJ license verification as mandatory first task (D24);
+   port CodeEditor from the quarry. (D10)
+7. Widgets by need: visualizers ported one by one as classes require them. (D10, D29)
+8. `create-class` skill v1 with its evolution guide. (D25)
+
+**v0.3 — "La cátedra"** *(= hito 1 complete)*
+9. Go backend: Google OAuth, SQLite in container, Miguel seeded, professors CRUD,
+   admin section behind login. (D12, D19, D23)
+10. Live sessions: relay with event envelope, location sync, session banner
+    (join code + counter). (D20–D22)
+11. VPS deploy (university or AWS free tier); frontend stays on Pages. (D14)
+
+**New ADR series** (in `docs/decisions/`):
+0001 client-side compute philosophy · 0002 content model (graph + index, stable ids)
+· 0003 MDX as document format · 0004 frontend stack · 0005 dev standards (bounded
+style, TDD, DocumentBuddy imports) · 0006 backend in Go · 0007 SQLite first ·
+0008 session event-envelope relay · 0009 professor-only auth (Google OAuth) ·
+0010 component contract + self-governing catalog.
+
+**Section 8 status: CLOSED. Design phase complete.** Next: create v0.1 issues via
+`refine-idea` and start developing.


### PR DESCRIPTION
## Summary
- Section 8 closed (D27–D29): version cut **v0.1 Esqueleto → v0.2 Contenido vivo → v0.3 La cátedra (hito 1)** — Java/content before sync per Miguel's call; component inventory is emergent.
- New ADR series in `docs/decisions/`: 0001 client-side compute, 0002 content model (graph+index, stable ids), 0003 MDX, 0004 frontend stack, 0005 dev standards, 0006 Go backend, 0007 SQLite first, 0008 session envelope relay, 0009 professor-only auth, 0010 component contract + catalog.
- **This completes the design phase** — the agenda is 8/8 closed. Next: refine v0.1 issues and start developing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UjgYwMF75pzdJAxMXbQ1Lf