### PR TITLE
feat: presentation mode + structural components (Slide, SectionBreak)

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -26,17 +26,20 @@ See `docs/standards/frontend-code-style.md` for the authoritative rules.
 
 ```
 src/
-├── app/                  # shell: entry, router (routes /d/:id + 404), providers
+├── app/                  # shell: entry, router (/d/:id, /d/:id/present + 404), MDX map
+├── components/           # catalog content components by family (structure: Slide, SectionBreak)
 ├── content/              # content pipeline: MDX registry, course index, wiki-links,
 │                         # book-mode page, build-time integrity gate
+├── presentation/         # presentation mode: mode context, slide parser, SlideDeck viewer
+├── lib/                  # pure TS utilities (componentMeta, reactText)
 ├── styles/               # Tailwind entry + design tokens
 ├── mdx.d.ts              # module typing for *.mdx imports
 └── architecture.test.ts  # import-direction invariants
 ```
 
-Remaining feature folders (`components/`, `catalog/`, `presentation/`) and
-`lib/` (pure TS utilities) are created by the WPs that populate them. How to
-author course material: `docs/standards/guides/add-a-course-document.md`.
+The remaining feature folder (`catalog/`) is created by the WP that populates
+it. How to author course material (frontmatter, wiki-links, slide markers):
+`docs/standards/guides/add-a-course-document.md`.
 
 ## Testing
 

--- a/apps/web/src/app/App.test.tsx
+++ b/apps/web/src/app/App.test.tsx
@@ -59,6 +59,17 @@ describe('routing', () => {
     expect(sequence).toHaveTextContent(titleOf(ids[2]!));
   });
 
