### PR TITLE
feat: deploy the new app to GitHub Pages (replace the POC)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
         working-directory: apps/web
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,18 @@
 name: Deploy to GitHub Pages
 
+# Publishes apps/web to https://so77id.github.io/nalanda/ (issue #66).
+# Actions are pinned by commit SHA, like ci.yml: a tag can be repointed at
+# another commit, a SHA cannot.
+
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'smoke/**'
+    paths:
+      # Course material lives outside apps/ (ADR-0002), so editing a class must
+      # republish the site — filtering on apps/web alone would silently not.
+      - 'apps/web/**'
+      - 'content/**'
+      - '.github/workflows/deploy.yml'
   workflow_dispatch:
 
 permissions:
@@ -21,24 +28,26 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: npm
-          cache-dependency-path: proof-of-concept/frontend/package-lock.json
+          cache-dependency-path: apps/web/package-lock.json
 
       - run: npm ci
-        working-directory: proof-of-concept/frontend
+        working-directory: apps/web
 
+      # base '/nalanda/' and the 404.html SPA fallback come from vite.config.ts,
+      # so the deployed build matches what `npm run build` produces locally.
       - name: Build
-        run: npm run build -- --base=/nalanda/
-        working-directory: proof-of-concept/frontend
+        run: npm run build
+        working-directory: apps/web
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
-          path: proof-of-concept/frontend/dist
+          path: apps/web/dist
 
   deploy:
     needs: build
@@ -48,4 +57,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,10 @@
 name: Deploy to GitHub Pages
 
 # Publishes apps/web to https://so77id.github.io/nalanda/ (issue #66).
-# Actions are pinned by commit SHA, like ci.yml: a tag can be repointed at
-# another commit, a SHA cannot.
+# Direct action references are pinned by commit SHA, like ci.yml: a tag can be
+# repointed at another commit, a SHA cannot. Note this holds one level deep —
+# actions that are themselves composite (upload-pages-artifact calls
+# upload-artifact@v4) resolve their own dependencies by tag.
 
 on:
   push:
@@ -15,10 +17,10 @@ on:
       - '.github/workflows/deploy.yml'
   workflow_dispatch:
 
+# Least privilege: the build job runs `npm ci` (third-party install scripts) and
+# only needs to read the repo; publishing rights live in the deploy job.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -29,6 +31,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          # Nothing here pushes to git; not persisting the token keeps it out of
+          # .git/config while third-party install scripts run.
+          persist-credentials: false
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -37,6 +43,16 @@ jobs:
           cache-dependency-path: apps/web/package-lock.json
 
       - run: npm ci
+        working-directory: apps/web
+
+      # CI runs in parallel on the same push and nothing consumes its result, so
+      # the publishing path verifies itself rather than trusting a sibling job.
+      - name: Lint
+        run: npm run lint
+        working-directory: apps/web
+
+      - name: Test
+        run: npm run test
         working-directory: apps/web
 
       # base '/nalanda/' and the 404.html SPA fallback come from vite.config.ts,
@@ -52,6 +68,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,8 +2,9 @@
 
 ## Description
 Interactive CS learning platform: theory, presentation, interactive visualizations,
-and live code execution in one browser-first site. Currently building **v0.1 "El
-esqueleto"** of the from-zero redesign.
+and live code execution in one browser-first site. **v0.1 "El esqueleto" is
+complete and live at <https://so77id.github.io/nalanda/>**; work moves to v0.2
+"El contenido vivo".
 
 This file holds **monorepo-shared** instructions only. Each app has its own
 `CLAUDE.md` with its commands, stack, and rules — read it before working there:
@@ -45,6 +46,11 @@ rules live in the plugin's `docs/defaults.md`. Engineering-practice doctrine
 
 ### Hard rules
 
+- **Merging to `main` publishes the site.** `.github/workflows/deploy.yml`
+  deploys `apps/web` to <https://so77id.github.io/nalanda/> on every push to
+  `main` touching `apps/web/**` or `content/**`. Mechanics (trigger, deep-link
+  fallback, rollback, what gets published): root `README.md` §Deployment;
+  decisions: ADR-0015.
 - **All changes go through PRs** — never push directly to `main`.
 - **Squash merge** is mandatory for every PR (manual, by the user).
 - **One commit per slice**; the slice list lives in the issue body as checkboxes.
@@ -68,4 +74,7 @@ rules live in the plugin's `docs/defaults.md`. Engineering-practice doctrine
 - Documentation ships in the same PR as the change that obligates it
   (`docs/standards/documentation.md`).
 - For UI changes, verify in a real browser before reporting done — protocols and
-  lint verify code correctness, not feature correctness.
+  lint verify code correctness, not feature correctness. Anything touching
+  paths, assets or routing must be checked with `npm run build && npm run
+  preview` (serves under `/nalanda/`, like production), not only `npm run dev`
+  (serves at `/`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,10 @@ This file holds **monorepo-shared** instructions only. Each app has its own
 - `docs/standards/documentation.md` — where each kind of knowledge lives.
 - `docs/decisions/` — ADRs, numbered sequentially (living architectural decisions).
 - `docs/design/2026-08-redesign.md` — design narrative + roadmap (v0.1 → v0.3).
+- `docs/standards/guides/add-a-course-document.md` — **read before editing
+  anything under `content/`**: the frontmatter contract, the slide markers, and
+  the fact that everything there is published (the index controls navigation,
+  never visibility).
 
 The original POC is archived in `proof-of-concept/` (runnable, reference only —
 port pieces from it as WPs require, refactoring to current standards on entry).

--- a/README.md
+++ b/README.md
@@ -52,6 +52,29 @@ and [`apps/web/README.md`](apps/web/README.md). Before contributing, read
 [`docs/standards/`](docs/standards/) — especially the two testing protocols
 (per-commit and pre-PR) in `testing-strategy.md`.
 
+## Deployment
+
+The site is live at **<https://so77id.github.io/nalanda/>** (GitHub Pages, free
+project-pages URL — a custom domain would only change the Vite `base`).
+
+- **What publishes it**: `.github/workflows/deploy.yml`, on every push to `main`
+  that touches `apps/web/**`, `content/**` or the workflow itself. Course
+  material lives outside `apps/` (ADR-0002), so writing a class republishes the
+  site; a docs-only commit does not. It can also be run by hand from the Actions
+  tab (`workflow_dispatch`) without committing anything.
+- **How deep links survive**: Pages is a static file server, so
+  `/nalanda/d/bienvenida` has no file behind it. The build copies `index.html`
+  to `404.html` (`apps/web/src/app/spaFallback.ts`), which Pages serves for
+  unknown paths, handing the URL to the router.
+- **How to verify after a deploy**: open `/nalanda/`, one deep document link
+  (e.g. `/nalanda/d/busqueda-binaria`), and `/nalanda/catalog`. Locally,
+  `npm run build && npm run preview` proves the base path and the router
+  basename — but NOT the fallback, because `vite preview` has its own SPA
+  fallback that masks a missing `404.html`; check `dist/404.html` exists.
+- **Rollback**: revert the offending commit on `main`. The revert is itself a
+  push to `main`, so it redeploys the previous version — there is no separate
+  deploy button to press.
+
 ## Workflow
 
 All changes go through PRs (squash-merged manually). See

--- a/README.md
+++ b/README.md
@@ -68,9 +68,12 @@ project-pages URL — a custom domain would only change the Vite `base`).
   unknown paths, handing the URL to the router.
 - **How to verify after a deploy**: open `/nalanda/`, one deep document link
   (e.g. `/nalanda/d/busqueda-binaria`), and `/nalanda/catalog`. Locally,
