### PR TITLE
feat: require landscape for presentation mode on a phone

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ prefix may not survive the move, so decide before handing URLs to students
   | Deploy job fails on permissions | repo Settings ▸ Pages source must be "GitHub Actions", and the `github-pages` environment must allow `main` | — |
   | Deploy job fails before Vite starts | `prebuild` could not reach Maven Central, or the ECJ checksum did not match | the script's own error; nothing is written on mismatch (ADR-0017) |
   | Site fine, but Ejecutar never finishes or never warms | a runtime CDN is down or blocked (`cjrtnc.leaningtech.com`, `cdn.jsdelivr.net`) | nothing — accepted risk, `docs/security-notes.md` |
+  | `/d/<id>/present` blank on an old iPhone | `MediaQueryList.addEventListener` needs Safari/iOS 14 | nothing — accepted baseline, ADR-0023 |
+  | `/d/<id>/present` shows "Gira el teléfono" and no slide | working as designed on a touch device held upright; rotate, or use the book view | `presentationRoute.test.tsx`, ADR-0023 |
 
 ## Workflow
 

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -37,10 +37,13 @@ SPA fallback and the `vite preview` gotcha). One home per fact, per
   1. _Execution_: every runtime is faked in jsdom, so any change under
      `src/runtime/**`, or to a component that drives a runtime (`CodeEditor`,
      `Exercise`, `harness.ts`) or the draft store, needs a browser too.
-  2. _Layout and focus_: jsdom lays nothing out and does not implement the
-     browser's tab order, so anything that enumerates focusables, moves focus,
-     or depends on a viewport width, a scroll position or a rule in
-     `styles/index.css` needs a browser too.
+  2. _Layout, focus and device shape_: jsdom lays nothing out and does not
+     implement the browser's tab order, so anything that enumerates focusables,
+     moves focus, depends on a viewport width, a scroll position, a device
+     capability asked through `window.matchMedia` (pointer type, orientation —
+     jsdom implements no media query at all), or a rule in `styles/index.css`
+     needs a browser too. A device rule also needs an emulated device, not
+     merely a small window: the recipe is in `testing-strategy.md` §Conventions.
 
   Written as classes rather than lists of names because the list was already
   stale once: `Exercise` arrived with the same shape and the same hazard, and

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -57,7 +57,8 @@ src/
 │                         #   (collapsed to the active path, filterable), breadcrumb,
 │                         #   section spine hook and its two placements: the rail
 │                         #   at 2xl, the drawer at every width below it
