### PR TITLE
fix: render GFM tables and declare the page's basics

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -41,7 +41,8 @@ files the standard does not carry.
 ```
 src/
 ├── app/                  # shell: entry, router (documents, presentation, catalog, 404),
-│                         # MDX map, deployed base/basename, SPA-fallback build plugin
+│                         # MDX map, per-route document title, deployed base/basename,
+│                         # SPA-fallback build plugin
 ├── catalog/              # /catalog surface: registry, family taxonomy, component +
 │                         # governance pages, live-example blocks
 ├── components/           # catalog content components by family (structure: Slide,
@@ -49,8 +50,9 @@ src/
 │                         # + their lazy wrappers, shared Panel/useRunShortcut/draft)
 │                         # + their colocated <Component>.catalog.tsx entries,
 │                         # + AuthoringError: shared across families, not a content component
-├── content/              # content pipeline: MDX registry, course index, wiki-links,
-│                         # fence-metadata plugin, book-mode page, build-time integrity gate
+├── content/              # content pipeline: MDX registry, course index, remark plugin
+│                         # list (wiki-links, fence metadata, GFM), element renderers
+│                         # (links, tables), book-mode page, build-time integrity gate
 ├── presentation/         # presentation mode: mode context, slide parser, SlideDeck viewer
 ├── runtime/              # code execution: worker contract, registry, useRuntime hook,
 │                         # one folder per language (java, cpp, python)

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,9 +1,13 @@
 <!doctype html>
-<html lang="en">
+<html lang="es">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- The surface colour, so a phone paints its own chrome to match instead
+         of framing the page in white. Kept in step with `html` in
+         src/styles/index.css by hand: a meta tag cannot read a CSS variable. -->
+    <meta name="theme-color" content="#020617" />
     <title>Nalanda</title>
   </head>
   <body>

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -22,6 +22,7 @@
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "react-router-dom": "^7.18.2",
+        "remark-gfm": "^4.0.1",
         "tailwindcss": "^4.3.3",
         "yaml": "^2.9.0"
       },
@@ -2346,7 +2347,6 @@
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
       "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
@@ -2397,7 +2397,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
       "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -2413,7 +2412,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2449,7 +2447,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@uiw/codemirror-extensions-basic-setup": {
@@ -2733,7 +2730,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
       "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2761,7 +2757,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
       "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2782,7 +2777,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
       "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2958,7 +2952,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2983,7 +2976,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
       "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "character-entities": "^2.0.0"
@@ -2997,7 +2989,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3016,7 +3007,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
       "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.0"
@@ -3105,7 +3095,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3239,7 +3228,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fault": {
@@ -3478,7 +3466,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3817,7 +3804,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
       "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3876,11 +3862,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
       "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -3914,6 +3925,107 @@
         "mdast-util-from-markdown": "^2.0.0",
         "mdast-util-to-markdown": "^2.0.0",
         "micromark-extension-frontmatter": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -4005,7 +4117,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
       "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -4042,7 +4153,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
       "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -4064,7 +4174,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
       "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0"
@@ -4085,7 +4194,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
       "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4121,7 +4229,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
       "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4160,6 +4267,127 @@
       "license": "MIT",
       "dependencies": {
         "fault": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
@@ -4280,7 +4508,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
       "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4302,7 +4529,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
       "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4353,7 +4579,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
       "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4374,7 +4599,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
       "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4397,7 +4621,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
       "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4420,7 +4643,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
       "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4441,7 +4663,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
       "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4461,7 +4682,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
       "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4483,7 +4703,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
       "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4504,7 +4723,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
       "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4524,7 +4742,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
       "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4547,7 +4764,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
       "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4590,7 +4806,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
       "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4607,7 +4822,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
       "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4627,7 +4841,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
       "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4647,7 +4860,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
       "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4669,7 +4881,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
       "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4692,7 +4903,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
       "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4709,7 +4919,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
       "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4751,7 +4960,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -5194,6 +5402,24 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-mdx": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz",
@@ -5231,7 +5457,6 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
       "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -5256,6 +5481,21 @@
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -5618,7 +5858,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
       "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5666,7 +5905,6 @@
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -5686,7 +5924,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
       "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -5747,7 +5984,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
       "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -5761,7 +5997,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
       "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -5777,7 +6012,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
       "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -5799,7 +6033,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
       "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -5814,7 +6047,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
       "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -6121,7 +6353,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -22,7 +22,6 @@
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "react-router-dom": "^7.18.2",
-        "remark-gfm": "^4.0.1",
         "tailwindcss": "^4.3.3",
         "yaml": "^2.9.0"
       },
@@ -43,6 +42,7 @@
         "prettier": "^3.9.6",
         "pyodide": "^314.0.3",
         "remark-frontmatter": "^5.0.0",
+        "remark-gfm": "^4.0.1",
         "remark-mdx-frontmatter": "^5.2.0",
         "typescript": "~6.0.2",
         "unist-util-visit": "^5.1.0",
@@ -2347,6 +2347,7 @@
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
       "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
@@ -2397,6 +2398,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
       "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -2412,6 +2414,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2447,6 +2450,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@uiw/codemirror-extensions-basic-setup": {
@@ -2730,6 +2734,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
       "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2757,6 +2762,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
       "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2777,6 +2783,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
       "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2952,6 +2959,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2976,6 +2984,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
       "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "character-entities": "^2.0.0"
@@ -2989,6 +2998,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -3007,6 +3017,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
       "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.0"
@@ -3095,6 +3106,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3228,6 +3240,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fault": {
@@ -3466,6 +3479,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3804,6 +3818,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
       "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3866,6 +3881,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
       "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3876,6 +3892,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
       "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -3892,6 +3909,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
       "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -3935,6 +3953,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
       "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mdast-util-from-markdown": "^2.0.0",
@@ -3954,6 +3973,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
       "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -3971,6 +3991,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
       "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -3988,6 +4009,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
       "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -4003,6 +4025,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
       "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -4020,6 +4043,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
       "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -4117,6 +4141,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
       "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -4153,6 +4178,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
       "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -4174,6 +4200,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
       "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0"
@@ -4194,6 +4221,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
       "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4229,6 +4257,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
       "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4280,6 +4309,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
       "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "micromark-extension-gfm-autolink-literal": "^2.0.0",
@@ -4300,6 +4330,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
       "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "micromark-util-character": "^2.0.0",
@@ -4316,6 +4347,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
       "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -4336,6 +4368,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
       "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -4354,6 +4387,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
       "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -4371,6 +4405,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
       "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "micromark-util-types": "^2.0.0"
@@ -4384,6 +4419,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
       "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -4508,6 +4544,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
       "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4529,6 +4566,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
       "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4579,6 +4617,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
       "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4599,6 +4638,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
       "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4621,6 +4661,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
       "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4643,6 +4684,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
       "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4663,6 +4705,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
       "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4682,6 +4725,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
       "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4703,6 +4747,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
       "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4723,6 +4768,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
       "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4742,6 +4788,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
       "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4764,6 +4811,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
       "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4806,6 +4854,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
       "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4822,6 +4871,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
       "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4841,6 +4891,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
       "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4860,6 +4911,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
       "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4881,6 +4933,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
       "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4903,6 +4956,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
       "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4919,6 +4973,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
       "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4960,6 +5015,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -5406,6 +5462,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
       "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -5457,6 +5514,7 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
       "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -5491,6 +5549,7 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
       "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -5858,6 +5917,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
       "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5905,6 +5965,7 @@
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -5924,6 +5985,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
       "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -5984,6 +6046,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
       "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -5997,6 +6060,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
       "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -6012,6 +6076,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
       "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -6033,6 +6098,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
       "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -6047,6 +6113,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
       "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -6353,6 +6420,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
       "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -26,6 +26,7 @@
         "yaml": "^2.9.0"
       },
       "devDependencies": {
+        "@mdx-js/mdx": "^3.1.1",
         "@mdx-js/rollup": "^3.1.1",
         "@tailwindcss/typography": "^0.5.20",
         "@testing-library/jest-dom": "^7.0.0",
@@ -45,6 +46,7 @@
         "remark-gfm": "^4.0.1",
         "remark-mdx-frontmatter": "^5.2.0",
         "typescript": "~6.0.2",
+        "unified": "^11.0.5",
         "unist-util-visit": "^5.1.0",
         "vite": "^8.2.0",
         "vitest": "^4.1.10"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,6 +34,7 @@
     "yaml": "^2.9.0"
   },
   "devDependencies": {
+    "@mdx-js/mdx": "^3.1.1",
     "@mdx-js/rollup": "^3.1.1",
     "@tailwindcss/typography": "^0.5.20",
     "@testing-library/jest-dom": "^7.0.0",
@@ -53,6 +54,7 @@
     "remark-gfm": "^4.0.1",
     "remark-mdx-frontmatter": "^5.2.0",
     "typescript": "~6.0.2",
+    "unified": "^11.0.5",
     "unist-util-visit": "^5.1.0",
     "vite": "^8.2.0",
     "vitest": "^4.1.10"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,6 +30,7 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-router-dom": "^7.18.2",
+    "remark-gfm": "^4.0.1",
     "tailwindcss": "^4.3.3",
     "yaml": "^2.9.0"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,7 +30,6 @@
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-router-dom": "^7.18.2",
-    "remark-gfm": "^4.0.1",
     "tailwindcss": "^4.3.3",
     "yaml": "^2.9.0"
   },
@@ -51,6 +50,7 @@
     "prettier": "^3.9.6",
     "pyodide": "^314.0.3",
     "remark-frontmatter": "^5.0.0",
+    "remark-gfm": "^4.0.1",
     "remark-mdx-frontmatter": "^5.2.0",
     "typescript": "~6.0.2",
     "unist-util-visit": "^5.1.0",

--- a/apps/web/src/app/AppRoutes.tsx
+++ b/apps/web/src/app/AppRoutes.tsx
@@ -4,6 +4,7 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 import { CatalogOverviewPage, ComponentPage, FamilyPage, GovernancePage } from '../catalog';
 import { DocumentPage, courseIndex, walkIndex } from '../content';
 import { PresentationPage } from '../presentation';
+import { DocumentTitle } from './DocumentTitle';
 import { NotFound } from './NotFound';
 import { mdxComponents } from './mdxComponents';
 
@@ -15,6 +16,7 @@ const firstDocId = walkIndex(courseIndex)[0];
 export function AppRoutes() {
   return (
     <MDXProvider components={mdxComponents}>
+      <DocumentTitle />
       <Routes>
         <Route
           path="/"

--- a/apps/web/src/app/DocumentTitle.tsx
+++ b/apps/web/src/app/DocumentTitle.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+import { families } from '../catalog';
+import { registry } from '../content';
+import { routeTitle } from './routeTitle';
+
+/**
+ * Keeps `document.title` in step with the route.
+ *
+ * Rendered once by the shell rather than by each page: the shell is the only
+ * place allowed to import from every feature, and a title is a property of the
+ * document, not of whatever happens to be inside it. It renders nothing.
+ */
+export function DocumentTitle() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    document.title = routeTitle(
+      pathname,
+      (id) => registry.get(id)?.meta.title,
+      (id) => families.find((family) => family.id === id)?.name,
+    );
+  }, [pathname]);
+
+  return null;
+}

--- a/apps/web/src/app/catalogRoute.test.tsx
+++ b/apps/web/src/app/catalogRoute.test.tsx
@@ -40,6 +40,20 @@ describe('/catalog', () => {
     );
   });
 
+  it('makes a family name look like the link it is', async () => {
+    renderAt('/catalog');
+    await screen.findByRole('heading', { name: /^catalog$/i });
+
+    // All four were <a> elements with no colour and no underline: nothing said
+    // they were navigable before the pointer was already on them, and a keyboard
+    // user got no signal at all.
+    for (const family of families) {
+      const link = screen.getByRole('link', { name: family.name });
+      expect(link.className, `${family.name} does not look like a link`).toMatch(/text-sky-\d00/);
+      expect(link.className).toContain('hover:underline');
+    }
+  });
+
   it('navigates from the overview into a family page by clicking its link', async () => {
     renderAt('/catalog');
     await screen.findByRole('heading', { name: /^catalog$/i });

--- a/apps/web/src/app/documentShell.test.ts
+++ b/apps/web/src/app/documentShell.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+// What the HTML document declares about itself, before React runs. None of it is
+// reachable from a component test: jsdom builds its own document, so the shipped
+// `index.html` and the global stylesheet are only ever asserted here.
+// vitest runs with apps/web as its cwd.
+const html = readFileSync(join(process.cwd(), 'index.html'), 'utf8');
+const css = readFileSync(join(process.cwd(), 'src/styles/index.css'), 'utf8');
+
+describe('the document shell', () => {
+  it('declares the language the course is written in', () => {
+    // Course content is Spanish (root CLAUDE.md). Left at `en`, a screen reader
+    // pronounces the whole site with English phonemes.
+    expect(html).toMatch(/<html[^>]*\blang="es"/);
+  });
+
+  it('declares a dark colour scheme', () => {
+    // Without it the language <select>, the stdin <textarea> and the scrollbars
+    // render with light-mode native chrome inside a dark UI.
+    expect(css).toMatch(/color-scheme:\s*dark/);
+  });
+
+  it('paints the surface on the document itself, not only on a div', () => {
+    // The dark background came from `div.bg-slate-950` inside #root, so macOS
+    // overscroll showed white behind the page.
+    expect(css).toMatch(/\bhtml\b[^{]*\{[^}]*background/s);
+  });
+
+  it('tells a mobile browser what colour to paint its own chrome', () => {
+    expect(html).toMatch(/<meta[^>]*name="theme-color"[^>]*content="#020617"/);
+  });
+
+  it('found real files (guards against a vacuous check)', () => {
+    expect(html).toContain('<div id="root">');
+    expect(css).toContain('@import');
+  });
+});

--- a/apps/web/src/app/documentShell.test.ts
+++ b/apps/web/src/app/documentShell.test.ts
@@ -33,6 +33,17 @@ describe('the document shell', () => {
     expect(html).toMatch(/<meta[^>]*name="theme-color"[^>]*content="#020617"/);
   });
 
+  it('gives focus a ring of its own, thick enough to see', () => {
+    // The browser default was a 1px #005FCC hairline at 3.13:1 — technically
+    // above the 3:1 minimum, and a colour used nowhere else in the product.
+    const rule = /:focus-visible\s*\{[^}]*\}/s.exec(css)?.[0] ?? '';
+    expect(rule, 'no :focus-visible rule at all').not.toBe('');
+    expect(rule).toMatch(/outline:\s*(?:[2-9]|\d{2,})px/);
+    // Offset so the ring lands on the surface AROUND a control: sky-400 is
+    // 6.95:1 on a panel and 1.76:1 on the emerald run button.
+    expect(rule).toMatch(/outline-offset:\s*[1-9]/);
+  });
+
   it('found real files (guards against a vacuous check)', () => {
     expect(html).toContain('<div id="root">');
     expect(css).toContain('@import');

--- a/apps/web/src/app/documentShell.test.ts
+++ b/apps/web/src/app/documentShell.test.ts
@@ -33,15 +33,33 @@ describe('the document shell', () => {
     expect(html).toMatch(/<meta[^>]*name="theme-color"[^>]*content="#020617"/);
   });
 
-  it('gives focus a ring of its own, thick enough to see', () => {
+  it('keeps the meta colour and the painted surface the same colour', () => {
+    // Both sides carry a comment saying they are kept in step by hand, and both
+    // were asserted in isolation — so moving the CSS to slate-900 shipped green
+    // with the phone chrome no longer matching the page. #020617 IS slate-950.
+    expect(css).toMatch(/html\s*\{[^}]*var\(--color-slate-950\)/s);
+    expect(html).toContain('content="#020617"');
+  });
+
+  it('gives focus an outline of its own, thick enough to see', () => {
     // The browser default was a 1px #005FCC hairline at 3.13:1 — technically
     // above the 3:1 minimum, and a colour used nowhere else in the product.
     const rule = /:focus-visible\s*\{[^}]*\}/s.exec(css)?.[0] ?? '';
     expect(rule, 'no :focus-visible rule at all').not.toBe('');
     expect(rule).toMatch(/outline:\s*(?:[2-9]|\d{2,})px/);
-    // Offset so the ring lands on the surface AROUND a control: sky-400 is
+    // Offset so the outline lands on the surface AROUND a control: sky-400 is
     // 6.95:1 on a panel and 1.76:1 on the emerald run button.
     expect(rule).toMatch(/outline-offset:\s*[1-9]/);
+  });
+
+  it('gives the code editor an outline, since CodeMirror removes its own', () => {
+    const rule = /\.cm-editor\.cm-focused\s*\{[^}]*\}/s.exec(css)?.[0] ?? '';
+    expect(rule, 'no rule for the focused editor').not.toBe('');
+    expect(rule).toMatch(/outline:\s*[2-9]px/);
+    // NEGATIVE, and the sign is the whole thing. Outward it is clipped by the
+    // scrolling box and the shell's overflow-hidden, and getComputedStyle keeps
+    // reporting an outline no screenshot has. Lose the minus and it vanishes.
+    expect(rule).toMatch(/outline-offset:\s*-\d/);
   });
 
   it('found real files (guards against a vacuous check)', () => {

--- a/apps/web/src/app/documentTitle.test.tsx
+++ b/apps/web/src/app/documentTitle.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import { AppRoutes } from './AppRoutes';
+
+/**
+ * Pins the WIRING, not the function.
+ *
+ * `routeTitle.test.ts` proves the pure function computes the right strings, and
+ * proves nothing about anyone calling it: deleting `<DocumentTitle />` from
+ * `AppRoutes` left the whole suite green while every tab went back to reading
+ * "Nalanda". That is the same shape as the plugin list that could be unwired
+ * with the suite green — the failure this WP exists to stop repeating.
+ */
+function renderAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <AppRoutes />
+    </MemoryRouter>,
+  );
+}
+
+describe('the document title, as the shell actually sets it', () => {
+  it('names the document being read', async () => {
+    renderAt('/d/java-desde-cpp');
+    await waitFor(() => expect(document.title).toBe('Java desde C++ · Nalanda'));
+  });
+
+  it('names the catalog and its pages', async () => {
+    renderAt('/catalog');
+    await waitFor(() => expect(document.title).toBe('Catalog · Nalanda'));
+  });
+
+  it('follows a navigation rather than only the first load', async () => {
+    const user = userEvent.setup();
+    renderAt('/catalog');
+    await waitFor(() => expect(document.title).toBe('Catalog · Nalanda'));
+
+    await user.click(await screen.findByRole('link', { name: 'Interactivos' }));
+
+    await waitFor(() => expect(document.title).toBe('Interactivos · Catalog · Nalanda'));
+  });
+
+  it('leaves a blank-page URL rendering the 404 instead of crashing the app', async () => {
+    // `/d/%` is a malformed percent-escape. React Router catches its own decode
+    // failure and falls through to the catch-all; the title effect used to throw
+    // URIError, and with no error boundary anywhere React unmounted the root —
+    // a link anyone can type turned the whole site into a blank page.
+    renderAt('/d/%');
+
+    expect(await screen.findByText(/no encontrad|not found/i)).toBeInTheDocument();
+    expect(document.title).toBe('Nalanda');
+  });
+});

--- a/apps/web/src/app/routeTitle.test.ts
+++ b/apps/web/src/app/routeTitle.test.ts
@@ -12,23 +12,27 @@ const familyName = (id: string): string | undefined => ({ interactivos: 'Interac
 
 describe('routeTitle', () => {
   it('names the document being read', () => {
-    expect(routeTitle('/d/java-desde-cpp', lookup)).toBe('Java desde C++ · Nalanda');
+    expect(routeTitle('/d/java-desde-cpp', lookup, familyName)).toBe('Java desde C++ · Nalanda');
   });
 
   it('gives a presented document the same name as the read one', () => {
     // Someone hunting through tabs is looking for the document, not the mode.
-    expect(routeTitle('/d/java-desde-cpp/present', lookup)).toBe('Java desde C++ · Nalanda');
+    expect(routeTitle('/d/java-desde-cpp/present', lookup, familyName)).toBe(
+      'Java desde C++ · Nalanda',
+    );
   });
 
   it('falls back to the brand for a document the registry does not know', () => {
     // `/d/<id>` serves documents the index never lists; an unknown id is a 404
     // in the page, and a title claiming otherwise would be worse than none.
-    expect(routeTitle('/d/no-existe', lookup)).toBe(BRAND);
+    expect(routeTitle('/d/no-existe', lookup, familyName)).toBe(BRAND);
   });
 
   it('names the catalog and its pages, most specific first', () => {
-    expect(routeTitle('/catalog', lookup)).toBe('Catalog · Nalanda');
-    expect(routeTitle('/catalog/governance', lookup)).toBe('Governance · Catalog · Nalanda');
+    expect(routeTitle('/catalog', lookup, familyName)).toBe('Catalog · Nalanda');
+    expect(routeTitle('/catalog/governance', lookup, familyName)).toBe(
+      'Governance · Catalog · Nalanda',
+    );
     expect(routeTitle('/catalog/interactivos', lookup, familyName)).toBe(
       'Interactivos · Catalog · Nalanda',
     );
@@ -36,28 +40,60 @@ describe('routeTitle', () => {
     expect(routeTitle('/catalog/inventada', lookup, familyName)).toBe(
       'inventada · Catalog · Nalanda',
     );
-    expect(routeTitle('/catalog/c/Exercise', lookup)).toBe('Exercise · Catalog · Nalanda');
+    expect(routeTitle('/catalog/c/Exercise', lookup, familyName)).toBe(
+      'Exercise · Catalog · Nalanda',
+    );
   });
 
   it('uses the bare brand for the home page', () => {
-    expect(routeTitle('/', lookup)).toBe(BRAND);
+    expect(routeTitle('/', lookup, familyName)).toBe(BRAND);
   });
 
   it('survives trailing slashes and an unknown route', () => {
-    expect(routeTitle('/d/bienvenida/', lookup)).toBe('Bienvenida · Nalanda');
-    expect(routeTitle('/quien-sabe', lookup)).toBe(BRAND);
-    expect(routeTitle('', lookup)).toBe(BRAND);
+    expect(routeTitle('/d/bienvenida/', lookup, familyName)).toBe('Bienvenida · Nalanda');
+    expect(routeTitle('/quien-sabe', lookup, familyName)).toBe(BRAND);
+    expect(routeTitle('', lookup, familyName)).toBe(BRAND);
+  });
+
+  it('survives a malformed percent-escape instead of throwing', () => {
+    // `/d/%` threw URIError inside an effect, and with no error boundary React
+    // unmounted the root: a URL anyone can type blanked the whole site where the
+    // router alone renders the 404 page.
+    expect(() => routeTitle('/d/%', lookup, familyName)).not.toThrow();
+    expect(routeTitle('/d/%', lookup, familyName)).toBe(BRAND);
+    expect(routeTitle('/catalog/%E0%A4%A', lookup, familyName)).toBe(
+      '%E0%A4%A · Catalog · Nalanda',
+    );
+  });
+
+  it('decodes an id before looking it up, on every route that carries one', () => {
+    const seen: string[] = [];
+    const spy = (id: string): string | undefined => {
+      seen.push(id);
+      return TITLES[id];
+    };
+    routeTitle('/d/java-desde-cpp', spy, familyName);
+    expect(seen).toContain('java-desde-cpp');
+
+    // The family branch decodes too, and had no test of its own.
+    expect(routeTitle('/catalog/inter%20activos', lookup, familyName)).toBe(
+      'inter activos · Catalog · Nalanda',
+    );
+  });
+
+  it('handles /catalog/c with no component name', () => {
+    expect(routeTitle('/catalog/c', lookup, familyName)).toBe('Catalog · Nalanda');
   });
 
   it('decodes a percent-encoded id', () => {
-    expect(routeTitle('/catalog/c/Side%20By%20Side', lookup)).toBe(
+    expect(routeTitle('/catalog/c/Side%20By%20Side', lookup, familyName)).toBe(
       'Side By Side · Catalog · Nalanda',
     );
   });
 
   it('gives every route a distinct title (the whole point)', () => {
     const paths = ['/', '/d/bienvenida', '/d/java-desde-cpp', '/catalog', '/catalog/governance'];
-    const titles = paths.map((p) => routeTitle(p, lookup));
+    const titles = paths.map((p) => routeTitle(p, lookup, familyName));
     expect(new Set(titles).size).toBe(paths.length);
   });
 });

--- a/apps/web/src/app/routeTitle.test.ts
+++ b/apps/web/src/app/routeTitle.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { BRAND, routeTitle } from './routeTitle';
+
+const TITLES: Record<string, string> = {
+  'java-desde-cpp': 'Java desde C++',
+  bienvenida: 'Bienvenida',
+};
+const lookup = (id: string): string | undefined => TITLES[id];
+// A family id is a route slug; its display name is what belongs in a tab.
+const familyName = (id: string): string | undefined => ({ interactivos: 'Interactivos' })[id];
+
+describe('routeTitle', () => {
+  it('names the document being read', () => {
+    expect(routeTitle('/d/java-desde-cpp', lookup)).toBe('Java desde C++ · Nalanda');
+  });
+
+  it('gives a presented document the same name as the read one', () => {
+    // Someone hunting through tabs is looking for the document, not the mode.
+    expect(routeTitle('/d/java-desde-cpp/present', lookup)).toBe('Java desde C++ · Nalanda');
+  });
+
+  it('falls back to the brand for a document the registry does not know', () => {
+    // `/d/<id>` serves documents the index never lists; an unknown id is a 404
+    // in the page, and a title claiming otherwise would be worse than none.
+    expect(routeTitle('/d/no-existe', lookup)).toBe(BRAND);
+  });
+
+  it('names the catalog and its pages, most specific first', () => {
+    expect(routeTitle('/catalog', lookup)).toBe('Catalog · Nalanda');
+    expect(routeTitle('/catalog/governance', lookup)).toBe('Governance · Catalog · Nalanda');
+    expect(routeTitle('/catalog/interactivos', lookup, familyName)).toBe(
+      'Interactivos · Catalog · Nalanda',
+    );
+    // An unknown family still gets a title rather than a crash.
+    expect(routeTitle('/catalog/inventada', lookup, familyName)).toBe(
+      'inventada · Catalog · Nalanda',
+    );
+    expect(routeTitle('/catalog/c/Exercise', lookup)).toBe('Exercise · Catalog · Nalanda');
+  });
+
+  it('uses the bare brand for the home page', () => {
+    expect(routeTitle('/', lookup)).toBe(BRAND);
+  });
+
+  it('survives trailing slashes and an unknown route', () => {
+    expect(routeTitle('/d/bienvenida/', lookup)).toBe('Bienvenida · Nalanda');
+    expect(routeTitle('/quien-sabe', lookup)).toBe(BRAND);
+    expect(routeTitle('', lookup)).toBe(BRAND);
+  });
+
+  it('decodes a percent-encoded id', () => {
+    expect(routeTitle('/catalog/c/Side%20By%20Side', lookup)).toBe(
+      'Side By Side · Catalog · Nalanda',
+    );
+  });
+
+  it('gives every route a distinct title (the whole point)', () => {
+    const paths = ['/', '/d/bienvenida', '/d/java-desde-cpp', '/catalog', '/catalog/governance'];
+    const titles = paths.map((p) => routeTitle(p, lookup));
+    expect(new Set(titles).size).toBe(paths.length);
+  });
+});

--- a/apps/web/src/app/routeTitle.ts
+++ b/apps/web/src/app/routeTitle.ts
@@ -1,0 +1,57 @@
+/** What every title ends in, so a tab is recognisable as this site at a glance. */
+export const BRAND = 'Nalanda';
+
+/**
+ * The document title for a path, most specific part first.
+ *
+ * Every route shipped the same `<title>Nalanda</title>`: ten open tabs were ten
+ * identical tabs, browser history was a wall of one word, and a bookmark said
+ * nothing about what it pointed at.
+ *
+ * It lives in the shell rather than in each page because titling the document is
+ * the shell's job — a feature may not import `app/`, and the alternative was a
+ * DOM-writing hook in `lib/`, which is for pure code (the same reason `draft.ts`
+ * was moved out of it in #76).
+ *
+ * `docTitle` resolves a document id; it returns undefined for an id that is not
+ * in the registry, which is a real case — `/d/<id>` serves documents the index
+ * never lists.
+ */
+export function routeTitle(
+  pathname: string,
+  docTitle: (id: string) => string | undefined,
+  familyName: (id: string) => string | undefined = () => undefined,
+): string {
+  const parts = pathname
+    .replace(/^\/+|\/+$/g, '')
+    .split('/')
+    .filter(Boolean);
+
+  if (parts.length === 0) return BRAND;
+
+  if (parts[0] === 'd' && parts[1] !== undefined) {
+    const title = docTitle(decodeURIComponent(parts[1]));
+    // The `/present` suffix is deliberately not in the title: it is the same
+    // document, and a reader hunting through tabs is looking for the document.
+    return title === undefined ? BRAND : `${title} · ${BRAND}`;
+  }
+
+  if (parts[0] === 'catalog') {
+    const rest = parts.slice(1);
+    if (rest.length === 0) return `Catalog · ${BRAND}`;
+    if (rest[0] === 'governance') return `Governance · Catalog · ${BRAND}`;
+    // `/catalog/c/:name` is a component, `/catalog/:family` is a family. A
+    // component's name IS its display name; a family's id is a route slug, and
+    // a tab reading "interactivos" is a leaked implementation detail.
+    if (rest[0] === 'c') {
+      const name = rest[1];
+      return name === undefined
+        ? `Catalog · ${BRAND}`
+        : `${decodeURIComponent(name)} · Catalog · ${BRAND}`;
+    }
+    const id = decodeURIComponent(rest[0]);
+    return `${familyName(id) ?? id} · Catalog · ${BRAND}`;
+  }
+
+  return BRAND;
+}

--- a/apps/web/src/app/routeTitle.ts
+++ b/apps/web/src/app/routeTitle.ts
@@ -17,10 +17,26 @@ export const BRAND = 'Nalanda';
  * in the registry, which is a real case — `/d/<id>` serves documents the index
  * never lists.
  */
+/**
+ * `decodeURIComponent` that survives a malformed escape.
+ *
+ * The bare call threw `URIError` on `/d/%`, inside an effect, in an app with no
+ * error boundary — so React unmounted the root and a URL anyone can type
+ * rendered a blank page. React Router itself catches its own decode failure and
+ * falls through to the catch-all; this used to be the one thing that did not.
+ */
+function safeDecode(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
 export function routeTitle(
   pathname: string,
   docTitle: (id: string) => string | undefined,
-  familyName: (id: string) => string | undefined = () => undefined,
+  familyName: (id: string) => string | undefined,
 ): string {
   const parts = pathname
     .replace(/^\/+|\/+$/g, '')
@@ -30,7 +46,7 @@ export function routeTitle(
   if (parts.length === 0) return BRAND;
 
   if (parts[0] === 'd' && parts[1] !== undefined) {
-    const title = docTitle(decodeURIComponent(parts[1]));
+    const title = docTitle(safeDecode(parts[1]));
     // The `/present` suffix is deliberately not in the title: it is the same
     // document, and a reader hunting through tabs is looking for the document.
     return title === undefined ? BRAND : `${title} · ${BRAND}`;
@@ -45,11 +61,9 @@ export function routeTitle(
     // a tab reading "interactivos" is a leaked implementation detail.
     if (rest[0] === 'c') {
       const name = rest[1];
-      return name === undefined
-        ? `Catalog · ${BRAND}`
-        : `${decodeURIComponent(name)} · Catalog · ${BRAND}`;
+      return name === undefined ? `Catalog · ${BRAND}` : `${safeDecode(name)} · Catalog · ${BRAND}`;
     }
-    const id = decodeURIComponent(rest[0]);
+    const id = safeDecode(rest[0]);
     return `${familyName(id) ?? id} · Catalog · ${BRAND}`;
   }
 

--- a/apps/web/src/catalog/CatalogOverviewPage.tsx
+++ b/apps/web/src/catalog/CatalogOverviewPage.tsx
@@ -21,7 +21,11 @@ export function CatalogOverviewPage() {
           <li key={family.id}>
             <div className="flex items-baseline gap-3">
               <h2 className="text-2xl font-semibold">
-                <Link to={`/catalog/${family.id}`} className="hover:text-sky-300">
+                {/* Coloured and underlined-on-hover like every other link here:
+                    with only `hover:text-sky-300` the four family names were
+                    indistinguishable from headings, and a keyboard user reached
+                    them with no sign they led anywhere. */}
+                <Link to={`/catalog/${family.id}`} className="text-sky-400 hover:underline">
                   {family.name}
                 </Link>
               </h2>

--- a/apps/web/src/content/MdxLink.tsx
+++ b/apps/web/src/content/MdxLink.tsx
@@ -25,6 +25,15 @@ type Props = AnchorHTMLAttributes<HTMLAnchorElement>;
  * Anchor renderer for MDX documents: resolves wiki: hrefs (emitted by
  * remarkWikiLinks) against the registry; unresolved ids and unsafe URL schemes
  * render visibly broken instead of linking.
+ *
+ * **The guard covers markdown, not literal JSX.** MDX passes markdown-generated
+ * elements through the component map, so `[x](…)`, `[[wiki]]` and — since #83 —
+ * GFM's bare-URL autolinks all arrive here and get the scheme check and the
+ * `rel` hardening. An `<a>` written as literal JSX in a document does not: it
+ * renders as authored, `rel` and all. That is accepted rather than fixed,
+ * because everything under `content/` is reviewed in-repo material and MDX is
+ * executable code regardless — but it means this component is not a sanitiser,
+ * and nothing downstream should treat it as one.
  */
 export function MdxLink({ href = '', children, ...rest }: Props) {
   if (href.startsWith(WIKI_PREFIX)) {

--- a/apps/web/src/content/MdxTable.tsx
+++ b/apps/web/src/content/MdxTable.tsx
@@ -1,0 +1,21 @@
+import type { ComponentPropsWithoutRef } from 'react';
+
+/**
+ * A markdown table, in a box that scrolls instead of widening the page.
+ *
+ * A table has a minimum content width; the paragraph of literal pipes it
+ * replaced simply wrapped. Measured on `/d/java-desde-cpp` at 390px the moment
+ * GFM landed: horizontal page overflow went from 108px to 340px. Reference
+ * tables are exactly the content a student reads on a phone, and a page that
+ * slides sideways under the thumb is worse than a table that does.
+ *
+ * The wrapper is what scrolls, not the table, so the header row and the column
+ * widths keep behaving like a table.
+ */
+export function MdxTable(props: ComponentPropsWithoutRef<'table'>) {
+  return (
+    <div className="overflow-x-auto">
+      <table {...props} />
+    </div>
+  );
+}

--- a/apps/web/src/content/codeMeta.test.ts
+++ b/apps/web/src/content/codeMeta.test.ts
@@ -1,6 +1,3 @@
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
-
 import type { Code, Root } from 'mdast';
 import { describe, expect, it } from 'vitest';
 
@@ -44,26 +41,12 @@ describe('remarkCodeMeta', () => {
   });
 });
 
-// A plugin that is not registered transforms nothing. Removing `remarkCodeMeta`
-// from the pipeline left the whole suite green while every exercise in the
-// published document degraded to the author-error banner — the unit tests above
-// drive the function directly and never notice.
+// Registration is pinned in `mdxWiring.test.ts`, which resolves vite.config.ts
+// and runs the MDX plugin on real markdown.
 //
-// What each half now covers, since #83 moved the list out of `vite.config.ts`:
-// `mdxPipeline.test.tsx` compiles real MDX through the exported list, so a
-// plugin removed from `mdxPlugins.ts` fails there. This is the other failure
-// mode — the list is fine but the build stops using it, which no amount of
-// compiling through the list can see.
-describe('registration in the MDX pipeline', () => {
-  // vitest runs with apps/web as its cwd.
-  const config = readFileSync(join(process.cwd(), 'vite.config.ts'), 'utf8');
-
-  it('wires the shared plugin list into the MDX transform', () => {
-    expect(config).toContain("from './src/content/mdxPlugins.ts'");
-    expect(config).toMatch(/mdx\(\{\s*remarkPlugins\b/);
-  });
-
-  it('found a real config (guards against a vacuous check)', () => {
-    expect(config).toContain('providerImportSource');
-  });
-});
+// It used to be pinned here, by reading the config as text and searching for
+// plugin names. That was replaced because it did not work: changing the build to
+// `remarkPlugins.filter(...)` — dropping GFM from what is actually compiled —
+// left this file 7/7 green, while the shipped document chunk fell 3.3 kB and its
+// tables turned back into paragraphs of pipes. Reading a config can prove a name
+// appears in it; only resolving it proves the value is used.

--- a/apps/web/src/content/codeMeta.test.ts
+++ b/apps/web/src/content/codeMeta.test.ts
@@ -48,25 +48,22 @@ describe('remarkCodeMeta', () => {
 // from the pipeline left the whole suite green while every exercise in the
 // published document degraded to the author-error banner — the unit tests above
 // drive the function directly and never notice.
+//
+// What each half now covers, since #83 moved the list out of `vite.config.ts`:
+// `mdxPipeline.test.tsx` compiles real MDX through the exported list, so a
+// plugin removed from `mdxPlugins.ts` fails there. This is the other failure
+// mode — the list is fine but the build stops using it, which no amount of
+// compiling through the list can see.
 describe('registration in the MDX pipeline', () => {
   // vitest runs with apps/web as its cwd.
   const config = readFileSync(join(process.cwd(), 'vite.config.ts'), 'utf8');
-  // Delimited by what follows the array, not by the first ']': the list holds
-  // a nested [plugin, options] pair, and stopping there cut it in half.
-  const remarkList = config.slice(
-    config.indexOf('remarkPlugins:'),
-    config.indexOf('providerImportSource'),
-  );
 
-  it('registers remarkCodeMeta', () => {
-    expect(remarkList).toContain('remarkCodeMeta');
+  it('wires the shared plugin list into the MDX transform', () => {
+    expect(config).toContain("from './src/content/mdxPlugins.ts'");
+    expect(config).toMatch(/mdx\(\{\s*remarkPlugins\b/);
   });
 
-  it('registers remarkWikiLinks, which was equally unpinned', () => {
-    expect(remarkList).toContain('remarkWikiLinks');
-  });
-
-  it('found a real plugin list (guards against a vacuous check)', () => {
-    expect(remarkList).toContain('remarkFrontmatter');
+  it('found a real config (guards against a vacuous check)', () => {
+    expect(config).toContain('providerImportSource');
   });
 });

--- a/apps/web/src/content/mdxComponents.ts
+++ b/apps/web/src/content/mdxComponents.ts
@@ -1,9 +1,11 @@
 import { MdxLink } from './MdxLink';
+import { MdxTable } from './MdxTable';
 import { headingFor } from './mdxHeading';
 
 /** Content-owned MDX element mappings; the shell composes them with catalog components. */
 export const contentMdxComponents = {
   a: MdxLink,
+  table: MdxTable,
   h2: headingFor(2),
   h3: headingFor(3),
   h4: headingFor(4),

--- a/apps/web/src/content/mdxHeading.test.tsx
+++ b/apps/web/src/content/mdxHeading.test.tsx
@@ -24,7 +24,7 @@ describe('mdxHeading', () => {
 
     // The anchor is transparent while the heading is unhovered. Focusable and
     // invisible is the worst pairing: tabbing lands on it, nothing on screen
-    // moves, and S4's focus ring outlines something nobody can see.
+    // moves, and S4's focus outline surrounds something nobody can see.
     expect(anchor.className).toContain('group-hover:opacity-100');
     expect(anchor.className).toContain('focus-visible:opacity-100');
   });

--- a/apps/web/src/content/mdxHeading.test.tsx
+++ b/apps/web/src/content/mdxHeading.test.tsx
@@ -18,6 +18,28 @@ describe('mdxHeading', () => {
     expect(anchor).toHaveAttribute('href', '#la-idea');
   });
 
+  it('reveals the anchor to a keyboard, not only to a mouse', () => {
+    render(<H2>Una sección</H2>);
+    const anchor = screen.getByRole('link');
+
+    // The anchor is transparent while the heading is unhovered. Focusable and
+    // invisible is the worst pairing: tabbing lands on it, nothing on screen
+    // moves, and S4's focus ring outlines something nobody can see.
+    expect(anchor.className).toContain('group-hover:opacity-100');
+    expect(anchor.className).toContain('focus-visible:opacity-100');
+  });
+
+  it('renders the anchor in a colour that clears the contrast floor', () => {
+    render(<H2>Una sección</H2>);
+
+    // slate-600 measured 2.66:1 against slate-950, below the 3:1 minimum — and
+    // below 4.5:1 for h3/h4, where the marker is normal-size text rather than
+    // large. slate-400 is 7.87:1, and it only ever appears once revealed.
+    const anchor = screen.getByRole('link');
+    expect(anchor.className).toContain('text-slate-400');
+    expect(anchor.className).not.toContain('text-slate-600');
+  });
+
   it('renders the requested heading level', () => {
     const H3 = headingFor(3);
     render(<H3>Detalle</H3>);

--- a/apps/web/src/content/mdxHeading.tsx
+++ b/apps/web/src/content/mdxHeading.tsx
@@ -36,7 +36,7 @@ export function headingFor(level: 2 | 3 | 4) {
           aria-label={`Link to section "${text}"`}
           // slate-600 was 2.66:1 against the page, under the 3:1 floor. And it
           // revealed itself only to a pointer: focusable-and-transparent meant a
-          // keyboard user landed on it with nothing to see, focus ring included.
+          // keyboard user landed on it with nothing to see, focus outline included.
           className="ml-2 text-slate-400 no-underline opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
         >
           #

--- a/apps/web/src/content/mdxHeading.tsx
+++ b/apps/web/src/content/mdxHeading.tsx
@@ -34,7 +34,10 @@ export function headingFor(level: 2 | 3 | 4) {
         <a
           href={`#${slug}`}
           aria-label={`Link to section "${text}"`}