-  `npm run build && npm run preview` proves the base path and the router
-  basename — but NOT the fallback, because `vite preview` has its own SPA
-  fallback that masks a missing `404.html`; check `dist/404.html` exists.
+  `npm run build && npm run preview` serves the real build under `/nalanda/` and
+  proves the base path and the router basename — but NOT the fallback, because
+  `vite preview` has its own SPA fallback that masks a missing `404.html`. That
+  mechanism is guarded by tests instead (`apps/web/src/app/spaFallback.test.ts`).
+- **What gets published**: every `.mdx` under `content/courses/**` — the index
+  only controls navigation (see `docs/security-notes.md`).
 - **Rollback**: revert the offending commit on `main`. The revert is itself a
   push to `main`, so it redeploys the previous version — there is no separate
   deploy button to press.

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ data-structure visualizations, and live code execution coexist.
 
 ## Status (August 2026)
 
-Building **v0.1 "El esqueleto"** of the from-zero redesign: monorepo foundation,
-content model (MDX wiki + teaching index), presentation mode, component catalog,
-and static deploy. Roadmap and design narrative:
+**v0.1 "El esqueleto" is complete** — monorepo foundation, content model (MDX
+wiki + teaching index), presentation mode, component catalog and static deploy
+are all in; the site is live (see [Deployment](#deployment)). Next: v0.2 "El
+contenido vivo". Roadmap and design narrative:
 [`docs/design/2026-08-redesign.md`](docs/design/2026-08-redesign.md) · living
 decisions: [`docs/decisions/`](docs/decisions/).
 
@@ -55,13 +56,19 @@ and [`apps/web/README.md`](apps/web/README.md). Before contributing, read
 ## Deployment
 
 The site is live at **<https://so77id.github.io/nalanda/>** (GitHub Pages, free
-project-pages URL — a custom domain would only change the Vite `base`).
+project-pages URL). A custom domain would change the Vite `base` and the
+`/nalanda/` assertions in `apps/web/src/app/deployedApp.test.tsx` — runtime code
+derives everything else from `BASE_URL` — but deep links already shared under the
+prefix may not survive the move, so decide before handing URLs to students
+(ADR-0015).
 
 - **What publishes it**: `.github/workflows/deploy.yml`, on every push to `main`
   that touches `apps/web/**`, `content/**` or the workflow itself. Course
   material lives outside `apps/` (ADR-0002), so writing a class republishes the
-  site; a docs-only commit does not. It can also be run by hand from the Actions
-  tab (`workflow_dispatch`) without committing anything.
+  site; a commit touching only `docs/**` or this README does not (app-local docs
+  under `apps/web/**` do trigger a republish — harmless, just a wasted build). It
+  can also be run by hand from the Actions tab (`workflow_dispatch`) without
+  committing anything.
 - **How deep links survive**: Pages is a static file server, so
   `/nalanda/d/bienvenida` has no file behind it. The build copies `index.html`
   to `404.html` (`apps/web/src/app/spaFallback.ts`), which Pages serves for
@@ -77,6 +84,15 @@ project-pages URL — a custom domain would only change the Vite `base`).
 - **Rollback**: revert the offending commit on `main`. The revert is itself a
   push to `main`, so it redeploys the previous version — there is no separate
   deploy button to press.
+- **When something is broken**, work back from the symptom:
+
+  | Symptom | Cause | Guarded by |
+  |---|---|---|
+  | Blank page, `/assets/*` 404 | wrong `base` in `vite.config.ts` | `deployedApp.test.tsx` |
+  | Deep link 404s live but works in dev | missing `404.html` | `spaFallback.test.ts` |
+  | Deep link renders "Page not found" | router basename | `basename.test.ts`, `deployedApp.test.tsx` |
+  | Workflow green, site unchanged | path filters did not match — rerun from the Actions tab | — |
+  | Deploy job fails on permissions | repo Settings ▸ Pages source must be "GitHub Actions", and the `github-pages` environment must allow `main` | — |
 
 ## Workflow
 

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -5,9 +5,11 @@ rules; this file covers what is specific to this app.
 
 ## Commands & stack
 
-Single home: [`README.md`](./README.md) — read it for the command list and the
-stack summary before working here (one home per fact, per
-`docs/standards/documentation.md`).
+Single home: [`README.md`](./README.md) — read it before working here for the
+command list, the stack summary, and the **deployed shape** (base path
+`/nalanda/`, router basename from `import.meta.env.BASE_URL`, the `404.html`
+SPA fallback and the `vite preview` gotcha). One home per fact, per
+`docs/standards/documentation.md`.
 
 ## Mandatory reading
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -12,7 +12,7 @@ CSS v4 (+ typography plugin) + framer-motion; course documents compile from MDX
 npm install          # dependencies
 npm run dev          # Vite dev server → http://localhost:5173
 npm run build        # tsc -b (type gate) + vite build → dist/
-npm run preview      # serve the production build locally
+npm run preview      # serve the production build locally, under /nalanda/
 npm run lint         # oxlint
 npm run format       # prettier --write
 npm run format:check # prettier --check