-├── presentation/         # presentation mode: mode context, slide parser, SlideDeck viewer
+├── presentation/         # presentation mode: mode context, slide parser, SlideDeck viewer,
+│                         # and the phone-orientation rule (ADR-0023)
 ├── runtime/              # code execution: worker contract, registry, useRuntime hook,
 │                         # one folder per language (java, cpp, python)
 ├── lib/                  # pure TS utilities + cross-feature contract types

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -79,6 +79,12 @@ adding a content component → `docs/standards/guides/add-a-content-component.md
 The site is published under **`/nalanda/`** (GitHub Pages project URL; the
 repo-level story — trigger, rollback — is in the root README).
 
+**Browser baseline: Safari 14+ / iOS 14+** (`MediaQueryList.addEventListener`),
+and in practice any browser that can run the in-browser runtimes — a much
+heavier bar, imposed by ADR-0016/0017 but never written as a version. No legacy
+fallbacks are shipped; the decision and the case that does not hold are in
+ADR-0023.
+
 - `vite.config.ts` owns the base path: `/nalanda/` for `build` and `preview`,
   `/` for `dev` so local URLs stay short. Runtime code never hardcodes it —
   `App.tsx` derives the router basename from `import.meta.env.BASE_URL`.

--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -145,6 +145,19 @@ describe('presentation on a phone held in portrait', () => {
     expect(await findCounter()).toHaveTextContent(/^2 \//);
   });
 
+  it('lets the reader leave the presentation for the book view of the document', async () => {
+    coarsePortrait(true);
+    renderAt(`/d/${firstId}/present`);
+    await screen.findByRole('alertdialog');
+
+    fireEvent.click(screen.getByRole('link', { name: /leer|libro|volver/i }));
+
+    // Still a coarse pointer in portrait — and the book view, which was built
+    // for exactly that (#84), is not covered by anything.
+    expect(await screen.findByRole('article')).toBeInTheDocument();
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+
   it('never covers a fine-pointer window, whatever its shape', async () => {
     coarsePortrait(false);
     renderAt(`/d/${firstId}/present`);

--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -1,6 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { courseIndex, registry, walkIndex } from '../content';
 
@@ -80,6 +80,77 @@ describe('PresentationPage viewer', () => {
     renderAt(`/d/${firstId}/present`);
     await findCounter();
     expect(screen.getByRole('button', { name: /pantalla completa/i })).toBeInTheDocument();
+  });
+});
+
+// The phone rule end to end, over the real route and a real document: what the
+// reader gets from /d/<id>/present, not what a component does in isolation.
+// The fake is local rather than shared with presentation/usePortraitPhone.test
+// because a cross-feature import may only go through the feature seam
+// (src/architecture.test.ts), and a test fake is not part of one.
+function coarsePortrait(initial: boolean) {
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+  let matches = initial;
+  window.matchMedia = ((query: string) =>
+    ({
+      media: query,
+      get matches() {
+        return matches;
+      },
+      addEventListener: (_type: string, listener: (event: MediaQueryListEvent) => void) => {
+        listeners.add(listener);
+      },
+      removeEventListener: (_type: string, listener: (event: MediaQueryListEvent) => void) => {
+        listeners.delete(listener);
+      },
+    }) as unknown as MediaQueryList) as typeof window.matchMedia;
+  return {
+    turn(next: boolean) {
+      matches = next;
+      act(() => {
+        for (const listener of listeners) listener({ matches: next } as MediaQueryListEvent);
+      });
+    },
+  };
+}
+
+describe('presentation on a phone held in portrait', () => {
+  afterEach(() => {
+    Reflect.deleteProperty(window, 'matchMedia');
+  });
+
+  it('covers the deck: the panel is shown and no slide is painted', async () => {
+    coarsePortrait(true);
+    renderAt(`/d/${firstId}/present`);
+
+    // Waiting for the panel also waits for the lazy document: the deck is what
+    // decides, so by now the slides exist and their absence is a decision.
+    expect(await screen.findByRole('alertdialog')).toBeInTheDocument();
+    expect(screen.queryByText(/^\d+ \/ \d+$/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: firstTitle })).not.toBeInTheDocument();
+  });
+
+  it('shows the deck at the reader’s slide when the phone is turned, and back', async () => {
+    const media = coarsePortrait(true);
+    renderAt(`/d/${firstId}/present?slide=2`);
+    await screen.findByRole('alertdialog');
+
+    media.turn(false);
+    expect(await findCounter()).toHaveTextContent(/^2 \//);
+
+    media.turn(true);
+    expect(await screen.findByRole('alertdialog')).toBeInTheDocument();
+
+    media.turn(false);
+    expect(await findCounter()).toHaveTextContent(/^2 \//);
+  });
+
+  it('never covers a fine-pointer window, whatever its shape', async () => {
+    coarsePortrait(false);
+    renderAt(`/d/${firstId}/present`);
+
+    expect(await findCounter()).toHaveTextContent(/^1 \//);
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { courseIndex, registry, walkIndex } from '../content';
 
@@ -91,19 +91,25 @@ describe('PresentationPage viewer', () => {
 function coarsePortrait(initial: boolean) {
   const listeners = new Set<(event: MediaQueryListEvent) => void>();
   let matches = initial;
-  window.matchMedia = ((query: string) =>
-    ({
+  window.matchMedia = ((query: string) => {
+    // Answers only the question it was written for. framer-motion asks this
+    // same fake about (prefers-reduced-motion) when the deck mounts, so a fake
+    // that returned `matches` for every query would also be telling it that
+    // reduced motion is on, for the rest of the file (#91 review).
+    const phoneRule = query.includes('pointer: coarse');
+    return {
       media: query,
       get matches() {
-        return matches;
+        return phoneRule && matches;
       },
       addEventListener: (_type: string, listener: (event: MediaQueryListEvent) => void) => {
-        listeners.add(listener);
+        if (phoneRule) listeners.add(listener);
       },
       removeEventListener: (_type: string, listener: (event: MediaQueryListEvent) => void) => {
         listeners.delete(listener);
       },
-    }) as unknown as MediaQueryList) as typeof window.matchMedia;
+    } as unknown as MediaQueryList;
+  }) as typeof window.matchMedia;
   return {
     turn(next: boolean) {
       matches = next;
@@ -128,6 +134,65 @@ describe('presentation on a phone held in portrait', () => {
     expect(await screen.findByRole('alertdialog')).toBeInTheDocument();
     expect(screen.queryByText(/^\d+ \/ \d+$/)).not.toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: firstTitle })).not.toBeInTheDocument();
+  });
+
+  it('leaves nothing but the way out reachable by keyboard', async () => {
+    coarsePortrait(true);
+    renderAt(`/d/${firstId}/present`);
+    await screen.findByRole('alertdialog');
+
+    // The whole route, not the panel's subtree: the claim is that no control of
+    // the deck survives anywhere, which asking the panel about itself cannot
+    // show. Enumerated by construction — jsdom has no tab order of its own —
+    // and cross-checked in Chromium, where five Tab presses reach only this
+    // link (testing-strategy.md §Layout and focus).
+    const reachable = [
+      ...document.querySelectorAll<HTMLElement>('a[href], button, [tabindex]:not([tabindex="-1"])'),
+    ];
+    expect(reachable.map((element) => element.textContent)).toEqual(['Leer en el libro']);
+  });
+
+  it('ignores the slide keys behind the panel, so the position cannot drift', async () => {
+    const media = coarsePortrait(true);
+    renderAt(`/d/${firstId}/present?slide=2`);
+    await screen.findByRole('alertdialog');
+
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    fireEvent.keyDown(window, { key: 'End' });
+
+    media.turn(false);
+    expect(await findCounter()).toHaveTextContent(/^2 \//);
+  });
+
+  it('still answers Escape behind the panel — a modal has a way out', async () => {
+    coarsePortrait(true);
+    renderAt(`/d/${firstId}/present`);
+    await screen.findByRole('alertdialog');
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(await screen.findByRole('article')).toBeInTheDocument();
+  });
+
+  it('leaves fullscreen when it takes the deck away, since the ⛶ button goes with it', async () => {
+    const exitFullscreen = vi.fn(() => Promise.resolve());
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      value: document.documentElement,
+    });
+    Object.defineProperty(document, 'exitFullscreen', {
+      configurable: true,
+      value: exitFullscreen,
+    });
+    try {
+      coarsePortrait(true);
+      renderAt(`/d/${firstId}/present`);
+      await screen.findByRole('alertdialog');
+      expect(exitFullscreen).toHaveBeenCalled();
+    } finally {
+      Reflect.deleteProperty(document, 'fullscreenElement');
+      Reflect.deleteProperty(document, 'exitFullscreen');
+    }
   });
 
   it('shows the deck at the reader’s slide when the phone is turned, and back', async () => {
@@ -158,7 +223,12 @@ describe('presentation on a phone held in portrait', () => {
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
   });
 
-  it('never covers a fine-pointer window, whatever its shape', async () => {
+  // Named for what it proves: the fake answers `false`, so this shows the route
+  // renders the deck when the rule says no. That the RULE excludes a fine
+  // pointer at any shape is pinned by the query-string assertion in
+  // presentation/usePortraitPhone.test.tsx and by the browser run — jsdom
+  // cannot evaluate a media query, so no test here can claim it.
+  it('renders the deck whenever the phone rule does not match', async () => {
     coarsePortrait(false);
     renderAt(`/d/${firstId}/present`);
 

--- a/apps/web/src/presentation/RotateNotice.test.tsx
+++ b/apps/web/src/presentation/RotateNotice.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { RotateNotice } from './RotateNotice';
+
+describe('RotateNotice', () => {
+  it('tells the reader, in Spanish, to turn the phone', () => {
+    render(<RotateNotice />);
+    expect(screen.getByRole('alertdialog')).toHaveTextContent(/gira el (teléfono|celular)/i);
+  });
+
+  it('is announced to assistive technology: a named alert dialog holding the focus', () => {
+    render(<RotateNotice />);
+    const panel = screen.getByRole('alertdialog');
+    expect(panel).toHaveAccessibleName(/gira el (teléfono|celular)/i);
+    expect(panel).toHaveAttribute('aria-modal', 'true');
+    // Announced on arrival, which is what makes it reachable at all: it appears
+    // without the reader acting, and nothing else on the route is rendered.
+    expect(panel).toHaveFocus();
+  });
+});

--- a/apps/web/src/presentation/RotateNotice.test.tsx
+++ b/apps/web/src/presentation/RotateNotice.test.tsx
@@ -36,11 +36,8 @@ describe('RotateNotice', () => {
     expect(out).toHaveAttribute('href', '/d/busqueda-binaria');
   });
 
-  it('keeps the way out reachable by keyboard from the panel', () => {
-    renderNotice();
-    const panel = screen.getByRole('alertdialog');
-    const out = screen.getByRole('link', { name: /leer|libro|volver/i });
-    expect(panel).toContainElement(out);
-    expect(out).not.toHaveAttribute('tabindex', '-1');
-  });
+  // What "nothing else is reachable" means is a claim about the whole route,
+  // not about this component, so it is asserted there — app/presentationRoute
+  // .test.tsx, "leaves nothing but the way out reachable by keyboard". Asking
+  // the panel whether it contains its own link proves only that the JSX says so.
 });

--- a/apps/web/src/presentation/RotateNotice.test.tsx
+++ b/apps/web/src/presentation/RotateNotice.test.tsx
@@ -1,21 +1,46 @@
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
 
 import { RotateNotice } from './RotateNotice';
 
+function renderNotice(docId = 'java-desde-cpp') {
+  render(
+    <MemoryRouter>
+      <RotateNotice docId={docId} />
+    </MemoryRouter>,
+  );
+}
+
 describe('RotateNotice', () => {
   it('tells the reader, in Spanish, to turn the phone', () => {
-    render(<RotateNotice />);
+    renderNotice();
     expect(screen.getByRole('alertdialog')).toHaveTextContent(/gira el (teléfono|celular)/i);
   });
 
   it('is announced to assistive technology: a named alert dialog holding the focus', () => {
-    render(<RotateNotice />);
+    renderNotice();
     const panel = screen.getByRole('alertdialog');
     expect(panel).toHaveAccessibleName(/gira el (teléfono|celular)/i);
     expect(panel).toHaveAttribute('aria-modal', 'true');
     // Announced on arrival, which is what makes it reachable at all: it appears
     // without the reader acting, and nothing else on the route is rendered.
     expect(panel).toHaveFocus();
+  });
+
+  it('offers a way out, in Spanish, that lands on the document rather than on history', () => {
+    // Not history.back(): a reader who opened /d/<id>/present directly — a link
+    // in a message, a bookmark — has nothing behind them to go back to.
+    renderNotice('busqueda-binaria');
+    const out = screen.getByRole('link', { name: /leer|libro|volver/i });
+    expect(out).toHaveAttribute('href', '/d/busqueda-binaria');
+  });
+
+  it('keeps the way out reachable by keyboard from the panel', () => {
+    renderNotice();
+    const panel = screen.getByRole('alertdialog');
+    const out = screen.getByRole('link', { name: /leer|libro|volver/i });
+    expect(panel).toContainElement(out);
+    expect(out).not.toHaveAttribute('tabindex', '-1');
   });
 });

--- a/apps/web/src/presentation/RotateNotice.tsx
+++ b/apps/web/src/presentation/RotateNotice.tsx
@@ -1,0 +1,36 @@
+import { RotateCwSquare } from 'lucide-react';
+import { useEffect, useRef } from 'react';
+
+/**
+ * What a phone held upright gets instead of the deck: slides need the long side
+ * of the screen, and nothing else on this route is rendered behind this panel.
+ */
+export function RotateNotice() {
+  const panel = useRef<HTMLDivElement>(null);
+
+  // The panel appears without the reader doing anything, so it takes the focus
+  // to be announced — and there is nothing else on the route to take it from.
+  useEffect(() => {
+    panel.current?.focus();
+  }, []);
+
+  return (
+    <div
+      ref={panel}
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="rotate-notice-title"
+      aria-describedby="rotate-notice-text"
+      tabIndex={-1}
+      className="fixed inset-0 z-40 flex flex-col items-center justify-center gap-4 bg-slate-950 px-8 text-center text-slate-100"
+    >
+      <RotateCwSquare size={48} aria-hidden="true" className="text-slate-500" />
+      <h1 id="rotate-notice-title" className="text-2xl font-bold tracking-tight">
+        Gira el teléfono
+      </h1>
+      <p id="rotate-notice-text" className="text-slate-400">
+        La presentación se ve en horizontal.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/presentation/RotateNotice.tsx
+++ b/apps/web/src/presentation/RotateNotice.tsx
@@ -1,11 +1,17 @@
 import { RotateCwSquare } from 'lucide-react';
 import { useEffect, useRef } from 'react';
+import { Link } from 'react-router-dom';
+
+interface Props {
+  /** Document to fall back to — the way out is the book view of this document. */
+  docId: string;
+}
 
 /**
  * What a phone held upright gets instead of the deck: slides need the long side
  * of the screen, and nothing else on this route is rendered behind this panel.
  */
-export function RotateNotice() {
+export function RotateNotice({ docId }: Props) {
   const panel = useRef<HTMLDivElement>(null);
 
   // The panel appears without the reader doing anything, so it takes the focus
@@ -31,6 +37,15 @@ export function RotateNotice() {
       <p id="rotate-notice-text" className="text-slate-400">
         La presentación se ve en horizontal.
       </p>
+      {/* An absolute route, not history.back(): a reader who opened /present
+          from a link or a bookmark has nothing behind them — and a phone with
+          rotation locked in the OS needs this to be a real way out. */}
+      <Link
+        to={`/d/${docId}`}
+        className="rounded border border-slate-700 px-4 py-2 text-slate-300 hover:bg-slate-800 hover:text-slate-100"
+      >
+        Leer en el libro
+      </Link>
     </div>
   );
 }

--- a/apps/web/src/presentation/SlideDeck.tsx
+++ b/apps/web/src/presentation/SlideDeck.tsx
@@ -87,7 +87,7 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
   // Replaces the deck rather than covering it: no slide is painted, so nothing
   // of it is readable behind the panel or reachable from it. The reader's
   // position is safe because it lives in ?slide=N, not in this component.
-  if (portraitPhone) return <RotateNotice />;
+  if (portraitPhone) return <RotateNotice docId={docId} />;
 
   return (
     <div className="fixed inset-0 z-40 flex flex-col bg-slate-950 text-slate-100">

--- a/apps/web/src/presentation/SlideDeck.tsx
+++ b/apps/web/src/presentation/SlideDeck.tsx
@@ -60,6 +60,13 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
       );
     };
     const onKeyDown = (event: KeyboardEvent) => {
+      // The panel replaces the deck's markup, not this window-level listener:
+      // hooks run above the early return, so behind the panel every slide key
+      // still moved ?slide with nothing painted — measured in Chromium at
+      // 390x844, two ArrowRight took ?slide=2 to 3 and rotating landed on the
+      // wrong slide (#91 review). Escape is deliberately still live: it is the
+      // way out of a modal, and the panel is one.
+      if (portraitPhone && event.key !== 'Escape') return;
       switch (event.key) {
         case 'ArrowRight':
         case ' ':
@@ -82,7 +89,14 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [docId, index, navigate, setSearchParams, slides.length]);
+  }, [docId, index, navigate, portraitPhone, setSearchParams, slides.length]);
+
+  // Fullscreen belongs to the deck, and the deck is about to be gone: the ⛶
+  // button is the only control that exits it, so leaving it on would strand the
+  // panel inside a fullscreen page with no way back out of it.
+  useEffect(() => {
+    if (portraitPhone && document.fullscreenElement) void document.exitFullscreen?.();
+  }, [portraitPhone]);
 
   // Replaces the deck rather than covering it: no slide is painted, so nothing
   // of it is readable behind the panel or reachable from it. The reader's

--- a/apps/web/src/presentation/SlideDeck.tsx
+++ b/apps/web/src/presentation/SlideDeck.tsx
@@ -5,6 +5,8 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { mdxChildrenOf } from './mdxChildren';
 import { computeSlides } from './parser';
+import { RotateNotice } from './RotateNotice';
+import { usePortraitPhone } from './usePortraitPhone';
 
 function toggleFullscreen(): void {
   if (document.fullscreenElement) {
@@ -37,6 +39,7 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
   );
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
+  const portraitPhone = usePortraitPhone();
 
   // Math.trunc: a crafted non-integer ?slide (e.g. 1.5) must not become a
   // fractional array index (white-screen crash — review finding, issue #64).
@@ -80,6 +83,11 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [docId, index, navigate, setSearchParams, slides.length]);
+
+  // Replaces the deck rather than covering it: no slide is painted, so nothing
+  // of it is readable behind the panel or reachable from it. The reader's
+  // position is safe because it lives in ?slide=N, not in this component.
+  if (portraitPhone) return <RotateNotice />;
 
   return (
     <div className="fixed inset-0 z-40 flex flex-col bg-slate-950 text-slate-100">

--- a/apps/web/src/presentation/usePortraitPhone.test.tsx
+++ b/apps/web/src/presentation/usePortraitPhone.test.tsx
@@ -1,0 +1,100 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { usePortraitPhone } from './usePortraitPhone';
+
+// jsdom does not implement `window.matchMedia` AT ALL — it is undefined, so a
+// hook that calls it unguarded throws here instead of getting `false`
+// (testing-strategy.md §Layout and focus). The fake is therefore both the way
+// to state an answer and the only way this hook can be exercised at all; the
+// real media query is verified in a browser.
+function fakeMatchMedia(initial: boolean) {
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+  const asked: string[] = [];
+  let matches = initial;
+
+  window.matchMedia = ((query: string) => {
+    asked.push(query);
+    return {
+      media: query,
+      get matches() {
+        return matches;
+      },
+      addEventListener: (_type: string, listener: (event: MediaQueryListEvent) => void) => {
+        listeners.add(listener);
+      },
+      removeEventListener: (_type: string, listener: (event: MediaQueryListEvent) => void) => {
+        listeners.delete(listener);
+      },
+    } as unknown as MediaQueryList;
+  }) as typeof window.matchMedia;
+
+  return {
+    asked,
+    get listenerCount() {
+      return listeners.size;
+    },
+    /** What the browser does when the phone is turned. */
+    set(next: boolean) {
+      matches = next;
+      act(() => {
+        for (const listener of listeners) listener({ matches: next } as MediaQueryListEvent);
+      });
+    },
+  };
+}
+
+function Harness() {
+  return <span data-testid="answer">{usePortraitPhone() ? 'yes' : 'no'}</span>;
+}
+
+function answer() {
+  return screen.getByTestId('answer').textContent;
+}
+
+afterEach(() => {
+  Reflect.deleteProperty(window, 'matchMedia');
+});
+
+describe('usePortraitPhone', () => {
+  it('asks for a coarse pointer AND portrait, so a narrow desktop window is not a phone', () => {
+    const media = fakeMatchMedia(false);
+    render(<Harness />);
+    // Asserted by construction: jsdom cannot evaluate a media query, so the only
+    // thing the suite can pin is which question is asked. Both halves matter —
+    // dropping `pointer: coarse` tells a laptop user to rotate their screen.
+    expect(media.asked.join(' ')).toContain('pointer: coarse');
+    expect(media.asked.join(' ')).toContain('orientation: portrait');
+  });
+
+  it('is false where the browser cannot answer, rather than throwing', () => {
+    render(<Harness />);
+    expect(answer()).toBe('no');
+  });
+
+  it('is true on a coarse pointer in portrait', () => {
+    fakeMatchMedia(true);
+    render(<Harness />);
+    expect(answer()).toBe('yes');
+  });
+
+  it('follows the phone when it is turned, both ways', () => {
+    const media = fakeMatchMedia(true);
+    render(<Harness />);
+
+    media.set(false);
+    expect(answer()).toBe('no');
+
+    media.set(true);
+    expect(answer()).toBe('yes');
+  });
+
+  it('stops listening when it unmounts', () => {
+    const media = fakeMatchMedia(true);
+    const { unmount } = render(<Harness />);
+    expect(media.listenerCount).toBe(1);
+
+    unmount();
+    expect(media.listenerCount).toBe(0);
+  });
+});

--- a/apps/web/src/presentation/usePortraitPhone.ts
+++ b/apps/web/src/presentation/usePortraitPhone.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useSyncExternalStore } from 'react';
 
 // Coarse pointer AND portrait, in one query. The pointer half is what keeps a
 // narrow or tall window on a laptop out of it: that is not a phone, and telling
@@ -12,20 +12,27 @@ function ask(): MediaQueryList | null {
   return typeof window.matchMedia === 'function' ? window.matchMedia(PHONE_IN_PORTRAIT) : null;
 }
 
-/** True while the reader holds a touch device upright. False anywhere it cannot be asked. */
+function subscribe(onChange: () => void): () => void {
+  const query = ask();
+  if (!query) return () => {};
+  query.addEventListener('change', onChange);
+  return () => query.removeEventListener('change', onChange);
+}
+
+function matches(): boolean {
+  return ask()?.matches ?? false;
+}
+
+/**
+ * True while the reader holds a touch device upright. False anywhere it cannot
+ * be asked.
+ *
+ * useSyncExternalStore rather than useState + an effect: React re-reads the
+ * snapshot after subscribing, which closes the render-to-effect gap by
+ * construction. Doing it by hand needs an extra re-read whose only possible
+ * test asserts render/effect ordering — an implementation detail, which
+ * `apps/web/CLAUDE.md` rules out of component tests (#91 review).
+ */
 export function usePortraitPhone(): boolean {
-  const [matches, setMatches] = useState(() => ask()?.matches ?? false);
-
-  useEffect(() => {
-    const query = ask();
-    if (!query) return;
-    // Re-read on mount: the phone can have been turned between the first render
-    // and this effect, and the `change` event for it is already gone.
-    setMatches(query.matches);
-    const onChange = (event: MediaQueryListEvent) => setMatches(event.matches);
-    query.addEventListener('change', onChange);
-    return () => query.removeEventListener('change', onChange);
-  }, []);
-
-  return matches;
+  return useSyncExternalStore(subscribe, matches);
 }

--- a/apps/web/src/presentation/usePortraitPhone.ts
+++ b/apps/web/src/presentation/usePortraitPhone.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+
+// Coarse pointer AND portrait, in one query. The pointer half is what keeps a
+// narrow or tall window on a laptop out of it: that is not a phone, and telling
+// its user to turn their screen sideways is worse than the layout ever was.
+const PHONE_IN_PORTRAIT = '(pointer: coarse) and (orientation: portrait)';
+
+function ask(): MediaQueryList | null {
+  // jsdom does not implement matchMedia at all, so the guard is what keeps the
+  // suite from throwing on a question the browser is the only one who can
+  // answer (testing-strategy.md §Layout and focus).
+  return typeof window.matchMedia === 'function' ? window.matchMedia(PHONE_IN_PORTRAIT) : null;
+}
+
+/** True while the reader holds a touch device upright. False anywhere it cannot be asked. */
+export function usePortraitPhone(): boolean {
+  const [matches, setMatches] = useState(() => ask()?.matches ?? false);
+
+  useEffect(() => {
+    const query = ask();
+    if (!query) return;
+    // Re-read on mount: the phone can have been turned between the first render
+    // and this effect, and the `change` event for it is already gone.
+    setMatches(query.matches);
+    const onChange = (event: MediaQueryListEvent) => setMatches(event.matches);
+    query.addEventListener('change', onChange);
+    return () => query.removeEventListener('change', onChange);
+  }, []);
+
+  return matches;
+}

--- a/docs/decisions/0013-presentation-pipeline.md
+++ b/docs/decisions/0013-presentation-pipeline.md
@@ -61,6 +61,14 @@ can drive it.
    keyboard `p`/`←`/`→`/`Space`/`Home`/`End`/`Esc`, fullscreen via
    `requestFullscreen`, minimal framer-motion fade).
 
+   **Constrained by ADR-0023** (#91): on a coarse pointer in portrait the deck
+   is replaced by a rotate panel — a second case where `/present` paints no
+   slide, and unlike `presentation: none` it does not redirect. While that panel
+   is up every slide key above is silenced at the window listener (`Esc` alone
+   stays live) and fullscreen is exited. A new deck shortcut wired at window
+   level inherits that gate or it will move `?slide` behind a panel showing no
+   slide.
+
 ## Alternatives considered
 
 - **Compile-time slide splitting** as the primary mechanism (mdx-deck style):

--- a/docs/decisions/0023-presentation-requires-landscape-on-a-phone.md
+++ b/docs/decisions/0023-presentation-requires-landscape-on-a-phone.md
@@ -2,16 +2,30 @@
 
 **Status:** Accepted
 **Date:** 2026-08-13
+**Decision-makers:** Miguel Rodriguez
+**Source:** Issue #91 (require landscape for presentation mode on a phone),
+found verifying #90. Constrains ADR-0013 (presentation pipeline) §2 and §5.
+**Covers:** why the deck refuses portrait on a touch device · why the pointer
+half of the query is load-bearing · what the panel must offer as a way out
 
 ## Context
 
 The slide deck is a landscape form: one idea per screen, a comfortable measure,
-a counter in a corner. Held upright on a phone it stops being that. Measured on
-`/d/java-desde-cpp`, slide 2, at 390x844: the paragraph runs edge to edge, the
-`h2` is pushed off screen, and nothing tells the reader that anything is wrong.
-The same slide at 844x390 reads correctly. A student who taps `Presentar` on
-their phone therefore gets the broken version by default (#91, found verifying
-#90).
+a counter in a corner. Held upright on a phone it stops being that. Measured in
+Chromium on `/d/java-desde-cpp`, slide 2, at 390x844: the paragraph is squeezed
+into a 262px column (the viewer's `px-16` leaves 64px of gutter on each side,
+at any width) and runs so far past the bottom that the `h2` sits 164px above
+the top of the screen — clipped by the viewer's `overflow-hidden`, with nothing
+telling the reader that anything is wrong. A student who taps `Presentar` on
+their phone gets that by default (#91, found verifying #90).
+
+At 844x390 the same paragraph reads in six lines instead of thirty and the
+slide is usable. **It is not, however, whole**: the review of this WP measured
+the heading at `y = -61` there too, so the title is clipped on a 390px-tall
+window as it is on any short one. The issue this ADR comes from said the
+landscape rendering "reads correctly"; that was checked again and is only true
+of the body. The remaining clipping is slide typography, deliberately out of
+scope here and recorded in the last Consequence.
 
 The book view already serves reading on a phone in portrait, by design (#84), so
 the platform is not missing a way to read the material there — only a way to
@@ -29,14 +43,12 @@ Three things this fixes in place:
 - **The pointer half is load-bearing.** A narrow or tall window on a laptop is
   not a phone; telling its user to turn their screen sideways is worse than the
   layout ever was.
-- **The panel replaces the deck, it does not sit over it.** No slide is painted,
-  so nothing is readable behind it, and the only control reachable by keyboard is
-  the way out. The deck's own `window` keydown listener is silenced while the
-  panel is up — hooks run above the early return, so it survives the swap
-  otherwise, and the slide keys were moving `?slide` behind a panel that shows
-  no slide (measured in Chromium at 390x844: `?slide=2` became 3, and rotating
-  landed on the wrong slide). `Escape` is the deliberate exception: it is the
-  way out of a modal, and it lands where the panel's own link lands.
+- **The panel replaces the deck, it does not sit over it, and it is modal.** No
+  slide is painted, the only control reachable by keyboard is the way out, and
+  the deck's slide keys are silenced at the window listener. `Escape` is the
+  deliberate exception — a modal has a way out, and this one lands where the
+  panel's own link lands. (Why the listener needs silencing at all is a
+  React mechanic; it lives in the code comment that guards it.)
 - **The way out is an absolute route** (`/d/<id>`), not `history.back()`: a
   reader who opened `/d/<id>/present` from a message or a bookmark has nothing
   behind them to go back to.
@@ -78,12 +90,24 @@ Three things this fixes in place:
   term would mean choosing a breakpoint nobody has measured. The panel says
   "Gira el teléfono" there; if that ever grates, the fix is the wording, not a
   second rule.
-- **Browser baseline: Safari 14+ / iOS 14+.** Older WebKit exposes only
-  `addListener`/`removeListener` on a `MediaQueryList`, so the hook's
-  `addEventListener('change', …)` throws there and takes the `/present` route
-  down with it. No legacy fallback is shipped: it is a decision, not an
-  oversight — the platform already requires a browser that runs the in-browser
-  runtimes (ADR-0016/0017), which is a much higher bar than this one.
+- **Browser baseline: Safari 14+ / iOS 14+, and no legacy fallback.**
+  `MediaQueryList.addEventListener` landed in Safari 14 (MDN browser-compat-data,
+  checked 2026-08-13; `addListener` goes back to 5.1), so on older WebKit the
+  hook throws and takes the whole `/present` route down — a blank page, worse
+  than the layout this WP fixes, on the device class it targets. Shipping it
+  anyway is the decision, not an oversight, and the case that does NOT hold is
+  named: **a pre-14 iOS phone loses presentation entirely, silently, and no test
+  guards it.** No other ADR states a browser floor — 0016/0017 impose a much
+  heavier one in practice (a browser that runs CheerpJ and WebAssembly) but never
+  wrote it down, so this is the repo's first recorded baseline and the operator
+  surface for it is `apps/web/README.md` §Deployed shape.
+- **Live sessions (ADR-0008) are not exempted, and that is not yet a decision.**
+  ADR-0013 makes `/present` + `?slide=N` the seam a session drives, so a student
+  following the class from a phone held upright will get this panel instead of
+  the slide the professor is on, while `?slide` keeps advancing behind it. The
+  rule is deliberately unconditional today — follower mode does not exist yet —
+  and whether it should stay that way is a question for whoever implements
+  ADR-0008 in v0.3, not one this ADR answers.
 - **Fullscreen is left when the rule takes over.** The `⛶` button is the only
   control that exits fullscreen and it lives in the deck being removed, so the
   panel would otherwise sit inside a fullscreen page with no way back. Verified

--- a/docs/decisions/0023-presentation-requires-landscape-on-a-phone.md
+++ b/docs/decisions/0023-presentation-requires-landscape-on-a-phone.md
@@ -1,0 +1,76 @@
+# ADR-0023: Presentation requires landscape on a phone
+
+**Status:** Accepted
+**Date:** 2026-08-13
+
+## Context
+
+The slide deck is a landscape form: one idea per screen, a comfortable measure,
+a counter in a corner. Held upright on a phone it stops being that. Measured on
+`/d/java-desde-cpp`, slide 2, at 390x844: the paragraph runs edge to edge, the
+`h2` is pushed off screen, and nothing tells the reader that anything is wrong.
+The same slide at 844x390 reads correctly. A student who taps `Presentar` on
+their phone therefore gets the broken version by default (#91, found verifying
+#90).
+
+The book view already serves reading on a phone in portrait, by design (#84), so
+the platform is not missing a way to read the material there — only a way to
+stop the deck from being the thing that answers.
+
+## Decision
+
+**A slide is never painted on a coarse pointer in portrait.** The viewer asks
+one media query — `(pointer: coarse) and (orientation: portrait)` — and when it
+matches it renders a panel in place of the deck: a rotate icon, one line in
+Spanish, and a link to the document's book view.
+
+Three things this fixes in place:
+
+- **The pointer half is load-bearing.** A narrow or tall window on a laptop is
+  not a phone; telling its user to turn their screen sideways is worse than the
+  layout ever was.
+- **The panel replaces the deck, it does not sit over it.** No slide is painted,
+  so nothing is readable behind it and nothing of it is reachable by keyboard.
+- **The way out is an absolute route** (`/d/<id>`), not `history.back()`: a
+  reader who opened `/d/<id>/present` from a message or a bookmark has nothing
+  behind them to go back to.
+
+## Alternatives considered
+
+- **`screen.orientation.lock('landscape')`** — the first idea, and the reason
+  this ADR exists. It only works inside fullscreen, and **iPhone Safari has no
+  Fullscreen API for a web page at all** (only native `<video>` gets it — which
+  is why YouTube can rotate an iPhone and a web page cannot imitate it). It would
+  deliver three different behaviours across browsers and a maintenance burden for
+  each, and would still leave the iPhone case unsolved. Rejected with that in
+  hand. `SlideDeck`'s existing `toggleFullscreen()` is where such a lock would
+  hang if a later WP ever wants it on the browsers that do support it.
+- **Requesting fullscreen automatically on entering presentation** — same
+  dependency, plus it takes a decision away from the reader. Rejected.
+- **Redesigning slide typography for narrow portrait** — makes the deck a second
+  reading surface competing with the book view, for a shape nobody presents in.
+  The decision is landscape, not "make portrait work".
+- **A "view it anyway" escape** — the way out is out (the book view), not
+  through. Two ways of reading the same document on a phone is the confusion the
+  book view exists to prevent.
+- **Doing nothing and documenting it** — the failure is silent, and silence is
+  what the WP was opened to fix.
+
+## Consequences
+
+- A phone with rotation locked in the OS cannot reach the deck at all. That is
+  accepted: the panel's link to the book view is the answer for it, which is why
+  the way out is a requirement of the rule and not a courtesy.
+- The rule lives in the viewer (`presentation/SlideDeck.tsx` + `RotateNotice`),
+  so every entry point to presentation inherits it — the `Presentar` button, the
+  `p` shortcut, and a deep link straight into `/present`.
+- The reader's position survives rotation for free: it lives in `?slide=N`, not
+  in the component.
+- **jsdom implements no `matchMedia` at all**, so the suite can pin which
+  question is asked and fake the answer, but never evaluate the query. The
+  behaviour is verified in a real browser at 390x844 and 844x390, with a coarse
+  pointer emulated and again without one (`testing-strategy.md`).
+- The deck's own behaviour on a short landscape phone screen is untouched by this
+  decision: a slide taller than the viewport is still clipped by the viewer's
+  `overflow-hidden`, as it is on any short window. That is slide typography, and
+  it is deliberately out of scope here.

--- a/docs/decisions/0023-presentation-requires-landscape-on-a-phone.md
+++ b/docs/decisions/0023-presentation-requires-landscape-on-a-phone.md
@@ -30,7 +30,13 @@ Three things this fixes in place:
   not a phone; telling its user to turn their screen sideways is worse than the
   layout ever was.
 - **The panel replaces the deck, it does not sit over it.** No slide is painted,
-  so nothing is readable behind it and nothing of it is reachable by keyboard.
+  so nothing is readable behind it, and the only control reachable by keyboard is
+  the way out. The deck's own `window` keydown listener is silenced while the
+  panel is up — hooks run above the early return, so it survives the swap
+  otherwise, and the slide keys were moving `?slide` behind a panel that shows
+  no slide (measured in Chromium at 390x844: `?slide=2` became 3, and rotating
+  landed on the wrong slide). `Escape` is the deliberate exception: it is the
+  way out of a modal, and it lands where the panel's own link lands.
 - **The way out is an absolute route** (`/d/<id>`), not `history.back()`: a
   reader who opened `/d/<id>/present` from a message or a bookmark has nothing
   behind them to go back to.
@@ -63,7 +69,27 @@ Three things this fixes in place:
   the way out is a requirement of the rule and not a courtesy.
 - The rule lives in the viewer (`presentation/SlideDeck.tsx` + `RotateNotice`),
   so every entry point to presentation inherits it — the `Presentar` button, the
-  `p` shortcut, and a deep link straight into `/present`.
+  `p` shortcut, and a deep link straight into `/present`. It sits in the viewer
+  rather than in `PresentationPage` because the document is then already loaded:
+  turning the phone shows the deck immediately, with no second fetch.
+- **Any coarse pointer in portrait gets the panel, tablets included.** An iPad
+  held upright has room for a slide and will still be told to turn — accepted,
+  because the WP asked for one mechanism, identical on every device, and a width
+  term would mean choosing a breakpoint nobody has measured. The panel says
+  "Gira el teléfono" there; if that ever grates, the fix is the wording, not a
+  second rule.
+- **Browser baseline: Safari 14+ / iOS 14+.** Older WebKit exposes only
+  `addListener`/`removeListener` on a `MediaQueryList`, so the hook's
+  `addEventListener('change', …)` throws there and takes the `/present` route
+  down with it. No legacy fallback is shipped: it is a decision, not an
+  oversight — the platform already requires a browser that runs the in-browser
+  runtimes (ADR-0016/0017), which is a much higher bar than this one.
+- **Fullscreen is left when the rule takes over.** The `⛶` button is the only
+  control that exits fullscreen and it lives in the deck being removed, so the
+  panel would otherwise sit inside a fullscreen page with no way back. Verified
+  in Chromium: enter fullscreen in landscape, rotate, `document.fullscreenElement`
+  is null and the panel is up. This does not touch the button itself, which the
+  WP put out of scope.
 - The reader's position survives rotation for free: it lives in `?slide=N`, not
   in the component.
 - **jsdom implements no `matchMedia` at all**, so the suite can pin which

--- a/docs/decisions/0023-presentation-requires-landscape-on-a-phone.md
+++ b/docs/decisions/0023-presentation-requires-landscape-on-a-phone.md
@@ -3,10 +3,10 @@
 **Status:** Accepted
 **Date:** 2026-08-13
 **Decision-makers:** Miguel Rodriguez
-**Source:** Issue #91 (require landscape for presentation mode on a phone),
-found verifying #90. Constrains ADR-0013 (presentation pipeline) §2 and §5.
 **Covers:** why the deck refuses portrait on a touch device · why the pointer
 half of the query is load-bearing · what the panel must offer as a way out
+**Source:** Issue #91 (require landscape for presentation mode on a phone),
+found verifying #90. Constrains ADR-0013 (presentation pipeline) §2 and §5.
 
 ## Context
 
@@ -19,13 +19,13 @@ the top of the screen — clipped by the viewer's `overflow-hidden`, with nothin
 telling the reader that anything is wrong. A student who taps `Presentar` on
 their phone gets that by default (#91, found verifying #90).
 
-At 844x390 the same paragraph reads in six lines instead of thirty and the
-slide is usable. **It is not, however, whole**: the review of this WP measured
-the heading at `y = -61` there too, so the title is clipped on a 390px-tall
-window as it is on any short one. The issue this ADR comes from said the
-landscape rendering "reads correctly"; that was checked again and is only true
-of the body. The remaining clipping is slide typography, deliberately out of
-scope here and recorded in the last Consequence.
+At 844x390 the same slide reads in nine lines of body instead of twenty-six,
+and it is usable. **It is not, however, whole**: measured again during this
+WP's review, the heading sits at `y = -61` there too and the closing paragraph
+falls below the fold — both clipped by the same `overflow-hidden`. The issue
+this ADR comes from said the landscape rendering "reads correctly"; re-measured,
+that is true only of the paragraphs that fit. The remaining clipping is slide
+typography, deliberately out of scope here and recorded in the last Consequence.
 
 The book view already serves reading on a phone in portrait, by design (#84), so
 the platform is not missing a way to read the material there — only a way to

--- a/docs/standards/frontend-code-style.md
+++ b/docs/standards/frontend-code-style.md
@@ -206,6 +206,22 @@ src/
 - Local `useState`/`useReducer` first; React context for genuinely cross-cutting
   concerns (e.g., presentation mode). No global state library — introducing one
   requires an ADR.
+- **A browser store is subscribed with `useSyncExternalStore`, not `useState` +
+  an effect.** A `MediaQueryList`, `document.fullscreenElement`, a storage
+  event: React re-reads the snapshot after subscribing, so the gap between the
+  first render and the effect closes by construction. Doing it by hand needs an
+  extra re-read for that gap, and the only test that can prove the re-read
+  asserts render/effect ordering — an implementation detail, which component
+  tests may not assert (`apps/web/CLAUDE.md`). Worked case:
+  `presentation/usePortraitPhone.ts` (#91), where the hand-rolled version passed
+  review and was replaced after the review measured that no permitted test could
+  kill its re-read.
+- **Layout breakpoints stay in Tailwind classes; a media query is only asked
+  from JS when device shape decides BEHAVIOUR** — what gets rendered at all,
+  not how wide it is. It belongs in a hook colocated in the feature that owns
+  the behaviour (`presentation/usePortraitPhone.ts`), never in a shared
+  `lib/useMediaQuery`, and the call is guarded with `typeof window.matchMedia`
+  so the suite gets `false` instead of a throw.
 
 ## Imports
 

--- a/docs/standards/frontend-code-style.md
+++ b/docs/standards/frontend-code-style.md
@@ -213,9 +213,9 @@ src/
   extra re-read for that gap, and the only test that can prove the re-read
   asserts render/effect ordering — an implementation detail, which component
   tests may not assert (`apps/web/CLAUDE.md`). Worked case:
-  `presentation/usePortraitPhone.ts` (#91), where the hand-rolled version passed
-  review and was replaced after the review measured that no permitted test could
-  kill its re-read.
+  `presentation/usePortraitPhone.ts` (#91), where the hand-rolled version
+  shipped in the first slice and was replaced in review, once the review
+  measured that no permitted test could kill its re-read.
 - **Layout breakpoints stay in Tailwind classes; a media query is only asked
   from JS when device shape decides BEHAVIOUR** — what gets rendered at all,
   not how wide it is. It belongs in a hook colocated in the feature that owns

--- a/docs/standards/frontend-code-style.md
+++ b/docs/standards/frontend-code-style.md
@@ -195,8 +195,11 @@ src/
   icon-only control inside a component's own dense chrome (`CodeEditor`'s
   expand). 16px for an icon-only control on the PAGE chrome, where the button is
   a touch target rather than part of a text row — the drawer toggle and its
-  close button (#84) are the only two. Adding a second icon set
-  needs the same discussion a dependency does (root `CLAUDE.md`).
+  close button (#84) are the only two. 48px when the icon is the illustration of
+  a full-screen panel rather than a control — it carries the message at a
+  glance, is `aria-hidden` because the text beside it says the same thing, and
+  is not clickable (worked case: `presentation/RotateNotice.tsx`, #91). Adding a
+  second icon set needs the same discussion a dependency does (root `CLAUDE.md`).
 
 ## State
 

--- a/docs/standards/guides/add-a-course-document.md
+++ b/docs/standards/guides/add-a-course-document.md
@@ -213,7 +213,10 @@ themselves rather than maintained by hand.
    `/nalanda/d/<id>`) and run every exercise you added: no amber authoring
    banner, the cases pass against a correct solution, and they fail against the
    starter. If a `<SideBySide>` or a `<Slide>` is involved, look at it in
-   presentation mode too — `/d/<id>/present`.
+   presentation mode too — `/d/<id>/present`. **Slides are checked in
+   landscape**: on a phone or tablet held upright the viewer deliberately shows
+   a "Gira el teléfono" panel instead of the deck (ADR-0023), so an empty
+   presentation there is the platform working, not a fault in your document.
 
 9. **Publish**: merging to `main` republishes
    <https://so77id.github.io/nalanda/> automatically — `content/**` is a deploy

--- a/docs/standards/testing-strategy.md
+++ b/docs/standards/testing-strategy.md
@@ -218,9 +218,12 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   and height **in the same context** so the page is not remounted, and run the
   same page once in a default desktop context to prove the rule does NOT fire on
   a narrow laptop window. Two mechanics worth knowing before they cost an hour
-  (#91): a fullscreen page cannot be resized by the driver at all
-  (`Browser.setWindowBounds` errors), so rotate it through
-  `Emulation.setDeviceMetricsOverride` over a CDP session instead; and the
+  (#91): on a **fullscreen** page the driver's resize call rejects
+  (`Browser.setWindowBounds`: "To resize minimized/maximized/fullscreen window,
+  restore it to normal state first") *after* the metrics override has already
+  landed — so the page has rotated, the app has reacted, and the script dies
+  holding a state it thinks it never reached. Rotate a fullscreen page through
+  `Emulation.setDeviceMetricsOverride` on a CDP session instead. And the
   emulated rotation is what makes `matchMedia` fire, so assert the query's own
   value in the page (`matchMedia('(pointer: coarse)').matches`) rather than
   trusting the preset.

--- a/docs/standards/testing-strategy.md
+++ b/docs/standards/testing-strategy.md
@@ -157,9 +157,28 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   query string plus the behaviour that follows from a faked match (worked case:
   `presentation/usePortraitPhone.test.tsx`, #91 — dropping `pointer: coarse`
   from the query tells a laptop user to rotate their screen, and the string
-  assertion is the only thing in the suite that can catch it). Code that asks
-  must also guard the call: an unguarded `window.matchMedia` throws in jsdom
-  instead of answering `false`.
+  assertion is the only thing in the suite that can catch it). Two riders, both
+  earned in #91's review: **guard the call** — `window.matchMedia` is universal
+  in browsers, so the `typeof` check exists purely so jsdom answers `false`
+  instead of throwing, and `vitest.setup.ts` is confirmation-gated
+  (`apps/web/CLAUDE.md`), which is why the accommodation lives in the code —
+  and **make the fake answer only its own query**: one that returns the same
+  `matches` for every question also answers framer-motion's
+  `(prefers-reduced-motion)`, silently changing the component under test.
+- **A browser-API fake needed by two features is duplicated, not shared.** The
+  seam invariant in `src/architecture.test.ts` has no `.test.` exemption for the
+  "goes through the feature root seam" case, so a shell test cannot import a
+  helper out of a feature folder, and `lib/` is for shipped pure code, not test
+  doubles. Worked case (#91): the `matchMedia` fake exists in
+  `app/presentationRoute.test.tsx` and in `presentation/usePortraitPhone.test.tsx`,
+  and they are not identical — only the second tracks which queries were asked.
+- **Asserting ABSENCE inside a lazy boundary needs a synchronisation point.**
+  `queryBy…` returns nothing while a `Suspense` child is still loading, so the
+  assertion passes before the code under test has run at all. First `await` an
+  element that can only exist on the far side of the boundary, and say so in a
+  comment. Worked case (#91): `app/presentationRoute.test.tsx` awaits the rotate
+  panel — which only the loaded document can render — before asserting that no
+  counter and no slide heading are on the page.
   Three worked cases, all from #84 and all green in jsdom at the time:
   an `IntersectionObserver` active-section rule that left the rail unmarked
   through 70% of a document (an observer fires on crossings; a reader inside a

--- a/docs/standards/testing-strategy.md
+++ b/docs/standards/testing-strategy.md
@@ -144,27 +144,39 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   skips and `focus()` silently refuses. So a test can assert a focus trap, a
   roving tabindex, an active-section rule or a breakpoint and stay green over
   code that fails on the page. Any change that enumerates focusable elements,
-  moves focus, depends on a viewport width or a scroll position, or is enforced
-  by a rule in `styles/index.css`, MUST also be verified in a real browser
-  against `npm run build && npm run preview`, at the widths that matter, judged
-  from a screenshot. In the suite these cases are asserted **by construction** —
-  place the headings and dispatch a scroll (`content/useSections.test.tsx`),
-  assert the list a trap computed through where focus lands
-  (`content/Drawer.test.tsx`) — and the construction must be checked against a
-  browser at least once, because it encodes an assumption jsdom cannot refute.
-  A media query is the sharpest case of it: the suite can pin **which question
-  is asked** and fake the answer, never evaluate it, so what is asserted is the
-  query string plus the behaviour that follows from a faked match (worked case:
-  `presentation/usePortraitPhone.test.tsx`, #91 — dropping `pointer: coarse`
-  from the query tells a laptop user to rotate their screen, and the string
-  assertion is the only thing in the suite that can catch it). Two riders, both
-  earned in #91's review: **guard the call** — `window.matchMedia` is universal
-  in browsers, so the `typeof` check exists purely so jsdom answers `false`
-  instead of throwing, and `vitest.setup.ts` is confirmation-gated
-  (`apps/web/CLAUDE.md`), which is why the accommodation lives in the code —
-  and **make the fake answer only its own query**: one that returns the same
-  `matches` for every question also answers framer-motion's
-  `(prefers-reduced-motion)`, silently changing the component under test.
+  moves focus, depends on a viewport width, a scroll position or a device
+  capability asked through `window.matchMedia` (pointer type, orientation), or
+  is enforced by a rule in `styles/index.css`, MUST also be verified in a real
+  browser against `npm run build && npm run preview`, at the widths that matter,
+  judged from a screenshot. In the suite these cases are asserted **by
+  construction** — place the headings and dispatch a scroll
+  (`content/useSections.test.tsx`), assert the list a trap computed through
+  where focus lands (`content/Drawer.test.tsx`) — and the construction must be
+  checked against a browser at least once, because it encodes an assumption
+  jsdom cannot refute.
+  Three worked cases, all from #84 and all green in jsdom at the time:
+  an `IntersectionObserver` active-section rule that left the rail unmarked
+  through 70% of a document (an observer fires on crossings; a reader inside a
+  long section crosses nothing); a focus trap that let Tab escape in Chromium to
+  the toggle behind the drawer; and the first fix for it, a visibility filter on
+  `offsetParent`, which under jsdom matched *nothing*, emptied the trap's list
+  and made its own tests pass while proving nothing.
+- **A media query is the sharpest case of it**: the suite can pin **which
+  question is asked** and fake the answer, never evaluate it, so what is
+  asserted is the query string plus the behaviour that follows from a faked
+  match (worked case: `presentation/usePortraitPhone.test.tsx`, #91 — dropping
+  `pointer: coarse` from the query tells a laptop user to rotate their screen,
+  and the string assertion is the only thing in the suite that can catch it).
+  Two riders, both earned in #91's review. **Guard the call**:
+  `window.matchMedia` is universal in browsers, so the `typeof` check exists
+  purely so jsdom answers `false` instead of throwing, and `vitest.setup.ts` is
+  confirmation-gated (`apps/web/CLAUDE.md`), which is why the accommodation
+  lives in the code. **Make the fake answer only its own query**: one that
+  returns the same `matches` for every question also answers framer-motion's
+  `(prefers-reduced-motion)` when the component under test mounts, silently
+  changing it — worked case `app/presentationRoute.test.tsx`, whose fake scopes
+  its answer to `pointer: coarse`, which the hook's own fake does not need
+  because its harness renders no motion component.
 - **A browser-API fake needed by two features is duplicated, not shared.** The
   seam invariant in `src/architecture.test.ts` has no `.test.` exemption for the
   "goes through the feature root seam" case, so a shell test cannot import a
@@ -179,13 +191,6 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   comment. Worked case (#91): `app/presentationRoute.test.tsx` awaits the rotate
   panel — which only the loaded document can render — before asserting that no
   counter and no slide heading are on the page.
-  Three worked cases, all from #84 and all green in jsdom at the time:
-  an `IntersectionObserver` active-section rule that left the rail unmarked
-  through 70% of a document (an observer fires on crossings; a reader inside a
-  long section crosses nothing); a focus trap that let Tab escape in Chromium to
-  the toggle behind the drawer; and the first fix for it, a visibility filter on
-  `offsetParent`, which under jsdom matched *nothing*, emptied the trap's list
-  and made its own tests pass while proving nothing.
 - **A fix is not done until its test has been seen to fail.** Revert the fix,
   watch the new test go red, restore it — and name the failing test in the
   commit message. Reviewing a test by reading it is how a test that cannot fail
@@ -205,6 +210,20 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   `-- --port <n>` when something already holds 4173.
   `guides/add-a-language-runtime.md` §7 keeps the runtime-specific checks and
   points here for the mechanics.
+  **A device rule needs an emulated device, not a small window.** A desktop
+  context reports `pointer: fine` at any size, so resizing Chromium to 390x844
+  proves nothing about a phone — the check silently passes over code that never
+  ran. Use a touch context (`browser.newContext({ ...devices['iPhone 13'] })`,
+  or `{ viewport, hasTouch: true, isMobile: true }`), rotate by swapping width
+  and height **in the same context** so the page is not remounted, and run the
+  same page once in a default desktop context to prove the rule does NOT fire on
+  a narrow laptop window. Two mechanics worth knowing before they cost an hour
+  (#91): a fullscreen page cannot be resized by the driver at all
+  (`Browser.setWindowBounds` errors), so rotate it through
+  `Emulation.setDeviceMetricsOverride` over a CDP session instead; and the
+  emulated rotation is what makes `matchMedia` fire, so assert the query's own
+  value in the page (`matchMedia('(pointer: coarse)').matches`) rather than
+  trusting the preset.
 - **Env-derived values go through a pure helper**: extract the transformation
   into a colocated, unit-tested module rather than inlining it in a component
   the suite cannot exercise. Worked case: `app/basename.ts` derives the router

--- a/docs/standards/testing-strategy.md
+++ b/docs/standards/testing-strategy.md
@@ -152,6 +152,14 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   assert the list a trap computed through where focus lands
   (`content/Drawer.test.tsx`) — and the construction must be checked against a
   browser at least once, because it encodes an assumption jsdom cannot refute.
+  A media query is the sharpest case of it: the suite can pin **which question
+  is asked** and fake the answer, never evaluate it, so what is asserted is the
+  query string plus the behaviour that follows from a faked match (worked case:
+  `presentation/usePortraitPhone.test.tsx`, #91 — dropping `pointer: coarse`
+  from the query tells a laptop user to rotate their screen, and the string
+  assertion is the only thing in the suite that can catch it). Code that asks
+  must also guard the call: an unguarded `window.matchMedia` throws in jsdom
+  instead of answering `false`.
   Three worked cases, all from #84 and all green in jsdom at the time:
   an `IntersectionObserver` active-section rule that left the rail unmarked
   through 70% of a document (an observer fires on crossings; a reader inside a


### PR DESCRIPTION
**Closes #91**

## Summary

A phone held upright no longer gets the slide deck. One rule, asked in the
viewer — `(pointer: coarse) and (orientation: portrait)` — replaces the deck
with a panel: a rotate icon, one line in Spanish, and a link to the document's
book view. The pointer half is load-bearing: a narrow window on a laptop is not
a phone and must never be told to rotate.

The panel is modal in the way that matters. No slide is painted, the only
control reachable by keyboard is the way out, the deck's slide keys are silenced
while it is up (`Escape` deliberately is not), and fullscreen is left behind
since the `⛶` button goes with the deck. The reader's position survives rotation
for free — it lives in `?slide=N`, not in the component.

`screen.orientation.lock` is not used, and ADR-0023 records why so nobody
re-derives it: it only works inside fullscreen, and iPhone Safari has no
Fullscreen API for a web page at all.

## Slices completed

- [x] S1 — cover the deck with a rotate panel on a phone held in portrait (`b0cbb13`)
- [x] S2 — offer a way out of the presentation from that panel (`bff6b29`)

Plus `4799696` (ADR + standards), `ac4c675` (round A review fixes), `93b1d44`
+ `d23f8ff` + `8c9f400` (round B docs fixes and the recheck's corrections).

## Acceptance criteria

Browser evidence throughout: Playwright/Chromium against `npm run build && npm
run preview` (served under `/nalanda/`), on an emulated iPhone 13 and on a
fine-pointer context of the identical size, screenshots looked at.

1. **Panel, no slide content, nothing of the deck reachable** — `SlideDeck`
   early-returns `<RotateNotice>` and gates the window keydown listener. Tests:
   `covers the deck: the panel is shown and no slide is painted`, `leaves
   nothing but the way out reachable by keyboard` (enumerates the whole route's
   focusables → exactly `["Leer en el libro"]`), `ignores the slide keys behind
   the panel, so the position cannot drift`. Browser at 390x844: panel up, no
   counter, focus on the `alertdialog`, five Tab presses reach only the way out.
2. **Rotating shows the deck at the reader's slide, incl. `?slide=N`** — test
   `shows the deck at the reader's slide when the phone is turned, and back`;
   browser: `?slide=2` portrait → panel, 844x390 → `2 / 10`.
3. **Rotating back keeps the position** — same test; browser: ArrowRight×2 +
   End behind the panel leave the URL at `?slide=2`. Before the review fix this
   sequence produced `3 / 3`.
4. **A way out that lands on the book view** — `<Link to={/d/${docId}}>`, an
   absolute route rather than `history.back()`. Tests for the href, for the
   click landing on `<article>`, and for `Escape`; browser confirms both.
5. **Never on a fine-pointer device, at any size or aspect ratio** — the query
   carries `(pointer: coarse)`, pinned by construction (`asks for a coarse
   pointer AND portrait`); jsdom cannot evaluate a query, so the route test is
   named for what it proves. Browser: fine pointer at 390x844 → deck, and at
   1440x900.
6. **Spanish + announced to AT** — `role="alertdialog"`, `aria-modal`,
   `aria-labelledby`/`aria-describedby`, focus on mount, icon `aria-hidden`.
7. **Fullscreen button and `p` / `Escape` unchanged** — untouched in the diff;
   browser at 1440x900: ArrowRight → `3 / 10`, Escape → book view; on the phone
   the deck's keys work again after rotation on the same mounted deck.
8. **Book view unaffected** — nothing outside `presentation/` changed;
   verified at 390x844 with a coarse pointer, and again after taking the way out.
9. **Verified in a real browser** — two runs (before and after the review
   fixes) plus the verifier's independent run.
10. **Protocols green** — per-commit before each of seven commits; pre-PR as
    the pipeline's gate and after every fix round: format ✓ lint ✓ 468/468 ✓
    build ✓.

## Tests

468 green (was 465 on `main`; +11 new, −8 by consolidation and renaming). New:
`presentation/usePortraitPhone.test.tsx` (5), `presentation/RotateNotice.test.tsx`
(3), and 8 route cases in `app/presentationRoute.test.tsx`.

Every fix was seen to fail before it landed: dropping the key guard fails
`ignores the slide keys behind the panel`; guarding `Escape` too fails `still
answers Escape behind the panel`; dropping the fullscreen effect fails `leaves
fullscreen when it takes the deck away`.

## Reviews run

Full pipeline, both rounds, every lens in its own worktree.

- **Round A (code)** — correctness+tests, architecture+simplicity, security.
  12 findings (2 important, 8 suggestions, 2 patterns); security returned none.
  The verifier CONFIRMED the important one in Chromium and DEFLATED the other,
  and improved the proposed fix (the panel is modal, so `Escape` must survive).
  Acted on all but one; `useSyncExternalStore` replaced the hand-rolled hook.
- **Round B (docs)** — completeness, accuracy, ADR hunter, agent readability.
  16 findings, heavy cross-lens agreement. Accuracy measured the built site and
  falsified two claims this ADR had inherited from the issue text (see Notes).
  All 14 accepted fixes rechecked: 14/14 resolved — and the recheck caught three
  *new* false sentences introduced by the corrections, fixed in `8c9f400`.

## Manual verification

1. Open `/nalanda/d/java-desde-cpp/present` on a phone (or emulate one).
   Portrait: "Gira el teléfono", no slide behind it.
2. Turn it sideways: the deck appears at the slide you were on. Turn it back:
   the panel, same position.
3. Tap **Leer en el libro**: you land on the document's book view.
4. Lock rotation in the OS and repeat 1 and 3 — the way out is the point of it.
5. Narrow a desktop window to phone size: you must get the deck, never the panel.
6. On a laptop, check nothing moved: `p` from the book, arrows, `Home`/`End`,
   `Escape`, and the `⛶` button.
7. Optional: enter fullscreen in landscape on a phone, then turn it upright —
   the page should leave fullscreen with the panel.

## Notes

- **Two claims from the issue text turned out to be wrong**, re-measured in the
  browser during review and corrected in ADR-0023: at 390x844 the paragraph does
  not run edge to edge (it sits in a 262px column — `px-16` has no responsive
  variant), and at 844x390 the deck does **not** "read correctly" — the heading
  is clipped at `y = -61` and the closing paragraph falls below the fold. That
  clipping is slide typography, an explicit non-goal here; it is now recorded
  rather than assumed away, and is a candidate for its own WP.
- **First recorded browser baseline in the repo**: Safari 14+ / iOS 14+, because
  `MediaQueryList.addEventListener` lands there. On older WebKit `/present`
  blanks, no test guards it, and shipping without a fallback was the decision
  taken here — with the case that does not hold named in ADR-0023 and the
  symptom in the root README table.
- **Live sessions**: when ADR-0008 arrives, a student following the class from
  a phone held upright will get this panel while `?slide` advances behind it.
  Recorded as an open question for v0.3, not decided here.
- **Pre-existing flake, not introduced here**: `presentationRoute.test.tsx >
  "opens on the cover slide…"` can exceed the 1000ms `findBy` default under
  parallel load (seen at 1402ms by two sessions, including on a branch that does
  not touch that file).
- Tablets in portrait deliberately get the panel too — one rule, no unmeasured
  breakpoint. The wording ("Gira el teléfono") is the thing to revisit if it
  ever grates, not the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s8pBXNvdMc6th4rxfZ9MW