+  it('renders the presentation placeholder at /d/:id/present', async () => {
+    renderAt(`/d/${ids[0]}/present`);
+    expect(await screen.findByRole('heading', { name: titleOf(ids[0]!) })).toBeInTheDocument();
+    expect(screen.queryByRole('article')).not.toBeInTheDocument();
+  });
+
+  it('shows the 404 page for an unknown id at /present', () => {
+    renderAt('/d/does-not-exist/present');
+    expect(screen.getByRole('heading', { name: /not found/i })).toBeInTheDocument();
+  });
+
   it('shows the 404 page for an unknown document id', () => {
     renderAt('/d/does-not-exist');
     expect(screen.getByRole('heading', { name: /not found/i })).toBeInTheDocument();

--- a/apps/web/src/app/App.test.tsx
+++ b/apps/web/src/app/App.test.tsx
@@ -59,7 +59,7 @@ describe('routing', () => {
     expect(sequence).toHaveTextContent(titleOf(ids[2]!));
   });
 
-  it('renders the presentation placeholder at /d/:id/present', async () => {
+  it('renders the presentation viewer at /d/:id/present', async () => {
     renderAt(`/d/${ids[0]}/present`);
     expect(await screen.findByRole('heading', { name: titleOf(ids[0]!) })).toBeInTheDocument();
     expect(screen.queryByRole('article')).not.toBeInTheDocument();

--- a/apps/web/src/app/AppRoutes.tsx
+++ b/apps/web/src/app/AppRoutes.tsx
@@ -1,6 +1,7 @@
 import { Navigate, Route, Routes } from 'react-router-dom';
 
 import { DocumentPage, courseIndex, walkIndex } from '../content';
+import { PresentationPage } from '../presentation';
 import { NotFound } from './NotFound';
 
 // Landing convention (issue #63): "/" goes to the first stop of the recorrido —
@@ -16,6 +17,7 @@ export function AppRoutes() {
         element={firstDocId ? <Navigate to={`/d/${firstDocId}`} replace /> : <NotFound />}
       />
       <Route path="/d/:id" element={<DocumentPage notFound={<NotFound />} />} />
+      <Route path="/d/:id/present" element={<PresentationPage notFound={<NotFound />} />} />
       <Route path="*" element={<NotFound />} />
     </Routes>
   );

--- a/apps/web/src/app/AppRoutes.tsx
+++ b/apps/web/src/app/AppRoutes.tsx
@@ -1,8 +1,10 @@
+import { MDXProvider } from '@mdx-js/react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 
 import { DocumentPage, courseIndex, walkIndex } from '../content';
 import { PresentationPage } from '../presentation';
 import { NotFound } from './NotFound';
+import { mdxComponents } from './mdxComponents';
 
 // Landing convention (issue #63): "/" goes to the first stop of the recorrido —
 // by convention the course welcome document.
@@ -11,14 +13,16 @@ const firstDocId = walkIndex(courseIndex)[0];
 /** Route table, router-free so tests can mount it inside a MemoryRouter. */
 export function AppRoutes() {
   return (
-    <Routes>
-      <Route
-        path="/"
-        element={firstDocId ? <Navigate to={`/d/${firstDocId}`} replace /> : <NotFound />}
-      />
-      <Route path="/d/:id" element={<DocumentPage notFound={<NotFound />} />} />
-      <Route path="/d/:id/present" element={<PresentationPage notFound={<NotFound />} />} />
-      <Route path="*" element={<NotFound />} />
-    </Routes>
+    <MDXProvider components={mdxComponents}>
+      <Routes>
+        <Route
+          path="/"
+          element={firstDocId ? <Navigate to={`/d/${firstDocId}`} replace /> : <NotFound />}
+        />
+        <Route path="/d/:id" element={<DocumentPage notFound={<NotFound />} />} />
+        <Route path="/d/:id/present" element={<PresentationPage notFound={<NotFound />} />} />
+        <Route path="*" element={<NotFound />} />
+      </Routes>
+    </MDXProvider>
   );
 }

--- a/apps/web/src/app/mdxComponents.test.ts
+++ b/apps/web/src/app/mdxComponents.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { SectionBreak, Slide } from '../components';
+import { mdxComponents } from './mdxComponents';
+
+const map: Record<string, unknown> = mdxComponents;
+
+describe('shell MDX components map', () => {
+  it('registers the structural markers so documents use them without imports', () => {
+    expect(map['Slide']).toBe(Slide);
+    expect(map['SectionBreak']).toBe(SectionBreak);
+  });
+
+  it('keeps the content mappings (links and anchor headings)', () => {
+    for (const key of ['a', 'h2', 'h3', 'h4']) {
+      expect(map[key], `missing mapping for ${key}`).toBeDefined();
+    }
+  });
+});

--- a/apps/web/src/app/mdxComponents.ts
+++ b/apps/web/src/app/mdxComponents.ts
@@ -1,0 +1,13 @@
+import { SectionBreak, Slide } from '../components';
+import { contentMdxComponents } from '../content';
+
+/**
+ * The full MDX components map — shell-composed so features stay decoupled
+ * (content maps its elements; catalog components register here). Documents
+ * use structural components without imports (ADR-0003 / ADR-0010).
+ */
+export const mdxComponents = {
+  ...contentMdxComponents,
+  Slide,
+  SectionBreak,
+};

--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -48,6 +48,9 @@ describe('PresentationPage viewer', () => {
     fireEvent.keyDown(window, { key: 'End' });
     expect(counter).toHaveTextContent(`${total} / ${total}`);
 
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    expect(counter).toHaveTextContent(`${total} / ${total}`);
+
     fireEvent.keyDown(window, { key: 'Home' });
     expect(counter).toHaveTextContent(/^1 \//);
 
@@ -58,6 +61,11 @@ describe('PresentationPage viewer', () => {
   it('deep-links to a slide via ?slide=N and clamps out-of-range values', async () => {
     renderAt(`/d/${firstId}/present?slide=2`);
     expect(await findCounter()).toHaveTextContent(/^2 \//);
+  });
+
+  it('survives a crafted non-integer ?slide value', async () => {
+    renderAt(`/d/${firstId}/present?slide=1.5`);
+    expect(await findCounter()).toHaveTextContent(/^1 \//);
   });
 
   it('returns to the book view on Escape', async () => {
@@ -103,5 +111,38 @@ describe('book-view entry points to presentation', () => {
     await screen.findByRole('article');
     fireEvent.keyDown(window, { key: 'p' });
     expect(await screen.findByText(/^\d+ \/ \d+$/)).toBeInTheDocument();
+  });
+});
+
+// busqueda-binaria is the DESIGNATED explicit-mode fixture (see its frontmatter):
+// these tests guard the real compiled <Slide> path through the mdxChildrenOf
+// adapter — the alarm the adapter's docs promise.
+describe('explicit-mode documents (real compiled markers)', () => {
+  const explicitId = ids.find((id) => registry.get(id)?.meta.presentation === 'explicit');
+
+  it('the seed course provides an explicit fixture', () => {
+    expect(explicitId).toBeDefined();
+  });
+
+  it('decks only the marked slides, leaving loose prose book-only', async () => {
+    renderAt(`/d/${explicitId}/present`);
+    const counter = await findCounter();
+    expect(counter).toHaveTextContent('1 / 3');
+
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    expect(await screen.findByRole('heading', { name: 'La idea' })).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'End' });
+    expect(screen.queryByText(/prosa de libro/)).not.toBeInTheDocument();
+  });
+
+  it('renders marked slides as heading + prose in the book view, with the loose section present', async () => {
+    renderAt(`/d/${explicitId}`);
+    const article = await screen.findByRole('article');
+    const { within } = await import('@testing-library/react');
+    expect(
+      await within(article).findByRole('heading', { level: 2, name: /La idea/ }),
+    ).toBeInTheDocument();
+    expect(within(article).getByRole('heading', { level: 2, name: /Costo/ })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -74,3 +74,12 @@ describe('PresentationPage viewer', () => {
     expect(screen.getByRole('button', { name: /fullscreen/i })).toBeInTheDocument();
   });
 });
+
+describe('presentation: none documents', () => {
+  it('redirects /present back to the book view', async () => {
+    const noneId = ids.find((id) => registry.get(id)?.meta.presentation === 'none');
+    expect(noneId, 'seed course needs a presentation:none document').toBeDefined();
+    renderAt(`/d/${noneId}/present`);
+    expect(await screen.findByRole('article')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import { courseIndex, registry, walkIndex } from '../content';
+
+import { AppRoutes } from './AppRoutes';
+
+const ids = walkIndex(courseIndex);
+const firstId = ids[0]!;
+const firstTitle = registry.get(firstId)?.meta.title ?? firstId;
+
+function renderAt(path: string) {
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <AppRoutes />
+    </MemoryRouter>,
+  );
+}
+
+async function findCounter() {
+  return screen.findByText(/^\d+ \/ \d+$/);
+}
+
+describe('PresentationPage viewer', () => {
+  it('opens on the cover slide with the document title and a counter', async () => {
+    renderAt(`/d/${firstId}/present`);
+    expect(await screen.findByRole('heading', { name: firstTitle })).toBeInTheDocument();
+    expect(await findCounter()).toHaveTextContent(/^1 \/ \d+$/);
+  });
+
+  it('navigates with ArrowRight/ArrowLeft and clamps at the edges', async () => {
+    renderAt(`/d/${firstId}/present`);
+    const counter = await findCounter();
+
+    fireEvent.keyDown(window, { key: 'ArrowLeft' });
+    expect(counter).toHaveTextContent(/^1 \//);
+
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    expect(counter).toHaveTextContent(/^2 \//);
+  });
+
+  it('advances with Space and jumps with Home/End', async () => {
+    renderAt(`/d/${firstId}/present`);
+    const counter = await findCounter();
+    const total = Number(counter.textContent!.split('/')[1]);
+
+    fireEvent.keyDown(window, { key: 'End' });
+    expect(counter).toHaveTextContent(`${total} / ${total}`);
+
+    fireEvent.keyDown(window, { key: 'Home' });
+    expect(counter).toHaveTextContent(/^1 \//);
+
+    fireEvent.keyDown(window, { key: ' ' });
+    expect(counter).toHaveTextContent(/^2 \//);
+  });
+
+  it('deep-links to a slide via ?slide=N and clamps out-of-range values', async () => {
+    renderAt(`/d/${firstId}/present?slide=2`);
+    expect(await findCounter()).toHaveTextContent(/^2 \//);
+  });
+
+  it('returns to the book view on Escape', async () => {
+    renderAt(`/d/${firstId}/present`);
+    await findCounter();
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(await screen.findByRole('article')).toBeInTheDocument();
+  });
+
+  it('offers a fullscreen control', async () => {
+    renderAt(`/d/${firstId}/present`);
+    await findCounter();
+    expect(screen.getByRole('button', { name: /fullscreen/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -83,3 +83,25 @@ describe('presentation: none documents', () => {
     expect(await screen.findByRole('article')).toBeInTheDocument();
   });
 });
+
+describe('book-view entry points to presentation', () => {
+  it('shows a Presentar toggle in the document header', async () => {
+    renderAt(`/d/${firstId}`);
+    const toggle = await screen.findByRole('link', { name: /presentar/i });
+    expect(toggle).toHaveAttribute('href', `/d/${firstId}/present`);
+  });
+
+  it('hides the toggle for presentation: none documents', async () => {
+    const noneId = ids.find((id) => registry.get(id)?.meta.presentation === 'none')!;
+    renderAt(`/d/${noneId}`);
+    await screen.findByRole('article');
+    expect(screen.queryByRole('link', { name: /presentar/i })).not.toBeInTheDocument();
+  });
+
+  it('enters presentation with the p key from the book view', async () => {
+    renderAt(`/d/${firstId}`);
+    await screen.findByRole('article');
+    fireEvent.keyDown(window, { key: 'p' });
+    expect(await screen.findByText(/^\d+ \/ \d+$/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/architecture.test.ts
+++ b/apps/web/src/architecture.test.ts
@@ -7,6 +7,12 @@ import { describe, expect, it } from 'vitest';
 // imports flow app → features → lib; lib imports nothing from above.
 const SRC = dirname(fileURLToPath(import.meta.url));
 const FEATURES = ['components', 'catalog', 'content', 'presentation'];
+// The ONLY allowed cross-feature dependencies (frontend-code-style.md).
+// Extending this map is an architectural decision — record it in the style doc.
+const FEATURE_EDGES: Record<string, string[]> = {
+  components: ['presentation'],
+  presentation: ['content'],
+};
 
 function walk(dir: string): string[] {
   return readdirSync(dir).flatMap((name) => {
@@ -24,16 +30,21 @@ function topSegmentOfImport(file: string, spec: string): string | null {
   return rel.split('/')[0] ?? null;
 }
 
-function violations(rule: (fileTop: string, importTop: string) => boolean): string[] {
+function violations(
+  rule: (fileTop: string, importTop: string, importRel: string, file: string) => boolean,
+): string[] {
   const found: string[] = [];
   for (const file of walk(SRC)) {
     const fileTop = relative(SRC, file).split('/')[0] ?? '';
     const source = readFileSync(file, 'utf8');
     // Covers `from '...'`, side-effect `import '...'`, and dynamic `import('...')`.
     for (const match of source.matchAll(/(?:from|import)\s*\(?\s*['"]([^'"]+)['"]/g)) {
-      const importTop = topSegmentOfImport(file, match[1] ?? '');
-      if (importTop && rule(fileTop, importTop)) {
-        found.push(`${relative(SRC, file)} imports from ${importTop}/`);
+      const spec = match[1] ?? '';
+      const importTop = topSegmentOfImport(file, spec);
+      if (!importTop) continue;
+      const importRel = relative(SRC, resolve(dirname(file), spec));
+      if (rule(fileTop, importTop, importRel, relative(SRC, file))) {
+        found.push(`${relative(SRC, file)} imports ${importRel}`);
       }
     }
   }
@@ -53,6 +64,35 @@ describe('architecture: import direction (app → features → lib)', () => {
   it('feature folders import nothing from app/', () => {
     expect(
       violations((fileTop, importTop) => FEATURES.includes(fileTop) && importTop === 'app'),
+    ).toEqual([]);
+  });
+});
+
+describe('architecture: cross-feature dependencies', () => {
+  it('only the allowed feature edges exist in production code', () => {
+    // Test files may exercise any feature through its seam (they are consumers,
+    // like the shell); the edge allowlist constrains production structure.
+    expect(
+      violations(
+        (fileTop, importTop, _importRel, file) =>
+          !file.includes('.test.') &&
+          FEATURES.includes(fileTop) &&
+          FEATURES.includes(importTop) &&
+          fileTop !== importTop &&
+          !(FEATURE_EDGES[fileTop] ?? []).includes(importTop),
+      ),
+    ).toEqual([]);
+  });
+
+  it('cross-feature imports go through the feature root seam', () => {
+    expect(
+      violations(
+        (fileTop, importTop, importRel) =>
+          FEATURES.includes(importTop) &&
+          fileTop !== importTop &&
+          importRel.includes('/') &&
+          importRel !== `${importTop}/index`,
+      ),
     ).toEqual([]);
   });
 });

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -1,0 +1,3 @@
+// Public seam of the components feature (import direction rule, frontend-code-style.md).
+export { SectionBreak } from './structure/SectionBreak';
+export { Slide } from './structure/Slide';

--- a/apps/web/src/components/structure/SectionBreak.test.tsx
+++ b/apps/web/src/components/structure/SectionBreak.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ModeProvider } from '../../presentation';
+
+import { SectionBreak } from './SectionBreak';
+
+describe('SectionBreak', () => {
+  it('renders a subtle divider in book mode', () => {
+    render(<SectionBreak />);
+    expect(screen.getByRole('separator')).toBeInTheDocument();
+  });
+
+  it('renders nothing in presentation mode', () => {
+    const { container } = render(
+      <ModeProvider mode="presentation">
+        <SectionBreak />
+      </ModeProvider>,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/src/components/structure/SectionBreak.tsx
+++ b/apps/web/src/components/structure/SectionBreak.tsx
@@ -1,10 +1,13 @@
 import { withMeta } from '../../lib/componentMeta';
+import { useMode } from '../../presentation';
 
 /**
- * Slide boundary without a heading (ADR-0010). Skeleton: book rendering only —
- * the per-mode contract completes in S3 of issue #64.
+ * Slide boundary without a heading (ADR-0010 contract). Book: a subtle
+ * divider. Presentation: nothing — the boundary is consumed by the parser.
  */
 export function SectionBreak() {
+  const mode = useMode();
+  if (mode === 'presentation') return null;
   return <hr className="my-8 border-slate-800" />;
 }
 

--- a/apps/web/src/components/structure/SectionBreak.tsx
+++ b/apps/web/src/components/structure/SectionBreak.tsx
@@ -1,0 +1,11 @@
+import { withMeta } from '../../lib/componentMeta';
+
+/**
+ * Slide boundary without a heading (ADR-0010). Skeleton: book rendering only —
+ * the per-mode contract completes in S3 of issue #64.
+ */
+export function SectionBreak() {
+  return <hr className="my-8 border-slate-800" />;
+}
+
+withMeta(SectionBreak, { slideBoundary: 'section-break' });

--- a/apps/web/src/components/structure/Slide.test.tsx
+++ b/apps/web/src/components/structure/Slide.test.tsx
@@ -1,0 +1,41 @@
+import { MDXProvider } from '@mdx-js/react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { headingFor } from '../../content/mdxHeading';
+import { ModeProvider } from '../../presentation';
+
+import { Slide } from './Slide';
+
+describe('Slide', () => {
+  it('renders title as an h2 plus flowing children in book mode', () => {
+    render(
+      <Slide title="La idea">
+        <p>contenido</p>
+      </Slide>,
+    );
+    expect(screen.getByRole('heading', { level: 2, name: /La idea/ })).toBeInTheDocument();
+    expect(screen.getByText('contenido')).toBeInTheDocument();
+  });
+
+  it('uses the MDX-mapped h2 when one is registered (anchor headings)', () => {
+    render(
+      <MDXProvider components={{ h2: headingFor(2) }}>
+        <Slide title="Búsqueda" />
+      </MDXProvider>,
+    );
+    expect(screen.getByRole('heading', { level: 2 })).toHaveAttribute('id', 'busqueda');
+  });
+
+  it('renders children without any heading in presentation mode', () => {
+    render(
+      <ModeProvider mode="presentation">
+        <Slide title="La idea">
+          <p>contenido</p>
+        </Slide>
+      </ModeProvider>,
+    );
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+    expect(screen.getByText('contenido')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/structure/Slide.test.tsx
+++ b/apps/web/src/components/structure/Slide.test.tsx
@@ -2,7 +2,7 @@ import { MDXProvider } from '@mdx-js/react';
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
-import { headingFor } from '../../content/mdxHeading';
+import { contentMdxComponents } from '../../content';
 import { ModeProvider } from '../../presentation';
 
 import { Slide } from './Slide';
@@ -20,7 +20,7 @@ describe('Slide', () => {
 
   it('uses the MDX-mapped h2 when one is registered (anchor headings)', () => {
     render(
-      <MDXProvider components={{ h2: headingFor(2) }}>
+      <MDXProvider components={{ h2: contentMdxComponents.h2 }}>
         <Slide title="Búsqueda" />
       </MDXProvider>,
     );

--- a/apps/web/src/components/structure/Slide.tsx
+++ b/apps/web/src/components/structure/Slide.tsx
@@ -1,6 +1,8 @@
-import type { ReactNode } from 'react';
+import { useMDXComponents } from '@mdx-js/react';
+import type { ElementType, ReactNode } from 'react';
 
 import { withMeta } from '../../lib/componentMeta';
+import { useMode } from '../../presentation';
 
 interface Props {
   title?: string;
@@ -8,13 +10,20 @@ interface Props {
 }
 
 /**
- * Explicit slide boundary (ADR-0010). Skeleton: book rendering only — the
- * per-mode contract completes in S3 of issue #64.
+ * Explicit slide boundary (ADR-0010 contract). Book: h2 (the MDX-mapped one,
+ * so anchors apply) + flowing children. Presentation: children only — the
+ * boundary itself is consumed by the slide parser, and the title becomes
+ * viewer chrome.
  */
 export function Slide({ title, children }: Props) {
+  const mode = useMode();
+  const components = useMDXComponents();
+
+  if (mode === 'presentation') return <>{children}</>;
+  const H2 = (components['h2'] ?? 'h2') as ElementType;
   return (
     <>
-      {title ? <h2>{title}</h2> : null}
+      {title ? <H2>{title}</H2> : null}
       {children}
     </>
   );

--- a/apps/web/src/components/structure/Slide.tsx
+++ b/apps/web/src/components/structure/Slide.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+
+import { withMeta } from '../../lib/componentMeta';
+
+interface Props {
+  title?: string;
+  children?: ReactNode;
+}
+
+/**
+ * Explicit slide boundary (ADR-0010). Skeleton: book rendering only — the
+ * per-mode contract completes in S3 of issue #64.
+ */
+export function Slide({ title, children }: Props) {
+  return (
+    <>
+      {title ? <h2>{title}</h2> : null}
+      {children}
+    </>
+  );
+}
+
+withMeta(Slide, { slideBoundary: 'slide' });

--- a/apps/web/src/content/DocumentPage.tsx
+++ b/apps/web/src/content/DocumentPage.tsx
@@ -1,22 +1,11 @@
-import { Suspense, lazy } from 'react';
-import type { ComponentType, ReactNode } from 'react';
+import { Suspense } from 'react';
+import type { ReactNode } from 'react';
 import { Link, useParams } from 'react-router-dom';
 
 import { Toc } from './Toc';
 import { prevNext } from './courseIndex';
+import { lazyDocumentComponent } from './lazyDoc';
 import { courseIndex, registry } from './liveContent';
-
-// lazy() must be called once per document, not per render, or React remounts the tree.
-const lazyCache = new Map<string, ComponentType>();
-
-function componentFor(id: string, load: () => Promise<{ default: ComponentType }>): ComponentType {
-  let cached = lazyCache.get(id);
-  if (!cached) {
-    cached = lazy(load);
-    lazyCache.set(id, cached);
-  }
-  return cached;
-}
 
 function titleOf(id: string): string {
   return registry.get(id)?.meta.title ?? id;
@@ -54,7 +43,7 @@ interface Props {
 export function DocumentPage({ notFound }: Props) {
   const { id = '' } = useParams();
   const entry = registry.get(id);
-  const Doc = entry ? componentFor(id, entry.load) : null;
+  const Doc = entry ? lazyDocumentComponent(entry) : null;
 
   if (!Doc) return <>{notFound}</>;
   return (

--- a/apps/web/src/content/DocumentPage.tsx
+++ b/apps/web/src/content/DocumentPage.tsx
@@ -1,6 +1,6 @@
-import { Suspense } from 'react';
+import { Suspense, useEffect } from 'react';
 import type { ReactNode } from 'react';
-import { Link, useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 
 import { Toc } from './Toc';
 import { prevNext } from './courseIndex';
@@ -42,8 +42,24 @@ interface Props {
 /** Renders the document whose frontmatter id matches the /d/:id route param. */
 export function DocumentPage({ notFound }: Props) {
   const { id = '' } = useParams();
+  const navigate = useNavigate();
   const entry = registry.get(id);
+  const presentable = entry !== undefined && entry.meta.presentation !== 'none';
   const Doc = entry ? lazyDocumentComponent(entry) : null;
+
+  // POC shortcut: p enters presentation from the book view (never while typing).
+  useEffect(() => {
+    if (!presentable) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'p' || event.metaKey || event.ctrlKey || event.altKey) return;
+      const target = event.target as HTMLElement;
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)
+        return;
+      void navigate(`/d/${id}/present`);
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [id, navigate, presentable]);
 
   if (!Doc) return <>{notFound}</>;
   return (
@@ -52,6 +68,16 @@ export function DocumentPage({ notFound }: Props) {
         <Toc index={courseIndex} />
       </aside>
       <main className="min-w-0 flex-1 px-8 py-10">
+        <div className="mx-auto flex max-w-3xl justify-end">
+          {presentable ? (
+            <Link
+              to={`/d/${id}/present`}
+              className="rounded border border-slate-700 px-3 py-1 text-sm text-slate-300 hover:bg-slate-800 hover:text-slate-100"
+            >
+              Presentar ▸
+            </Link>
+          ) : null}
+        </div>
         <article className="prose prose-invert prose-slate mx-auto max-w-3xl">
           <Suspense fallback={null}>
             <Doc />

--- a/apps/web/src/content/DocumentPage.tsx
+++ b/apps/web/src/content/DocumentPage.tsx
@@ -1,15 +1,10 @@
-import { MDXProvider } from '@mdx-js/react';
 import { Suspense, lazy } from 'react';
 import type { ComponentType, ReactNode } from 'react';
 import { Link, useParams } from 'react-router-dom';
 
-import { MdxLink } from './MdxLink';
 import { Toc } from './Toc';
 import { prevNext } from './courseIndex';
 import { courseIndex, registry } from './liveContent';
-import { headingFor } from './mdxHeading';
-
-const mdxComponents = { a: MdxLink, h2: headingFor(2), h3: headingFor(3), h4: headingFor(4) };
 
 // lazy() must be called once per document, not per render, or React remounts the tree.
 const lazyCache = new Map<string, ComponentType>();
@@ -69,11 +64,9 @@ export function DocumentPage({ notFound }: Props) {
       </aside>
       <main className="min-w-0 flex-1 px-8 py-10">
         <article className="prose prose-invert prose-slate mx-auto max-w-3xl">
-          <MDXProvider components={mdxComponents}>
-            <Suspense fallback={null}>
-              <Doc />
-            </Suspense>
-          </MDXProvider>
+          <Suspense fallback={null}>
+            <Doc />
+          </Suspense>
           <SequenceNav id={id} />
         </article>
       </main>

--- a/apps/web/src/content/documentMeta.test.ts
+++ b/apps/web/src/content/documentMeta.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { parseFrontmatterBlock } from './documentMeta';
+import { parseDocumentMeta, parseFrontmatterBlock } from './documentMeta';
 
 describe('parseFrontmatterBlock', () => {
   it('parses the YAML block delimited by --- fences', () => {
@@ -14,5 +14,26 @@ describe('parseFrontmatterBlock', () => {
 
   it('does not treat a --- ruler later in the body as frontmatter', () => {
     expect(parseFrontmatterBlock('# Body\n\n---\nid: nope\n---\n')).toBeNull();
+  });
+});
+
+describe('parseDocumentMeta — presentation config', () => {
+  const base = { id: 'doc-a', title: 'Doc A' };
+
+  it('defaults to auto when absent (every document is presentable for now)', () => {
+    expect(parseDocumentMeta('a.mdx', base).presentation).toBe('auto');
+  });
+
+  it('accepts explicit and none', () => {
+    expect(parseDocumentMeta('a.mdx', { ...base, presentation: 'explicit' }).presentation).toBe(
+      'explicit',
+    );
+    expect(parseDocumentMeta('a.mdx', { ...base, presentation: 'none' }).presentation).toBe('none');
+  });
+
+  it('rejects unknown values naming the field and file', () => {
+    expect(() => parseDocumentMeta('a.mdx', { ...base, presentation: 'slides' })).toThrowError(
+      /presentation.*auto.*explicit.*none.*a\.mdx/s,
+    );
   });
 });

--- a/apps/web/src/content/documentMeta.ts
+++ b/apps/web/src/content/documentMeta.ts
@@ -4,7 +4,12 @@ import { parse } from 'yaml';
 export interface DocumentMeta {
   id: string;
   title: string;
+  /** How the document presents (issue #64): auto = h2 slicing, explicit = only marked slides, none = book-only. */
+  presentation: 'auto' | 'explicit' | 'none';
 }
+
+const PRESENTATION_VALUES = ['auto', 'explicit', 'none'] as const;
+type Presentation = (typeof PRESENTATION_VALUES)[number];
 
 const FRONTMATTER_BLOCK = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
 const KEBAB_CASE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
@@ -21,7 +26,7 @@ export function parseDocumentMeta(sourcePath: string, raw: unknown): DocumentMet
   if (typeof raw !== 'object' || raw === null) {
     throw new Error(`Content registry: no frontmatter found in ${sourcePath}`);
   }
-  const { id, title } = raw as Record<string, unknown>;
+  const { id, title, presentation } = raw as Record<string, unknown>;
   if (typeof id !== 'string' || id === '') {
     throw new Error(`Content registry: missing frontmatter "id" in ${sourcePath}`);
   }
@@ -33,5 +38,13 @@ export function parseDocumentMeta(sourcePath: string, raw: unknown): DocumentMet
   if (typeof title !== 'string' || title === '') {
     throw new Error(`Content registry: missing frontmatter "title" in ${sourcePath}`);
   }
-  return { id, title };
+  if (
+    presentation !== undefined &&
+    !(PRESENTATION_VALUES as readonly unknown[]).includes(presentation)
+  ) {
+    throw new Error(
+      `Content registry: "presentation" must be one of ${PRESENTATION_VALUES.join(', ')} in ${sourcePath}`,
+    );
+  }
+  return { id, title, presentation: (presentation as Presentation | undefined) ?? 'auto' };
 }

--- a/apps/web/src/content/index.ts
+++ b/apps/web/src/content/index.ts
@@ -4,3 +4,4 @@ export { DocumentPage } from './DocumentPage';
 export { walkIndex } from './courseIndex';
 export { courseIndex, registry } from './liveContent';
 export { contentMdxComponents } from './mdxComponents';
+export { lazyDocumentComponent } from './lazyDoc';

--- a/apps/web/src/content/index.ts
+++ b/apps/web/src/content/index.ts
@@ -3,3 +3,4 @@
 export { DocumentPage } from './DocumentPage';
 export { walkIndex } from './courseIndex';
 export { courseIndex, registry } from './liveContent';
+export { contentMdxComponents } from './mdxComponents';

--- a/apps/web/src/content/lazyDoc.ts
+++ b/apps/web/src/content/lazyDoc.ts
@@ -1,0 +1,21 @@
+import { lazy } from 'react';
+import type { ComponentType } from 'react';
+
+import type { RegistryEntry } from './registry';
+
+type DocComponent = ComponentType<{ components?: Record<string, ComponentType> }>;
+
+// lazy() must be called once per document, not per render, or React remounts
+// the tree. Shared by the book page and the presentation page so both routes
+// reuse the same loaded chunk.
+const cache = new Map<string, DocComponent>();
+
+/** The lazy React component of a registry entry (per-document cache). */
+export function lazyDocumentComponent(entry: RegistryEntry): DocComponent {
+  let cached = cache.get(entry.meta.id);
+  if (!cached) {
+    cached = lazy(entry.load) as unknown as DocComponent;
+    cache.set(entry.meta.id, cached);
+  }
+  return cached;
+}

--- a/apps/web/src/content/mdxComponents.ts
+++ b/apps/web/src/content/mdxComponents.ts
@@ -1,0 +1,10 @@
+import { MdxLink } from './MdxLink';
+import { headingFor } from './mdxHeading';
+
+/** Content-owned MDX element mappings; the shell composes them with catalog components. */
+export const contentMdxComponents = {
+  a: MdxLink,
+  h2: headingFor(2),
+  h3: headingFor(3),
+  h4: headingFor(4),
+};

--- a/apps/web/src/content/mdxHeading.tsx
+++ b/apps/web/src/content/mdxHeading.tsx
@@ -1,10 +1,7 @@
 import type { ReactNode } from 'react';
 
-function textOf(node: ReactNode): string {
-  if (typeof node === 'string' || typeof node === 'number') return String(node);
-  if (Array.isArray(node)) return node.map(textOf).join('');
-  return '';
-}
+import { withMeta } from '../lib/componentMeta';
+import { textOf } from '../lib/reactText';
 
 function slugify(text: string): string {
   return text
@@ -44,5 +41,5 @@ export function headingFor(level: 2 | 3 | 4) {
       </Tag>
     );
   }
-  return MdxHeading;
+  return withMeta(MdxHeading, { headingLevel: level });
 }

--- a/apps/web/src/lib/componentMeta.ts
+++ b/apps/web/src/lib/componentMeta.ts
@@ -1,0 +1,22 @@
+/**
+ * Static metadata attached to component functions so features can recognize
+ * elements by role WITHOUT importing each other's components (no feature
+ * cycles: consumers import only lib/).
+ */
+export interface ComponentMeta {
+  /** Heading level rendered by this component (set by the MDX heading factory). */
+  headingLevel?: 1 | 2 | 3 | 4;
+  /** This component marks a slide boundary in presentation mode. */
+  slideBoundary?: 'slide' | 'section-break';
+}
+
+/** Attaches meta to a component and returns it (typed passthrough). */
+export function withMeta<C>(component: C, meta: ComponentMeta): C {
+  return Object.assign(component as object, { componentMeta: meta }) as C;
+}
+
+/** Reads the meta of a React element type; empty object for plain tags/unknown. */
+export function metaOf(type: unknown): ComponentMeta {
+  if (typeof type !== 'function') return {};
+  return (type as { componentMeta?: ComponentMeta }).componentMeta ?? {};
+}

--- a/apps/web/src/lib/reactText.ts
+++ b/apps/web/src/lib/reactText.ts
@@ -1,0 +1,8 @@
+import type { ReactNode } from 'react';
+
+/** Concatenated text content of a node tree (elements contribute nothing themselves). */
+export function textOf(node: ReactNode): string {
+  if (typeof node === 'string' || typeof node === 'number') return String(node);
+  if (Array.isArray(node)) return node.map(textOf).join('');
+  return '';
+}

--- a/apps/web/src/presentation/ModeProvider.tsx
+++ b/apps/web/src/presentation/ModeProvider.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from 'react';
+
+import { ModeContext } from './mode';
+import type { Mode } from './mode';
+
+interface Props {
+  mode: Mode;
+  children: ReactNode;
+}
+
+/** Set by the route (/d/:id → book, /d/:id/present → presentation), never by props drilling. */
+export function ModeProvider({ mode, children }: Props) {
+  return <ModeContext.Provider value={mode}>{children}</ModeContext.Provider>;
+}

--- a/apps/web/src/presentation/PresentationPage.tsx
+++ b/apps/web/src/presentation/PresentationPage.tsx
@@ -1,26 +1,44 @@
+import { Suspense, useMemo } from 'react';
 import type { ReactNode } from 'react';
 import { useParams } from 'react-router-dom';
 
-import { registry } from '../content';
+import { lazyDocumentComponent, registry } from '../content';
 import { ModeProvider } from './ModeProvider';
+import { SlideDeck } from './SlideDeck';
 
 interface Props {
   /** Rendered when the id is unknown — injected by the shell so the feature never imports app/. */
   notFound: ReactNode;
 }
 
-/** Presentation route for a document. Placeholder viewer until S4 delivers the real one. */
+/**
+ * Presentation route: renders the document with an MDX wrapper that hands the
+ * rendered children to the SlideDeck instead of painting them as a page.
+ */
 export function PresentationPage({ notFound }: Props) {
   const { id = '' } = useParams();
   const entry = registry.get(id);
 
+  const components = useMemo(() => {
+    if (!entry) return undefined;
+    const { id: docId, title } = entry.meta;
+    function DeckWrapper({ children }: { children?: ReactNode }) {
+      return (
+        <SlideDeck docId={docId} title={title}>
+          {children}
+        </SlideDeck>
+      );
+    }
+    return { wrapper: DeckWrapper };
+  }, [entry]);
+
   if (!entry) return <>{notFound}</>;
+  const Doc = lazyDocumentComponent(entry);
   return (
     <ModeProvider mode="presentation">
-      <div className="fixed inset-0 z-40 flex flex-col items-center justify-center bg-slate-950 text-slate-100">
-        <h1 className="text-5xl font-bold tracking-tight">{entry.meta.title}</h1>
-        <p className="mt-4 text-slate-400">Presentation mode</p>
-      </div>
+      <Suspense fallback={null}>
+        <Doc components={components} />
+      </Suspense>
     </ModeProvider>
   );
 }

--- a/apps/web/src/presentation/PresentationPage.tsx
+++ b/apps/web/src/presentation/PresentationPage.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react';
+import { useParams } from 'react-router-dom';
+
+import { registry } from '../content';
+import { ModeProvider } from './ModeProvider';
+
+interface Props {
+  /** Rendered when the id is unknown — injected by the shell so the feature never imports app/. */
+  notFound: ReactNode;
+}
+
+/** Presentation route for a document. Placeholder viewer until S4 delivers the real one. */
+export function PresentationPage({ notFound }: Props) {
+  const { id = '' } = useParams();
+  const entry = registry.get(id);
+
+  if (!entry) return <>{notFound}</>;
+  return (
+    <ModeProvider mode="presentation">
+      <div className="fixed inset-0 z-40 flex flex-col items-center justify-center bg-slate-950 text-slate-100">
+        <h1 className="text-5xl font-bold tracking-tight">{entry.meta.title}</h1>
+        <p className="mt-4 text-slate-400">Presentation mode</p>
+      </div>
+    </ModeProvider>
+  );
+}

--- a/apps/web/src/presentation/PresentationPage.tsx
+++ b/apps/web/src/presentation/PresentationPage.tsx
@@ -1,6 +1,6 @@
 import { Suspense, useMemo } from 'react';
 import type { ReactNode } from 'react';
-import { useParams } from 'react-router-dom';
+import { Navigate, useParams } from 'react-router-dom';
 
 import { lazyDocumentComponent, registry } from '../content';
 import { ModeProvider } from './ModeProvider';
@@ -21,10 +21,14 @@ export function PresentationPage({ notFound }: Props) {
 
   const components = useMemo(() => {
     if (!entry) return undefined;
-    const { id: docId, title } = entry.meta;
+    const { id: docId, title, presentation } = entry.meta;
     function DeckWrapper({ children }: { children?: ReactNode }) {
       return (
-        <SlideDeck docId={docId} title={title}>
+        <SlideDeck
+          docId={docId}
+          title={title}
+          configMode={presentation === 'explicit' ? 'explicit' : 'auto'}
+        >
           {children}
         </SlideDeck>
       );
@@ -33,6 +37,8 @@ export function PresentationPage({ notFound }: Props) {
   }, [entry]);
 
   if (!entry) return <>{notFound}</>;
+  // presentation: none — the document has no slide form; back to the book (AC3).
+  if (entry.meta.presentation === 'none') return <Navigate to={`/d/${id}`} replace />;
   const Doc = lazyDocumentComponent(entry);
   return (
     <ModeProvider mode="presentation">

--- a/apps/web/src/presentation/SlideDeck.tsx
+++ b/apps/web/src/presentation/SlideDeck.tsx
@@ -1,0 +1,109 @@
+import { AnimatePresence, motion } from 'framer-motion';
+import { useEffect, useMemo } from 'react';
+import type { ReactNode } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
+import { mdxChildrenOf } from './mdxChildren';
+import { computeSlides } from './parser';
+
+function toggleFullscreen(): void {
+  if (document.fullscreenElement) {
+    void document.exitFullscreen();
+  } else {
+    void document.documentElement.requestFullscreen?.();
+  }
+}
+
+interface Props {
+  docId: string;
+  title: string;
+  /** The document's rendered MDX children — injected via the MDX wrapper component. */
+  children?: ReactNode;
+}
+
+/**
+ * Full-viewport slide viewer (POC-style fixed overlay). The current slide is
+ * derived from ?slide=N — the URL is the single source of truth, which is
+ * also what session sync will drive in v0.3.
+ */
+export function SlideDeck({ docId, title, children }: Props) {
+  // Unconditional and first: mdxChildrenOf runs a useContext internally (see its docs).
+  const siblings = mdxChildrenOf(children);
+  const slides = useMemo(() => computeSlides(siblings, { title }), [siblings, title]);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigate = useNavigate();
+
+  const requested = Number(searchParams.get('slide') ?? '1');
+  const index = Math.min(
+    Math.max(Number.isFinite(requested) ? requested - 1 : 0, 0),
+    slides.length - 1,
+  );
+  const slide = slides[index]!;
+
+  useEffect(() => {
+    const go = (target: number) => {
+      const next = Math.min(Math.max(target, 0), slides.length - 1);
+      setSearchParams({ slide: String(next + 1) }, { replace: true });
+    };
+    const onKeyDown = (event: KeyboardEvent) => {
+      switch (event.key) {
+        case 'ArrowRight':
+        case ' ':
+          event.preventDefault();
+          go(index + 1);
+          break;
+        case 'ArrowLeft':
+          go(index - 1);
+          break;
+        case 'Home':
+          go(0);
+          break;
+        case 'End':
+          go(slides.length - 1);
+          break;
+        case 'Escape':
+          void navigate(`/d/${docId}`);
+          break;
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [docId, index, navigate, setSearchParams, slides.length]);
+
+  return (
+    <div className="fixed inset-0 z-40 flex flex-col bg-slate-950 text-slate-100">
+      <div className="flex flex-1 items-center justify-center overflow-hidden px-16">
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={index}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            className="w-full max-w-4xl"
+          >
+            {slide.title ? (
+              <h2 className="mb-10 text-5xl font-bold tracking-tight">{slide.title}</h2>
+            ) : null}
+            <div className="prose prose-invert prose-slate prose-xl max-w-none">
+              {slide.content}
+            </div>
+          </motion.div>
+        </AnimatePresence>
+      </div>
+      <footer className="flex items-center justify-between px-6 py-3 text-sm text-slate-500">
+        <button
+          type="button"
+          aria-label="Toggle fullscreen"
+          onClick={toggleFullscreen}
+          className="rounded px-2 py-1 hover:bg-slate-800 hover:text-slate-200"
+        >
+          ⛶
+        </button>
+        <span>
+          {index + 1} / {slides.length}
+        </span>
+      </footer>
+    </div>
+  );
+}

--- a/apps/web/src/presentation/SlideDeck.tsx
+++ b/apps/web/src/presentation/SlideDeck.tsx
@@ -38,17 +38,23 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
 
-  const requested = Number(searchParams.get('slide') ?? '1');
-  const index = Math.min(
-    Math.max(Number.isFinite(requested) ? requested - 1 : 0, 0),
-    slides.length - 1,
-  );
+  // Math.trunc: a crafted non-integer ?slide (e.g. 1.5) must not become a
+  // fractional array index (white-screen crash — review finding, issue #64).
+  const raw = Number(searchParams.get('slide') ?? '1');
+  const requested = Number.isFinite(raw) ? Math.trunc(raw) : 1;
+  const index = Math.min(Math.max(requested - 1, 0), slides.length - 1);
   const slide = slides[index]!;
 
   useEffect(() => {
     const go = (target: number) => {
       const next = Math.min(Math.max(target, 0), slides.length - 1);
-      setSearchParams({ slide: String(next + 1) }, { replace: true });
+      setSearchParams(
+        (prev) => {
+          prev.set('slide', String(next + 1));
+          return prev;
+        },
+        { replace: true },
+      );
     };
     const onKeyDown = (event: KeyboardEvent) => {
       switch (event.key) {

--- a/apps/web/src/presentation/SlideDeck.tsx
+++ b/apps/web/src/presentation/SlideDeck.tsx
@@ -17,6 +17,8 @@ function toggleFullscreen(): void {
 interface Props {
   docId: string;
   title: string;
+  /** Parser mode from the document frontmatter (auto | explicit). */
+  configMode?: 'auto' | 'explicit';
   /** The document's rendered MDX children — injected via the MDX wrapper component. */
   children?: ReactNode;
 }
@@ -26,10 +28,13 @@ interface Props {
  * derived from ?slide=N — the URL is the single source of truth, which is
  * also what session sync will drive in v0.3.
  */
-export function SlideDeck({ docId, title, children }: Props) {
+export function SlideDeck({ docId, title, configMode = 'auto', children }: Props) {
   // Unconditional and first: mdxChildrenOf runs a useContext internally (see its docs).
   const siblings = mdxChildrenOf(children);
-  const slides = useMemo(() => computeSlides(siblings, { title }), [siblings, title]);
+  const slides = useMemo(
+    () => computeSlides(siblings, { title, mode: configMode }),
+    [siblings, title, configMode],
+  );
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
 

--- a/apps/web/src/presentation/index.ts
+++ b/apps/web/src/presentation/index.ts
@@ -1,5 +1,7 @@
 // Public seam of the presentation feature (import direction rule, frontend-code-style.md).
+// NOTE: importing this seam evaluates PresentationPage and, transitively, the
+// content registry (accepted for v0.1 — components only need useMode; revisit
+// with a leaf seam if module-eval cost ever matters).
 export { ModeProvider } from './ModeProvider';
-export type { Mode } from './mode';
 export { useMode } from './useMode';
 export { PresentationPage } from './PresentationPage';

--- a/apps/web/src/presentation/index.ts
+++ b/apps/web/src/presentation/index.ts
@@ -1,0 +1,5 @@
+// Public seam of the presentation feature (import direction rule, frontend-code-style.md).
+export { ModeProvider } from './ModeProvider';
+export type { Mode } from './mode';
+export { useMode } from './useMode';
+export { PresentationPage } from './PresentationPage';

--- a/apps/web/src/presentation/mdxChildren.ts
+++ b/apps/web/src/presentation/mdxChildren.ts
@@ -1,0 +1,27 @@
+import { Children, Fragment, isValidElement } from 'react';
+import type { ReactNode } from 'react';
+
+/**
+ * Unwraps the sibling list of a compiled MDX document.
+ *
+ * MDX v3 hands the layout wrapper ONE opaque element (_createMdxContent), not
+ * the sibling array (that was MDX v1 behavior). That element's type is a plain
+ * function component from our pinned toolchain whose only hook is
+ * useMDXComponents (a useContext), so invoking it during OUR render keeps the
+ * hook order legal — the caller must invoke this unconditionally, first thing
+ * in render — and yields the sibling fragment the slide parser groups.
+ *
+ * If an MDX upgrade changes this compiled shape, the presentation route tests
+ * fail here first; the recorded fallback (issue #64 discussion, option B) is
+ * compile-time grouping via a remark plugin — swap this adapter, keep the
+ * parser and viewer untouched.
+ */
+export function mdxChildrenOf(children: ReactNode): ReactNode {
+  const element = Children.only(children);
+  if (!isValidElement(element) || typeof element.type !== 'function') return children;
+  const rendered = (element.type as (props: unknown) => ReactNode)(element.props);
+  if (isValidElement(rendered) && rendered.type === Fragment) {
+    return (rendered.props as { children?: ReactNode }).children;
+  }
+  return rendered;
+}

--- a/apps/web/src/presentation/mdxChildren.ts
+++ b/apps/web/src/presentation/mdxChildren.ts
@@ -12,9 +12,9 @@ import type { ReactNode } from 'react';
  * in render — and yields the sibling fragment the slide parser groups.
  *
  * If an MDX upgrade changes this compiled shape, the presentation route tests
- * fail here first; the recorded fallback (issue #64 discussion, option B) is
- * compile-time grouping via a remark plugin — swap this adapter, keep the
- * parser and viewer untouched.
+ * fail here first. The decision and its recorded fallback (compile-time
+ * grouping via a remark plugin — swap this adapter, keep parser and viewer
+ * untouched) live in ADR-0013 (docs/decisions/0013-presentation-pipeline.md).
  */
 export function mdxChildrenOf(children: ReactNode): ReactNode {
   const element = Children.only(children);

--- a/apps/web/src/presentation/mode.ts
+++ b/apps/web/src/presentation/mode.ts
@@ -1,0 +1,7 @@
+import { createContext } from 'react';
+
+/** How a document is being rendered right now (D15 dual rendering). */
+export type Mode = 'book' | 'presentation';
+
+/** Shared by ModeProvider and useMode — not exported from the feature seam. */
+export const ModeContext = createContext<Mode>('book');

--- a/apps/web/src/presentation/parser.test.tsx
+++ b/apps/web/src/presentation/parser.test.tsx
@@ -1,12 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { SectionBreak } from '../components/structure/SectionBreak';
-import { Slide } from '../components/structure/Slide';
-import { headingFor } from '../content/mdxHeading';
+import { SectionBreak, Slide } from '../components';
+import { contentMdxComponents } from '../content';
 
 import { computeSlides } from './parser';
 
-const H2 = headingFor(2);
+const H2 = contentMdxComponents.h2;
 const DOC = { title: 'Mi documento' };
 
 function titles(slides: ReturnType<typeof computeSlides>) {

--- a/apps/web/src/presentation/parser.test.tsx
+++ b/apps/web/src/presentation/parser.test.tsx
@@ -91,6 +91,15 @@ describe('computeSlides — auto mode', () => {
     expect(slides[0]!.content).toHaveLength(0);
   });
 
+  it('excludes the document h1 from slide content (the cover chrome owns the title)', () => {
+    const slides = computeSlides(
+      [<h1 key="1">Mi documento</h1>, <p key="2">intro</p>, <H2 key="3">Tema</H2>],
+      DOC,
+    );
+    expect(slides[0]!.content).toHaveLength(1);
+    expect(titles(slides)).toEqual(['Mi documento', 'Tema']);
+  });
+
   it('drops empty untitled groups (e.g. SectionBreak straight into an h2)', () => {
     const slides = computeSlides(
       [<SectionBreak key="1" />, <H2 key="2">Unica</H2>, <p key="3">x</p>],

--- a/apps/web/src/presentation/parser.test.tsx
+++ b/apps/web/src/presentation/parser.test.tsx
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+
+import { SectionBreak } from '../components/structure/SectionBreak';
+import { Slide } from '../components/structure/Slide';
+import { headingFor } from '../content/mdxHeading';
+
+import { computeSlides } from './parser';
+
+const H2 = headingFor(2);
+const DOC = { title: 'Mi documento' };
+
+function titles(slides: ReturnType<typeof computeSlides>) {
+  return slides.map((s) => s.title);
+}
+
+describe('computeSlides — auto mode', () => {
+  it('returns only a cover slide for an empty document', () => {
+    const slides = computeSlides([], DOC);
+    expect(slides).toHaveLength(1);
+    expect(slides[0]).toMatchObject({ title: 'Mi documento' });
+  });
+
+  it('puts content before the first boundary into the cover slide', () => {
+    const slides = computeSlides([<p key="a">intro</p>, <H2 key="b">Tema</H2>], DOC);
+    expect(slides).toHaveLength(2);
+    expect(slides[0]!.content).toHaveLength(1);
+    expect(slides[1]!.title).toBe('Tema');
+  });
+
+  it('slices by h2 headings, using the heading text as slide title', () => {
+    const slides = computeSlides(
+      [
+        <H2 key="1">La idea</H2>,
+        <p key="2">uno</p>,
+        <p key="3">dos</p>,
+        <H2 key="4">Costo</H2>,
+        <p key="5">tres</p>,
+      ],
+      DOC,
+    );
+    expect(titles(slides)).toEqual(['Mi documento', 'La idea', 'Costo']);
+    expect(slides[1]!.content).toHaveLength(2);
+    expect(slides[2]!.content).toHaveLength(1);
+  });
+
+  it('also recognizes plain h2 elements as boundaries', () => {
+    const slides = computeSlides([<h2 key="1">Plano</h2>, <p key="2">x</p>], DOC);
+    expect(titles(slides)).toEqual(['Mi documento', 'Plano']);
+  });
+
+  it('treats an explicit Slide container as one slide with its own children', () => {
+    const slides = computeSlides(
+      [
+        <Slide key="1" title="Marcada">
+          <p>dentro</p>
+          <p>tambien dentro</p>
+        </Slide>,
+        <p key="2">suelto</p>,
+        <H2 key="3">Seccion</H2>,
+      ],
+      DOC,
+    );
+    expect(titles(slides)).toEqual(['Mi documento', 'Marcada', undefined, 'Seccion']);
+    expect(slides[1]!.content).toHaveLength(2);
+    expect(slides[2]!.content).toHaveLength(1);
+  });
+
+  it('starts an untitled slide after a SectionBreak', () => {
+    const slides = computeSlides(
+      [<H2 key="1">Antes</H2>, <p key="2">a</p>, <SectionBreak key="3" />, <p key="4">b</p>],
+      DOC,
+    );
+    expect(titles(slides)).toEqual(['Mi documento', 'Antes', undefined]);
+    expect(slides[2]!.content).toHaveLength(1);
+  });
+
+  it('ignores whitespace text nodes (MDX interleaves "\\n" between siblings)', () => {
+    const slides = computeSlides(
+      [
+        '\n',
+        <Slide key="1" title="Sola">
+          {'\n'}
+        </Slide>,
+        '\n',
+        <H2 key="2">Otra</H2>,
+        '\n',
+      ],
+      DOC,
+    );
+    expect(titles(slides)).toEqual(['Mi documento', 'Sola', 'Otra']);
+    expect(slides[0]!.content).toHaveLength(0);
+  });
+
+  it('drops empty untitled groups (e.g. SectionBreak straight into an h2)', () => {
+    const slides = computeSlides(
+      [<SectionBreak key="1" />, <H2 key="2">Unica</H2>, <p key="3">x</p>],
+      DOC,
+    );
+    expect(titles(slides)).toEqual(['Mi documento', 'Unica']);
+  });
+});
+
+describe('computeSlides — explicit mode', () => {
+  it('includes only marked content: Slide containers and post-SectionBreak groups', () => {
+    const slides = computeSlides(
+      [
+        <p key="1">prosa solo-libro</p>,
+        <H2 key="2">Ignorada como corte</H2>,
+        <Slide key="3" title="Uno">
+          <p>a</p>
+        </Slide>,
+        <p key="4">tambien solo-libro</p>,
+        <SectionBreak key="5" />,
+        <p key="6">incluida</p>,
+      ],
+      { title: 'Doc', mode: 'explicit' },
+    );
+    expect(titles(slides)).toEqual(['Doc', 'Uno', undefined]);
+    expect(slides[0]!.content).toHaveLength(0);
+    expect(slides[2]!.content).toHaveLength(1);
+  });
+});

--- a/apps/web/src/presentation/parser.ts
+++ b/apps/web/src/presentation/parser.ts
@@ -49,6 +49,8 @@ export function computeSlides(children: ReactNode, { title, mode = 'auto' }: Opt
     // MDX interleaves "\n" text nodes between siblings — never content.
     if (typeof child === 'string' && child.trim() === '') continue;
     if (isValidElement(child)) {
+      // The document h1 never enters a slide: the cover chrome owns the title.
+      if (child.type === 'h1' || metaOf(child.type).headingLevel === 1) continue;
       const boundary = metaOf(child.type).slideBoundary;
       if (boundary === 'slide') {
         closeIfEmpty();

--- a/apps/web/src/presentation/parser.ts
+++ b/apps/web/src/presentation/parser.ts
@@ -1,0 +1,84 @@
+import { Children, isValidElement } from 'react';
+import type { ReactNode } from 'react';
+
+import { metaOf } from '../lib/componentMeta';
+import { textOf } from '../lib/reactText';
+
+export interface SlideDef {
+  title?: string;
+  content: ReactNode[];
+}
+
+interface Options {
+  /** Document title — becomes the cover slide. */
+  title: string;
+  /** auto: h2 headings also cut slides; explicit: only markers do, loose prose is book-only. */
+  mode?: 'auto' | 'explicit';
+}
+
+function isH2(child: ReactNode): child is React.ReactElement {
+  if (!isValidElement(child)) return false;
+  return child.type === 'h2' || metaOf(child.type).headingLevel === 2;
+}
+
+/**
+ * Pure slide computation over the MDX-rendered element array (the same list
+ * both modes paint). Boundaries: <Slide> containers, <SectionBreak/>, and —
+ * in auto mode — h2 headings. Content before the first boundary joins the
+ * cover slide (auto) or stays book-only (explicit). Empty untitled groups
+ * are dropped; the cover always exists.
+ */
+export function computeSlides(children: ReactNode, { title, mode = 'auto' }: Options): SlideDef[] {
+  const auto = mode === 'auto';
+  const slides: SlideDef[] = [];
+  const cover: SlideDef = { title, content: [] };
+  slides.push(cover);
+
+  // The group open for loose siblings; null when loose content is not collected
+  // (explicit mode outside any post-SectionBreak group).
+  let open: SlideDef | null = auto ? cover : null;
+
+  const closeIfEmpty = () => {
+    const last = slides[slides.length - 1];
+    if (last && last !== cover && last === open && !last.title && last.content.length === 0) {
+      slides.pop();
+    }
+  };
+
+  for (const child of Children.toArray(children)) {
+    // MDX interleaves "\n" text nodes between siblings — never content.
+    if (typeof child === 'string' && child.trim() === '') continue;
+    if (isValidElement(child)) {
+      const boundary = metaOf(child.type).slideBoundary;
+      if (boundary === 'slide') {
+        closeIfEmpty();
+        const props = child.props as { title?: string; children?: ReactNode };
+        slides.push({ title: props.title, content: Children.toArray(props.children) });
+        open = null;
+        continue;
+      }
+      if (boundary === 'section-break') {
+        closeIfEmpty();
+        open = { title: undefined, content: [] };
+        slides.push(open);
+        continue;
+      }
+      if (auto && isH2(child)) {
+        closeIfEmpty();
+        open = { title: textOf((child.props as { children?: ReactNode }).children), content: [] };
+        slides.push(open);
+        continue;
+      }
+    }
+    if (open === null) {
+      // Loose content after an explicit Slide: auto opens an untitled group;
+      // explicit keeps it book-only.
+      if (!auto) continue;
+      open = { title: undefined, content: [] };
+      slides.push(open);
+    }
+    open.content.push(child);
+  }
+  closeIfEmpty();
+  return slides;
+}

--- a/apps/web/src/presentation/useMode.test.tsx
+++ b/apps/web/src/presentation/useMode.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ModeProvider } from './ModeProvider';
+import { useMode } from './useMode';
+
+function ShowMode() {
+  return <span>{useMode()}</span>;
+}
+
+describe('useMode', () => {
+  it('defaults to book outside any provider', () => {
+    render(<ShowMode />);
+    expect(screen.getByText('book')).toBeInTheDocument();
+  });
+
+  it('returns the mode set by the nearest provider', () => {
+    render(
+      <ModeProvider mode="presentation">
+        <ShowMode />
+      </ModeProvider>,
+    );
+    expect(screen.getByText('presentation')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/presentation/useMode.ts
+++ b/apps/web/src/presentation/useMode.ts
@@ -1,0 +1,9 @@
+import { useContext } from 'react';
+
+import { ModeContext } from './mode';
+import type { Mode } from './mode';
+
+/** Current rendering mode; defaults to book outside any provider. */
+export function useMode(): Mode {
+  return useContext(ModeContext);
+}

--- a/content/courses/sample-course/02-intro-estructuras.mdx
+++ b/content/courses/sample-course/02-intro-estructuras.mdx
@@ -22,4 +22,6 @@ Por ejemplo, buscar en una lista desordenada cuesta tiempo lineal, mientras que
 [[busqueda-binaria|la búsqueda binaria]] sobre un arreglo ordenado cuesta
 tiempo logarítmico.
 
+<SectionBreak />
+
 Cuando termines, vuelve a la [[bienvenida]] o continúa con el recorrido.

--- a/content/courses/sample-course/03-busqueda-binaria.mdx
+++ b/content/courses/sample-course/03-busqueda-binaria.mdx
@@ -1,21 +1,22 @@
 ---
 id: busqueda-binaria
 title: Búsqueda binaria
+presentation: explicit
 ---
 
 # Búsqueda binaria
 
 Sobre un arreglo **ordenado**, la búsqueda binaria descarta la mitad del
-espacio de búsqueda en cada paso.
+espacio de búsqueda en cada paso. Esta página usa `presentation: explicit`:
+solo el contenido marcado forma parte del deck.
 
-## La idea
+<Slide title="La idea">
+  Comparamos el objetivo con el elemento del medio: si es menor, seguimos en la
+  mitad izquierda; si es mayor, en la derecha. Repetimos hasta encontrarlo o
+  quedarnos sin elementos.
+</Slide>
 
-Comparamos el objetivo con el elemento del medio: si es menor, seguimos en la
-mitad izquierda; si es mayor, en la derecha. Repetimos hasta encontrarlo o
-quedarnos sin elementos.
-
-## Implementación
-
+<Slide title="Implementación">
 ```java
 int busquedaBinaria(int[] a, int objetivo) {
   int lo = 0, hi = a.length - 1;
@@ -28,9 +29,10 @@ int busquedaBinaria(int[] a, int objetivo) {
   return -1;
 }
 ```
+</Slide>
 
 ## Costo
 
 Cada iteración reduce el rango a la mitad: sobre `n` elementos hay a lo más
-`log₂(n) + 1` iteraciones. Contrasta esto con el recorrido lineal que vimos en
-[[intro-estructuras|la introducción]].
+`log₂(n) + 1` iteraciones. Esta sección es prosa de libro: al no estar marcada,
+no aparece en el deck. Contrasta con [[intro-estructuras|la introducción]].

--- a/content/courses/sample-course/04-apuntes.mdx
+++ b/content/courses/sample-course/04-apuntes.mdx
@@ -1,0 +1,12 @@
+---
+id: apuntes-del-curso
+title: Apuntes del curso
+presentation: none
+---
+
+# Apuntes del curso
+
+Esta página es material de referencia: existe solo como página de libro y no
+tiene forma de presentación (`presentation: none`).
+
+Volver a la [[bienvenida]].

--- a/content/courses/sample-course/index.yaml
+++ b/content/courses/sample-course/index.yaml
@@ -5,3 +5,4 @@ entries:
     children:
       - docId: intro-estructuras
       - docId: busqueda-binaria
+  - docId: apuntes-del-curso

--- a/docs/decisions/0013-presentation-pipeline.md
+++ b/docs/decisions/0013-presentation-pipeline.md
@@ -1,0 +1,90 @@
+# ADR-0013: Presentation pipeline — slide grammar, mode routing, MDX children adapter
+
+**Status:** Accepted
+**Date:** 2026-08-07
+**Decision-makers:** Miguel Rodriguez
+**Source:** Issue #64 (WP3, presentation mode). Extends ADR-0010 (component
+contract, which defined the two render modes) and ADR-0012 (content pipeline);
+details the seam ADR-0008 deferred ("sync is a navigation state").
+
+## Context
+
+D15 makes every document dual: one MDX source renders as a book page and as a
+slide deck. Building it forced four decisions: how a document becomes slides,
+how boundaries are recognized across features, how the viewer obtains the
+rendered content from MDX v3, and where the mode lives so v0.3 live sessions
+can drive it.
+
+## Decision
+
+1. **Slide grammar** (runtime, `presentation/parser.ts`, pure and unit-tested):
+   a document's sibling elements are grouped into slides. Boundaries: `<Slide>`
+   containers (one slide each, title = viewer chrome), `<SectionBreak/>`
+   (untitled group), and — in `auto` mode — `h2` headings (heading text =
+   slide title). The **cover slide always exists** (document title; content
+   before the first boundary joins it in auto mode). The document `h1` never
+   enters a slide. In `explicit` mode loose prose stays book-only unless it
+   follows a `<SectionBreak/>` — a curated deck.
+
+2. **`presentation` frontmatter field**: `auto | explicit | none`, absent =
+   `auto` (every document is presentable for now; future document types arrive
+   as new values by real need). Invalid values fail the build via the
+   contentIntegrity gate. `none` hides the Presentar toggle and `/present`
+   redirects to the book view. Extends the ADR-0012 frontmatter contract.
+
+3. **Boundary identity travels as static metadata** (`lib/componentMeta.ts`:
+   `withMeta`/`metaOf` — components declare `slideBoundary` / `headingLevel`).
+   The parser dispatches on metadata, never on component-identity imports.
+   Chosen over direct imports to keep the feature graph acyclic
+   (content → components → presentation → content would otherwise close).
+
+4. **MDX children adapter** (`presentation/mdxChildren.ts`): MDX v3 hands the
+   layout wrapper ONE opaque `_createMdxContent` element, not the sibling list
+   (that was v1 behavior). **Option A (decided with Miguel, 2026-08-07): invoke
+   that compiled content function during render** to obtain the siblings — a
+   known coupling to the pinned toolchain's compiled shape, guarded by the
+   presentation route tests (including the explicit-marker fixture).
+   **Fallback (option B, if an MDX upgrade breaks the shape)**: group slides at
+   compile time with a remark plugin over the mdast (wrap boundary runs, inject
+   a slides metadata export) — swap the adapter; parser and viewer unchanged.
+   This departs from ADR-0012's suggestion that the `?frontmatter`
+   virtual-module pattern could serve slide metadata: that pattern serves
+   build-time metadata well, but slides need the *rendered element stream*,
+   which only exists at runtime under option A's model.
+
+5. **Mode is set by the route; the URL is the sync seam**: `/d/:id` = book,
+   `/d/:id/present` = presentation (`ModeProvider` + `useMode()`, never props
+   drilling), and the current slide derives from `?slide=N` — the URL is the
+   single source of truth. This is the concrete seam for ADR-0008 live
+   sessions: sync-follow = driving route + query from `location` events;
+   detaching = navigating freely. Viewer chrome is POC-style (fixed overlay,
+   keyboard `p`/`←`/`→`/`Space`/`Home`/`End`/`Esc`, fullscreen via
+   `requestFullscreen`, minimal framer-motion fade).
+
+## Alternatives considered
+
+- **Compile-time slide splitting** as the primary mechanism (mdx-deck style):
+  robust, public APIs, but more build machinery, two artifacts per document,
+  and the runtime parser is simpler while documents are components. Kept as
+  the recorded fallback (Decision 4).
+- **Boundary recognition by component reference** (issue's original wording):
+  rejected — it wires the feature cycle componentMeta exists to prevent.
+- **Mode via prop drilling or global store**: rejected (ADR-0004/state rules;
+  the route already encodes it).
+- **Slide state in React state instead of the URL**: rejected — kills deep
+  links and the v0.3 sync seam.
+
+## Consequences
+
+- Authors control decks with frontmatter + two markers; the authoring guide
+  documents the contract (`docs/standards/guides/add-a-course-document.md`).
+- `Slide`/`SectionBreak` ship BEFORE the catalog exists (deferral recorded in
+  issue #64 Non-goals; issue #65 makes their catalog entries its first
+  obligation and adds the every-component-has-an-entry test).
+- The MDX upgrade path is constrained by the adapter (Decision 4): any MDX
+  major bump must run the presentation route tests and, on breakage, execute
+  the recorded fallback instead of patching around it.
+- The security posture of executing compiled content functions rests on the
+  repo-controlled-content invariant recorded in `docs/security-notes.md`.
+- Cross-feature edges are now an explicit allowlist enforced by
+  `src/architecture.test.ts` and recorded in `frontend-code-style.md`.

--- a/docs/security-notes.md
+++ b/docs/security-notes.md
@@ -19,3 +19,19 @@ names its trigger for re-evaluation — nothing is "accepted forever".
 - **Review trigger**: the next react-router upgrade evaluation, or the moment any
   server runtime/SSR/RSC enters the frontend (v0.3 backend does NOT count — it is
   a separate Go service). Re-check with `npm audit` at each dependency review.
+
+## Accepted invariants
+
+### All bundled MDX is repo-controlled content (recorded 2026-08-07)
+
+- **What relies on it**: the presentation pipeline executes compiled MDX content
+  functions directly (`apps/web/src/presentation/mdxChildren.ts`, ADR-0013), and
+  MDX itself compiles content into arbitrary components (ADR-0003 by design).
+  Both are safe only while every `.mdx` that reaches the build comes from the
+  repo-controlled `content/` tree, reviewed like code.
+- **Why currently safe**: content ships exclusively via git + PR review; there is
+  no runtime ingestion, no user-contributed documents, no CMS.
+- **Review trigger**: the moment ANY non-repo-authored content path appears —
+  v0.2 authoring-agent output that bypasses PR review, a future in-platform
+  editor (vision phase C), or user-submitted material. At that point the MDX
+  pipeline and this adapter must be re-reviewed as an injection surface.

--- a/docs/standards/frontend-code-style.md
+++ b/docs/standards/frontend-code-style.md
@@ -37,6 +37,22 @@ src/
   features only through deliberate public seams (their root export); `lib` imports
   from no feature; no cycles ever. (Enforced by `src/architecture.test.ts` —
   pattern imported from DocumentBuddy's architecture tests.)
+- **Cross-feature dependencies are an explicit allowlist**, mirrored by
+  `FEATURE_EDGES` in `src/architecture.test.ts`. Current edges:
+  `components → presentation` (mode awareness via `useMode`) and
+  `presentation → content` (registry + lazy document access). Adding an edge is
+  an architectural decision: extend the map AND record the new edge + rationale
+  here in the same PR. Test files may cross any feature through its seam (they
+  are consumers, like the shell); production code follows the allowlist.
+- **Cross-feature element identity travels as static metadata**, never as
+  component-identity imports: declare with `withMeta` and inspect with `metaOf`
+  (`lib/componentMeta.ts`). Worked case: the slide parser recognizes
+  `slideBoundary`/`headingLevel` without importing `Slide` or the heading
+  factory — which would close a feature cycle.
+- **MDX component maps are shell-composed**: features export partial maps
+  (e.g., `content/mdxComponents.ts`), and `app/mdxComponents.ts` merges them
+  into the provider around the routes. Features never assemble the global map;
+  documents use registered components without imports (ADR-0003/0010).
 - **Route-level pages**: shell-owned pages (e.g., `NotFound`) live in `app/`;
   feature pages live in their feature folder.
 - **Shell UI reaches features by injection**: when a feature needs shell-owned

--- a/docs/standards/guides/add-a-course-document.md
+++ b/docs/standards/guides/add-a-course-document.md
@@ -2,7 +2,8 @@
 
 How to add (or move) a document in a Nalanda course. Registered in
 `docs/standards/integration-guides.md`; born with WP2 (#63). Decisions behind
-this design: ADR-0002 (ids, graph + index), ADR-0003 (MDX), ADR-0012 (pipeline).
+this design: ADR-0002 (ids, graph + index), ADR-0003 (MDX), ADR-0012 (pipeline),
+ADR-0013 (presentation).
 
 ## When to use
 
@@ -15,9 +16,10 @@ The seed course `content/courses/sample-course/` exercises everything:
 
 ```
 content/courses/sample-course/
-├── 01-bienvenida.mdx          # id: bienvenida
-├── 02-intro-estructuras.mdx   # id: intro-estructuras
-├── 03-busqueda-binaria.mdx    # id: busqueda-binaria
+├── 01-bienvenida.mdx          # id: bienvenida        (presentation: auto — h2 slicing)
+├── 02-intro-estructuras.mdx   # id: intro-estructuras (auto, uses <SectionBreak/>)
+├── 03-busqueda-binaria.mdx    # id: busqueda-binaria  (presentation: explicit, uses <Slide>)
+├── 04-apuntes.mdx             # id: apuntes-del-curso (presentation: none — book-only)
 └── index.yaml                 # the ordered teaching path
 ```
 
@@ -37,18 +39,32 @@ the frontmatter `id`, never the path. v0.1 supports exactly ONE course directory
    ---
    id: busqueda-binaria # kebab-case, UNIQUE across the whole content/ tree
    title: Búsqueda binaria # shown in the TOC, prev/next, and lookups
+   presentation: explicit # OPTIONAL: auto (default) | explicit | none
    ---
    ```
+
+   `presentation` controls the document's slide form (ADR-0013): `auto`
+   (default when absent) slices the deck on `h2` headings; `explicit` decks
+   ONLY content marked with `<Slide>` / `<SectionBreak/>` (loose prose stays
+   book-only); `none` means book-only — no Presentar toggle, `/present`
+   redirects back.
 
 3. **Write prose in Markdown.** Headings h2–h4 get automatic slug anchors
    (deep-linkable). Code fences render book-style.
 
-4. **Cross-reference with wiki-links**: `[[otro-id]]` renders that document's
+4. **Mark slides (optional)**: `<Slide title="...">...</Slide>` and
+   `<SectionBreak />` are available WITHOUT imports. In the book view a Slide
+   renders as its heading + flowing prose and a SectionBreak as a subtle
+   divider; in presentation they cut slide boundaries. Worked example:
+   `03-busqueda-binaria.mdx`. Full component docs arrive with the catalog
+   (WP4).
+
+5. **Cross-reference with wiki-links**: `[[otro-id]]` renders that document's
    link, `[[otro-id|texto visible]]` overrides the label. A target that doesn't
    exist does NOT fail the build: it renders visibly broken (red wavy underline)
    and logs a console warning — forward links to drafts are allowed on purpose.
 
-5. **Register it in the teaching path** (`index.yaml`) if it belongs to the
+6. **Register it in the teaching path** (`index.yaml`) if it belongs to the
    recorrido. Schema (strictly validated; unknown keys fail the build):
 
    ```yaml
@@ -65,15 +81,17 @@ the frontmatter `id`, never the path. v0.1 supports exactly ONE course directory
    on the FIRST entry — by convention the course welcome document). A document
    not listed in the index is still reachable by wiki-link and URL.
 
-6. **Verify**: `npm run build` from `apps/web/`. The contentIntegrity gate fails
+7. **Verify**: `npm run build` from `apps/web/`. The contentIntegrity gate fails
    the build (and CI — `content/**` triggers it) with a file-and-field message
-   on: missing/non-kebab/duplicate `id`, missing `title`, malformed `index.yaml`
-   (unknown key, group without docId nor label, empty children), duplicate or unknown
-   `docId` in the index.
+   on: missing/non-kebab/duplicate `id`, missing `title`, invalid `presentation`
+   value (must be auto, explicit, or none), malformed `index.yaml` (unknown key,
+   group without docId nor label, empty children), duplicate or unknown `docId`
+   in the index.
 
 ## Checklist
 
-- [ ] Frontmatter has kebab-case `id` (unique) + `title`.
+- [ ] Frontmatter has kebab-case `id` (unique) + `title` (+ `presentation` if
+      the default `auto` doesn't fit).
 - [ ] Wiki-links point at real ids (or are intentional forward links).
 - [ ] Listed in `index.yaml` if it belongs to the recorrido.
 - [ ] `npm run build` green from `apps/web/` (content integrity gate).

--- a/docs/standards/testing-strategy.md
+++ b/docs/standards/testing-strategy.md
@@ -45,7 +45,8 @@ it. Numeric gates may be introduced later if drift appears.
 npm run format:check   # prettier
 npm run lint           # oxlint
 npm run build          # tsc -b + vite build (type gate + content/ integrity gate:
-                       # frontmatter ids and index.yaml validated by contentIntegrity)
+                       # document frontmatter (id, title, presentation) and
+                       # index.yaml validated by contentIntegrity)
 npm run test           # vitest run — at minimum the touched scope, in green
 ```
 


### PR DESCRIPTION
**Closes #64**

## Summary

Every document is now dual (D15): the same MDX renders as a wiki page AND as a
slide deck. This WP delivers the mode machinery (`useMode` set by the route,
`/d/:id/present`), a pure slide parser, the catalog's first two inhabitants
(`<Slide>`, `<SectionBreak>` — ADR-0010 contract), a POC-style full-viewport
viewer (keyboard, counter, fade, fullscreen, `?slide=N` deep links), and the
`presentation: auto | explicit | none` frontmatter config. Decisions recorded
in **ADR-0013**; authoring contract updated in the guide.

## Slices completed

- [x] S1 — Mode context + `useMode()` + `/d/:id/present` route
- [x] S2 — Pure slide parser (boundaries via `lib/componentMeta` statics)
- [x] S3 — `<Slide>`/`<SectionBreak>` per-mode contract + shell-composed MDX map
- [x] S4 — SlideDeck viewer + `mdxChildrenOf` adapter (option A, discussed)
- [x] S5 — Frontmatter `presentation` config end-to-end
- [x] S6 — Header toggle + `p` shortcut + seeds covering auto/explicit/none
- [x] Review fixes (Round A) + docs round (Round B)

## Acceptance criteria

- **AC1** (explicit `<Slide>` markers → slides; keyboard, counter, Esc):
  `presentationRoute.test.tsx` explicit-fixture tests (counter `1 / 3`, slide 2
  "La idea", Esc → book) + browser verification (code slide renders, Esc URL).
- **AC2** (auto slices by h2 with cover): parser unit tests + route tests on the
  auto doc (cover title, counter, prev/next of slides) + browser (deck 1/3).
- **AC3** (`none`: no toggle, `/present` redirects): route tests + browser
  (apuntes: toggle count 0, redirect verified).
- **AC4** (book mode intact: Slide = heading + prose, SectionBreak = divider):
  `Slide.test.tsx` / `SectionBreak.test.tsx` + book-view route test (La idea +
  Costo headings inside the article) + browser (3 h2s, 1 hr, no artifacts).
- **AC5** (parser unit tests: markers, h2 fallback, cover, mixed, empty): 11
  parser cases incl. whitespace nodes, h1 exclusion, empty-group dropping, and
  explicit-mode semantics.
- **AC6** (`?slide=N` deep-link): route tests (`?slide=2`, non-integer `1.5`
  hardened) + browser deep-link (`?slide=3` → counter 3/4). Lint + tests +
  build green.

## Tests

`npm run format:check` ✓ · `npm run lint` ✓ · `npm run test` → 16 files /
**86 tests** ✓ · `npm run build` ✓. Browser verification via Playwright:
explicit deck (Costo excluded), keyboard nav (→/End/Esc), TOC → toggle → `p`,
`none` redirect, SectionBreak divider, fade transition.

## Reviews run

Full pipeline (both rounds), panels + adversarial verifier + per-fix lens
rechecks:

- **Round A (code)**: 3 lenses (performance skipped — no hot paths, announced).
  11 findings → 10 after dedup: 4 important (verifier: 3 confirmed, 1 deflated),
  4 suggestions, 2 patterns. **Acted on all.** Highlights: non-integer `?slide`
  white-screen fixed (reproduced independently by 2 lenses); the explicit-seed
  route tests now guard the `mdxChildrenOf` adapter (its promised alarm); the
  architecture test now enforces a cross-feature **edge allowlist + seam-only
  rule** (the style doc's "no cycles ever" claim was unenforced). Fixes commit
  `88516ab`; all rechecks: resolved.
- **Round B (docs)**: 4 lenses. 21 findings → 8 after dedup (heavy cross-lens
  agreement). Verifier **refuted one critical** (the ADR-0010 catalog
  "contradiction" was already recorded in issues #64/#65 — dismissed, with a
  consequence line in the ADR as belt-and-braces). Acted on the other 7:
  **ADR-0013** (slide grammar, `presentation` field, adapter decision +
  fallback, mode-by-route/URL as the ADR-0008 sync seam), security-notes
  invariant entry, style-doc recordings (edges, componentMeta idiom,
  shell-composed maps), authoring guide, README. Docs commit `94dfb57`; all
  rechecks: resolved (one wording nit found and fixed in the amend).
- **Patterns recorded**: repo-controlled-content invariant
  (`docs/security-notes.md`), componentMeta + shell-composed-maps idioms
  (`frontend-code-style.md`).

## Manual verification

- [ ] `cd apps/web && npm install && npm run dev` → in **Bienvenida**, click
  **Presentar ▸** (header) → deck opens with the cover slide and `1 / 3`.
- [ ] Navigate with `→`/`Space`; `Home`/`End` jump; `Esc` returns to the same
  document in book view. `p` re-enters.
- [ ] Fullscreen button (bottom-left ⛶) enters real fullscreen; first `Esc`
  exits fullscreen, second exits the presentation.
- [ ] `/d/busqueda-binaria/present`: deck has **3 slides** (cover, La idea,
  Implementación with the Java code) — the "Costo" section is book-only.
- [ ] `/d/busqueda-binaria` (book): La idea / Implementación / Costo all render
  as normal sections; no slide artifacts.
- [ ] **Apuntes del curso**: no Presentar toggle; forcing
  `/d/apuntes-del-curso/present` redirects to the book.
- [ ] `?slide=2` in the URL deep-links; share it and it opens on that slide.
- [ ] Read `docs/decisions/0013-presentation-pipeline.md` (drafted for your
  approval) and the updated authoring guide.

## Notes

- **No new dependencies**; `vite.config.ts` and tsconfigs untouched.
- The `mdxChildrenOf` adapter is the one knowingly-fragile point (MDX v3
  compiled shape); its alarm (route tests) and fallback plan are recorded in
  ADR-0013 — an MDX major bump must run those tests first.
- Slide/SectionBreak catalog entries are WP4 (#65)'s first obligation (recorded
  in ADR-0013 consequences; #65 already plans the enforcement test).
- Cross-feature imports are now allowlisted by `src/architecture.test.ts`
  (components→presentation, presentation→content) — extending the list requires
  a same-PR record in the style doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MW6Zi5awCpwEGo3BNEnTg