@@ -26,7 +26,8 @@ See `docs/standards/frontend-code-style.md` for the authoritative rules.
 
 ```
 src/
-├── app/                  # shell: entry, router (documents, presentation, catalog, 404), MDX map
+├── app/                  # shell: entry, router (documents, presentation, catalog, 404),
+│                         # MDX map, deployed base/basename, SPA-fallback build plugin
 ├── catalog/              # /catalog surface: registry, family taxonomy, component +
 │                         # governance pages, live-example blocks
 ├── components/           # catalog content components by family (structure: Slide,
@@ -45,6 +46,21 @@ All feature folders now exist. Guides: authoring course material (frontmatter,
 wiki-links, slide markers) → `docs/standards/guides/add-a-course-document.md`;
 adding a content component → `docs/standards/guides/add-a-content-component.md`
 (its rules are rendered at `/catalog/governance`).
+
+## Deployed shape
+
+The site is published under **`/nalanda/`** (GitHub Pages project URL; the
+repo-level story — trigger, rollback — is in the root README).
+
+- `vite.config.ts` owns the base path: `/nalanda/` for `build` and `preview`,
+  `/` for `dev` so local URLs stay short. Runtime code never hardcodes it —
+  `App.tsx` derives the router basename from `import.meta.env.BASE_URL`.
+- `src/app/spaFallback.ts` copies `index.html` to `404.html` at build time.
+  Pages serves that file for paths with no file behind them, which is what makes
+  `/nalanda/d/<id>` load instead of 404ing.
+- Gotcha: `vite preview` has its own SPA fallback, so it cannot prove the
+  `404.html` exists — `src/app/spaFallback.test.ts` and the build-shape cases in
+  `src/app/deployedApp.test.tsx` are what actually guard both mechanisms.
 
 ## Testing
 

--- a/apps/web/src/app/App.test.tsx
+++ b/apps/web/src/app/App.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it } from 'vitest';
 
 import { courseIndex, registry, walkIndex } from '../content';
 import { AppRoutes } from './AppRoutes';
+import { routerBasename } from './basename';
 
 // Assertions derive from the live index/registry (never hardcoded titles) so
 // editing course material — an authoring act — cannot break shell tests.
@@ -78,5 +79,16 @@ describe('routing', () => {
   it('shows the 404 page for an unknown route', () => {
     renderAt('/nope');
     expect(screen.getByRole('heading', { name: /not found/i })).toBeInTheDocument();
+  });
+});
+
+describe('routerBasename', () => {
+  it('is empty in dev, where the app is served from the domain root', () => {
+    expect(routerBasename('/')).toBe('');
+  });
+
+  it('drops the trailing slash of a deployed base path', () => {
+    // Vite's BASE_URL always ends in '/', react-router's basename must not.
+    expect(routerBasename('/nalanda/')).toBe('/nalanda');
   });
 });

--- a/apps/web/src/app/App.test.tsx
+++ b/apps/web/src/app/App.test.tsx
@@ -4,7 +4,6 @@ import { describe, expect, it } from 'vitest';
 
 import { courseIndex, registry, walkIndex } from '../content';
 import { AppRoutes } from './AppRoutes';
-import { routerBasename } from './basename';
 
 // Assertions derive from the live index/registry (never hardcoded titles) so
 // editing course material — an authoring act — cannot break shell tests.
@@ -79,16 +78,5 @@ describe('routing', () => {
   it('shows the 404 page for an unknown route', () => {
     renderAt('/nope');
     expect(screen.getByRole('heading', { name: /not found/i })).toBeInTheDocument();
-  });
-});
-
-describe('routerBasename', () => {
-  it('is empty in dev, where the app is served from the domain root', () => {
-    expect(routerBasename('/')).toBe('');
-  });
-
-  it('drops the trailing slash of a deployed base path', () => {
-    // Vite's BASE_URL always ends in '/', react-router's basename must not.
-    expect(routerBasename('/nalanda/')).toBe('/nalanda');
   });
 });

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -1,10 +1,11 @@
 import { BrowserRouter } from 'react-router-dom';
 
 import { AppRoutes } from './AppRoutes';
+import { routerBasename } from './basename';
 
 export function App() {
   return (
-    <BrowserRouter>
+    <BrowserRouter basename={routerBasename(import.meta.env.BASE_URL)}>
       <AppRoutes />
     </BrowserRouter>
   );

--- a/apps/web/src/app/basename.test.ts
+++ b/apps/web/src/app/basename.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { routerBasename } from './basename';
+
+describe('routerBasename', () => {
+  it('is empty in dev, where the app is served from the domain root', () => {
+    expect(routerBasename('/')).toBe('');
+  });
+
+  it('drops the trailing slash of a deployed base path', () => {
+    // Vite's BASE_URL always ends in '/', react-router's basename must not.
+    expect(routerBasename('/nalanda/')).toBe('/nalanda');
+  });
+
+  it('leaves an already-trimmed base untouched', () => {
+    expect(routerBasename('/nalanda')).toBe('/nalanda');
+  });
+
+  it('handles a multi-segment base', () => {
+    expect(routerBasename('/a/b/')).toBe('/a/b');
+  });
+});

--- a/apps/web/src/app/basename.ts
+++ b/apps/web/src/app/basename.ts
@@ -1,0 +1,8 @@
+/**
+ * react-router's basename from Vite's BASE_URL. Vite always ends BASE_URL with
+ * a slash ('/' in dev, '/nalanda/' on Pages); react-router wants no trailing
+ * slash, and an empty string at the domain root.
+ */
+export function routerBasename(baseUrl: string): string {
+  return baseUrl.replace(/\/$/, '');
+}

--- a/apps/web/src/app/deployedApp.test.tsx
+++ b/apps/web/src/app/deployedApp.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { courseIndex, registry, walkIndex } from '../content';
+
+import viteConfig from '../../vite.config';
+
+// jsdom always sees BASE_URL='/', and no other test mounts <App/>, so the two
+// things that only exist in the deployed build — the base path and the router
+// basename — would otherwise regress silently and green (issue #66 review).
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+async function renderAppAt(path: string) {
+  window.history.pushState({}, '', path);
+  const { App } = await import('./App');
+  render(<App />);
+}
+
+describe('deployed build shape', () => {
+  it('builds under the Pages base path', () => {
+    const config = viteConfig as unknown as (env: { command: string; mode: string }) => {
+      base: string;
+      plugins: unknown[];
+    };
+
+    expect(config({ command: 'build', mode: 'production' }).base).toBe('/nalanda/');
+  });
+
+  it('keeps the dev server at the root for short local URLs', () => {
+    const config = viteConfig as unknown as (env: { command: string; mode: string }) => {
+      base: string;
+    };
+
+    expect(config({ command: 'serve', mode: 'development' }).base).toBe('/');
+  });
+
+  it('emits the SPA fallback in the build pipeline', () => {
+    const config = viteConfig as unknown as (env: { command: string; mode: string }) => {
+      plugins: { name?: string }[];
+    };
+    const names = config({ command: 'build', mode: 'production' })
+      .plugins.flat()
+      .map((p) => p?.name);
+
+    expect(names).toContain('nalanda:spa-fallback');
+  });
+});
+
+describe('App under a deployed base path', () => {
+  it('resolves a deep link that carries the base prefix', async () => {
+    vi.stubEnv('BASE_URL', '/nalanda/');
+    const id = walkIndex(courseIndex)[1]!;
+    const title = registry.get(id)!.meta.title;
+
+    await renderAppAt(`/nalanda/d/${id}`);
+
+    // The title, not a bare level-1 heading: NotFound renders an h1 too, so a
+    // generic assertion would pass even with the basename removed.
+    expect(await screen.findByRole('heading', { level: 1, name: title })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/deployedApp.test.tsx
+++ b/apps/web/src/app/deployedApp.test.tsx
@@ -1,16 +1,25 @@
 import { render, screen } from '@testing-library/react';
+import type { ConfigEnv, UserConfig, UserConfigFnObject } from 'vite';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { courseIndex, registry, walkIndex } from '../content';
 
 import viteConfig from '../../vite.config';
 
-// jsdom always sees BASE_URL='/', and no other test mounts <App/>, so the two
-// things that only exist in the deployed build — the base path and the router
-// basename — would otherwise regress silently and green (issue #66 review).
+// jsdom always sees BASE_URL='/', and no other test mounts <App/>, so the three
+// things that only exist outside dev — the built base, the preview base and the
+// router basename — would otherwise regress silently and green (issue #66).
+// Vite's own ConfigEnv, not a hand-written shape: the partial cast this file
+// first used is what hid `isPreview` from view in the first place.
+const config = viteConfig as UserConfigFnObject;
+const resolve = (env: ConfigEnv): UserConfig => config(env) as UserConfig;
+
 afterEach(() => {
   vi.unstubAllEnvs();
   vi.resetModules();
+  // pushState mutates history for the whole file; without this the next test
+  // starts on a prefixed URL with the basename already restored to ''.
+  window.history.pushState({}, '', '/');
 });
 
 async function renderAppAt(path: string) {
@@ -21,29 +30,24 @@ async function renderAppAt(path: string) {
 
 describe('deployed build shape', () => {
   it('builds under the Pages base path', () => {
-    const config = viteConfig as unknown as (env: { command: string; mode: string }) => {
-      base: string;
-      plugins: unknown[];
-    };
+    expect(resolve({ command: 'build', mode: 'production' }).base).toBe('/nalanda/');
+  });
 
-    expect(config({ command: 'build', mode: 'production' }).base).toBe('/nalanda/');
+  it('previews under the Pages base path too', () => {
+    // preview serves the built dist, whose asset URLs already carry the prefix;
+    // serving it at '/' answers every bundle with index.html (the COR-1 bug).
+    expect(resolve({ command: 'serve', mode: 'production', isPreview: true }).base).toBe(
+      '/nalanda/',
+    );
   });
 
   it('keeps the dev server at the root for short local URLs', () => {
-    const config = viteConfig as unknown as (env: { command: string; mode: string }) => {
-      base: string;
-    };
-
-    expect(config({ command: 'serve', mode: 'development' }).base).toBe('/');
+    expect(resolve({ command: 'serve', mode: 'development' }).base).toBe('/');
   });
 
   it('emits the SPA fallback in the build pipeline', () => {
-    const config = viteConfig as unknown as (env: { command: string; mode: string }) => {
-      plugins: { name?: string }[];
-    };
-    const names = config({ command: 'build', mode: 'production' })
-      .plugins.flat()
-      .map((p) => p?.name);
+    const plugins = resolve({ command: 'build', mode: 'production' }).plugins ?? [];
+    const names = plugins.flat().map((p) => (p as { name?: string } | null)?.name);
 
     expect(names).toContain('nalanda:spa-fallback');
   });

--- a/apps/web/src/app/spaFallback.test.ts
+++ b/apps/web/src/app/spaFallback.test.ts
@@ -1,0 +1,57 @@
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ResolvedConfig } from 'vite';
+import { describe, expect, it } from 'vitest';
+
+import { spaFallback } from './spaFallback';
+
+// The plugin is the whole mechanism keeping deep links alive on a static host,
+// so it is unit-tested directly: driving the two hooks is cheaper and far more
+// precise than asserting on a full build.
+function drive(outDir: string, root: string, writeIndex: boolean) {
+  const plugin = spaFallback();
+  const dir = join(root, outDir);
+  mkdirSync(dir, { recursive: true });
+  if (writeIndex) writeFileSync(join(dir, 'index.html'), '<!doctype html><title>x</title>');
+
+  const configResolved = plugin.configResolved as (c: ResolvedConfig) => void;
+  configResolved({ root, build: { outDir } } as unknown as ResolvedConfig);
+  const writeBundle = plugin.writeBundle as () => void;
+  return { run: () => writeBundle(), dir };
+}
+
+describe('spaFallback', () => {
+  it('writes 404.html as a byte-identical copy of index.html', () => {
+    const root = mkdtempSync(join(tmpdir(), 'spa-'));
+    const { run, dir } = drive('dist', root, true);
+
+    run();
+
+    expect(readFileSync(join(dir, '404.html'), 'utf8')).toBe(
+      readFileSync(join(dir, 'index.html'), 'utf8'),
+    );
+  });
+
+  it('honors a non-default outDir', () => {
+    const root = mkdtempSync(join(tmpdir(), 'spa-'));
+    const { run, dir } = drive('build-output', root, true);
+
+    run();
+
+    expect(existsSync(join(dir, '404.html'))).toBe(true);
+  });
+
+  it('fails loudly when the build produced no index.html', () => {
+    const root = mkdtempSync(join(tmpdir(), 'spa-'));
+    const { run } = drive('dist', root, false);
+
+    expect(run).toThrowError(/index\.html was not produced/);
+  });
+
+  it('runs on writeBundle, never on closeBundle (which also fires on failed builds)', () => {
+    const plugin = spaFallback();
+    expect(plugin.writeBundle).toBeDefined();
+    expect(plugin.closeBundle).toBeUndefined();
+  });
+});

--- a/apps/web/src/app/spaFallback.ts
+++ b/apps/web/src/app/spaFallback.ts
@@ -1,0 +1,30 @@
+import { copyFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import type { Plugin, ResolvedConfig } from 'vite';
+
+/**
+ * GitHub Pages is a static file server: a deep link like /nalanda/d/bienvenida
+ * has no file behind it and would 404 before the SPA ever loads. Pages serves
+ * 404.html for unknown paths, so shipping a copy of index.html under that name
+ * hands the request to the router instead (issue #66).
+ *
+ * A Vite plugin rather than a `cp` in the build script: same behavior on every
+ * OS and in CI, and it respects a configured outDir.
+ */
+export function spaFallback(): Plugin {
+  let outDir = '';
+  return {
+    name: 'nalanda:spa-fallback',
+    apply: 'build',
+    configResolved(config: ResolvedConfig) {
+      outDir = path.resolve(config.root, config.build.outDir);
+    },
+    closeBundle() {
+      const index = path.join(outDir, 'index.html');
+      if (!existsSync(index)) {
+        throw new Error(`SPA fallback: ${index} was not produced by the build`);
+      }
+      copyFileSync(index, path.join(outDir, '404.html'));
+    },
+  };
+}

--- a/apps/web/src/app/spaFallback.ts
+++ b/apps/web/src/app/spaFallback.ts
@@ -1,5 +1,5 @@
 import { copyFileSync, existsSync } from 'node:fs';
-import path from 'node:path';
+import { join, resolve } from 'node:path';
 import type { Plugin, ResolvedConfig } from 'vite';
 
 /**
@@ -17,14 +17,16 @@ export function spaFallback(): Plugin {
     name: 'nalanda:spa-fallback',
     apply: 'build',
     configResolved(config: ResolvedConfig) {
-      outDir = path.resolve(config.root, config.build.outDir);
+      outDir = resolve(config.root, config.build.outDir);
     },
-    closeBundle() {
-      const index = path.join(outDir, 'index.html');
+    // writeBundle, not closeBundle: closeBundle also runs when the build FAILS,
+    // and the missing-index error would then replace the real root cause in the log.
+    writeBundle() {
+      const index = join(outDir, 'index.html');
       if (!existsSync(index)) {
         throw new Error(`SPA fallback: ${index} was not produced by the build`);
       }
-      copyFileSync(index, path.join(outDir, '404.html'));
+      copyFileSync(index, join(outDir, '404.html'));
     },
   };
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -8,6 +8,7 @@ import remarkFrontmatter from 'remark-frontmatter';
 import remarkMdxFrontmatter from 'remark-mdx-frontmatter';
 import { defineConfig } from 'vite';
 
+import { spaFallback } from './src/app/spaFallback.ts';
 import { contentIntegrity } from './src/content/contentIntegrity.ts';
 import { remarkWikiLinks } from './src/content/wikiLinks.ts';
 
@@ -22,6 +23,7 @@ export default defineConfig({
   base: process.env['NODE_ENV'] === 'production' ? '/nalanda/' : '/',
   plugins: [
     contentIntegrity(contentDir),
+    spaFallback(),
     // MDX must transform before the React plugin sees the file.
     {
       enforce: 'pre',

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -17,10 +17,11 @@ const appDir = path.dirname(fileURLToPath(import.meta.url));
 const contentDir = path.resolve(appDir, '../../content');
 
 // https://vite.dev/config/
-export default defineConfig({
-  // Project Pages serve under /<repo>/ (issue #66). Dev keeps the root so
-  // local URLs stay short; the router derives its basename from BASE_URL.
-  base: process.env['NODE_ENV'] === 'production' ? '/nalanda/' : '/',
+export default defineConfig(({ command }) => ({
+  // Project Pages serve under /<repo>/ (issue #66). Dev keeps the root so local
+  // URLs stay short; the router derives its basename from BASE_URL. Keyed on
+  // `command` rather than NODE_ENV, which depends on when the config is evaluated.
+  base: command === 'build' ? '/nalanda/' : '/',
   plugins: [
     contentIntegrity(contentDir),
     spaFallback(),
@@ -53,4 +54,4 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: './vitest.setup.ts',
   },
-});
+}));

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -17,6 +17,9 @@ const contentDir = path.resolve(appDir, '../../content');
 
 // https://vite.dev/config/
 export default defineConfig({
+  // Project Pages serve under /<repo>/ (issue #66). Dev keeps the root so
+  // local URLs stay short; the router derives its basename from BASE_URL.
+  base: process.env['NODE_ENV'] === 'production' ? '/nalanda/' : '/',
   plugins: [
     contentIntegrity(contentDir),
     // MDX must transform before the React plugin sees the file.

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -17,11 +17,12 @@ const appDir = path.dirname(fileURLToPath(import.meta.url));
 const contentDir = path.resolve(appDir, '../../content');
 
 // https://vite.dev/config/
-export default defineConfig(({ command }) => ({
-  // Project Pages serve under /<repo>/ (issue #66). Dev keeps the root so local
-  // URLs stay short; the router derives its basename from BASE_URL. Keyed on
-  // `command` rather than NODE_ENV, which depends on when the config is evaluated.
-  base: command === 'build' ? '/nalanda/' : '/',
+export default defineConfig(({ command, isPreview }) => ({
+  // Project Pages serve under /<repo>/ (issue #66); the router derives its
+  // basename from BASE_URL. Preview must use the deployed base too — it serves
+  // the built dist, whose asset URLs already carry the prefix — while dev keeps
+  // the root so local URLs stay short.
+  base: command === 'build' || isPreview ? '/nalanda/' : '/',
   plugins: [
     contentIntegrity(contentDir),
     spaFallback(),

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -144,6 +144,12 @@ For changes that meet ALL of these criteria, the workflow above can be bypassed:
 
 Commit directly to `main` with a clear message. Do not create an issue.
 
+**A yolo commit under `apps/web/**` or `content/**` publishes the live site**
+(`deploy.yml` triggers on those paths). The deploy job runs lint and tests
+first, so a broken commit fails to publish rather than publishing broken — but
+the change goes live unreviewed. Check the live URL right after pushing; the
+rollback is a revert, which redeploys the previous version (README §Deployment).
+
 ## Issue body structure
 
 Every refined issue body must contain, in this order:

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -145,9 +145,9 @@ For changes that meet ALL of these criteria, the workflow above can be bypassed:
 Commit directly to `main` with a clear message. Do not create an issue.
 
 **A yolo commit under `apps/web/**` or `content/**` publishes the live site**
-(`deploy.yml` triggers on those paths). The deploy job runs lint and tests
-first, so a broken commit fails to publish rather than publishing broken — but
-the change goes live unreviewed. Check the live URL right after pushing; the
+(`deploy.yml` triggers on those paths). Its `build` job runs lint and tests
+first, so a commit that fails those never publishes — but runtime breakage the
+suite cannot see does, and the change goes live unreviewed. Check the live URL right after pushing; the
 rollback is a revert, which redeploys the previous version (README §Deployment).
 
 ## Issue body structure

--- a/docs/decisions/0012-content-pipeline-implementation.md
+++ b/docs/decisions/0012-content-pipeline-implementation.md
@@ -65,6 +65,10 @@ rest of the platform (authoring skill, catalog, presentation mode) will build on
 
 - Content contract violations surface at build/CI time (CI now triggers on
   `content/**`), before any deploy.
+- **Publication is glob-driven** (recorded with #66/ADR-0015): presence under
+  `content/courses/` publishes a document at `/d/<id>`; `index.yaml` controls
+  navigation only. Material that must not be public lives outside that tree —
+  see `docs/security-notes.md` §Accepted invariants.
 - Authoring is documented in `docs/standards/guides/add-a-course-document.md`;
   the create-class skill (v0.2) targets that contract.
 - v0.1 runtime asserts exactly ONE course directory; multi-course requires

--- a/docs/decisions/0015-static-publishing-pipeline.md
+++ b/docs/decisions/0015-static-publishing-pipeline.md
@@ -41,8 +41,8 @@ files, and what gates the publish.
    Implemented as a plugin rather than a `cp` in the build script: identical on
    every OS and in CI, and it honors `outDir`.
 
-5. **The publishing path verifies itself**: the deploy job runs lint and tests
-   before building. CI runs in parallel on the same push and nothing consumes
+5. **The publishing path verifies itself**: the publish workflow's `build` job
+   runs lint and tests before building (the `deploy` job only uploads). CI runs in parallel on the same push and nothing consumes
    its result, so gating on a sibling job would be gating on nothing.
    Permissions are least-privilege — the build job (which runs third-party
    install scripts) is read-only; `pages: write` and `id-token: write` live on
@@ -84,6 +84,9 @@ files, and what gates the publish.
   browsers; relevant if analytics or crawlers are ever added.
 - Lint and tests run twice per push to `main` (CI and the deploy job).
 - Merging to `main` publishes. With no branch protection (deferred, recorded in
-  `docs/security-notes.md`), a direct push to `main` also publishes — though the
-  deploy job's own lint/test gate means a broken commit fails to publish rather
-  than publishing broken.
+  `docs/security-notes.md`), a direct push to `main` also publishes. The gate is
+  partial: a commit that fails lint, the tests or the build never reaches the
+  deploy job, but **runtime breakage the suite cannot see still publishes** —
+  there is no browser smoke yet (testing-strategy L5 remains pending), which is
+  exactly how the blank-page regression inside this WP survived until a human
+  looked at the page.

--- a/docs/decisions/0015-static-publishing-pipeline.md
+++ b/docs/decisions/0015-static-publishing-pipeline.md
@@ -1,0 +1,89 @@
+# ADR-0015: Static publishing pipeline — URL shape, SPA fallback, self-verifying deploy
+
+**Status:** Accepted
+**Date:** 2026-08-11
+**Decision-makers:** Miguel Rodriguez
+**Source:** Issue #66 (WP5, deploy to GitHub Pages — the last v0.1 work package).
+Extends ADR-0004 and D14, which chose "fully static site on GitHub Pages" as the
+platform but fixed nothing about how it is published.
+
+## Context
+
+v0.1 ends with the app publicly reachable. Publishing a client-side router on a
+plain file server forces three decisions the platform choice does not answer:
+what URL the site lives at, how deep links survive a host that only serves
+files, and what gates the publish.
+
+## Decision
+
+1. **Project-Pages URL**: `https://so77id.github.io/nalanda/`. Free, zero
+   configuration, and it unblocks v0.1 today. Consequence: every deployed URL
+   carries the `/nalanda/` prefix.
+
+2. **A custom domain is deferred, not rejected** (discussed with Miguel,
+   2026-08-10). Moving later costs a DNS record, the `base` value, and the
+   `/nalanda/` assertions in `deployedApp.test.tsx` — but **deep links already
+   shared under the prefix may not survive the move**. Review trigger: before
+   handing deep links to a cohort of students. A university subdomain is the
+   likeliest form.
+
+3. **The base path is owned by `vite.config.ts`**, for `build` and `preview`
+   alike, and `/` for `dev` so local URLs stay short. Runtime code never
+   hardcodes it: the router derives its basename from `import.meta.env.BASE_URL`
+   (`app/basename.ts`). CI passes no `--base` flag — a CI-only flag makes local
+   builds unreproducible, and the first version of this WP proved the hazard in
+   the other direction: keying the base on `command === 'build'` alone silently
+   broke `vite preview`, which resolves as `serve`.
+
+4. **Deep links survive via a build-emitted `404.html`** — a copy of
+   `index.html` written by the `spaFallback` Vite plugin. Pages serves that file
+   for paths with no file behind them, so the router receives the URL.
+   Implemented as a plugin rather than a `cp` in the build script: identical on
+   every OS and in CI, and it honors `outDir`.
+
+5. **The publishing path verifies itself**: the deploy job runs lint and tests
+   before building. CI runs in parallel on the same push and nothing consumes
+   its result, so gating on a sibling job would be gating on nothing.
+   Permissions are least-privilege — the build job (which runs third-party
+   install scripts) is read-only; `pages: write` and `id-token: write` live on
+   the deploy job. Actions are pinned by commit SHA, which holds for direct
+   references only: composite actions resolve their own dependencies by tag.
+
+6. **Publication is glob-driven**: every `.mdx` under `content/courses/` is
+   compiled and served at `/d/<id>`. `index.yaml` controls navigation, never
+   visibility — there is no unpublish mechanism. Recorded as an accepted
+   invariant with its review trigger in `docs/security-notes.md`.
+
+## Alternatives considered
+
+- **Custom domain now**: no prefix, no future migration of shared links; costs a
+  domain and a decision Miguel does not need to make to finish v0.1. Deferred
+  (Decision 2), not rejected.
+- **HashRouter** (`/#/d/bienvenida`): no 404.html needed and works on any host,
+  but ugly URLs, broken fragment anchors (the catalog and heading anchors both
+  use them), and a URL shape that cannot later become clean without breaking
+  every shared link. Rejected.
+- **A server or meta-framework with rewrite rules**: the correct answer for a
+  dynamic site and the wrong one here — ADR-0001 (client-side compute) and
+  ADR-0004 (static) both push the other way, and it would add hosting cost.
+- **`--base` flag in the workflow** (what the POC's workflow did): keeps the
+  config generic, but the local build then differs from the deployed one.
+  Rejected in favour of Decision 3.
+- **Gating deploy on CI via `workflow_run`**: composes the gates instead of
+  duplicating them, at the cost of a second workflow hop and a trigger shape
+  that is easy to get wrong. Rejected for now; the duplication is ~40 seconds.
+
+## Consequences
+
+- The `/nalanda/` prefix is a standing constraint: assets, links and any future
+  absolute path must derive from `BASE_URL`.
+- `404.html` is generated, never hand-edited. `vite preview` cannot prove it
+  exists (it has its own SPA fallback), so `spaFallback.test.ts` and the
+  build-shape cases in `deployedApp.test.tsx` are what guard the mechanism.
+- Every legitimate deep link is served with an HTTP 404 status. Harmless for
+  browsers; relevant if analytics or crawlers are ever added.
+- Lint and tests run twice per push to `main` (CI and the deploy job).
+- Merging to `main` publishes. With no branch protection (deferred, recorded in
+  `docs/security-notes.md`), a direct push to `main` also publishes — though the
+  deploy job's own lint/test gate means a broken commit fails to publish rather
+  than publishing broken.

--- a/docs/security-notes.md
+++ b/docs/security-notes.md
@@ -27,6 +27,19 @@ names its trigger for re-evaluation — nothing is "accepted forever".
 
 ## Accepted invariants
 
+### Everything under content/courses/ is published (recorded 2026-08-10)
+
+- **What it means**: the document registry globs `content/courses/**/*.mdx`, so
+  every document is compiled into the bundle and reachable at `/d/<id>` — being
+  absent from `index.yaml` only hides it from the TOC and prev/next, it does NOT
+  keep it off the site. Since #66 the site is public, so "unlisted" reads as
+  "unpublished" and is wrong.
+- **Why it is safe today**: the repo is public anyway, and the tree holds only
+  sample documents.
+- **Review trigger**: the first time material that must not be seen (exam keys,
+  solutions, unreleased classes) needs a home. Park it OUTSIDE
+  `content/courses/` — omitting it from the index is not a control.
+
 ### All bundled MDX is repo-controlled content (recorded 2026-08-07)
 
 - **What relies on it**: the presentation pipeline executes compiled MDX content

--- a/docs/security-notes.md
+++ b/docs/security-notes.md
@@ -4,6 +4,23 @@ Durable record of security decisions that are not ADR-scale: accepted-risk
 deferrals, advisory dispositions, and their review dates. Every deferral here
 names its trigger for re-evaluation — nothing is "accepted forever".
 
+## Deferred controls
+
+### No branch protection on `main` (deferred 2026-08-10)
+
+- **What is missing**: `main` has no ruleset. The hard rule "all changes go
+  through PRs, never push to main" (CLAUDE.md) is convention, not enforcement.
+- **Why it matters more since #66**: the deploy workflow triggers on push to
+  `main`, so an accidental direct push publishes to a public URL with no review.
+- **Why deferred**: single-maintainer repo; the owner decides whether to trade
+  the ability to push directly for the guarantee. Not expressible in a diff —
+  it needs repo admin rights.
+- **Review trigger**: a second contributor gains write access, or the first
+  accidental direct push. **When enabling**: require a PR; only make the `web`
+  check *required* after replacing ci.yml's path filters with in-job change
+  detection — the note at the top of ci.yml explains why (a docs-only PR would
+  otherwise wait forever on a check that never runs).
+
 ## Resolved advisories
 
 ### GHSA-qwww-vcr4-c8h2 — react-router RSC-mode CSRF (deferred 2026-08-06, RESOLVED 2026-08-10)

--- a/docs/standards/documentation.md
+++ b/docs/standards/documentation.md
@@ -20,6 +20,7 @@ finished until its documentation exists, and review verifies it (ADR-0005).
 | Content-component usage (what authors see) | The **catalog** (`/catalog` in-app) | when to use `<Slide>`, props, examples |
 | Component governance (contract, how-to-add, doc + review checklists) | The **catalog governance page** (`/catalog/governance`, authored in `apps/web/src/catalog/GovernancePage.tsx`) — the operational home authors and agents read; ADR-0010/0014 hold the decisions and win on disagreement, `guides/add-a-content-component.md` maps them onto repo paths | the seven contract points |
 | Workflow conventions (kanban, branches, PRs) | `docs/conventions.md` | commit format |
+| How an app is published & operated | Root `README.md` §Deployment (repo-level: URL, trigger, rollback, what to verify) + that app's `README.md` (app-level build shape: base path, emitted artifacts, gotchas) | Pages publication of `apps/web` (#66) |
 | Security deferrals / advisory dispositions | `docs/security-notes.md` | accepted-risk records with review triggers |
 | Course planning material | `docs/course-graph.md` + `docs/graphs/` | topic dependencies, topology diagrams |
 
@@ -33,6 +34,12 @@ page, expose it as a product surface, and add an L4 invariant that fails on
 hollow entries — empty required prose, missing examples, examples that render
 nothing, published paths that do not resolve. Prose pages stay the default for
 one-off narratives. Worked case: the catalog (#65).
+
+The same rule covers **facts the test environment cannot observe** — build-resolved
+config, emitted artifacts, host behavior. Document them in prose once, and pin
+each documented claim with an assertion against the real source (the config
+object, the emitted file), so the doc fails the suite when it goes stale. Worked
+case: the deployed shape (#66).
 
 ## Rules
 

--- a/docs/standards/frontend-code-style.md
+++ b/docs/standards/frontend-code-style.md
@@ -67,14 +67,17 @@ src/
   UI (error pages, layout slots), the shell passes it via props/children —
   features never import from `app/`. Worked case: `AppRoutes` injects
   `<NotFound />` into `DocumentPage`'s `notFound` prop.
-- **Build-time Vite plugins live with the concern they serve**, not in a separate
-  tooling folder: `content/contentIntegrity.ts` gates content, `content/wikiLinks.ts`
-  transforms it, `app/spaFallback.ts` serves the shell's router. They are Node-only,
-  never imported by browser code, and wired exclusively from `vite.config.ts`.
-- **Deployment-shape values** (base path, outDir) are declared once in
-  `vite.config.ts`; runtime code derives from `import.meta.env.BASE_URL` and CI
-  never overrides them on the command line — a CI-only flag makes local builds
-  unreproducible.
+- **Build-time plugins live with the concern they serve**, not in a separate
+  tooling folder: `content/contentIntegrity.ts` (Vite plugin) gates content,
+  `content/wikiLinks.ts` (remark plugin) transforms it, `app/spaFallback.ts`
+  (Vite plugin) serves the shell's router. They are Node-only, never imported by
+  browser code, and wired exclusively from `vite.config.ts` — a
+  confirmation-gated file (see `apps/web/CLAUDE.md`): propose the wiring diff and
+  get confirmation before editing it.
+- **The deployment base path is declared once**, in `vite.config.ts` (`outDir`
+  stays at the Vite default); runtime code derives from `import.meta.env.BASE_URL`
+  and CI never overrides it on the command line — a CI-only flag makes local
+  builds unreproducible (ADR-0015).
 - Directories are created when their first real file arrives — never empty.
 
 ## Naming

--- a/docs/standards/frontend-code-style.md
+++ b/docs/standards/frontend-code-style.md
@@ -19,7 +19,8 @@ pass before every commit.
 
 ```
 src/
