### PR TITLE
feat: component catalog route with self-governance

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -13,6 +13,7 @@ stack summary before working here (one home per fact, per
 
 - `docs/standards/frontend-code-style.md` — folder layout (`src/app|components|catalog|content|presentation|lib|styles`), naming, component rules, import direction (`app → features → lib`). **Follow, don't innovate.**
 - `docs/standards/testing-strategy.md` — the `apps/web` per-commit and pre-PR protocols. Nothing is committed in red.
+- `docs/standards/integration-guides.md` — index of the extension-point guides; read the matching guide before adding a component, a document, or an app.
 
 ## App-specific rules
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -26,20 +26,25 @@ See `docs/standards/frontend-code-style.md` for the authoritative rules.
 
 ```
 src/
-├── app/                  # shell: entry, router (/d/:id, /d/:id/present + 404), MDX map
-├── components/           # catalog content components by family (structure: Slide, SectionBreak)
+├── app/                  # shell: entry, router (documents, presentation, catalog, 404), MDX map
+├── catalog/              # /catalog surface: registry, family taxonomy, component +
+│                         # governance pages, live-example blocks
+├── components/           # catalog content components by family (structure: Slide,
+│                         # SectionBreak) + their colocated <Component>.catalog.tsx entries
 ├── content/              # content pipeline: MDX registry, course index, wiki-links,
 │                         # book-mode page, build-time integrity gate
 ├── presentation/         # presentation mode: mode context, slide parser, SlideDeck viewer
-├── lib/                  # pure TS utilities (componentMeta, reactText)
+├── lib/                  # pure TS utilities + cross-feature contract types
+│                         # (catalogEntry, componentMeta, reactText)
 ├── styles/               # Tailwind entry + design tokens
 ├── mdx.d.ts              # module typing for *.mdx imports
 └── architecture.test.ts  # import-direction invariants
 ```
 
-The remaining feature folder (`catalog/`) is created by the WP that populates
-it. How to author course material (frontmatter, wiki-links, slide markers):
-`docs/standards/guides/add-a-course-document.md`.
+All feature folders now exist. Guides: authoring course material (frontmatter,
+wiki-links, slide markers) → `docs/standards/guides/add-a-course-document.md`;
+adding a content component → `docs/standards/guides/add-a-content-component.md`
+(its rules are rendered at `/catalog/governance`).
 
 ## Testing
 

--- a/apps/web/src/app/AppRoutes.tsx
+++ b/apps/web/src/app/AppRoutes.tsx
@@ -1,7 +1,7 @@
 import { MDXProvider } from '@mdx-js/react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 
-import { CatalogOverviewPage, FamilyPage } from '../catalog';
+import { CatalogOverviewPage, ComponentPage, FamilyPage } from '../catalog';
 import { DocumentPage, courseIndex, walkIndex } from '../content';
 import { PresentationPage } from '../presentation';
 import { NotFound } from './NotFound';
@@ -23,6 +23,7 @@ export function AppRoutes() {
         <Route path="/d/:id" element={<DocumentPage notFound={<NotFound />} />} />
         <Route path="/d/:id/present" element={<PresentationPage notFound={<NotFound />} />} />
         <Route path="/catalog" element={<CatalogOverviewPage />} />
+        <Route path="/catalog/c/:name" element={<ComponentPage notFound={<NotFound />} />} />
         <Route path="/catalog/:family" element={<FamilyPage notFound={<NotFound />} />} />
         <Route path="*" element={<NotFound />} />
       </Routes>

--- a/apps/web/src/app/AppRoutes.tsx
+++ b/apps/web/src/app/AppRoutes.tsx
@@ -1,7 +1,7 @@
 import { MDXProvider } from '@mdx-js/react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 
-import { CatalogOverviewPage, ComponentPage, FamilyPage } from '../catalog';
+import { CatalogOverviewPage, ComponentPage, FamilyPage, GovernancePage } from '../catalog';
 import { DocumentPage, courseIndex, walkIndex } from '../content';
 import { PresentationPage } from '../presentation';
 import { NotFound } from './NotFound';
@@ -23,6 +23,7 @@ export function AppRoutes() {
         <Route path="/d/:id" element={<DocumentPage notFound={<NotFound />} />} />
         <Route path="/d/:id/present" element={<PresentationPage notFound={<NotFound />} />} />
         <Route path="/catalog" element={<CatalogOverviewPage />} />
+        <Route path="/catalog/governance" element={<GovernancePage />} />
         <Route path="/catalog/c/:name" element={<ComponentPage notFound={<NotFound />} />} />
         <Route path="/catalog/:family" element={<FamilyPage notFound={<NotFound />} />} />
         <Route path="*" element={<NotFound />} />

--- a/apps/web/src/app/AppRoutes.tsx
+++ b/apps/web/src/app/AppRoutes.tsx
@@ -1,6 +1,7 @@
 import { MDXProvider } from '@mdx-js/react';
 import { Navigate, Route, Routes } from 'react-router-dom';
 
+import { CatalogOverviewPage, FamilyPage } from '../catalog';
 import { DocumentPage, courseIndex, walkIndex } from '../content';
 import { PresentationPage } from '../presentation';
 import { NotFound } from './NotFound';
@@ -21,6 +22,8 @@ export function AppRoutes() {
         />
         <Route path="/d/:id" element={<DocumentPage notFound={<NotFound />} />} />
         <Route path="/d/:id/present" element={<PresentationPage notFound={<NotFound />} />} />
+        <Route path="/catalog" element={<CatalogOverviewPage />} />
+        <Route path="/catalog/:family" element={<FamilyPage notFound={<NotFound />} />} />
         <Route path="*" element={<NotFound />} />
       </Routes>
     </MDXProvider>

--- a/apps/web/src/app/catalogRoute.test.tsx
+++ b/apps/web/src/app/catalogRoute.test.tsx
@@ -26,3 +26,10 @@ describe('/catalog', () => {
     expect(await screen.findByRole('heading', { name: 'Estructura' })).toBeInTheDocument();
   });
 });
+
+describe('/catalog/c/:name', () => {
+  it('shows the 404 page for an unknown component', async () => {
+    renderAt('/catalog/c/nope');
+    expect(await screen.findByRole('heading', { name: /not found/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/catalogRoute.test.tsx
+++ b/apps/web/src/app/catalogRoute.test.tsx
@@ -33,3 +33,24 @@ describe('/catalog/c/:name', () => {
     expect(await screen.findByRole('heading', { name: /not found/i })).toBeInTheDocument();
   });
 });
+
+describe('component entries (AC2)', () => {
+  for (const name of ['Slide', 'SectionBreak']) {
+    it(`renders a complete page for ${name} with live examples`, async () => {
+      renderAt(`/catalog/c/${name}`);
+      expect(await screen.findByRole('heading', { level: 1, name })).toBeInTheDocument();
+      expect(screen.getByText(/when to use/i)).toBeInTheDocument();
+      const propsDocumented =
+        screen.queryByRole('table') !== null || screen.queryByText(/takes no props/i) !== null;
+      expect(propsDocumented).toBe(true);
+      const examples = screen.getAllByRole('heading', { level: 3 });
+      expect(examples.length).toBeGreaterThanOrEqual(2);
+    });
+  }
+
+  it('lists both structural components in the estructura family', async () => {
+    renderAt('/catalog/estructura');
+    expect(await screen.findByRole('link', { name: 'Slide' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'SectionBreak' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/catalogRoute.test.tsx
+++ b/apps/web/src/app/catalogRoute.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
+
+import { catalog, families } from '../catalog';
 
 import { AppRoutes } from './AppRoutes';
 
@@ -13,17 +15,73 @@ function renderAt(path: string) {
 }
 
 describe('/catalog', () => {
-  it('lists the four families with their definitions', async () => {
+  it('lists every family with its definition', async () => {
     renderAt('/catalog');
-    expect(await screen.findByRole('heading', { name: /catalog/i })).toBeInTheDocument();
-    for (const family of ['Estructura', 'Semánticos', 'Interactivos', 'Media']) {
-      expect(screen.getByRole('heading', { name: family })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /^catalog$/i })).toBeInTheDocument();
+    for (const family of families) {
+      expect(screen.getByRole('heading', { name: family.name })).toBeInTheDocument();
+      expect(screen.getByText(family.definition)).toBeInTheDocument();
     }
   });
 
-  it('navigates into a family page', async () => {
+  it('points each family link at its route segment, not its display name', async () => {
+    renderAt('/catalog');
+    await screen.findByRole('heading', { name: /^catalog$/i });
+    for (const family of families) {
+      // Guards the accented-name mistake: ids are route segments, names are not.
+      expect(screen.getByRole('link', { name: family.name })).toHaveAttribute(
+        'href',
+        `/catalog/${family.id}`,
+      );
+    }
+    expect(screen.getByRole('link', { name: /governance/i })).toHaveAttribute(
+      'href',
+      '/catalog/governance',
+    );
+  });
+
+  it('navigates from the overview into a family page by clicking its link', async () => {
+    renderAt('/catalog');
+    await screen.findByRole('heading', { name: /^catalog$/i });
+
+    fireEvent.click(screen.getByRole('link', { name: 'Semánticos' }));
+    expect(
+      await screen.findByRole('heading', { level: 1, name: 'Semánticos' }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows the empty-family copy for families with no components yet', async () => {
+    const empty = families.find((f) => catalog.byFamily(f.id).length === 0)!;
+    renderAt(`/catalog/${empty.id}`);
+    expect(await screen.findByText(/no components in this family yet/i)).toBeInTheDocument();
+  });
+
+  it('shows the 404 page for an unknown family', async () => {
+    renderAt('/catalog/nope');
+    expect(await screen.findByRole('heading', { name: /not found/i })).toBeInTheDocument();
+  });
+});
+
+describe('/catalog/:family', () => {
+  it('lists its components with links to their pages', async () => {
     renderAt('/catalog/estructura');
-    expect(await screen.findByRole('heading', { name: 'Estructura' })).toBeInTheDocument();
+    await screen.findByRole('heading', { level: 1, name: 'Estructura' });
+    const entries = catalog.byFamily('estructura');
+    expect(entries.length).toBeGreaterThan(0);
+    for (const entry of entries) {
+      expect(screen.getByRole('link', { name: entry.name })).toHaveAttribute(
+        'href',
+        `/catalog/c/${entry.name}`,
+      );
+    }
+  });
+
+  it('navigates into a component page by clicking its link', async () => {
+    renderAt('/catalog/estructura');
+    await screen.findByRole('heading', { level: 1, name: 'Estructura' });
+
+    fireEvent.click(screen.getByRole('link', { name: 'Slide' }));
+    expect(await screen.findByRole('heading', { level: 1, name: 'Slide' })).toBeInTheDocument();
   });
 });
 
@@ -32,37 +90,40 @@ describe('/catalog/c/:name', () => {
     renderAt('/catalog/c/nope');
     expect(await screen.findByRole('heading', { name: /not found/i })).toBeInTheDocument();
   });
-});
 
-describe('component entries (AC2)', () => {
-  for (const name of ['Slide', 'SectionBreak']) {
-    it(`renders a complete page for ${name} with live examples`, async () => {
-      renderAt(`/catalog/c/${name}`);
-      expect(await screen.findByRole('heading', { level: 1, name })).toBeInTheDocument();
-      expect(screen.getByText(/when to use/i)).toBeInTheDocument();
-      const propsDocumented =
-        screen.queryByRole('table') !== null || screen.queryByText(/takes no props/i) !== null;
-      expect(propsDocumented).toBe(true);
-      const examples = screen.getAllByRole('heading', { level: 3 });
-      expect(examples.length).toBeGreaterThanOrEqual(2);
+  for (const entry of catalog.entries) {
+    it(`documents ${entry.name} with its examples and a back link to its family`, async () => {
+      renderAt(`/catalog/c/${entry.name}`);
+      await screen.findByRole('heading', { level: 1, name: entry.name });
+
+      expect(screen.getByText(entry.whenToUse)).toBeInTheDocument();
+      for (const example of entry.examples) {
+        expect(screen.getByRole('heading', { level: 3, name: example.title })).toBeInTheDocument();
+      }
+      expect(screen.getByRole('link', { name: new RegExp(entry.family) })).toHaveAttribute(
+        'href',
+        `/catalog/${entry.family}`,
+      );
     });
   }
 
-  it('lists both structural components in the estructura family', async () => {
-    renderAt('/catalog/estructura');
-    expect(await screen.findByRole('link', { name: 'Slide' })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'SectionBreak' })).toBeInTheDocument();
-  });
-});
+  it('renders the real Slide component in both modes (not just page chrome)', async () => {
+    renderAt('/catalog/c/Slide');
+    await screen.findByRole('heading', { level: 1, name: 'Slide' });
 
-describe('/catalog/governance (AC3)', () => {
-  it('renders the how-to-add guide and the three checklists', async () => {
-    renderAt('/catalog/governance');
-    expect(await screen.findByRole('heading', { name: /governance/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: /how to add a component/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: /component contract/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: /documentation checklist/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: /review checklist/i })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: /changing these rules/i })).toBeInTheDocument();
+    // Both examples render the same prose (the selector excludes the code
+    // snippets, which quote it); only the book one adds the heading.
+    expect(screen.getAllByText(/Comparamos el objetivo/, { selector: 'p' })).toHaveLength(2);
+    // Name is a regex: the shell MDX map renders h2s through the anchor factory.
+    expect(screen.getByRole('heading', { level: 2, name: /La idea/ })).toBeInTheDocument();
+  });
+
+  it('renders the real SectionBreak component (divider in book, nothing in presentation)', async () => {
+    renderAt('/catalog/c/SectionBreak');
+    const article = await screen.findByRole('main');
+    await screen.findByRole('heading', { level: 1, name: 'SectionBreak' });
+
+    expect(within(article).getAllByRole('separator')).toHaveLength(1);
+    expect(screen.getAllByText('Antes…')).toHaveLength(2);
   });
 });

--- a/apps/web/src/app/catalogRoute.test.tsx
+++ b/apps/web/src/app/catalogRoute.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import { AppRoutes } from './AppRoutes';
+
+function renderAt(path: string) {
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <AppRoutes />
+    </MemoryRouter>,
+  );
+}
+
+describe('/catalog', () => {
+  it('lists the four families with their definitions', async () => {
+    renderAt('/catalog');
+    expect(await screen.findByRole('heading', { name: /catalog/i })).toBeInTheDocument();
+    for (const family of ['Estructura', 'Semánticos', 'Interactivos', 'Media']) {
+      expect(screen.getByRole('heading', { name: family })).toBeInTheDocument();
+    }
+  });
+
+  it('navigates into a family page', async () => {
+    renderAt('/catalog/estructura');
+    expect(await screen.findByRole('heading', { name: 'Estructura' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/catalogRoute.test.tsx
+++ b/apps/web/src/app/catalogRoute.test.tsx
@@ -54,3 +54,15 @@ describe('component entries (AC2)', () => {
     expect(screen.getByRole('link', { name: 'SectionBreak' })).toBeInTheDocument();
   });
 });
+
+describe('/catalog/governance (AC3)', () => {
+  it('renders the how-to-add guide and the three checklists', async () => {
+    renderAt('/catalog/governance');
+    expect(await screen.findByRole('heading', { name: /governance/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /how to add a component/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /component contract/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /documentation checklist/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /review checklist/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /changing these rules/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/catalogRoute.test.tsx
+++ b/apps/web/src/app/catalogRoute.test.tsx
@@ -51,8 +51,12 @@ describe('/catalog', () => {
   });
 
   it('shows the empty-family copy for families with no components yet', async () => {
-    const empty = families.find((f) => catalog.byFamily(f.id).length === 0)!;
-    renderAt(`/catalog/${empty.id}`);
+    const empty = families.find((f) => catalog.byFamily(f.id).length === 0);
+    expect(
+      empty,
+      'every family now has components — cover the empty branch with a direct FamilyPage test',
+    ).toBeDefined();
+    renderAt(`/catalog/${empty!.id}`);
     expect(await screen.findByText(/no components in this family yet/i)).toBeInTheDocument();
   });
 
@@ -125,5 +129,27 @@ describe('/catalog/c/:name', () => {
 
     expect(within(article).getAllByRole('separator')).toHaveLength(1);
     expect(screen.getAllByText('Antes…')).toHaveLength(2);
+  });
+});
+
+describe('/catalog/governance', () => {
+  it('renders the self-governance rules and links back to the catalog', async () => {
+    renderAt('/catalog/governance');
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /governance/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /component contract/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /review checklist/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /catalog/i })).toHaveAttribute('href', '/catalog');
+  });
+
+  it('derives the family folder mapping from the taxonomy', async () => {
+    renderAt('/catalog/governance');
+    await screen.findByRole('heading', { level: 1, name: /governance/i });
+    for (const family of families) {
+      expect(
+        screen.getByText(new RegExp(`${family.name} → ${family.folder}/`)),
+      ).toBeInTheDocument();
+    }
   });
 });

--- a/apps/web/src/app/mdxComponents.test.ts
+++ b/apps/web/src/app/mdxComponents.test.ts
@@ -22,7 +22,7 @@ describe('shell MDX components map', () => {
 // The MDX map and the catalog must stay in lockstep in BOTH directions. This
 // pair lives in app/ because features may not import app/; the entry-shape
 // invariants live in catalog/architecture.test.tsx.
-describe('catalog completeness (ADR-0010 / ADR-0013)', () => {
+describe('catalog completeness (ADR-0010 / ADR-0014)', () => {
   const componentNames = Object.keys(map).filter((key) => /^[A-Z]/.test(key));
 
   it('the MDX map registers components (guards against a vacuous check)', () => {

--- a/apps/web/src/app/mdxComponents.test.ts
+++ b/apps/web/src/app/mdxComponents.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { catalog } from '../catalog';
 import { SectionBreak, Slide } from '../components';
 import { mdxComponents } from './mdxComponents';
 
@@ -14,6 +15,16 @@ describe('shell MDX components map', () => {
   it('keeps the content mappings (links and anchor headings)', () => {
     for (const key of ['a', 'h2', 'h3', 'h4']) {
       expect(map[key], `missing mapping for ${key}`).toBeDefined();
+    }
+  });
+});
+
+describe('catalog completeness (ADR-0010 / ADR-0013)', () => {
+  it('every registered MDX component has a catalog entry', () => {
+    const componentNames = Object.keys(map).filter((key) => /^[A-Z]/.test(key));
+    expect(componentNames.length).toBeGreaterThan(0);
+    for (const name of componentNames) {
+      expect(catalog.byName(name), `missing catalog entry for <${name}>`).toBeDefined();
     }
   });
 });

--- a/apps/web/src/app/mdxComponents.test.ts
+++ b/apps/web/src/app/mdxComponents.test.ts
@@ -19,12 +19,28 @@ describe('shell MDX components map', () => {
   });
 });
 
+// The MDX map and the catalog must stay in lockstep in BOTH directions. This
+// pair lives in app/ because features may not import app/; the entry-shape
+// invariants live in catalog/architecture.test.tsx.
 describe('catalog completeness (ADR-0010 / ADR-0013)', () => {
-  it('every registered MDX component has a catalog entry', () => {
-    const componentNames = Object.keys(map).filter((key) => /^[A-Z]/.test(key));
+  const componentNames = Object.keys(map).filter((key) => /^[A-Z]/.test(key));
+
+  it('the MDX map registers components (guards against a vacuous check)', () => {
     expect(componentNames.length).toBeGreaterThan(0);
+  });
+
+  it('every registered MDX component has a catalog entry', () => {
     for (const name of componentNames) {
       expect(catalog.byName(name), `missing catalog entry for <${name}>`).toBeDefined();
+    }
+  });
+
+  it('every catalog entry is a registered MDX component', () => {
+    for (const entry of catalog.entries) {
+      expect(
+        componentNames,
+        `catalog entry <${entry.name}> is documented but not registered in the MDX map`,
+      ).toContain(entry.name);
     }
   });
 });

--- a/apps/web/src/architecture.test.ts
+++ b/apps/web/src/architecture.test.ts
@@ -10,6 +10,7 @@ const FEATURES = ['components', 'catalog', 'content', 'presentation'];
 // The ONLY allowed cross-feature dependencies (frontend-code-style.md).
 // Extending this map is an architectural decision — record it in the style doc.
 const FEATURE_EDGES: Record<string, string[]> = {
+  catalog: ['components'],
   components: ['presentation'],
   presentation: ['content'],
 };

--- a/apps/web/src/catalog/CatalogLayout.tsx
+++ b/apps/web/src/catalog/CatalogLayout.tsx
@@ -7,8 +7,8 @@ interface Props {
   children: ReactNode;
 }
 
-/** The shared page shell of every catalog surface (fourth use — extracted per style rule). */
-export function CatalogPage({ back, children }: Props) {
+/** The shared layout of every catalog surface (not a route — those are the *Page files). */
+export function CatalogLayout({ back, children }: Props) {
   return (
     <main className="mx-auto min-h-screen max-w-3xl bg-slate-950 px-8 py-10 text-slate-100">
       {back ? (

--- a/apps/web/src/catalog/CatalogOverviewPage.tsx
+++ b/apps/web/src/catalog/CatalogOverviewPage.tsx
@@ -1,12 +1,13 @@
 import { Link } from 'react-router-dom';
 
+import { CatalogPage } from './CatalogPage';
 import { catalog } from './registry';
 import { families } from './families';
 
 /** /catalog — the four families, their definitions, and entry counts. */
 export function CatalogOverviewPage() {
   return (
-    <main className="mx-auto min-h-screen max-w-3xl bg-slate-950 px-8 py-10 text-slate-100">
+    <CatalogPage>
       <h1 className="text-4xl font-bold tracking-tight">Catalog</h1>
       <p className="mt-3 text-slate-400">
         The components a document can use — the platform&apos;s grammar (ADR-0010). Four editable
@@ -33,6 +34,6 @@ export function CatalogOverviewPage() {
           </li>
         ))}
       </ul>
-    </main>
+    </CatalogPage>
   );
 }

--- a/apps/web/src/catalog/CatalogOverviewPage.tsx
+++ b/apps/web/src/catalog/CatalogOverviewPage.tsx
@@ -10,7 +10,10 @@ export function CatalogOverviewPage() {
       <h1 className="text-4xl font-bold tracking-tight">Catalog</h1>
       <p className="mt-3 text-slate-400">
         The components a document can use — the platform&apos;s grammar (ADR-0010). Four editable
-        families; every component ships its entry here.
+        families; every component ships its entry here.{' '}
+        <Link to="/catalog/governance" className="text-sky-400 hover:underline">
+          Governance →
+        </Link>
       </p>
       <ul className="mt-10 space-y-8">
         {families.map((family) => (

--- a/apps/web/src/catalog/CatalogOverviewPage.tsx
+++ b/apps/web/src/catalog/CatalogOverviewPage.tsx
@@ -1,0 +1,35 @@
+import { Link } from 'react-router-dom';
+
+import { catalog } from './registry';
+import { families } from './families';
+
+/** /catalog — the four families, their definitions, and entry counts. */
+export function CatalogOverviewPage() {
+  return (
+    <main className="mx-auto min-h-screen max-w-3xl bg-slate-950 px-8 py-10 text-slate-100">
+      <h1 className="text-4xl font-bold tracking-tight">Catalog</h1>
+      <p className="mt-3 text-slate-400">
+        The components a document can use — the platform&apos;s grammar (ADR-0010). Four editable
+        families; every component ships its entry here.
+      </p>
+      <ul className="mt-10 space-y-8">
+        {families.map((family) => (
+          <li key={family.id}>
+            <div className="flex items-baseline gap-3">
+              <h2 className="text-2xl font-semibold">
+                <Link to={`/catalog/${family.id}`} className="hover:text-sky-300">
+                  {family.name}
+                </Link>
+              </h2>
+              <span className="text-sm text-slate-500">
+                {catalog.byFamily(family.id).length} component(s)
+              </span>
+            </div>
+            <p className="mt-1 text-slate-300">{family.definition}</p>
+            <p className="mt-1 text-sm text-slate-500">{family.whatBelongs}</p>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/apps/web/src/catalog/CatalogOverviewPage.tsx
+++ b/apps/web/src/catalog/CatalogOverviewPage.tsx
@@ -1,13 +1,13 @@
 import { Link } from 'react-router-dom';
 
-import { CatalogPage } from './CatalogPage';
+import { CatalogLayout } from './CatalogLayout';
 import { catalog } from './registry';
 import { families } from './families';
 
 /** /catalog — the four families, their definitions, and entry counts. */
 export function CatalogOverviewPage() {
   return (
-    <CatalogPage>
+    <CatalogLayout>
       <h1 className="text-4xl font-bold tracking-tight">Catalog</h1>
       <p className="mt-3 text-slate-400">
         The components a document can use — the platform&apos;s grammar (ADR-0010). Four editable
@@ -34,6 +34,6 @@ export function CatalogOverviewPage() {
           </li>
         ))}
       </ul>
-    </CatalogPage>
+    </CatalogLayout>
   );
 }

--- a/apps/web/src/catalog/CatalogPage.tsx
+++ b/apps/web/src/catalog/CatalogPage.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+
+interface Props {
+  /** Optional breadcrumb back-link shown above the title. */
+  back?: { to: string; label: string };
+  children: ReactNode;
+}
+
+/** The shared page shell of every catalog surface (fourth use — extracted per style rule). */
+export function CatalogPage({ back, children }: Props) {
+  return (
+    <main className="mx-auto min-h-screen max-w-3xl bg-slate-950 px-8 py-10 text-slate-100">
+      {back ? (
+        <p className="text-sm">
+          <Link to={back.to} className="text-sky-400 hover:underline">
+            ← {back.label}
+          </Link>
+        </p>
+      ) : null}
+      {children}
+    </main>
+  );
+}

--- a/apps/web/src/catalog/ComponentArticle.test.tsx
+++ b/apps/web/src/catalog/ComponentArticle.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import type { CatalogEntry } from '../lib/catalogEntry';
+
+import { ComponentArticle } from './ComponentArticle';
+
+const entry: CatalogEntry = {
+  name: 'Demo',
+  family: 'estructura',
+  description: 'A demo component for the template test.',
+  whenToUse: 'Only inside this test.',
+  props: [
+    { name: 'title', type: 'string', description: 'Heading shown in book mode.' },
+    { name: 'open', type: 'boolean', default: 'false', description: 'Starts expanded.' },
+  ],
+  examples: [
+    { title: 'Basic', code: '<Demo title="hola" />', render: () => <em>live one</em> },
+    { title: 'Open', code: '<Demo open />', render: () => <em>live two</em> },
+  ],
+};
+
+function renderArticle() {
+  render(
+    <MemoryRouter>
+      <ComponentArticle entry={entry} />
+    </MemoryRouter>,
+  );
+}
+
+describe('ComponentArticle', () => {
+  it('renders name, description and when-to-use', () => {
+    renderArticle();
+    expect(screen.getByRole('heading', { name: 'Demo' })).toBeInTheDocument();
+    expect(screen.getByText('A demo component for the template test.')).toBeInTheDocument();
+    expect(screen.getByText('Only inside this test.')).toBeInTheDocument();
+  });
+
+  it('renders the props table with defaults', () => {
+    renderArticle();
+    const table = screen.getByRole('table');
+    expect(table).toHaveTextContent('title');
+    expect(table).toHaveTextContent('string');
+    expect(table).toHaveTextContent('Heading shown in book mode.');
+    expect(table).toHaveTextContent('false');
+  });
+
+  it('renders every example with its live output and source snippet', () => {
+    renderArticle();
+    expect(screen.getByRole('heading', { name: 'Basic' })).toBeInTheDocument();
+    expect(screen.getByText('live one')).toBeInTheDocument();
+    expect(screen.getByText('<Demo title="hola" />')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Open' })).toBeInTheDocument();
+    expect(screen.getByText('live two')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/catalog/ComponentArticle.tsx
+++ b/apps/web/src/catalog/ComponentArticle.tsx
@@ -1,8 +1,8 @@
-import { Link } from 'react-router-dom';
-
 import type { CatalogEntry } from '../lib/catalogEntry';
 
+import { CatalogPage } from './CatalogPage';
 import { ExampleBlock } from './ExampleBlock';
+import { folderOf } from './families';
 
 interface Props {
   entry: CatalogEntry;
@@ -11,14 +11,14 @@ interface Props {
 /** The component page template: description, when-to-use, props table, live examples. */
 export function ComponentArticle({ entry }: Props) {
   return (
-    <main className="mx-auto min-h-screen max-w-3xl bg-slate-950 px-8 py-10 text-slate-100">
-      <p className="text-sm">
-        <Link to={`/catalog/${entry.family}`} className="text-sky-400 hover:underline">
-          ← {entry.family}
-        </Link>
-      </p>
+    <CatalogPage back={{ to: `/catalog/${entry.family}`, label: entry.family }}>
       <h1 className="mt-4 text-4xl font-bold tracking-tight">{entry.name}</h1>
       <p className="mt-3 text-slate-300">{entry.description}</p>
+      <p className="mt-1 text-sm text-slate-500">
+        <code>
+          src/components/{folderOf(entry.family)}/{entry.name}.tsx
+        </code>
+      </p>
 
       <h2 className="mt-8 text-2xl font-semibold">When to use</h2>
       <p className="mt-2 text-slate-300">{entry.whenToUse}</p>
@@ -52,9 +52,9 @@ export function ComponentArticle({ entry }: Props) {
       <h2 className="mt-8 text-2xl font-semibold">Examples</h2>
       {entry.examples.map((example) => (
         <ExampleBlock key={example.title} title={example.title} code={example.code}>
-          {example.render()}
+          <example.render />
         </ExampleBlock>
       ))}
-    </main>
+    </CatalogPage>
   );
 }

--- a/apps/web/src/catalog/ComponentArticle.tsx
+++ b/apps/web/src/catalog/ComponentArticle.tsx
@@ -1,0 +1,60 @@
+import { Link } from 'react-router-dom';
+
+import type { CatalogEntry } from '../lib/catalogEntry';
+
+import { ExampleBlock } from './ExampleBlock';
+
+interface Props {
+  entry: CatalogEntry;
+}
+
+/** The component page template: description, when-to-use, props table, live examples. */
+export function ComponentArticle({ entry }: Props) {
+  return (
+    <main className="mx-auto min-h-screen max-w-3xl bg-slate-950 px-8 py-10 text-slate-100">
+      <p className="text-sm">
+        <Link to={`/catalog/${entry.family}`} className="text-sky-400 hover:underline">
+          ← {entry.family}
+        </Link>
+      </p>
+      <h1 className="mt-4 text-4xl font-bold tracking-tight">{entry.name}</h1>
+      <p className="mt-3 text-slate-300">{entry.description}</p>
+
+      <h2 className="mt-8 text-2xl font-semibold">When to use</h2>
+      <p className="mt-2 text-slate-300">{entry.whenToUse}</p>
+
+      <h2 className="mt-8 text-2xl font-semibold">Props</h2>
+      {entry.props.length === 0 ? (
+        <p className="mt-2 text-slate-500">This component takes no props.</p>
+      ) : (
+        <table className="mt-2 w-full text-left text-sm">
+          <thead>
+            <tr className="border-b border-slate-700 text-slate-400">
+              <th className="py-2 pr-4">Name</th>
+              <th className="py-2 pr-4">Type</th>
+              <th className="py-2 pr-4">Default</th>
+              <th className="py-2">Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            {entry.props.map((prop) => (
+              <tr key={prop.name} className="border-b border-slate-800 align-top">
+                <td className="py-2 pr-4 font-mono">{prop.name}</td>
+                <td className="py-2 pr-4 font-mono text-slate-400">{prop.type}</td>
+                <td className="py-2 pr-4 font-mono text-slate-400">{prop.default ?? '—'}</td>
+                <td className="py-2 text-slate-300">{prop.description}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      <h2 className="mt-8 text-2xl font-semibold">Examples</h2>
+      {entry.examples.map((example) => (
+        <ExampleBlock key={example.title} title={example.title} code={example.code}>
+          {example.render()}
+        </ExampleBlock>
+      ))}
+    </main>
+  );
+}

--- a/apps/web/src/catalog/ComponentArticle.tsx
+++ b/apps/web/src/catalog/ComponentArticle.tsx
@@ -1,6 +1,6 @@
 import type { CatalogEntry } from '../lib/catalogEntry';
 
-import { CatalogPage } from './CatalogPage';
+import { CatalogLayout } from './CatalogLayout';
 import { ExampleBlock } from './ExampleBlock';
 import { folderOf } from './families';
 
@@ -11,7 +11,7 @@ interface Props {
 /** The component page template: description, when-to-use, props table, live examples. */
 export function ComponentArticle({ entry }: Props) {
   return (
-    <CatalogPage back={{ to: `/catalog/${entry.family}`, label: entry.family }}>
+    <CatalogLayout back={{ to: `/catalog/${entry.family}`, label: entry.family }}>
       <h1 className="mt-4 text-4xl font-bold tracking-tight">{entry.name}</h1>
       <p className="mt-3 text-slate-300">{entry.description}</p>
       <p className="mt-1 text-sm text-slate-500">
@@ -55,6 +55,6 @@ export function ComponentArticle({ entry }: Props) {
           <example.render />
         </ExampleBlock>
       ))}
-    </CatalogPage>
+    </CatalogLayout>
   );
 }

--- a/apps/web/src/catalog/ComponentPage.tsx
+++ b/apps/web/src/catalog/ComponentPage.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react';
+import { useParams } from 'react-router-dom';
+
+import { ComponentArticle } from './ComponentArticle';
+import { catalog } from './registry';
+
+interface Props {
+  /** Rendered when the component name is unknown — injected by the shell. */
+  notFound: ReactNode;
+}
+
+/** /catalog/c/:name — a component's catalog page. */
+export function ComponentPage({ notFound }: Props) {
+  const { name = '' } = useParams();
+  const entry = catalog.byName(name);
+
+  if (!entry) return <>{notFound}</>;
+  return <ComponentArticle entry={entry} />;
+}

--- a/apps/web/src/catalog/ExampleBlock.tsx
+++ b/apps/web/src/catalog/ExampleBlock.tsx
@@ -6,7 +6,7 @@ interface Props {
   children: ReactNode;
 }
 
-/** A live example: the real component running, with its source beside it (plain <pre>, #65). */
+/** A live example: the real component running, with its source beside it (plain <pre>, ADR-0014). */
 export function ExampleBlock({ title, code, children }: Props) {
   return (
     <section className="mt-6">

--- a/apps/web/src/catalog/ExampleBlock.tsx
+++ b/apps/web/src/catalog/ExampleBlock.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from 'react';
+
+interface Props {
+  title: string;
+  code: string;
+  children: ReactNode;
+}
+
+/** A live example: the real component running, with its source beside it (plain <pre>, #65). */
+export function ExampleBlock({ title, code, children }: Props) {
+  return (
+    <section className="mt-6">
+      <h3 className="text-lg font-semibold">{title}</h3>
+      <div className="mt-2 rounded border border-slate-800 p-4">{children}</div>
+      <pre className="mt-2 overflow-x-auto rounded bg-slate-900 p-3 text-sm text-slate-300">
+        <code>{code}</code>
+      </pre>
+    </section>
+  );
+}

--- a/apps/web/src/catalog/FamilyPage.tsx
+++ b/apps/web/src/catalog/FamilyPage.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import { Link, useParams } from 'react-router-dom';
 
+import { CatalogPage } from './CatalogPage';
 import { catalog } from './registry';
 import { families } from './families';
 
@@ -17,15 +18,13 @@ export function FamilyPage({ notFound }: Props) {
   if (!family) return <>{notFound}</>;
   const entries = catalog.byFamily(family.id);
   return (
-    <main className="mx-auto min-h-screen max-w-3xl bg-slate-950 px-8 py-10 text-slate-100">
-      <p className="text-sm">
-        <Link to="/catalog" className="text-sky-400 hover:underline">
-          ← Catalog
-        </Link>
-      </p>
+    <CatalogPage back={{ to: '/catalog', label: 'Catalog' }}>
       <h1 className="mt-4 text-4xl font-bold tracking-tight">{family.name}</h1>
       <p className="mt-3 text-slate-300">{family.definition}</p>
       <p className="mt-1 text-sm text-slate-500">{family.whatBelongs}</p>
+      <p className="mt-1 text-sm text-slate-500">
+        Components live in <code>src/components/{family.folder}/</code>.
+      </p>
       {entries.length === 0 ? (
         <p className="mt-10 text-slate-500">
           No components in this family yet — the inventory is emergent (D29).
@@ -45,6 +44,6 @@ export function FamilyPage({ notFound }: Props) {
           ))}
         </ul>
       )}
-    </main>
+    </CatalogPage>
   );
 }

--- a/apps/web/src/catalog/FamilyPage.tsx
+++ b/apps/web/src/catalog/FamilyPage.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import { Link, useParams } from 'react-router-dom';
 
-import { CatalogPage } from './CatalogPage';
+import { CatalogLayout } from './CatalogLayout';
 import { catalog } from './registry';
 import { families } from './families';
 
@@ -18,7 +18,7 @@ export function FamilyPage({ notFound }: Props) {
   if (!family) return <>{notFound}</>;
   const entries = catalog.byFamily(family.id);
   return (
-    <CatalogPage back={{ to: '/catalog', label: 'Catalog' }}>
+    <CatalogLayout back={{ to: '/catalog', label: 'Catalog' }}>
       <h1 className="mt-4 text-4xl font-bold tracking-tight">{family.name}</h1>
       <p className="mt-3 text-slate-300">{family.definition}</p>
       <p className="mt-1 text-sm text-slate-500">{family.whatBelongs}</p>
@@ -44,6 +44,6 @@ export function FamilyPage({ notFound }: Props) {
           ))}
         </ul>
       )}
-    </CatalogPage>
+    </CatalogLayout>
   );
 }

--- a/apps/web/src/catalog/FamilyPage.tsx
+++ b/apps/web/src/catalog/FamilyPage.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from 'react';
+import { Link, useParams } from 'react-router-dom';
+
+import { catalog } from './registry';
+import { families } from './families';
+
+interface Props {
+  /** Rendered when the family id is unknown — injected by the shell. */
+  notFound: ReactNode;
+}
+
+/** /catalog/:family — the family definition and its components. */
+export function FamilyPage({ notFound }: Props) {
+  const { family: familyId = '' } = useParams();
+  const family = families.find((f) => f.id === familyId);
+
+  if (!family) return <>{notFound}</>;
+  const entries = catalog.byFamily(family.id);
+  return (
+    <main className="mx-auto min-h-screen max-w-3xl bg-slate-950 px-8 py-10 text-slate-100">
+      <p className="text-sm">
+        <Link to="/catalog" className="text-sky-400 hover:underline">
+          ← Catalog
+        </Link>
+      </p>
+      <h1 className="mt-4 text-4xl font-bold tracking-tight">{family.name}</h1>
+      <p className="mt-3 text-slate-300">{family.definition}</p>
+      <p className="mt-1 text-sm text-slate-500">{family.whatBelongs}</p>
+      {entries.length === 0 ? (
+        <p className="mt-10 text-slate-500">
+          No components in this family yet — the inventory is emergent (D29).
+        </p>
+      ) : (
+        <ul className="mt-10 space-y-4">
+          {entries.map((entry) => (
+            <li key={entry.name}>
+              <Link
+                to={`/catalog/c/${entry.name}`}
+                className="text-xl text-sky-300 hover:underline"
+              >
+                {entry.name}
+              </Link>
+              <p className="text-slate-400">{entry.description}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/apps/web/src/catalog/GovernancePage.tsx
+++ b/apps/web/src/catalog/GovernancePage.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { CatalogPage } from './CatalogPage';
 
 const CONTRACT_POINTS = [
   'Explicit render per mode — no component may ignore a mode (even if the answer is "I don\'t appear").',
@@ -12,8 +12,8 @@ const CONTRACT_POINTS = [
 
 const ADD_STEPS = [
   'Pick the family (estructura, semánticos, interactivos, media) — or propose a family change here first.',
-  'Implement the component in src/components/<family>/ satisfying the seven contract points below; register it in the shell MDX map (app/mdxComponents.ts) if documents use it directly.',
-  'Write its colocated <Component>.catalog.tsx entry (CatalogEntry from lib/) and export it through the components seam — the completeness test enforces this.',
+  'Implement the component in the family folder under src/components/ (estructura → structure/, semánticos → semantic/, interactivos → interactive/, media → media/), satisfying the seven contract points below; register it in the shell MDX map (app/mdxComponents.ts) if documents use it directly.',
+  'Write its colocated <Component>.catalog.tsx entry (CatalogEntry from lib/) and export it through the components seam — the catalog invariants test enforces this.',
   "Test per-mode behavior (contract point 1 gives the concrete cases) plus the component's own logic.",
   'Run the review flow: the review checklist below is part of the PR review.',
 ];
@@ -26,7 +26,7 @@ const DOC_CHECKLIST = [
 
 const REVIEW_CHECKLIST = [
   'All seven contract points verified (see Component contract).',
-  'Catalog entry present and accurate — the completeness test is green.',
+  'Catalog entry present and accurate — the catalog invariants test is green.',
   'Per-mode tests exist and pass; lint + build + full suite green.',
   'The integration guide steps were followed (docs/standards/integration-guides.md).',
 ];
@@ -34,12 +34,7 @@ const REVIEW_CHECKLIST = [
 /** /catalog/governance — the catalog's own rules (self-governing, ADR-0010). */
 export function GovernancePage() {
   return (
-    <main className="mx-auto min-h-screen max-w-3xl bg-slate-950 px-8 py-10 text-slate-100">
-      <p className="text-sm">
-        <Link to="/catalog" className="text-sky-400 hover:underline">
-          ← Catalog
-        </Link>
-      </p>
+    <CatalogPage back={{ to: '/catalog', label: 'Catalog' }}>
       <h1 className="mt-4 text-4xl font-bold tracking-tight">Governance</h1>
       <p className="mt-3 text-slate-400">
         The catalog governs itself (ADR-0010): these pages are the rules, and changing the rules
@@ -80,6 +75,6 @@ export function GovernancePage() {
         architectural (new family, contract point added/removed, catalog mechanics), it also needs
         an ADR extending ADR-0010 — documentation ships in the same PR.
       </p>
-    </main>
+    </CatalogPage>
   );
 }

--- a/apps/web/src/catalog/GovernancePage.tsx
+++ b/apps/web/src/catalog/GovernancePage.tsx
@@ -1,4 +1,8 @@
-import { CatalogPage } from './CatalogPage';
+import { CatalogLayout } from './CatalogLayout';
+import { families } from './families';
+
+// Derived, never retyped: a new family updates this page automatically.
+const FAMILY_FOLDERS = families.map((f) => `${f.name} → ${f.folder}/`).join(', ');
 
 const CONTRACT_POINTS = [
   'Explicit render per mode — no component may ignore a mode (even if the answer is "I don\'t appear").',
@@ -12,7 +16,7 @@ const CONTRACT_POINTS = [
 
 const ADD_STEPS = [
   'Pick the family (estructura, semánticos, interactivos, media) — or propose a family change here first.',
-  'Implement the component in the family folder under src/components/ (estructura → structure/, semánticos → semantic/, interactivos → interactive/, media → media/), satisfying the seven contract points below; register it in the shell MDX map (app/mdxComponents.ts) if documents use it directly.',
+  `Implement the component in its family folder under src/components/ (${FAMILY_FOLDERS}), satisfying the seven contract points below; register it in the shell MDX map (app/mdxComponents.ts) if documents use it directly.`,
   'Write its colocated <Component>.catalog.tsx entry (CatalogEntry from lib/) and export it through the components seam — the catalog invariants test enforces this.',
   "Test per-mode behavior (contract point 1 gives the concrete cases) plus the component's own logic.",
   'Run the review flow: the review checklist below is part of the PR review.',
@@ -34,7 +38,7 @@ const REVIEW_CHECKLIST = [
 /** /catalog/governance — the catalog's own rules (self-governing, ADR-0010). */
 export function GovernancePage() {
   return (
-    <CatalogPage back={{ to: '/catalog', label: 'Catalog' }}>
+    <CatalogLayout back={{ to: '/catalog', label: 'Catalog' }}>
       <h1 className="mt-4 text-4xl font-bold tracking-tight">Governance</h1>
       <p className="mt-3 text-slate-400">
         The catalog governs itself (ADR-0010): these pages are the rules, and changing the rules
@@ -75,6 +79,6 @@ export function GovernancePage() {
         architectural (new family, contract point added/removed, catalog mechanics), it also needs
         an ADR extending ADR-0010 — documentation ships in the same PR.
       </p>
-    </CatalogPage>
+    </CatalogLayout>
   );
 }

--- a/apps/web/src/catalog/GovernancePage.tsx
+++ b/apps/web/src/catalog/GovernancePage.tsx
@@ -1,0 +1,85 @@
+import { Link } from 'react-router-dom';
+
+const CONTRACT_POINTS = [
+  'Explicit render per mode — no component may ignore a mode (even if the answer is "I don\'t appear").',
+  'Typed props schema (TypeScript) — the public contract.',
+  'Mandatory catalog entry — usage docs, when-to-use, live examples. A PR adding a component without its entry fails review AND the completeness test.',
+  'Reserved optional sync interface — which session event types it emits/consumes (ADR-0008), designed per component when needed.',
+  'Client-side compute (ADR-0001) for any heavy work.',
+  'Feature-toggle props — capabilities switch on/off per instance.',
+  'Composition — abstract components may receive/render injected components.',
+];
+
+const ADD_STEPS = [
+  'Pick the family (estructura, semánticos, interactivos, media) — or propose a family change here first.',
+  'Implement the component in src/components/<family>/ satisfying the seven contract points below; register it in the shell MDX map (app/mdxComponents.ts) if documents use it directly.',
+  'Write its colocated <Component>.catalog.tsx entry (CatalogEntry from lib/) and export it through the components seam — the completeness test enforces this.',
+  "Test per-mode behavior (contract point 1 gives the concrete cases) plus the component's own logic.",
+  'Run the review flow: the review checklist below is part of the PR review.',
+];
+
+const DOC_CHECKLIST = [
+  'Entry complete: description, when-to-use, full props table (name, type, default, description).',
+  'At least two live examples that actually run — covering both modes when the component behaves differently per mode.',
+  'When-to-use says when NOT to use it too (what to prefer instead).',
+];
+
+const REVIEW_CHECKLIST = [
+  'All seven contract points verified (see Component contract).',
+  'Catalog entry present and accurate — the completeness test is green.',
+  'Per-mode tests exist and pass; lint + build + full suite green.',
+  'The integration guide steps were followed (docs/standards/integration-guides.md).',
+];
+
+/** /catalog/governance — the catalog's own rules (self-governing, ADR-0010). */
+export function GovernancePage() {
+  return (
+    <main className="mx-auto min-h-screen max-w-3xl bg-slate-950 px-8 py-10 text-slate-100">
+      <p className="text-sm">
+        <Link to="/catalog" className="text-sky-400 hover:underline">
+          ← Catalog
+        </Link>
+      </p>
+      <h1 className="mt-4 text-4xl font-bold tracking-tight">Governance</h1>
+      <p className="mt-3 text-slate-400">
+        The catalog governs itself (ADR-0010): these pages are the rules, and changing the rules
+        goes through the process at the bottom.
+      </p>
+
+      <h2 className="mt-10 text-2xl font-semibold">How to add a component</h2>
+      <ol className="mt-3 list-decimal space-y-2 pl-6 text-slate-300">
+        {ADD_STEPS.map((step) => (
+          <li key={step}>{step}</li>
+        ))}
+      </ol>
+
+      <h2 className="mt-10 text-2xl font-semibold">Component contract</h2>
+      <ol className="mt-3 list-decimal space-y-2 pl-6 text-slate-300">
+        {CONTRACT_POINTS.map((point) => (
+          <li key={point}>{point}</li>
+        ))}
+      </ol>
+
+      <h2 className="mt-10 text-2xl font-semibold">Documentation checklist</h2>
+      <ul className="mt-3 list-disc space-y-2 pl-6 text-slate-300">
+        {DOC_CHECKLIST.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+
+      <h2 className="mt-10 text-2xl font-semibold">Review checklist</h2>
+      <ul className="mt-3 list-disc space-y-2 pl-6 text-slate-300">
+        {REVIEW_CHECKLIST.map((item) => (
+          <li key={item}>{item}</li>
+        ))}
+      </ul>
+
+      <h2 className="mt-10 text-2xl font-semibold">Changing these rules</h2>
+      <p className="mt-3 text-slate-300">
+        A PR that edits these governance pages, reviewed like any other change. If the change is
+        architectural (new family, contract point added/removed, catalog mechanics), it also needs
+        an ADR extending ADR-0010 — documentation ships in the same PR.
+      </p>
+    </main>
+  );
+}

--- a/apps/web/src/catalog/GovernancePage.tsx
+++ b/apps/web/src/catalog/GovernancePage.tsx
@@ -15,16 +15,17 @@ const CONTRACT_POINTS = [
 ];
 
 const ADD_STEPS = [
-  'Pick the family (estructura, semánticos, interactivos, media) — or propose a family change here first.',
-  `Implement the component in its family folder under src/components/ (${FAMILY_FOLDERS}), satisfying the seven contract points below; register it in the shell MDX map (app/mdxComponents.ts) if documents use it directly.`,
-  'Write its colocated <Component>.catalog.tsx entry (CatalogEntry from lib/) and export it through the components seam — the catalog invariants test enforces this.',
+  `Pick the family (${families.map((f) => f.name).join(', ')}) — or propose a family change here first.`,
+  `Implement the component in its family folder under src/components/ (${FAMILY_FOLDERS}), satisfying the seven contract points below.`,
+  'Register it in the shell MDX map (app/mdxComponents.ts). Not optional: the catalog and the MDX map are asserted to be the same set in both directions, so today a component that must not be document-facing does not get an entry either (ADR-0014 reserves an explicit opt-out for the composed-component case).',
+  'Write its colocated <Component>.catalog.tsx entry (CatalogEntry from lib/) and add it to catalogEntries in the components seam. A forgotten export makes the entry invisible to the catalog; app/mdxComponents.test.ts is what catches it ("missing catalog entry for <Name>"), not the entry-shape invariants.',
   "Test per-mode behavior (contract point 1 gives the concrete cases) plus the component's own logic.",
   'Run the review flow: the review checklist below is part of the PR review.',
 ];
 
 const DOC_CHECKLIST = [
-  'Entry complete: description, when-to-use, full props table (name, type, default, description).',
-  'At least two live examples that actually run — covering both modes when the component behaves differently per mode.',
+  'Entry complete: non-empty description and when-to-use, and every prop documented with a type and a description.',
+  'At least two live examples that actually run, with distinct titles — covering both modes when the component behaves differently per mode.',
   'When-to-use says when NOT to use it too (what to prefer instead).',
 ];
 

--- a/apps/web/src/catalog/architecture.test.tsx
+++ b/apps/web/src/catalog/architecture.test.tsx
@@ -1,0 +1,67 @@
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import { catalog } from './registry';
+import { families } from './families';
+
+// L4 invariants over the live catalog (testing-strategy.md). These enforce the
+// documentation checklist the governance page publishes — without them the
+// checklist would be review-only, and a hollow entry would ship green.
+// The MDX-map <-> catalog binding lives in app/mdxComponents.test.ts instead:
+// features may not import app/, so only the shell can hold that pair.
+describe('architecture: catalog entry invariants', () => {
+  it('the catalog is not empty (guards against a vacuous suite)', () => {
+    expect(catalog.entries.length).toBeGreaterThan(0);
+  });
+
+  it('every family in the taxonomy has a definition and a components folder', () => {
+    for (const family of families) {
+      expect(family.name.trim(), `family ${family.id} needs a name`).not.toBe('');
+      expect(family.folder.trim(), `family ${family.id} needs a folder`).not.toBe('');
+      expect(family.definition.trim(), `family ${family.id} needs a definition`).not.toBe('');
+    }
+  });
+
+  for (const entry of catalog.entries) {
+    describe(entry.name, () => {
+      it('documents description and when-to-use', () => {
+        expect(entry.description.trim()).not.toBe('');
+        expect(entry.whenToUse.trim()).not.toBe('');
+      });
+
+      it('belongs to a known family', () => {
+        expect(families.map((f) => f.id)).toContain(entry.family);
+      });
+
+      it('documents every prop fully', () => {
+        for (const prop of entry.props) {
+          expect(prop.name.trim(), 'prop needs a name').not.toBe('');
+          expect(prop.type.trim(), `prop ${prop.name} needs a type`).not.toBe('');
+          expect(prop.description.trim(), `prop ${prop.name} needs a description`).not.toBe('');
+        }
+      });
+
+      it('ships at least two examples with distinct titles', () => {
+        expect(entry.examples.length).toBeGreaterThanOrEqual(2);
+        const titles = entry.examples.map((e) => e.title);
+        expect(new Set(titles).size, `duplicate example titles: ${titles.join(', ')}`).toBe(
+          titles.length,
+        );
+      });
+
+      for (const example of entry.examples) {
+        it(`renders live output for "${example.title}"`, () => {
+          const Example = example.render;
+          const { container } = render(
+            <MemoryRouter>
+              <Example />
+            </MemoryRouter>,
+          );
+          expect(container, 'the example rendered nothing').not.toBeEmptyDOMElement();
+          expect(example.code.trim(), 'the example needs a source snippet').not.toBe('');
+        });
+      }
+    });
+  }
+});

--- a/apps/web/src/catalog/architecture.test.tsx
+++ b/apps/web/src/catalog/architecture.test.tsx
@@ -3,7 +3,10 @@ import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
 
 import { catalog } from './registry';
-import { families } from './families';
+import { families, folderOf } from './families';
+
+// The catalog publishes each component's source path; this proves it resolves.
+const componentModules = import.meta.glob('../components/*/*.tsx');
 
 // L4 invariants over the live catalog (testing-strategy.md). These enforce the
 // documentation checklist the governance page publishes — without them the
@@ -32,6 +35,12 @@ describe('architecture: catalog entry invariants', () => {
 
       it('belongs to a known family', () => {
         expect(families.map((f) => f.id)).toContain(entry.family);
+      });
+
+      it('the source path the catalog publishes actually exists', () => {
+        expect(Object.keys(componentModules)).toContain(
+          `../components/${folderOf(entry.family)}/${entry.name}.tsx`,
+        );
       });
 
       it('documents every prop fully', () => {

--- a/apps/web/src/catalog/families.ts
+++ b/apps/web/src/catalog/families.ts
@@ -2,39 +2,53 @@ import type { CatalogFamily } from '../lib/catalogEntry';
 
 export interface FamilyDef {
   id: CatalogFamily;
-  /** Display name (family ids stay kebab-safe for routes). */
+  /** Display name (ids stay unaccented because they are route segments). */
   name: string;
+  /** Folder under src/components/ — English, unlike the Spanish family id. */
+  folder: string;
   definition: string;
   whatBelongs: string;
 }
 
-/** The four editable families (ADR-0010). Order is display order. */
-export const families: FamilyDef[] = [
-  {
-    id: 'estructura',
+// Record (not an array) so adding a CatalogFamily member without its definition
+// fails to compile — the family taxonomy cannot drift from its presentation.
+const definitions: Record<CatalogFamily, Omit<FamilyDef, 'id'>> = {
+  estructura: {
     name: 'Estructura',
+    folder: 'structure',
     definition: 'Components that shape how a document flows and breaks into slides.',
     whatBelongs:
       'Anything that organizes content without being content itself: slide boundaries, section breaks, future layout blocks.',
   },
-  {
-    id: 'semanticos',
+  semanticos: {
     name: 'Semánticos',
+    folder: 'semantic',
     definition: 'Components that mark what a piece of content MEANS.',
     whatBelongs:
       'Definitions, theorems, warnings, key ideas — semantic wrappers that style and index meaning, not behavior.',
   },
-  {
-    id: 'interactivos',
+  interactivos: {
     name: 'Interactivos',
+    folder: 'interactive',
     definition: 'Components the student operates: they hold state and respond.',
     whatBelongs:
       'Visualizers, code editors, quizzes, steppers — anything with client-side behavior (ADR-0001).',
   },
-  {
-    id: 'media',
+  media: {
     name: 'Media',
+    folder: 'media',
     definition: 'Components that embed external or heavy media.',
     whatBelongs: 'Images with behavior, video, audio, embeds — media beyond plain Markdown.',
   },
-];
+};
+
+/** The four families in display order (ADR-0010). */
+export const families: FamilyDef[] = (Object.keys(definitions) as CatalogFamily[]).map((id) => ({
+  id,
+  ...definitions[id],
+}));
+
+/** The src/components/ folder a family's components live in. */
+export function folderOf(family: CatalogFamily): string {
+  return definitions[family].folder;
+}

--- a/apps/web/src/catalog/families.ts
+++ b/apps/web/src/catalog/families.ts
@@ -1,0 +1,40 @@
+import type { CatalogFamily } from '../lib/catalogEntry';
+
+export interface FamilyDef {
+  id: CatalogFamily;
+  /** Display name (family ids stay kebab-safe for routes). */
+  name: string;
+  definition: string;
+  whatBelongs: string;
+}
+
+/** The four editable families (ADR-0010). Order is display order. */
+export const families: FamilyDef[] = [
+  {
+    id: 'estructura',
+    name: 'Estructura',
+    definition: 'Components that shape how a document flows and breaks into slides.',
+    whatBelongs:
+      'Anything that organizes content without being content itself: slide boundaries, section breaks, future layout blocks.',
+  },
+  {
+    id: 'semanticos',
+    name: 'Semánticos',
+    definition: 'Components that mark what a piece of content MEANS.',
+    whatBelongs:
+      'Definitions, theorems, warnings, key ideas — semantic wrappers that style and index meaning, not behavior.',
+  },
+  {
+    id: 'interactivos',
+    name: 'Interactivos',
+    definition: 'Components the student operates: they hold state and respond.',
+    whatBelongs:
+      'Visualizers, code editors, quizzes, steppers — anything with client-side behavior (ADR-0001).',
+  },
+  {
+    id: 'media',
+    name: 'Media',
+    definition: 'Components that embed external or heavy media.',
+    whatBelongs: 'Images with behavior, video, audio, embeds — media beyond plain Markdown.',
+  },
+];

--- a/apps/web/src/catalog/index.ts
+++ b/apps/web/src/catalog/index.ts
@@ -3,4 +3,5 @@ export { CatalogOverviewPage } from './CatalogOverviewPage';
 export { ComponentPage } from './ComponentPage';
 export { FamilyPage } from './FamilyPage';
 export { GovernancePage } from './GovernancePage';
+export { families } from './families';
 export { catalog } from './registry';

--- a/apps/web/src/catalog/index.ts
+++ b/apps/web/src/catalog/index.ts
@@ -1,3 +1,4 @@
 // Public seam of the catalog feature (import direction rule, frontend-code-style.md).
 export { CatalogOverviewPage } from './CatalogOverviewPage';
+export { ComponentPage } from './ComponentPage';
 export { FamilyPage } from './FamilyPage';

--- a/apps/web/src/catalog/index.ts
+++ b/apps/web/src/catalog/index.ts
@@ -2,3 +2,5 @@
 export { CatalogOverviewPage } from './CatalogOverviewPage';
 export { ComponentPage } from './ComponentPage';
 export { FamilyPage } from './FamilyPage';
+export { GovernancePage } from './GovernancePage';
+export { catalog } from './registry';

--- a/apps/web/src/catalog/index.ts
+++ b/apps/web/src/catalog/index.ts
@@ -1,0 +1,3 @@
+// Public seam of the catalog feature (import direction rule, frontend-code-style.md).
+export { CatalogOverviewPage } from './CatalogOverviewPage';
+export { FamilyPage } from './FamilyPage';

--- a/apps/web/src/catalog/registry.test.ts
+++ b/apps/web/src/catalog/registry.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CatalogEntry } from '../lib/catalogEntry';
+
+import { buildCatalog } from './registry';
+
+function entry(name: string, family: CatalogEntry['family']): CatalogEntry {
+  return {
+    name,
+    family,
+    description: `${name} description`,
+    whenToUse: 'whenever',
+    props: [],
+    examples: [],
+  };
+}
+
+describe('buildCatalog', () => {
+  it('indexes entries by name and groups them by family', () => {
+    const catalog = buildCatalog([entry('Slide', 'estructura'), entry('Video', 'media')]);
+
+    expect(catalog.byName('Slide')?.family).toBe('estructura');
+    expect(catalog.byName('missing')).toBeUndefined();
+    expect(catalog.byFamily('estructura').map((e) => e.name)).toEqual(['Slide']);
+    expect(catalog.byFamily('interactivos')).toEqual([]);
+  });
+
+  it('throws on duplicate entry names', () => {
+    expect(() =>
+      buildCatalog([entry('Slide', 'estructura'), entry('Slide', 'media')]),
+    ).toThrowError(/duplicate catalog entry "Slide"/);
+  });
+});

--- a/apps/web/src/catalog/registry.test.ts
+++ b/apps/web/src/catalog/registry.test.ts
@@ -25,6 +25,17 @@ describe('buildCatalog', () => {
     expect(catalog.byFamily('interactivos')).toEqual([]);
   });
 
+  it('snapshots its input: later mutation of the source array changes nothing', () => {
+    const source = [entry('Slide', 'estructura')];
+    const built = buildCatalog(source);
+
+    source.push(entry('Latecomer', 'media'));
+
+    expect(built.entries).toHaveLength(1);
+    expect(built.byName('Latecomer')).toBeUndefined();
+    expect(built.byFamily('media')).toEqual([]);
+  });
+
   it('throws on duplicate entry names', () => {
     expect(() =>
       buildCatalog([entry('Slide', 'estructura'), entry('Slide', 'media')]),

--- a/apps/web/src/catalog/registry.ts
+++ b/apps/web/src/catalog/registry.ts
@@ -8,7 +8,7 @@ export interface Catalog {
 }
 
 /** Builds the catalog index; throws on duplicate names (fail-fast, like the content registry). */
-export function buildCatalog(entries: CatalogEntry[]): Catalog {
+export function buildCatalog(entries: readonly CatalogEntry[]): Catalog {
   // Snapshot: later mutation of the caller's array must not desynchronize the
   // name index from the family lists (nor bypass the duplicate check).
   const all: readonly CatalogEntry[] = Object.freeze([...entries]);

--- a/apps/web/src/catalog/registry.ts
+++ b/apps/web/src/catalog/registry.ts
@@ -2,24 +2,27 @@ import { catalogEntries } from '../components';
 import type { CatalogEntry, CatalogFamily } from '../lib/catalogEntry';
 
 export interface Catalog {
-  entries: CatalogEntry[];
+  entries: readonly CatalogEntry[];
   byName(name: string): CatalogEntry | undefined;
   byFamily(family: CatalogFamily): CatalogEntry[];
 }
 
 /** Builds the catalog index; throws on duplicate names (fail-fast, like the content registry). */
 export function buildCatalog(entries: CatalogEntry[]): Catalog {
+  // Snapshot: later mutation of the caller's array must not desynchronize the
+  // name index from the family lists (nor bypass the duplicate check).
+  const all: readonly CatalogEntry[] = Object.freeze([...entries]);
   const byName = new Map<string, CatalogEntry>();
-  for (const entry of entries) {
+  for (const entry of all) {
     if (byName.has(entry.name)) {
       throw new Error(`Catalog: duplicate catalog entry "${entry.name}"`);
     }
     byName.set(entry.name, entry);
   }
   return {
-    entries,
+    entries: all,
     byName: (name) => byName.get(name),
-    byFamily: (family) => entries.filter((e) => e.family === family),
+    byFamily: (family) => all.filter((e) => e.family === family),
   };
 }
 

--- a/apps/web/src/catalog/registry.ts
+++ b/apps/web/src/catalog/registry.ts
@@ -1,0 +1,27 @@
+import { catalogEntries } from '../components';
+import type { CatalogEntry, CatalogFamily } from '../lib/catalogEntry';
+
+export interface Catalog {
+  entries: CatalogEntry[];
+  byName(name: string): CatalogEntry | undefined;
+  byFamily(family: CatalogFamily): CatalogEntry[];
+}
+
+/** Builds the catalog index; throws on duplicate names (fail-fast, like the content registry). */
+export function buildCatalog(entries: CatalogEntry[]): Catalog {
+  const byName = new Map<string, CatalogEntry>();
+  for (const entry of entries) {
+    if (byName.has(entry.name)) {
+      throw new Error(`Catalog: duplicate catalog entry "${entry.name}"`);
+    }
+    byName.set(entry.name, entry);
+  }
+  return {
+    entries,
+    byName: (name) => byName.get(name),
+    byFamily: (family) => entries.filter((e) => e.family === family),
+  };
+}
+
+/** The live catalog over every entry exported by the component features. */
+export const catalog = buildCatalog(catalogEntries);

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -1,3 +1,8 @@
 // Public seam of the components feature (import direction rule, frontend-code-style.md).
+import type { CatalogEntry } from '../lib/catalogEntry';
+
 export { SectionBreak } from './structure/SectionBreak';
 export { Slide } from './structure/Slide';
+
+/** Every catalog entry this feature ships (colocated *.catalog.tsx files). */
+export const catalogEntries: CatalogEntry[] = [];

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -1,8 +1,11 @@
 // Public seam of the components feature (import direction rule, frontend-code-style.md).
 import type { CatalogEntry } from '../lib/catalogEntry';
 
+import { sectionBreakCatalogEntry } from './structure/SectionBreak.catalog';
+import { slideCatalogEntry } from './structure/Slide.catalog';
+
 export { SectionBreak } from './structure/SectionBreak';
 export { Slide } from './structure/Slide';
 
 /** Every catalog entry this feature ships (colocated *.catalog.tsx files). */
-export const catalogEntries: CatalogEntry[] = [];
+export const catalogEntries: CatalogEntry[] = [slideCatalogEntry, sectionBreakCatalogEntry];

--- a/apps/web/src/components/structure/SectionBreak.catalog.tsx
+++ b/apps/web/src/components/structure/SectionBreak.catalog.tsx
@@ -1,0 +1,39 @@
+import type { CatalogEntry } from '../../lib/catalogEntry';
+import { ModeProvider } from '../../presentation';
+
+import { SectionBreak } from './SectionBreak';
+
+/** Catalog entry (ADR-0010) — colocated with the component, exported via the seam. */
+export const sectionBreakCatalogEntry: CatalogEntry = {
+  name: 'SectionBreak',
+  family: 'estructura',
+  description:
+    'Slide boundary without a heading. In the book it reads as a subtle divider; in presentation mode it cuts a new untitled slide and renders nothing itself.',
+  whenToUse:
+    'When the deck needs a cut that the book should barely notice — e.g., a closing remark on its own slide, or including unmarked prose in an explicit deck.',
+  props: [],
+  examples: [
+    {
+      title: 'Book mode (default): a subtle divider between paragraphs',
+      code: '<p>Antes…</p>\n<SectionBreak />\n<p>Después…</p>',
+      render: () => (
+        <>
+          <p>Antes…</p>
+          <SectionBreak />
+          <p>Después…</p>
+        </>
+      ),
+    },
+    {
+      title: 'Presentation mode: renders nothing (the parser consumes the boundary)',
+      code: '<ModeProvider mode="presentation">\n  <p>Antes…</p>\n  <SectionBreak />\n  <p>Después…</p>\n</ModeProvider>',
+      render: () => (
+        <ModeProvider mode="presentation">
+          <p>Antes…</p>
+          <SectionBreak />
+          <p>Después…</p>
+        </ModeProvider>
+      ),
+    },
+  ],
+};

--- a/apps/web/src/components/structure/Slide.catalog.tsx
+++ b/apps/web/src/components/structure/Slide.catalog.tsx
@@ -1,0 +1,48 @@
+import type { CatalogEntry } from '../../lib/catalogEntry';
+import { ModeProvider } from '../../presentation';
+
+import { Slide } from './Slide';
+
+/** Catalog entry (ADR-0010) — colocated with the component, exported via the seam. */
+export const slideCatalogEntry: CatalogEntry = {
+  name: 'Slide',
+  family: 'estructura',
+  description:
+    'Explicit slide boundary. In the book it reads as a normal section (heading + flowing prose); in presentation mode it becomes one slide whose title is the viewer chrome.',
+  whenToUse:
+    'When a section of the document should be exactly one slide — especially with presentation: explicit, where ONLY marked content forms the deck. Prefer plain h2 sections when auto slicing already gives the deck you want.',
+  props: [
+    {
+      name: 'title',
+      type: 'string',
+      description: 'Section heading in the book; slide title in the presentation.',
+    },
+    {
+      name: 'children',
+      type: 'ReactNode',
+      description: 'The slide content — flows as prose in the book.',
+    },
+  ],
+  examples: [
+    {
+      title: 'Book mode (default): heading + flowing prose',
+      code: '<Slide title="La idea">\n  Comparamos el objetivo con el elemento del medio…\n</Slide>',
+      render: () => (
+        <Slide title="La idea">
+          <p>Comparamos el objetivo con el elemento del medio…</p>
+        </Slide>
+      ),
+    },
+    {
+      title: 'Presentation mode: children only (the title becomes viewer chrome)',
+      code: '<ModeProvider mode="presentation">\n  <Slide title="La idea">…</Slide>\n</ModeProvider>',
+      render: () => (
+        <ModeProvider mode="presentation">
+          <Slide title="La idea">
+            <p>Comparamos el objetivo con el elemento del medio…</p>
+          </Slide>
+        </ModeProvider>
+      ),
+    },
+  ],
+};

--- a/apps/web/src/lib/catalogEntry.ts
+++ b/apps/web/src/lib/catalogEntry.ts
@@ -1,0 +1,33 @@
+import type { ReactNode } from 'react';
+
+/**
+ * The catalog contract every content component ships (ADR-0010): colocated as
+ * `<Component>.catalog.tsx` beside the component, exported through the owning
+ * feature's seam. Lives in lib/ so entries never import the catalog feature
+ * (which would close a feature cycle) — same reasoning as componentMeta.
+ */
+export type CatalogFamily = 'estructura' | 'semanticos' | 'interactivos' | 'media';
+
+export interface CatalogPropDef {
+  name: string;
+  type: string;
+  default?: string;
+  description: string;
+}
+
+export interface CatalogExample {
+  title: string;
+  /** Source snippet shown beside the live render (plain <pre>, decided in #65). */
+  code: string;
+  render: () => ReactNode;
+}
+
+export interface CatalogEntry {
+  /** Must match the MDX-registered name (the completeness test keys on it). */
+  name: string;
+  family: CatalogFamily;
+  description: string;
+  whenToUse: string;
+  props: CatalogPropDef[];
+  examples: CatalogExample[];
+}

--- a/apps/web/src/lib/catalogEntry.ts
+++ b/apps/web/src/lib/catalogEntry.ts
@@ -1,11 +1,6 @@
-import type { ReactNode } from 'react';
+import type { ComponentType } from 'react';
 
-/**
- * The catalog contract every content component ships (ADR-0010): colocated as
- * `<Component>.catalog.tsx` beside the component, exported through the owning
- * feature's seam. Lives in lib/ so entries never import the catalog feature
- * (which would close a feature cycle) — same reasoning as componentMeta.
- */
+/** The four editable catalog families (ADR-0010); ids double as route segments. */
 export type CatalogFamily = 'estructura' | 'semanticos' | 'interactivos' | 'media';
 
 export interface CatalogPropDef {
@@ -19,9 +14,16 @@ export interface CatalogExample {
   title: string;
   /** Source snippet shown beside the live render (plain <pre>, decided in #65). */
   code: string;
-  render: () => ReactNode;
+  /** A component, not a call: each example gets its own React instance (own hooks/state). */
+  render: ComponentType;
 }
 
+/**
+ * The catalog contract every content component ships (ADR-0010): colocated as
+ * `<Component>.catalog.tsx` beside the component, exported through the owning
+ * feature's seam. Lives in lib/ so entries never import the catalog feature
+ * (which would close a feature cycle) — same reasoning as componentMeta.
+ */
 export interface CatalogEntry {
   /** Must match the MDX-registered name (the completeness test keys on it). */
   name: string;

--- a/apps/web/src/lib/catalogEntry.ts
+++ b/apps/web/src/lib/catalogEntry.ts
@@ -12,7 +12,7 @@ export interface CatalogPropDef {
 
 export interface CatalogExample {
   title: string;
-  /** Source snippet shown beside the live render (plain <pre>, decided in #65). */
+  /** Source snippet shown beside the live render; plain <pre>, no highlighter (ADR-0014). */
   code: string;
   /** A component, not a call: each example gets its own React instance (own hooks/state). */
   render: ComponentType;

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -107,6 +107,10 @@ Refs #<N>
 
 PRs must be **squash-merged** manually by the user.
 
+**Component PRs**: any PR adding or modifying a content component must include
+its catalog entry (ADR-0010; enforced by the completeness test and the review
+checklist at `/catalog/governance`).
+
 ## Worktrees
 
 Each WP is developed in its own worktree to allow parallel work:

--- a/docs/decisions/0014-catalog-implementation.md
+++ b/docs/decisions/0014-catalog-implementation.md
@@ -1,0 +1,98 @@
+# ADR-0014: Catalog implementation — entry model, registry, enforcement
+
+**Status:** Accepted
+**Date:** 2026-08-10
+**Decision-makers:** Miguel Rodriguez
+**Source:** Issue #65 (WP4, component catalog). Extends ADR-0010 (component
+contract and self-governing catalog), which decided the catalog exists, named
+the four families, and deferred its shape to v0.1.
+
+## Context
+
+ADR-0010 made a catalog entry mandatory for every content component but fixed no
+shape for it, no place to keep it, and no way to enforce it. WP4 turned contract
+point 3 into running code, which forced decisions about the entry model, how
+entries reach the catalog, and what a machine can check.
+
+## Decision
+
+1. **Entry model** — `CatalogEntry` (`lib/catalogEntry.ts`): `name`, `family`,
+   `description`, `whenToUse`, a hand-authored `props` table
+   (`{name, type, default?, description}`), and `examples`
+   (`{title, code, render}`). The type lives in `lib/` so a colocated entry
+   never imports the catalog feature (cycle avoidance, as with `componentMeta`).
+   **Accepted limits**: the props table is prose, not derived from the component's
+   TS interface, and each example's `code` string is written beside its `render`
+   component — both can drift from the implementation, and nothing detects it.
+   The entry covers ADR-0010 contract points 2 and 3 only; there is no field for
+   point 1 (per-mode behavior — it is proven by tests and shown by the examples)
+   nor point 4 (sync interface — nothing emits session events yet). Fields get
+   added when a component needs them, not speculatively (D29).
+
+2. **Entries are colocated and reach the catalog through their feature's seam**:
+   `<Component>.catalog.tsx` beside the component, aggregated in the components
+   seam as `catalogEntries`, consumed by `catalog/registry.ts`. Chosen over
+   `import.meta.glob` auto-discovery: the explicit array is greppable, the
+   registry stays a pure function testable with fixtures, and a forgotten export
+   is caught by the completeness gate anyway.
+
+3. **The catalog set equals the MDX-registered set** — asserted in both
+   directions (`app/mdxComponents.test.ts`). A document-facing component must
+   have an entry (ADR-0010 point 3), and a catalogued component must be nameable
+   in a document, otherwise the catalog documents something authors cannot use.
+   **Known future exception**: ADR-0010 point 7 anticipates abstract components
+   that render injected components. If such a component is genuinely never named
+   bare in MDX, it is admitted by adding an explicit opt-out to the entry (e.g.
+   `documentFacing: false`) and scoping the reverse assertion to entries without
+   it — not by weakening or deleting the test.
+
+4. **Enforcement is executable, split across two L4 files**: entry-shape
+   invariants in `catalog/architecture.test.tsx` (non-empty description and
+   when-to-use, every prop typed and described, ≥2 examples with distinct
+   titles, every example rendered and asserted non-empty, and the source path the
+   catalog publishes resolving via `import.meta.glob`); the MDX-map binding in
+   `app/mdxComponents.test.ts`, which must live in the shell because features may
+   not import `app/`. Both are registry-driven with a non-vacuity guard
+   (`testing-strategy.md`).
+
+5. **Governance is product surface**: the contract, the how-to-add steps and the
+   checklists render at `/catalog/governance`. Authority: this ADR and ADR-0010
+   record the decisions and why; the governance page is the living operational
+   source authors and agents read; the integration guide maps it onto repo paths.
+   On disagreement the ADRs win until superseded — changing the rules
+   architecturally requires an ADR extending ADR-0010.
+
+6. **Routes**: `/catalog`, `/catalog/:family`, `/catalog/c/:name`,
+   `/catalog/governance`. The `/c/` segment exists so component names cannot
+   collide with family ids. Family ids are unaccented Spanish (they double as
+   route segments, matching ADR-0010's Spanish family names) while component
+   folders are English per the code-style rule; the mapping is typed once in
+   `catalog/families.ts`.
+
+7. **Example snippets are plain `<pre>`** — no syntax highlighter. Deferred
+   until a real need appears, per the dependency rule.
+
+## Alternatives considered
+
+- **Storybook / CSF**: rejected at catalog level by ADR-0010; restated here at
+  entry level — the catalog is product surface for authors, not a dev tool.
+- **Props derived from TS types** (react-docgen-typescript or similar): removes
+  the drift accepted in Decision 1, but adds build machinery for two components.
+  Revisit when the inventory grows or the first drift bites.
+- **Single-sourced examples** (import the snippet from the rendered file):
+  removes the `code`/`render` drift; costs a raw-import pipeline. Deferred.
+- **Glob auto-discovery of entries**: less ceremony, but implicit registration
+  and a registry that cannot be unit-tested with fixtures.
+- **Governance in `docs/` only**: rejected — ADR-0010 chose a self-governing
+  catalog, and authors read the product, not the repo.
+
+## Consequences
+
+- Adding a component has a fixed, machine-checked cost: entry + registration +
+  two examples that must actually render. The checklist is no longer advisory.
+- Props tables and code snippets can lie without any gate; reviewers own that
+  until an alternative above is adopted. Recorded so the gap is deliberate.
+- The first abstract/injected component will exercise the escape hatch in
+  Decision 3 — the test is written to be scoped, not deleted.
+- `catalog → components` is an allowed feature edge (recorded in
+  `frontend-code-style.md`); the catalog imports no other feature.

--- a/docs/security-notes.md
+++ b/docs/security-notes.md
@@ -4,9 +4,9 @@ Durable record of security decisions that are not ADR-scale: accepted-risk
 deferrals, advisory dispositions, and their review dates. Every deferral here
 names its trigger for re-evaluation — nothing is "accepted forever".
 
-## Deferred advisories
+## Resolved advisories
 
-### GHSA-qwww-vcr4-c8h2 — react-router RSC-mode CSRF (deferred 2026-08-06)
+### GHSA-qwww-vcr4-c8h2 — react-router RSC-mode CSRF (deferred 2026-08-06, RESOLVED 2026-08-10)
 
 - **Affected**: `react-router` >=7.12.0 <8.3.0 (installed 7.18.2, transitive via
   `react-router-dom`).
@@ -15,10 +15,15 @@ names its trigger for re-evaluation — nothing is "accepted forever".
   runtime — premise backed by ADR-0001/0004/0011; static hosting on GitHub Pages
   pending, WP5 #66). Verified independently by the security review lens
   (PR #67 pipeline run).
-- **Patched line**: 8.3.0 — a major bump; not worth forcing for an unreachable path.
-- **Review trigger**: the next react-router upgrade evaluation, or the moment any
-  server runtime/SSR/RSC enters the frontend (v0.3 backend does NOT count — it is
-  a separate Go service). Re-check with `npm audit` at each dependency review.
+- **Resolution (2026-08-10)**: the advisory was later amended upstream — its 7.x
+  range is `>=7.12.0 <7.18.2`, first patched in **7.18.2**, which is the version
+  already installed. `npm audit` in `apps/web` reports 0 vulnerabilities.
+  Nothing was ever exposed and no upgrade is owed; the original note's "patched
+  line 8.3.0 — a major bump" was accurate against the advisory as published on
+  2026-08-06 and is superseded. Kept as a record, not as an open deferral.
+- **Lesson kept**: the deferral rationale (static SPA, RSC path unreachable) was
+  the right call and cost nothing; re-checking with `npm audit` at each
+  dependency review is what surfaced the amendment.
 
 ## Accepted invariants
 

--- a/docs/standards/documentation.md
+++ b/docs/standards/documentation.md
@@ -18,12 +18,21 @@ finished until its documentation exists, and review verifies it (ADR-0005).
 | Architectural decisions | `docs/decisions/` (ADRs, numbered) | why Go, why MDX |
 | Design narratives | `docs/design/` | 2026-08 redesign |
 | Content-component usage (what authors see) | The **catalog** (`/catalog` in-app) | when to use `<Slide>`, props, examples |
+| Component governance (contract, how-to-add, doc + review checklists) | The **catalog governance page** (`/catalog/governance`, authored in `apps/web/src/catalog/GovernancePage.tsx`) — the operational home authors and agents read; ADR-0010/0014 hold the decisions and win on disagreement, `guides/add-a-content-component.md` maps them onto repo paths | the seven contract points |
 | Workflow conventions (kanban, branches, PRs) | `docs/conventions.md` | commit format |
 | Security deferrals / advisory dispositions | `docs/security-notes.md` | accepted-risk records with review triggers |
 | Course planning material | `docs/course-graph.md` + `docs/graphs/` | topic dependencies, topology diagrams |
 
 **One home per fact.** If two documents need the same fact, one states it and the
 other links to it. Duplicated prose drifts.
+
+**Documentation that must never drift is written as code and gated by a test.**
+When a doc describes a set that grows (components today; event types, endpoints
+tomorrow), prefer a typed entry colocated with each member over a hand-maintained
+page, expose it as a product surface, and add an L4 invariant that fails on
+hollow entries — empty required prose, missing examples, examples that render
+nothing, published paths that do not resolve. Prose pages stay the default for
+one-off narratives. Worked case: the catalog (#65).
 
 ## Rules
 

--- a/docs/standards/frontend-code-style.md
+++ b/docs/standards/frontend-code-style.md
@@ -39,13 +39,18 @@ src/
   pattern imported from DocumentBuddy's architecture tests.)
 - **Cross-feature dependencies are an explicit allowlist**, mirrored by
   `FEATURE_EDGES` in `src/architecture.test.ts`. Current edges:
-  `components → presentation` (mode awareness via `useMode`),
+  `components → presentation` (mode awareness via `useMode`; `ModeProvider` to
+  stage per-mode catalog examples),
   `presentation → content` (registry + lazy document access), and
   `catalog → components` (renders the entries and live examples the components
   feature exports through its seam). Adding an edge is
   an architectural decision: extend the map AND record the new edge + rationale
   here in the same PR. Test files may cross any feature through its seam (they
   are consumers, like the shell); production code follows the allowlist.
+- **Cross-feature contract types live in `lib/`** (e.g. `lib/catalogEntry.ts`,
+  `lib/componentMeta.ts`) so the producing feature never imports the consuming
+  one. Worked case: a component's colocated catalog entry types itself from
+  `lib/` — importing the catalog feature would close a cycle.
 - **Cross-feature element identity travels as static metadata**, never as
   component-identity imports: declare with `withMeta` and inspect with `metaOf`
   (`lib/componentMeta.ts`). Worked case: the slide parser recognizes
@@ -66,6 +71,9 @@ src/
 ## Naming
 
 - Component files: `PascalCase.tsx`, named after the component (`NotFound.tsx`).
+- Colocated catalog entries: `<Component>.catalog.tsx` beside the component,
+  exporting `<component>CatalogEntry: CatalogEntry` — a `.tsx` module that
+  exports data, not a component (its examples are JSX).
 - Hooks: `useThing.ts`, exported as `useThing`.
 - Everything else: `camelCase.ts` (`parser.ts`, `wikiLinks.ts`).
 - One exported component per file; small private subcomponents may live beside it

--- a/docs/standards/frontend-code-style.md
+++ b/docs/standards/frontend-code-style.md
@@ -73,7 +73,8 @@ src/
 - Component files: `PascalCase.tsx`, named after the component (`NotFound.tsx`).
 - Colocated catalog entries: `<Component>.catalog.tsx` beside the component,
   exporting `<component>CatalogEntry: CatalogEntry` — a `.tsx` module that
-  exports data, not a component (its examples are JSX).
+  exports data, not a component (its examples are JSX). Full walkthrough:
+  `docs/standards/guides/add-a-content-component.md`.
 - Hooks: `useThing.ts`, exported as `useThing`.
 - Everything else: `camelCase.ts` (`parser.ts`, `wikiLinks.ts`).
 - One exported component per file; small private subcomponents may live beside it

--- a/docs/standards/frontend-code-style.md
+++ b/docs/standards/frontend-code-style.md
@@ -39,8 +39,10 @@ src/
   pattern imported from DocumentBuddy's architecture tests.)
 - **Cross-feature dependencies are an explicit allowlist**, mirrored by
   `FEATURE_EDGES` in `src/architecture.test.ts`. Current edges:
-  `components → presentation` (mode awareness via `useMode`) and
-  `presentation → content` (registry + lazy document access). Adding an edge is
+  `components → presentation` (mode awareness via `useMode`),
+  `presentation → content` (registry + lazy document access), and
+  `catalog → components` (renders the entries and live examples the components
+  feature exports through its seam). Adding an edge is
   an architectural decision: extend the map AND record the new edge + rationale
   here in the same PR. Test files may cross any feature through its seam (they
   are consumers, like the shell); production code follows the allowlist.

--- a/docs/standards/guides/add-a-content-component.md
+++ b/docs/standards/guides/add-a-content-component.md
@@ -1,0 +1,56 @@
+# Guide — Add a content component
+
+How to add a component that documents can use (`<Slide>`-class). Registered in
+`docs/standards/integration-guides.md`; born with WP4 (#65). The **living
+source of the rules is the catalog itself** (`/catalog/governance`, ADR-0010) —
+this guide maps those rules onto the repo.
+
+## When to use
+
+A real class needs a component that doesn't exist (inventory is emergent, D29):
+a semantic wrapper, a visualizer, a media embed, a structural block.
+
+## Worked example
+
+`Slide` and `SectionBreak` (family *estructura*) are the reference
+implementations: component + colocated entry + seam export + MDX registration
++ per-mode tests.
+
+```
+apps/web/src/components/structure/
+├── Slide.tsx              # the component (ADR-0010 contract)
+├── Slide.test.tsx         # per-mode behavior tests
+├── Slide.catalog.tsx      # its catalog entry (CatalogEntry from lib/)
+└── ...                    # SectionBreak.* — same shape
+```
+
+## Step-by-step
+
+1. **Pick the family** — estructura, semánticos, interactivos, media (see
+   `/catalog` for definitions). A new family is a governance change (see
+   `/catalog/governance` → Changing these rules).
+2. **Implement** in `apps/web/src/components/<family>/<Name>.tsx`, satisfying
+   the seven contract points (`/catalog/governance` → Component contract). If
+   the component reacts to the render mode, read it with `useMode()`
+   (presentation seam); if a parser must recognize it, declare metadata with
+   `withMeta` (`lib/componentMeta.ts`) — never expect identity imports.
+3. **Register it** in the shell MDX map (`apps/web/src/app/mdxComponents.ts`)
+   if documents use it without imports.
+4. **Write the catalog entry**: `<Name>.catalog.tsx` beside the component,
+   typed as `CatalogEntry` (`lib/catalogEntry.ts`), with description,
+   when-to-use, full props table, and ≥2 live examples (both modes when
+   behavior differs). Export it from the components seam
+   (`apps/web/src/components/index.ts` → `catalogEntries`).
+5. **Test**: per-mode behavior + the component's own logic. The **completeness
+   test** (`src/app/mdxComponents.test.ts`) fails the battery if a registered
+   component lacks its entry.
+6. **Verify**: per-commit protocol green; review the PR against the review
+   checklist (`/catalog/governance`).
+
+## Checklist
+
+- [ ] Family chosen; seven contract points satisfied.
+- [ ] Registered in `app/mdxComponents.ts` (if document-facing).
+- [ ] Colocated `.catalog.tsx` entry exported via the components seam.
+- [ ] ≥2 live examples; per-mode tests; completeness test green.
+- [ ] PR reviewed against the catalog's review checklist.

--- a/docs/standards/guides/add-a-content-component.md
+++ b/docs/standards/guides/add-a-content-component.md
@@ -29,7 +29,11 @@ apps/web/src/components/structure/
 1. **Pick the family** — estructura, semánticos, interactivos, media (see
    `/catalog` for definitions). A new family is a governance change (see
    `/catalog/governance` → Changing these rules).
-2. **Implement** in `apps/web/src/components/<family>/<Name>.tsx`, satisfying
+   **Family ids are Spanish; their folders are English**: estructura →
+   `structure/`, semánticos → `semantic/`, interactivos → `interactive/`,
+   media → `media/` (the mapping lives in `catalog/families.ts` and is shown on
+   each family page).
+2. **Implement** in `apps/web/src/components/<folder>/<Name>.tsx`, satisfying
    the seven contract points (`/catalog/governance` → Component contract). If
    the component reacts to the render mode, read it with `useMode()`
    (presentation seam); if a parser must recognize it, declare metadata with
@@ -41,9 +45,11 @@ apps/web/src/components/structure/
    when-to-use, full props table, and ≥2 live examples (both modes when
    behavior differs). Export it from the components seam
    (`apps/web/src/components/index.ts` → `catalogEntries`).
-5. **Test**: per-mode behavior + the component's own logic. The **completeness
-   test** (`src/app/mdxComponents.test.ts`) fails the battery if a registered
-   component lacks its entry.
+5. **Test**: per-mode behavior + the component's own logic. Two L4 invariant
+   tests gate the entry: `src/catalog/architecture.test.tsx` fails if the entry
+   is hollow (missing description/when-to-use, fewer than two examples, an
+   example that renders nothing), and `src/app/mdxComponents.test.ts` fails if
+   the MDX map and the catalog drift apart in either direction.
 6. **Verify**: per-commit protocol green; review the PR against the review
    checklist (`/catalog/governance`).
 

--- a/docs/standards/guides/add-a-content-component.md
+++ b/docs/standards/guides/add-a-content-component.md
@@ -2,8 +2,11 @@
 
 How to add a component that documents can use (`<Slide>`-class). Registered in
 `docs/standards/integration-guides.md`; born with WP4 (#65). The **living
-source of the rules is the catalog itself** (`/catalog/governance`, ADR-0010) —
-this guide maps those rules onto the repo.
+source of the rules is the catalog itself**: rendered at `/catalog/governance`
+(`npm run dev`), authored in `apps/web/src/catalog/GovernancePage.tsx` — read
+that file when working headless. ADR-0010 records why the contract exists and
+ADR-0014 how the catalog implements it; this guide maps the rules onto repo
+paths.
 
 ## When to use
 
@@ -26,37 +29,48 @@ apps/web/src/components/structure/
 
 ## Step-by-step
 
-1. **Pick the family** — estructura, semánticos, interactivos, media (see
-   `/catalog` for definitions). A new family is a governance change (see
+1. **Pick the family** — Estructura, Semánticos, Interactivos, Media (see
+   `/catalog` for definitions; these are display names — the ids used in code
+   and URLs are their unaccented forms). A new family is a governance change (see
    `/catalog/governance` → Changing these rules).
-   **Family ids are Spanish; their folders are English**: estructura →
-   `structure/`, semánticos → `semantic/`, interactivos → `interactive/`,
-   media → `media/` (the mapping lives in `catalog/families.ts` and is shown on
-   each family page).
+   **Family ids are unaccented Spanish (they double as route segments); their
+   folders are English.** The authoritative mapping is
+   `apps/web/src/catalog/families.ts`, rendered on `/catalog/governance` and on
+   each family page — read it there rather than from this guide.
 2. **Implement** in `apps/web/src/components/<folder>/<Name>.tsx`, satisfying
    the seven contract points (`/catalog/governance` → Component contract). If
    the component reacts to the render mode, read it with `useMode()`
    (presentation seam); if a parser must recognize it, declare metadata with
    `withMeta` (`lib/componentMeta.ts`) — never expect identity imports.
-3. **Register it** in the shell MDX map (`apps/web/src/app/mdxComponents.ts`)
-   if documents use it without imports.
+3. **Register it** in the shell MDX map (`apps/web/src/app/mdxComponents.ts`).
+   Not optional: the catalog and the MDX map must be the same set, asserted in
+   both directions. A component that must NOT be document-facing therefore does
+   not get a catalog entry either — it is not a content component (ADR-0014).
 4. **Write the catalog entry**: `<Name>.catalog.tsx` beside the component,
    typed as `CatalogEntry` (`lib/catalogEntry.ts`), with description,
    when-to-use, full props table, and ≥2 live examples (both modes when
    behavior differs). Export it from the components seam
-   (`apps/web/src/components/index.ts` → `catalogEntries`).
+   (`apps/web/src/components/index.ts` → `catalogEntries`) — an entry that never
+   reaches that array is invisible to the catalog.
+   `name` is the component's identity in three places at once: it MUST equal the
+   component file's basename, the MDX map key, and the `/catalog/c/:name`
+   segment. Components live DIRECTLY in the family folder (the invariant test
+   globs one level deep).
 5. **Test**: per-mode behavior + the component's own logic. Two L4 invariant
    tests gate the entry: `src/catalog/architecture.test.tsx` fails if the entry
-   is hollow (missing description/when-to-use, fewer than two examples, an
-   example that renders nothing), and `src/app/mdxComponents.test.ts` fails if
-   the MDX map and the catalog drift apart in either direction.
+   is hollow (empty description or when-to-use, a prop missing type or
+   description, fewer than two examples, two examples sharing a title, an
+   example that renders nothing, or a name/family pair that does not resolve to
+   `src/components/<folder>/<name>.tsx`); `src/app/mdxComponents.test.ts` fails
+   if the MDX map and the catalog drift apart in either direction — that is also
+   what catches a forgotten seam export.
 6. **Verify**: per-commit protocol green; review the PR against the review
    checklist (`/catalog/governance`).
 
 ## Checklist
 
 - [ ] Family chosen; seven contract points satisfied.
-- [ ] Registered in `app/mdxComponents.ts` (if document-facing).
+- [ ] Registered in `app/mdxComponents.ts` (mandatory for every catalogued component).
 - [ ] Colocated `.catalog.tsx` entry exported via the components seam.
 - [ ] ≥2 live examples; per-mode tests; completeness test green.
 - [ ] PR reviewed against the catalog's review checklist.

--- a/docs/standards/guides/add-a-course-document.md
+++ b/docs/standards/guides/add-a-course-document.md
@@ -56,8 +56,9 @@ the frontmatter `id`, never the path. v0.1 supports exactly ONE course directory
    `<SectionBreak />` are available WITHOUT imports. In the book view a Slide
    renders as its heading + flowing prose and a SectionBreak as a subtle
    divider; in presentation they cut slide boundaries. Worked example:
-   `03-busqueda-binaria.mdx`. Full component docs arrive with the catalog
-   (WP4).
+   `03-busqueda-binaria.mdx`. Full usage docs, props and live examples for every
+   document-facing component live in the catalog: `/catalog/c/Slide`,
+   `/catalog/c/SectionBreak`.
 
 5. **Cross-reference with wiki-links**: `[[otro-id]]` renders that document's
    link, `[[otro-id|texto visible]]` overrides the label. A target that doesn't

--- a/docs/standards/integration-guides.md
+++ b/docs/standards/integration-guides.md
@@ -11,12 +11,12 @@ guide here** (ADR-0005).
 |---|---|---|
 | Add a new app to the monorepo | `repository-structure.md` § "How to add a new app" | Creating `apps/server` or any future app |
 | Add a course document | [`guides/add-a-course-document.md`](guides/add-a-course-document.md) | Writing course material: MDX frontmatter contract, wiki-links, index registration |
+| Add a content component | [`guides/add-a-content-component.md`](guides/add-a-content-component.md) | New document-facing component: contract, catalog entry, families, review checklist |
 
 ## Pending guides (registered by the WP that creates the extension point)
 
 | Guide | Arrives with | Will cover |
 |---|---|---|
-| Add a content component | WP4 (#65) — catalog | Component contract compliance, catalog entry, families, review checklist |
 | Add a session event type | v0.3 — live sessions | Envelope protocol, emit/consume declaration, relay transparency |
 | Add a backend endpoint | v0.3 — `apps/server` | Handler + repository + tests pattern |
 

--- a/docs/standards/testing-strategy.md
+++ b/docs/standards/testing-strategy.md
@@ -23,7 +23,7 @@ the add-new-app checklist in `repository-structure.md`).
 | L1 Static | Types, lint, format | `tsc` + oxlint + prettier | Every commit |
 | L2 Unit | Pure logic: parsers, registries, index walks | Vitest | Every commit (TDD red→green per slice) |
 | L3 Component | Components honor their contract (e.g., per-mode rendering) | Vitest + Testing Library (jsdom) | Every commit, touched scope |
-| L4 Architecture | System invariants: import direction, catalog completeness, unique ids | Vitest (pattern imported from DocumentBuddy) | Pre-PR + CI |
+| L4 Architecture | System invariants: import direction + feature edges (`src/architecture.test.ts`), content ids (`src/content/architecture.test.ts`), catalog entry shape (`src/catalog/architecture.test.tsx`), MDX map ↔ catalog completeness (`src/app/mdxComponents.test.ts`) | Vitest (pattern imported from DocumentBuddy) | Pre-PR + CI |
 | L5 Browser smoke | The real app boots; key flows render in a real browser | **Playwright** (decided 2026-08-06; introduced with the first real smoke, WP2+) | Pre-PR + CI |
 | L6 Backend integration | Go handlers against real SQLite + fakes | Go testing | Defined when `apps/server` is born (v0.3) |
 | L7 Cross-app e2e | browser → web → server | Top-level `e2e/` | v0.3+ |
@@ -73,7 +73,19 @@ battery (full tests + integration L6), same rigor as `apps/web`.
 - Component tests assert behavior/contract (what renders per mode/props), not
   implementation details or snapshots.
 - Architecture tests live in `src/` near what they guard and are named
-  `architecture.test.ts` — they encode invariants agreed in standards/ADRs.
+  `architecture.test.ts(x)` (`.tsx` when the invariant must render) — they encode
+  invariants agreed in standards/ADRs. **Exception**: an invariant that binds a
+  feature to the shell cannot live in the feature (features may not import
+  `app/`), so it lives in the shell test that owns the pair and states its L4
+  role in a comment — e.g. the MDX map ↔ catalog completeness check in
+  `src/app/mdxComponents.test.ts`.
+- **Registry-driven invariants**: when a standard applies to every member of a
+  live registry, iterate the registry at module scope and generate one case per
+  entry, so a new entry is gated the moment it is registered — never hand-write
+  one test per member. Every such loop MUST be paired with a non-vacuity
+  assertion (`expect(registry.length).toBeGreaterThan(0)`): a loop over an empty
+  collection is a green suite that verifies nothing. Worked cases:
+  `catalog/architecture.test.tsx`, `app/mdxComponents.test.ts` (#65).
 - Test fakes live next to the tests that use them (see placement criteria in
   `repository-structure.md`).
 


### PR DESCRIPTION
**Closes #65**

## Summary

The catalog — the platform's grammar and the future editor's palette (ADR-0010).
`/catalog` presents the four families; each component gets a page with
when-to-use, a props table and **live examples running the real component**; and
the rules for adding a component live in the product itself at
`/catalog/governance`. Entries are colocated with their components
(`Slide.catalog.tsx`), typed from `lib/`, and — the part that matters — the
documentation checklist is now **executed, not just reviewed**: two L4 invariant
tests fail on a hollow entry, a dead example, or a published path that doesn't
resolve. Decisions recorded in **ADR-0014**.

## Slices completed

- [x] S1 — `CatalogEntry` type + registry + `/catalog` overview
- [x] S2 — Component page template + `ExampleBlock`
- [x] S3 — Slide and SectionBreak entries (pays the WP3 debt from ADR-0013)
- [x] S4 — Governance pages + completeness test
- [x] S5 — Integration guide + review-flow hook
- [x] Review fixes (two passes) + docs round

## Acceptance criteria

- **AC1** (four families, navigation works): `catalogRoute.test.tsx` asserts every
  family link's href **derived from the taxonomy** plus two real click
  navigations; browser: overview → Estructura → Slide.
- **AC2** (complete pages, ≥2 live examples of the real component):
  `catalog/architecture.test.tsx` renders **every example of every entry** and
  asserts non-empty output; route tests assert the real Slide (book h2 + prose in
  one example, children-only in the other) and SectionBreak (exactly one
  divider). Browser: 2 props rows, 2 examples, live heading present.
- **AC3** (governance consistent with ADR-0010): `/catalog/governance` renders 6
  add-steps, **7 contract points**, 3 documentation-checklist items, 4
  review-checklist items and the rule-change process — verified in-browser and by
  route tests.
- **AC4** (`CatalogEntry` + registry + colocated entries + completeness test):
  type in `lib/catalogEntry.ts`, `catalog/registry.ts` (snapshotting, fail-fast on
  duplicates), entries beside their components, and the two-way MDX-map binding in
  `app/mdxComponents.test.ts`.
- **AC5** (integration guide linked): `guides/add-a-content-component.md`,
  registered in `integration-guides.md`; discoverable from `apps/web/CLAUDE.md`,
  the style doc and the README.
- **AC6**: `npm run format:check` ✓ · `lint` ✓ · `test` → 20 files / **125 tests** ✓ ·
  `build` ✓.

## Tests

125 tests (99 before the review). Browser verification via Playwright at each
stage. **Mutation-tested**: the review verifier proved the original suite let
three independent defects ship green — a hollow entry, examples rendering
nothing, and every link pointing at a 404. Eight mutations were run in total
(hollow entry, dead `render()`, broken links, wrong folder claim, deleted
governance route, removed snapshot, retyped family mapping, `family.name` vs
`family.id`); **all eight now fail.**

## Reviews run

- **Round A (code)**: 3 lenses (performance skipped — static pages, announced).
  15 findings → 5 important verified. Security: **zero findings**. Fixes in
  `48dce26`; the per-fix rechecks then raised 6 more (a published source path
  nothing verified, a governance route that could be deleted green, a snapshot
  with no regression test…), fixed in `c77ff78`. All resolved, each proven by a
  failing mutation.
- **Round B (docs)**: 4 lenses, 25 findings → 12 after dedup; verifier confirmed
  6 (correcting two: the family binding was already recorded, and the security
  note was accurate when written — the advisory was amended upstream afterwards).
  Docs commit `f62b629`: **ADR-0014**, README, `testing-strategy` (four L4 gates
  named + registry-driven invariants canonized), governance corrections, guide
  fixes. All rechecks resolved; one residual caught and fixed in the amend.
- **Patterns recorded**: *executable documentation* (`documentation.md`) and
  *registry-driven invariants with a mandatory non-vacuity guard*
  (`testing-strategy.md`).

## Manual verification

- [ ] `cd apps/web && npm install && npm run dev` → open `/catalog`: four
  families with definitions and component counts.
- [ ] Estructura → **Slide**: when-to-use, props table, and two examples where
  the *real* component renders — the book one shows the heading, the
  presentation one doesn't.
- [ ] `/catalog/c/SectionBreak`: the divider appears in the book example and is
  absent in the presentation one.
- [ ] `/catalog/governance`: seven contract points, both checklists, and the
  family→folder mapping (derived from code, not retyped).
- [ ] Read `docs/decisions/0014-catalog-implementation.md` (drafted for your
  approval) — especially **Decision 3**: the catalog set equals the MDX-registered
  set, with a reserved opt-out for the composed components ADR-0010 point 7
  anticipates. That's the one call I'd like you to confirm.
- [ ] Try breaking it: empty a `description` in `Slide.catalog.tsx`, or point a
  family's `folder` at a wrong name → `npm run test` should fail with a named
  message.

## Notes

- **No new dependencies.** New allowed feature edge `catalog → components`,
  recorded in `frontend-code-style.md` per the allowlist protocol.
- `docs/security-notes.md`: the react-router advisory is now recorded as
  **resolved** — 7.18.2 is the patched version and `npm audit` reports zero.
  Pre-existing drift surfaced by the note's own re-check trigger; it removes a
  phantom "major bump required" blocker from WP5 (#66).
- Known limits, recorded in ADR-0014 rather than hidden: props tables and code
  snippets are hand-authored and can drift from the implementation; the entry
  documents contract points 2 and 3 only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MW6Zi5awCpwEGo3BNEnTg