-          className="ml-2 text-slate-600 no-underline opacity-0 transition-opacity group-hover:opacity-100"
+          // slate-600 was 2.66:1 against the page, under the 3:1 floor. And it
+          // revealed itself only to a pointer: focusable-and-transparent meant a
+          // keyboard user landed on it with nothing to see, focus ring included.
+          className="ml-2 text-slate-400 no-underline opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
         >
           #
         </a>

--- a/apps/web/src/content/mdxPipeline.test.tsx
+++ b/apps/web/src/content/mdxPipeline.test.tsx
@@ -1,0 +1,94 @@
+import { evaluate } from '@mdx-js/mdx';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import * as runtime from 'react/jsx-runtime';
+import { describe, expect, it } from 'vitest';
+
+import { contentMdxComponents } from './mdxComponents';
+import { remarkPlugins } from './mdxPlugins';
+
+/**
+ * Compiles and renders MDX through the *same* plugin list the build uses.
+ *
+ * Every other test in this folder drives a plugin's transform directly, which
+ * says nothing about what a document turns into. This is the only place that
+ * answers "what does an author actually get".
+ */
+async function renderMdx(source: string): Promise<HTMLElement> {
+  const { default: Content } = await evaluate(source, { ...runtime, remarkPlugins });
+  // Through the real component map, and inside a router: wiki links render
+  // react-router `Link`s, and a document is never rendered outside one.
+  return render(
+    <MemoryRouter>
+      <Content components={contentMdxComponents} />
+    </MemoryRouter>,
+  ).container;
+}
+
+const TABLE = `
+| Palabra | Qué dice |
+|---|---|
+| public | Se puede llamar desde fuera |
+| static | Pertenece a la clase |
+`;
+
+describe('the MDX pipeline', () => {
+  it('turns a markdown table into a table', async () => {
+    const container = await renderMdx(TABLE);
+
+    // Without GFM, CommonMark has no table syntax and the whole block arrives as
+    // one paragraph of literal pipes — which is what the published Java document
+    // shipped: 0 tables, 4 pipe paragraphs, from 5 tables of reference material.
+    const table = container.querySelector('table');
+    expect(table, 'the table rendered as prose, not as a table').not.toBeNull();
+    expect(table?.querySelectorAll('th')).toHaveLength(2);
+    expect(table?.querySelectorAll('tbody tr')).toHaveLength(2);
+    expect(container.textContent).not.toContain('|---|');
+  });
+
+  it('lets a wide table scroll on its own instead of widening the page', async () => {
+    const container = await renderMdx(TABLE);
+
+    // Measured at 390px before this existed: the page overflowed by 340px, up
+    // from 108px, because a table has a minimum content width where the
+    // paragraph of pipes it replaced simply wrapped. The page must never be the
+    // thing that scrolls sideways.
+    const scroller = container.querySelector('table')?.parentElement;
+    expect(scroller?.className).toContain('overflow-x-auto');
+  });
+
+  it('renders the tables of the shipped Java document', async () => {
+    // The real thing, not a fixture: this file is why the WP exists.
+    const source = readFileSync(
+      join(process.cwd(), '../../content/courses/sample-course/06-java-desde-cpp.mdx'),
+      'utf8',
+    );
+    // Only the tables are under test here; the document's components are not the
+    // pipeline's business. Non-table lines are blanked rather than dropped —
+    // dropping them glues consecutive tables into one, which is a bug in the test
+    // and looks exactly like a bug in the code.
+    const tables = source
+      .split('\n')
+      .map((line) => (line.startsWith('|') ? line : ''))
+      .join('\n');
+
+    const container = await renderMdx(tables);
+
+    expect(container.querySelectorAll('table').length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('still keeps a fence meta as a data attribute', async () => {
+    const container = await renderMdx('```java starter\nint x = 1;\n```\n');
+
+    // GFM arriving must not disturb what Exercise reads its fences by (ADR-0019).
+    expect(container.querySelector('code')?.getAttribute('data-meta')).toBe('starter');
+  });
+
+  it('still renders a wiki link', async () => {
+    const container = await renderMdx('Ver [[busqueda-binaria]].\n');
+
+    expect(container.querySelector('a')).not.toBeNull();
+  });
+});

--- a/apps/web/src/content/mdxPipeline.test.tsx
+++ b/apps/web/src/content/mdxPipeline.test.tsx
@@ -40,7 +40,7 @@ describe('the MDX pipeline', () => {
 
     // Without GFM, CommonMark has no table syntax and the whole block arrives as
     // one paragraph of literal pipes — which is what the published Java document
-    // shipped: 0 tables, 4 pipe paragraphs, from 5 tables of reference material.
+    // shipped: 0 tables, 4 pipe paragraphs, from 4 tables of reference material.
     const table = container.querySelector('table');
     expect(table, 'the table rendered as prose, not as a table').not.toBeNull();
     expect(table?.querySelectorAll('th')).toHaveLength(2);
@@ -76,7 +76,9 @@ describe('the MDX pipeline', () => {
 
     const container = await renderMdx(tables);
 
-    expect(container.querySelectorAll('table').length).toBeGreaterThanOrEqual(4);
+    // A count, not a floor: the document has exactly four tables, and a floor
+    // that happens to equal the real number proves nothing about either.
+    expect(container.querySelectorAll('table')).toHaveLength(4);
   });
 
   it('still keeps a fence meta as a data attribute', async () => {

--- a/apps/web/src/content/mdxPlugins.ts
+++ b/apps/web/src/content/mdxPlugins.ts
@@ -1,0 +1,31 @@
+import remarkFrontmatter from 'remark-frontmatter';
+import remarkGfm from 'remark-gfm';
+import remarkMdxFrontmatter from 'remark-mdx-frontmatter';
+import type { PluggableList } from 'unified';
+
+import { remarkCodeMeta } from './codeMeta.ts';
+import { remarkWikiLinks } from './wikiLinks.ts';
+
+/**
+ * The remark plugins every course document is compiled with.
+ *
+ * Extracted from `vite.config.ts` so a test can compile MDX through the *same*
+ * list the build uses. It lived inline, and the only thing pinning it was a test
+ * that read the config file as text and searched for plugin names — which
+ * catches a deletion but proves nothing about what the pipeline produces.
+ *
+ * Order matters: frontmatter is stripped and exported before anything else can
+ * mistake it for content, and `remarkGfm` comes next because it is a *syntax*
+ * extension — it changes what the parser recognises at all — while the two
+ * below it walk the tree that parsing produced.
+ */
+export const remarkPlugins: PluggableList = [
+  remarkFrontmatter,
+  [remarkMdxFrontmatter, { name: 'frontmatter' }],
+  // MDX parses CommonMark, which has no tables. Without this, a markdown table
+  // is one paragraph of literal `|` characters — as five tables of reference
+  // material in the published Java document were (#83).
+  remarkGfm,
+  remarkWikiLinks,
+  remarkCodeMeta,
+];

--- a/apps/web/src/content/mdxPlugins.ts
+++ b/apps/web/src/content/mdxPlugins.ts
@@ -23,7 +23,7 @@ export const remarkPlugins: PluggableList = [
   remarkFrontmatter,
   [remarkMdxFrontmatter, { name: 'frontmatter' }],
   // MDX parses CommonMark, which has no tables. Without this, a markdown table
-  // is one paragraph of literal `|` characters — as five tables of reference
+  // is one paragraph of literal `|` characters — as four tables of reference
   // material in the published Java document were (#83).
   remarkGfm,
   remarkWikiLinks,

--- a/apps/web/src/content/mdxWiring.test.ts
+++ b/apps/web/src/content/mdxWiring.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import config from '../../vite.config';
+
+/**
+ * Proves the BUILD compiles markdown the way `mdxPipeline.test.tsx` proves the
+ * plugin list does.
+ *
+ * These are two different failure modes and the second is the one that bit.
+ * Extracting the list into `mdxPlugins.ts` moved the risk rather than removing
+ * it: compiling through the exported array says nothing about what
+ * `vite.config.ts` actually hands to `@mdx-js/rollup`. The first attempt guarded
+ * that with `expect(config).toMatch(/mdx\(\{\s*remarkPlugins\b/)` over the
+ * config's source text, which the review walked straight through — changing the
+ * build to `remarkPlugins.filter(...)` dropped GFM, and lint, tsc, vite build and
+ * all 347 tests stayed green while the shipped document chunk fell 3.3 kB and
+ * every table in it turned back into a paragraph of pipes.
+ *
+ * A test that reads a config as text can prove a name appears. It cannot prove
+ * the value is used. `testing-strategy.md` already said so; this resolves the
+ * config and runs the plugin, which is what that section prescribes.
+ */
+async function transformMdx(source: string): Promise<string> {
+  const resolved = await config({ command: 'build', mode: 'production' });
+  const plugins = (resolved.plugins ?? []).flat() as {
+    name?: string;
+    transform?: (code: string, id: string) => Promise<{ code?: string; value?: string } | string>;
+  }[];
+  const mdxPlugin = plugins.find((plugin) => plugin?.name === '@mdx-js/rollup');
+  expect(mdxPlugin?.transform, 'no @mdx-js/rollup plugin in the resolved config').toBeTypeOf(
+    'function',
+  );
+
+  const out = await mdxPlugin!.transform!.call({}, source, '/probe/table.mdx');
+  return typeof out === 'string' ? out : (out?.code ?? out?.value ?? '');
+}
+
+describe('what the build actually compiles', () => {
+  it('turns a markdown table into a table', async () => {
+    const compiled = await transformMdx('| a | b |\n|---|---|\n| 1 | 2 |\n');
+
+    // MDX emits element names for the component map to resolve.
+    expect(compiled).toContain('table');
+    expect(compiled).toContain('thead');
+  });
+
+  it('keeps a fence meta, which is the other plugin nobody was pinning', async () => {
+    const compiled = await transformMdx('```java starter\nint x = 1;\n```\n');
+
+    expect(compiled).toContain('data-meta');
+  });
+
+  it('compiled something real (guards against a vacuous check)', async () => {
+    const compiled = await transformMdx('Sólo un párrafo.\n');
+
+    expect(compiled).toContain('jsx');
+    expect(compiled).not.toContain('thead');
+  });
+});

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -29,36 +29,53 @@ html {
   background-color: var(--color-slate-950);
 }
 
-/* One focus ring for the whole product.
+/* One focus outline for the whole product.
 
    The browser default was a 1px `#005FCC` hairline: 3.13:1 against slate-950,
    scraping past the 3:1 minimum, in a blue that appears nowhere else here.
 
    `outline-offset` is load-bearing, not decoration. Measured against sky-400:
    the page is 9.42:1, panels 6.95:1, the sidebar 6.83:1 — but the emerald
-   Ejecutar/Comprobar button is **1.76:1**. Offsetting draws the ring on the
+   Ejecutar/Comprobar button is **1.76:1**. Offsetting draws the outline on the
    surface *around* the control instead of on the control, so the one surface it
    would fail against is never the one it lands on.
 
    `:focus-visible`, not `:focus`: a mouse click on a button should not leave a
-   ring behind, and the browser already knows the difference. */
+   mark behind, and the browser already knows the difference.
+
+   No `border-radius` here. It was added, and it silently overrode every
+   component's own corners: these rules are unlayered, Tailwind v4 emits its
+   utilities inside `@layer`, and unlayered wins regardless of specificity — so a
+   `rounded-lg` button measured 8px idle and 2px while focused. An outline
+   already follows the element's own radius; the declaration bought nothing and
+   cost that. */
 :focus-visible {
   outline: 2px solid var(--color-sky-400);
   outline-offset: 2px;
-  border-radius: 2px;
 }
 
-/* CodeMirror sets `outline: none` on itself, so the rule above never reached the
-   one control a student spends the most time in: tabbing into an editor left no
-   sign of having arrived. The ring goes on `.cm-editor` rather than on the
-   focused `.cm-content` inside it, because what should look focused is the box.
+/* The one place this stylesheet names a third-party class, and it has to.
 
-   The offset is NEGATIVE here, and that is the whole trick. An editor sits
-   inside a scrolling `max-h-*` container inside a shell with `overflow-hidden`,
-   and an ancestor that clips its overflow also clips an outline drawn outside
-   its child. With `+2px` the computed style reported a 2px sky ring that no
-   screenshot ever showed. Drawn inward it is inside the clip, and inside the
-   editor's own dark background, where sky-400 keeps its contrast. */
+   CodeMirror sets `outline: none` on itself, so the rule above never reached the
+   control a student spends the most time in: tabbing into an editor left no sign
+   of having arrived. Review proposed moving this into `CodeEditor.tsx` as a
+   Tailwind `focus-within:` utility, which would keep vendor knowledge with the
+   component that owns the dependency. It cannot work, and the reason is the same
+   cascade rule that made a `border-radius` here override every button:
+   **unlayered declarations beat layered ones regardless of specificity.**
+   Tailwind v4 emits its utilities inside `@layer utilities`; CodeMirror injects
+   its own styles unlayered at runtime. Measured after trying it: the editor
+   computed CodeMirror's `1px dotted rgb(33, 33, 33)`, not ours. An unlayered
+   rule here is the only thing that wins.
+
+   Two details, each of which was measured wrong once — and both times
+   `getComputedStyle` reported an outline no screenshot ever had:
+
+   - The offset is NEGATIVE. Drawn outward it is clipped: the editor sits in a
+     scrolling `max-h-*` box inside a shell with `overflow-hidden`, and an
+     ancestor that clips its overflow clips an outline drawn outside its child.
+   - It goes on `.cm-editor`, never on that scrolling wrapper. On the wrapper an
+     inward outline is painted over by the editor's own opaque background. */
 .cm-editor.cm-focused {
   outline: 2px solid var(--color-sky-400);
   outline-offset: -2px;

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -29,6 +29,41 @@ html {
   background-color: var(--color-slate-950);
 }
 
+/* One focus ring for the whole product.
+
+   The browser default was a 1px `#005FCC` hairline: 3.13:1 against slate-950,
+   scraping past the 3:1 minimum, in a blue that appears nowhere else here.
+
+   `outline-offset` is load-bearing, not decoration. Measured against sky-400:
+   the page is 9.42:1, panels 6.95:1, the sidebar 6.83:1 — but the emerald
+   Ejecutar/Comprobar button is **1.76:1**. Offsetting draws the ring on the
+   surface *around* the control instead of on the control, so the one surface it
+   would fail against is never the one it lands on.
+
+   `:focus-visible`, not `:focus`: a mouse click on a button should not leave a
+   ring behind, and the browser already knows the difference. */
+:focus-visible {
+  outline: 2px solid var(--color-sky-400);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* CodeMirror sets `outline: none` on itself, so the rule above never reached the
+   one control a student spends the most time in: tabbing into an editor left no
+   sign of having arrived. The ring goes on `.cm-editor` rather than on the
+   focused `.cm-content` inside it, because what should look focused is the box.
+
+   The offset is NEGATIVE here, and that is the whole trick. An editor sits
+   inside a scrolling `max-h-*` container inside a shell with `overflow-hidden`,
+   and an ancestor that clips its overflow also clips an outline drawn outside
+   its child. With `+2px` the computed style reported a 2px sky ring that no
+   screenshot ever showed. Drawn inward it is inside the clip, and inside the
+   editor's own dark background, where sky-400 keeps its contrast. */
+.cm-editor.cm-focused {
+  outline: 2px solid var(--color-sky-400);
+  outline-offset: -2px;
+}
+
 /* The typography plugin decorates inline code with literal backticks via
    ::before/::after, so `System.out.println` renders WITH its markup delimiters
    showing. Course prose is full of inline identifiers; the code style already

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -11,6 +11,24 @@
   --text-3xs: 0.65rem;
 }
 
+/* What the page is, declared on the document rather than assumed by a div.
+
+   `color-scheme` is what makes the browser's OWN widgets dark: the language
+   <select> and its dropdown, the stdin <textarea>, the scrollbars. Without it
+   they arrive in light-mode chrome inside a dark UI.
+
+   The surface colour was painted only by `div.bg-slate-950` inside #root, which
+   is not the canvas: macOS rubber-band overscroll showed white behind the page,
+   and so did any gap the app did not cover. Painting `html` fixes both, and
+   `body` inherits it.
+
+   Kept in step with the `theme-color` meta in index.html by hand — a meta tag
+   cannot read a CSS variable. */
+html {
+  color-scheme: dark;
+  background-color: var(--color-slate-950);
+}
+
 /* The typography plugin decorates inline code with literal backticks via
    ::before/::after, so `System.out.println` renders WITH its markup delimiters
    showing. Course prose is full of inline identifiers; the code style already

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -4,14 +4,11 @@ import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import remarkFrontmatter from 'remark-frontmatter';
-import remarkMdxFrontmatter from 'remark-mdx-frontmatter';
 import { defineConfig } from 'vite';
 
 import { spaFallback } from './src/app/spaFallback.ts';
-import { remarkCodeMeta } from './src/content/codeMeta.ts';
 import { contentIntegrity } from './src/content/contentIntegrity.ts';
-import { remarkWikiLinks } from './src/content/wikiLinks.ts';
+import { remarkPlugins } from './src/content/mdxPlugins.ts';
 
 const appDir = path.dirname(fileURLToPath(import.meta.url));
 // Course material lives at the repo root (Material domain, outside apps/) — ADR-0002.
@@ -30,15 +27,10 @@ export default defineConfig(({ command, isPreview }) => ({
     // MDX must transform before the React plugin sees the file.
     {
       enforce: 'pre',
-      ...mdx({
-        remarkPlugins: [
-          remarkFrontmatter,
-          [remarkMdxFrontmatter, { name: 'frontmatter' }],
-          remarkWikiLinks,
-          remarkCodeMeta,
-        ],
-        providerImportSource: '@mdx-js/react',
-      }),
+      // The list lives in src/content/mdxPlugins.ts so the suite can compile MDX
+      // through the same one the build uses, instead of scraping this file for
+      // plugin names.
+      ...mdx({ remarkPlugins, providerImportSource: '@mdx-js/react' }),
     },
     react(),
     tailwindcss(),

--- a/docs/standards/frontend-code-style.md
+++ b/docs/standards/frontend-code-style.md
@@ -94,7 +94,25 @@ src/
   (Vite plugin) serves the shell's router. They are Node-only, never imported by
   browser code, and wired exclusively from `vite.config.ts` — a
   confirmation-gated file (see `apps/web/CLAUDE.md`): propose the wiring diff and
-  get confirmation before editing it.
+  get confirmation before editing it. The remark list itself lives in
+  `content/mdxPlugins.ts` so the suite can compile MDX through the same array the
+  build uses; its order is an invariant — syntax extensions (`remark-gfm`) before
+  the plugins that walk the tree parsing produced.
+- **The shell titles the document, and owns anything else that is a property of
+  the page rather than of a feature.** A render-nothing component in `app/` with
+  an effect is the shape for it (worked case: `app/DocumentTitle.tsx`). It cannot
+  live in a feature — features may not import `app/`, and only the shell may
+  import every feature — and it must not live in `lib/`, which is for pure code
+  (the rule that moved `draft.ts` out of it in #76).
+- **The global stylesheet may name a third-party class only when nothing else
+  can win**, and the rule says why in place. Worked case: `.cm-editor.cm-focused`
+  in `styles/index.css`. CodeMirror injects `outline: none` **unlayered**, and
+  Tailwind v4 emits its utilities inside `@layer utilities` — unlayered beats
+  layered regardless of specificity, so a `focus-within:` utility on the
+  component loses. The same rule cuts the other way and is worth knowing before
+  writing anything here: an unlayered declaration in this file overrides every
+  Tailwind utility on the page, which is how a `border-radius` in `:focus-visible`
+  silently reshaped every focused button (#83).
 - **The deployment base path is declared once**, in `vite.config.ts` (`outDir`
   stays at the Vite default); runtime code derives from `import.meta.env.BASE_URL`
   and CI never overrides it on the command line — a CI-only flag makes local

--- a/docs/standards/guides/add-a-course-document.md
+++ b/docs/standards/guides/add-a-course-document.md
@@ -148,6 +148,11 @@ Full usage docs, props and live examples for every document-facing component
 live in the catalog — browse `/catalog`, which is generated from the components
 themselves rather than maintained by hand.
 
+5d. **External links**: write them as explicit `https://`. Markdown now parses
+   GFM, so a bare URL becomes a link on its own — and a bare `www.host` resolves
+   to **`http://`**, a cleartext link the reader can be downgraded on. Tables,
+   strikethrough (`~~`), task lists and footnotes also work now.
+
 6. **Cross-reference with wiki-links**: `[[otro-id]]` renders that document's
    link, `[[otro-id|texto visible]]` overrides the label. A target that doesn't
    exist does NOT fail the build: it renders visibly broken (red wavy underline)

--- a/docs/standards/testing-strategy.md
+++ b/docs/standards/testing-strategy.md
@@ -100,6 +100,16 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   resolved Vite config (import `vite.config.ts` and call it with a `ConfigEnv`)
   or by driving the plugin's hooks directly, and name the level in a header
   comment. A green jsdom suite says nothing about the deployed build.
+- **Extracting a build-time value for testability moves the risk to its wiring**,
+  and the wiring is pinned by resolving the config and running the plugin —
+  never by matching identifier text in `vite.config.ts`. Worked case (#83): the
+  remark plugin list was extracted so a test could compile MDX through it, and
+  the config was guarded with `expect(config).toMatch(/mdx\(\{\s*remarkPlugins\b/)`
+  over its source. Changing the build to `remarkPlugins.filter(...)` — dropping
+  GFM from what is actually compiled — left lint, `tsc`, `vite build` and all 347
+  tests green while the shipped document chunk fell 3.3 kB and its tables turned
+  back into paragraphs of pipes. Reading a config proves a name appears in it;
+  only resolving it proves the value is used (`content/mdxWiring.test.ts`).
 - **Execution is invisible to the suite**: every runtime is faked in jsdom
   (`CodeEditor.test.tsx` mocks CodeMirror and the worker; `java/runtime.test.ts`
   stubs the CheerpJ globals), and jsdom has no `Worker`, no CheerpJ DOM loader


### PR DESCRIPTION
Closes #83

## Summary

Seven defects a UX/UI audit found, and the one that matters is the first: **markdown tables were not tables.**

MDX parses CommonMark, and tables are a GFM extension. Without `remark-gfm` every table in the course arrived as a paragraph of literal pipe characters — measured on the published document: 0 `<table>` elements, 4 pipe paragraphs, from 33 rows across 4 tables. Primitive types, the words of `main`, the operators, the `Scanner` methods: the reference material a student comes back to was the least readable thing on the page. **This blocks #77–#81**, which are all reference-heavy.

The other six are small and each is a defect rather than a preference: a Spanish site declaring `lang="en"`, native form controls rendering light inside a dark UI, a canvas nothing painted (macOS overscroll showed white), eight routes sharing one `<title>`, a browser-default focus outline, and links that did not look like links.

## Slices

- [x] S1: Render GFM tables, and pin the plugin so the suite notices if it leaves
- [x] S2: Declare the page's language, colour scheme and painted surface
- [x] S3: Give every route its own document title
- [x] S4: Give focus a visible outline from the design system
- [x] S5: Make links look like links — catalog families and heading anchors

## Acceptance criteria

Everything below ran against `npm run build && npm run preview` (base `/nalanda/`, as deployed).

| # | Criterion | Evidence |
|---|---|---|
| 1 | A table renders as `<table>`, asserted through the real pipeline | `mdxPipeline.test.tsx` compiles MDX with the same array the build imports |
| 2 | Removing `remark-gfm` turns that test red | Ablation: removed it from `mdxPlugins.ts` → 3 tests red; restored → green |
| 3 | The document's tables render in both modes at 1440 and 390, no page overflow | Book: 4 tables, 0 pipe paragraphs, 0px overflow @1440. Presentation: the table renders on its slide, 0px @1440 and @390. **@390 book reports 108px** — see Notes |
| 4 | Existing content unchanged apart from tables | `content/` has no bare URLs, no `~~`, no task lists — GFM's other syntax cannot alter anything shipped |
| 5 | `lang`, `color-scheme`, painted `html`, `theme-color` | Browser: `es` · `dark` · html paints · meta present. The language `<select>` now computes `color-scheme: dark` |
| 6 | Each route sets a distinct title ending in `· Nalanda` | 6 routes → 6 distinct titles, and it follows an in-app navigation, not only first load |
| 7 | ≥2px focus outline at ≥3:1 on every focusable element | Tabbed 14 elements: all `2px solid` sky-400. See Notes on the one that reads `none` |
| 8 | Catalog family names look like links | Computed `oklch(0.746 0.16 232.661)` = sky-400, plus `hover:underline` |
| 9 | Heading anchors ≥3:1 | slate-400 = **7.87:1** (was slate-600 = 2.66:1) |
| 10 | Protocols green | format · lint · **357 tests** · build |

## Tests

357 tests, 44 files. Up from 326 on `main`.

## Reviews run

Full pipeline, Round A with four lenses (correctness, architecture, security, performance) over `main...HEAD`: 20 raw findings, 16 unique, 15 applied, 1 deferred. The adversarial verifier was skipped — nearly every finding arrived with executed proof rather than a claim.

**The sharpest one was aimed at my own fix.** Extracting the plugin list so a test could compile through it moved the risk rather than removing it, and the guard I left behind — matching the config's *source text* — was **weaker than the inline-array scrape it replaced**. Changing the build to `remarkPlugins.filter(...)` dropped GFM from what is actually compiled: lint, tsc, build and all 347 tests green, while the shipped chunk fell 3.3 kB and every table went back to being pipes. The exact bug this WP exists to fix, reintroducible in silence. `mdxWiring.test.ts` now resolves the config and runs the plugin; verified against that mutation, old test 7/7 green, new one red.

Three more of mine:

- **A crash.** `/d/%` threw `URIError` inside the title effect; with no error boundary React unmounted the root, so a URL anyone can type blanked the site where the router alone renders the 404.
- **S3 shipped with its own outcome untested** — deleting `<DocumentTitle />` left 347/347 green. Same shape as the plugin list, one slice later. Now 4 tests fail.
- **`border-radius: 2px` in the global focus rule** overrode every `rounded` control while focused (8px → 2px, measured), because these rules are unlayered and Tailwind's utilities are layered.

And one nobody would find by reading: **the word "ring"** in my comments and test names made Tailwind emit an unused `.ring` utility plus 14 `@property` declarations — 83% of this branch's CSS growth, in the render-blocking stylesheet. Reworded to "outline".

**A review suggestion I tried and reverted**, because it is worth knowing: moving the CodeMirror outline into the component as a Tailwind utility cannot work. CodeMirror injects `outline: none` **unlayered**; Tailwind emits utilities inside `@layer utilities`; unlayered wins regardless of specificity. Measured after trying: the editor computed CodeMirror's `1px dotted`. The unlayered global rule is the only thing that beats it — by exactly the mechanism that made the `border-radius` a bug. Both attempts failed in a way `getComputedStyle` could not see; only a screenshot disagreed, twice.

Round B folded into the same pass: three structural rules this branch invented had no home (where the remark list lives and that its order is an invariant, that the shell titles the document, when the stylesheet may name a vendor class), plus the config-text-versus-resolved-config lesson in `testing-strategy.md`.

## Manual verification

- [ ] `/nalanda/d/java-desde-cpp` — the four tables read as tables. This is the point of the PR.
- [ ] Same document at `/present`: the table on its slide.
- [ ] Open a few pages and look at the browser tabs — each says what it is.
- [ ] Tab through a document with the keyboard: you can always see where you are, editors included.
- [ ] `/nalanda/catalog` — the family names look clickable before you touch them.
- [ ] Visit `/nalanda/d/%` — you should get the 404 page, not a blank one.
- [ ] Anywhere with a language picker: the dropdown is dark, not white.

## Notes

**AC3 at 390px reports 108px of overflow, not zero.** That is the sidebar, which never collapses — #84's scope and an explicit non-goal here. The performance lens measured it independently at 108px on **both** `main` and this branch, with the widest element being `.cm-content`, not a table. Tables contribute nothing; GFM briefly made it 340px and the `MdxTable` scroll wrapper took that back.

**AC7's `3px none`** among the focused elements is CodeMirror's `.cm-content`, which removes its own outline. The visible outline sits on its parent `.cm-editor` — verified by screenshot, and pinned by a test that asserts the rule *and the sign of its offset*.

**Deferred:** ARQ-1, unifying the route table with `AppRoutes` so titles cannot drift from routes. It is a shell refactor larger than this WP, and the test added for COR-1 closes the gap that made the duplication dangerous.

**Dependencies:** `remark-gfm` (build-time, `devDependencies`), plus `@mdx-js/mdx` and `unified`, which were already being imported and resolving only through npm hoisting. `npm audit` 0; the lockfile's integrity for `remark-gfm` is byte-identical to the registry's, and regenerating it reproduces the subtree exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTpxW23vb8Aqax45FauHtr