-├── app/            # shell: entry (main.tsx), router (App.tsx), providers, global layout
+├── app/            # shell: entry (main.tsx), router (App.tsx), providers, global layout,
+│                   # and the shell's own build plugin (spaFallback.ts)
 ├── components/     # catalog content components, by family:
 │   ├── structure/  ├── semantic/  ├── interactive/  └── media/
 ├── catalog/        # /catalog feature: registry, catalog pages
@@ -66,6 +67,14 @@ src/
   UI (error pages, layout slots), the shell passes it via props/children —
   features never import from `app/`. Worked case: `AppRoutes` injects
   `<NotFound />` into `DocumentPage`'s `notFound` prop.
+- **Build-time Vite plugins live with the concern they serve**, not in a separate
+  tooling folder: `content/contentIntegrity.ts` gates content, `content/wikiLinks.ts`
+  transforms it, `app/spaFallback.ts` serves the shell's router. They are Node-only,
+  never imported by browser code, and wired exclusively from `vite.config.ts`.
+- **Deployment-shape values** (base path, outDir) are declared once in
+  `vite.config.ts`; runtime code derives from `import.meta.env.BASE_URL` and CI
+  never overrides them on the command line — a CI-only flag makes local builds
+  unreproducible.
 - Directories are created when their first real file arrives — never empty.
 
 ## Naming

