### PR TITLE
docs: record the two lessons #83 learned and did not write down

### DIFF
--- a/.claude/workflow-bindings.md
+++ b/.claude/workflow-bindings.md
@@ -93,5 +93,15 @@ anonymize: false
 ## Overrides
 
 ```
-(none)
+review-pipeline: spawn every lens with isolation: worktree
 ```
+
+The lenses do not read a diff, they execute it — they run `npm run build`, drive
+Playwright, and mutate source to see what stays green. Run in one shared
+worktree they fight over `dist/` and over each other's probe files: in #83 the
+performance lens had its build clobbered mid-measurement and redid every number
+in two worktrees of its own, another lens saw a sibling's untracked test file and
+reported it, and a third measured test counts that shifted under it from 347 to
+355. The orchestrator's own browser checks could not run at all while they
+worked. One worktree each costs a few hundred milliseconds of setup and removes
+the whole class of problem.

--- a/docs/standards/testing-strategy.md
+++ b/docs/standards/testing-strategy.md
@@ -110,6 +110,15 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   tests green while the shipped document chunk fell 3.3 kB and its tables turned
   back into paragraphs of pipes. Reading a config proves a name appears in it;
   only resolving it proves the value is used (`content/mdxWiring.test.ts`).
+- **In the browser, the evidence is the pixels.** `getComputedStyle` reporting a
+  value is not proof it was painted: it answers what the cascade resolved, not
+  what the compositor drew. Anything visual is verified by taking a screenshot
+  and looking at it. Worked case (#83), which cost the lesson twice in one WP:
+  a focus outline on the code editor computed as `2px solid` sky-400 and was
+  invisible both times — first because an ancestor with `overflow-hidden` clips
+  an outline drawn outside its child, then because an opaque child paints over
+  one drawn inward. Both times the DOM agreed with the intention and only the
+  screenshot disagreed.
 - **Execution is invisible to the suite**: every runtime is faked in jsdom
   (`CodeEditor.test.tsx` mocks CodeMirror and the worker; `java/runtime.test.ts`
   stubs the CheerpJ globals), and jsdom has no `Worker`, no CheerpJ DOM loader


### PR DESCRIPTION
Follow-up to #88, which owed these and shipped without them.

Both were about to be pasted by hand into the next conversation as "context the next session needs" — which is precisely the signal that they belong in the repo instead. The rule this repo already has: documentation ships with the change that obligates it.

## What lands

**`docs/standards/testing-strategy.md` — the evidence for anything visual is the pixels.** `getComputedStyle` answers what the cascade resolved, not what the compositor drew. #83 paid for that twice in one WP: the editor's focus outline computed as `2px solid` sky-400 and was invisible both times — once because an ancestor with `overflow-hidden` clips an outline drawn outside its child, once because an opaque child paints over one drawn inward. The DOM agreed with the intention both times; only the screenshot disagreed.

**`.claude/workflow-bindings.md` — review lenses get a worktree each.** They do not read a diff, they execute it: building, driving Playwright, mutating source to see what stays green. Sharing one worktree they collide, and in #83 they did: the performance lens lost its `dist/` mid-measurement and repeated every number in two worktrees of its own, one lens reported a sibling's untracked probe file as a finding, another watched the test count shift under it from 347 to 355, and the orchestrator could not start a preview server while they ran.

## Not included

The third lesson from that WP — unlayered CSS in `styles/index.css` beats every Tailwind utility regardless of specificity — **did** ship, in `frontend-code-style.md`. Checked before writing this.

## Verification

Documentation only; no code, no content. `npm run format:check` green. Nothing under `apps/web/**` or `content/**`, so this does not trigger a deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTpxW23vb8Aqax45FauHtr