### PR TITLE
fix: paint the catalog background on the page, not the reading column

### DIFF
--- a/apps/web/src/catalog/CatalogLayout.tsx
+++ b/apps/web/src/catalog/CatalogLayout.tsx
@@ -10,15 +10,19 @@ interface Props {
 /** The shared layout of every catalog surface (not a route — those are the *Page files). */
 export function CatalogLayout({ back, children }: Props) {
   return (
-    <main className="mx-auto min-h-screen max-w-3xl bg-slate-950 px-8 py-10 text-slate-100">
-      {back ? (
-        <p className="text-sm">
-          <Link to={back.to} className="text-sky-400 hover:underline">
-            ← {back.label}
-          </Link>
-        </p>
-      ) : null}
-      {children}
-    </main>
+    // The background belongs to the page, not to the reading column: putting it
+    // on the max-w-3xl <main> leaves the rest of a wide viewport unpainted.
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <main className="mx-auto max-w-3xl px-8 py-10">
+        {back ? (
+          <p className="text-sm">
+            <Link to={back.to} className="text-sky-400 hover:underline">
+              ← {back.label}
+            </Link>
+          </p>
+        ) : null}
+        {children}
+      </main>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

The catalog rendered as a phone-width dark strip on a white page at any viewport wider than 768px: `CatalogLayout` applied `bg-slate-950` to the `max-w-3xl` `<main>` itself, so everything outside the reading column stayed unpainted. The background now lives on a full-height wrapper — the same shape `DocumentPage` and `NotFound` already use. The reading column keeps its 768px width on purpose.

Affects all four catalog surfaces (overview, family, component, governance).

## Tests

`format:check` ✓ · `lint` ✓ · `test` → 125 ✓ · `build` ✓. Verified in a real browser at 1440×900: before, `main` was 768px on a transparent body; after, the left edge at x=40 paints `oklch(0.129 0.042 264.695)` on all three catalog routes.

## Manual verification

- [ ] `npm run dev` → /catalog on a maximized window: dark background edge to edge, content centred.
- [ ] Same on /catalog/c/Slide and /catalog/governance.

## Notes

Not taken as a yolo commit: the diff is more than three lines and it is user-visible, so it goes through a PR per `docs/conventions.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MW6Zi5awCpwEGo3BNEnTg