--- a/docs/standards/guides/add-a-course-document.md
+++ b/docs/standards/guides/add-a-course-document.md
@@ -80,7 +80,8 @@ the frontmatter `id`, never the path. v0.1 supports exactly ONE course directory
 
    Depth-first order of `entries` = reading order (TOC, prev/next, and `/` lands
    on the FIRST entry — by convention the course welcome document). A document
-   not listed in the index is still reachable by wiki-link and URL.
+   not listed in the index is still compiled and served at `/d/<id>`: **the index
+   controls navigation, never visibility.**
 
 7. **Verify**: `npm run build` from `apps/web/`. The contentIntegrity gate fails
    the build (and CI — `content/**` triggers it) with a file-and-field message
@@ -88,6 +89,14 @@ the frontmatter `id`, never the path. v0.1 supports exactly ONE course directory
    value (must be auto, explicit, or none), malformed `index.yaml` (unknown key,
    group without docId nor label, empty children), duplicate or unknown `docId`
    in the index.
+
+8. **Publish**: merging to `main` republishes
+   <https://so77id.github.io/nalanda/> automatically — `content/**` is a deploy
+   trigger (ADR-0015). **Everything under `content/courses/` becomes public**,
+   listed or not: material that must not be seen (exam keys, solutions,
+   unreleased classes) does not belong here — omitting it from the index is not
+   a control (`docs/security-notes.md` §Accepted invariants). Check the document
+   on the live URL after the merge.
 
 ## Checklist
 
@@ -97,3 +106,4 @@ the frontmatter `id`, never the path. v0.1 supports exactly ONE course directory
 - [ ] Listed in `index.yaml` if it belongs to the recorrido.
 - [ ] `npm run build` green from `apps/web/` (content integrity gate).
 - [ ] Content language: Spanish is fine (user-facing course material).
+- [ ] Nothing here must stay private — merging publishes it at `/d/<id>`.

--- a/docs/standards/repository-structure.md
+++ b/docs/standards/repository-structure.md
@@ -84,6 +84,11 @@ Checklist for any new application under `apps/` (e.g., `apps/server` in v0.3):
       at root and app-specific concerns live in the app — no duplication.
 - [ ] Own CI job with **path filters**: changes under `apps/<name>/**` trigger only
       that app's pipeline.
+- [ ] If the app is user-facing, its **publication** wired into
+      `.github/workflows/deploy.yml` with the same filters — including any
+      directory outside `apps/` whose content it serves (`content/**` for
+      `apps/web`, ADR-0002/ADR-0015). A filter that misses that directory means
+      editing content never republishes.
 - [ ] Entry in the root `README.md` repository layout.
 - [ ] If it introduces a new language, it brings that language's standards document
       into `docs/standards/` (e.g., `backend-code-style.md` is born with

--- a/docs/standards/testing-strategy.md
+++ b/docs/standards/testing-strategy.md
@@ -13,6 +13,12 @@ protocols in this document:**
 2. **Pre-PR protocol** — runs before publishing ANY pull request. The full battery.
    CI mirrors this protocol exactly; a PR is not opened if any step fails locally.
 
+**Gates in CI** (`apps/web`): `ci.yml` mirrors the pre-PR protocol on PRs and on
+pushes to `main`. `deploy.yml` re-runs lint + test + build on the publish path —
+CI runs in parallel on the same push and nothing consumes its result, so the
+publishing job verifies itself (ADR-0015). It omits `format:check` deliberately:
+formatting cannot affect the deployed artifact.
+
 A new app cannot merge its first PR without registering both protocols here (see
 the add-new-app checklist in `repository-structure.md`).
 
@@ -23,7 +29,7 @@ the add-new-app checklist in `repository-structure.md`).
 | L1 Static | Types, lint, format | `tsc` + oxlint + prettier | Every commit |
 | L2 Unit | Pure logic: parsers, registries, index walks | Vitest | Every commit (TDD red→green per slice) |
 | L3 Component | Components honor their contract (e.g., per-mode rendering) | Vitest + Testing Library (jsdom) | Every commit, touched scope |
-| L4 Architecture | System invariants: import direction + feature edges (`src/architecture.test.ts`), content ids (`src/content/architecture.test.ts`), catalog entry shape (`src/catalog/architecture.test.tsx`), MDX map ↔ catalog completeness (`src/app/mdxComponents.test.ts`) | Vitest (pattern imported from DocumentBuddy) | Pre-PR + CI |
+| L4 Architecture | System invariants: import direction + feature edges (`src/architecture.test.ts`), content ids (`src/content/architecture.test.ts`), catalog entry shape (`src/catalog/architecture.test.tsx`), MDX map ↔ catalog completeness (`src/app/mdxComponents.test.ts`), deployed build shape (`src/app/deployedApp.test.tsx`, `src/app/spaFallback.test.ts`) | Vitest (pattern imported from DocumentBuddy) | Pre-PR + CI |
 | L5 Browser smoke | The real app boots; key flows render in a real browser | **Playwright** (decided 2026-08-06; introduced with the first real smoke, WP2+) | Pre-PR + CI |
 | L6 Backend integration | Go handlers against real SQLite + fakes | Go testing | Defined when `apps/server` is born (v0.3) |
 | L7 Cross-app e2e | browser → web → server | Top-level `e2e/` | v0.3+ |
@@ -79,6 +85,16 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   `app/`), so it lives in the shell test that owns the pair and states its L4
   role in a comment — e.g. the MDX map ↔ catalog completeness check in
   `src/app/mdxComponents.test.ts`.
+- **Build-shape invariants**: facts that only exist outside dev — the resolved
+  `base`, emitted artifacts like `404.html` — are invisible to the jsdom suite,
+  where `import.meta.env.BASE_URL` is always `/`. Pin them by asserting the
+  resolved Vite config (import `vite.config.ts` and call it with a `ConfigEnv`)
+  or by driving the plugin's hooks directly, and name the level in a header
+  comment. A green jsdom suite says nothing about the deployed build.
+- **Env-derived values go through a pure helper**: extract the transformation
+  into a colocated, unit-tested module rather than inlining it in a component
+  the suite cannot exercise. Worked case: `app/basename.ts` derives the router
+  basename from `BASE_URL` (#66).
 - **Registry-driven invariants**: when a standard applies to every member of a
   live registry, iterate the registry at module scope and generate one case per
   entry, so a new entry is gated the moment it is registered — never hand-write


### PR DESCRIPTION
**Closes #66**

## Summary

The last v0.1 work package: `apps/web` takes over the Pages deployment from the
archived POC. The site builds under `/nalanda/`, deep links survive a static
host via a build-emitted `404.html`, and the publish workflow lints, tests and
builds before uploading — with least-privilege permissions and SHA-pinned
actions. Decisions recorded in **ADR-0015**.

**Merging this PR publishes the site.** That is the point, and it is also why
the live checks are in your checklist below rather than in mine.

## Slices completed

- [x] S1 — Base path `/nalanda/` + router basename derived from `BASE_URL`
- [x] S2 — SPA fallback (`404.html`) as a Vite plugin
- [x] S3 — `deploy.yml` rewritten for `apps/web`
- [x] S4 — Deployment documented
- [x] Review fixes (two passes) + docs round

## Acceptance criteria

Verified against a static server that mimics Pages (serves the file if it
exists, else `404.html` with a 404 status) — **not** `vite preview`, whose own
SPA fallback would mask a missing file:

- **AC1** (pre-PR half): `/nalanda/` → "Bienvenida", `/nalanda/catalog` →
  "Catalog". Live half is yours, below.
- **AC2** (deep links): `/nalanda/d/busqueda-binaria` → the document,
  `/nalanda/d/bienvenida/present` → the deck at `1 / 3`,
  `/nalanda/catalog/c/Slide` → the component page. Zero console errors.
- **AC3** (POC no longer deployed): `deploy.yml` contains zero references to
  `proof-of-concept`; it stays runnable from source.
- **AC4** (documented): root README §Deployment (trigger, mechanism,
  verification, rollback, symptom→cause table) + `apps/web` README §Deployed
  shape + ADR-0015.
- **AC5** (path filters): `apps/web/**`, `content/**`, the workflow itself. The
  spec originally said `apps/web/**` only — that would have meant **writing a
  class never republishes the site**, which is the whole point of v0.1.
- **AC6** (SHA-pinned): 4 of 4 actions pinned by commit SHA.

## Tests

138 tests (127 before the review). `format:check` ✓ `lint` ✓ `test` ✓ `build` ✓.
Every mechanism this WP adds is now mutation-verified: reverting the base, the
`isPreview` branch, the `basename` prop, the plugin registration or its hook all
turn the suite red.

## Reviews run

- **Round A (code)**: 3 lenses. 17 findings; the verifier confirmed all 5
  important by reproducing them. **The worst one was mine**: hardening the base
  in S3 broke `vite preview` — it served the `/nalanda/` build at `/`, returning
  every JS bundle as `text/html`, i.e. a blank page — while the README I wrote
  claimed preview proved exactly that. Also caught: the fallback plugin ran in
  `closeBundle`, which Vite also runs on *failed* builds, so its error masked
  real ones (including the content-integrity gate's). Fixes in `34118f9`; the
  rechecks then found the `isPreview` fix was itself unguarded → `62d644e`.
- **Round B (docs)**: 4 lenses, 26 findings → 17 after dedup. Beyond ADR-0015,
  three process gaps that only exist now that the site self-publishes: **yolo
  mode** still authorized direct commits to `main`; the **authoring guide** said
  an unlisted document is "still reachable", reinforcing that omitting it hides
  it; and no `CLAUDE.md` mentioned that merging publishes. All closed in
  `b744064`, `04707c2`, `d3e312d` — the last one correcting two claims the
  accuracy recheck caught in my own ADR.
- **Patterns recorded**: build-shape invariants + env-derived helpers
  (`testing-strategy.md`); executable documentation extended to facts the test
  environment cannot observe (`documentation.md`).

## Manual verification (after merging)

The deploy runs on merge; give it ~2 minutes, then:

- [ ] <https://so77id.github.io/nalanda/> loads the welcome document.
- [ ] <https://so77id.github.io/nalanda/d/busqueda-binaria> opens **directly**
  (paste it in a fresh tab — that is the deep-link case).
- [ ] <https://so77id.github.io/nalanda/catalog> and
  <https://so77id.github.io/nalanda/catalog/governance>.
- [ ] Presentation mode: open a document, press `p`, navigate with `→`.
- [ ] If anything is broken: README §Deployment has a symptom→cause table, and
  the rollback is `git revert` of the merge commit (which redeploys).
- [ ] Read `docs/decisions/0015-static-publishing-pipeline.md` — especially
  Decision 2 (custom domain deferred): the cost of switching later is that deep
  links already shared under `/nalanda/` may not survive, so it is worth
  deciding before you hand URLs to students.

## Notes

- **No new dependencies.** `vite.config.ts` changes were approved via the issue.
- Two things deliberately left as yours: **branch protection on `main`** (you
  said no — recorded as a deferral with its trigger in `docs/security-notes.md`)
  and the **custom domain** (ADR-0015 Decision 2).
- Honest limit, recorded in the ADR: the publish gate catches lint, test and
  build failures — runtime breakage the suite cannot see still publishes. There
  is no browser smoke yet (L5, pending). The blank-page regression in this very
  WP is the worked example.
- With this merged, **v0.1 "El esqueleto" is complete** and the next milestone is
  v0.2 "El contenido vivo" — which starts with converting your real classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011MW6Zi5awCpwEGo3BNEnTg
