### PR TITLE
feat: highlight every code fence with the read-only code component

### DIFF
--- a/apps/web/src/app/documentFences.test.tsx
+++ b/apps/web/src/app/documentFences.test.tsx
@@ -131,9 +131,12 @@ describe('the pre-not-code rule that keeps Exercise working', () => {
     const container = await renderThroughTheShellMap(source);
 
     await vi.waitFor(() => expect(container.textContent).toContain('Escribe'));
-    // The amber banner is what a broken fence lookup produces.
+    // The amber banner is what a broken fence lookup produces, and its real
+    // wording is "<Exercise> sin bloque starter: …". The first version of this
+    // line looked for "espera", which appears only in SideBySide's message —
+    // it could never fire, and said in a comment that it protected this.
     expect(container.textContent, 'the exercise rendered as an authoring error').not.toContain(
-      'espera',
+      'sin bloque',
     );
     // And the cases stay hidden until the student runs (ADR-0019).
     expect(container.textContent).not.toContain('check(Solution.esPar(4)');

--- a/apps/web/src/app/documentFences.test.tsx
+++ b/apps/web/src/app/documentFences.test.tsx
@@ -90,3 +90,52 @@ describe('the fences of the shipped Java document', () => {
     expect(container.querySelector('pre')?.textContent).toContain('npm run build');
   });
 });
+
+// The sharp edge of the whole WP. `fencesByMeta` / `withoutFences` identify an
+// exercise's fences by the literal `code` intrinsic type, so mapping `code`
+// instead of `pre` would leave every <Exercise> unable to find its own body — it
+// renders the amber authoring banner where the exercise should be. Nothing else
+// in the suite compiles a document through the shell map, so nothing else can
+// see this.
+describe('the pre-not-code rule that keeps Exercise working', () => {
+  const exercises = DOCUMENT.split('<Exercise').length - 1;
+
+  it('the document really ships exercises (guards against a vacuous check)', () => {
+    expect(exercises).toBeGreaterThan(0);
+  });
+
+  it('maps the wrapper, never the fence itself', () => {
+    const map: Record<string, unknown> = mdxComponents;
+    expect(map['pre'], 'the fence mapping disappeared').toBeDefined();
+    expect(map['code'], 'mapping `code` breaks every Exercise').toBeUndefined();
+  });
+
+  it('lets an exercise find its starter and hide its cases, through the shell map', async () => {
+    const source = [
+      '<Exercise title="¿Es par?">',
+      '',
+      'Escribe `esPar`.',
+      '',
+      '```java starter',
+      'class Solution {}',
+      '```',
+      '',
+      '```java test',
+      'check(Solution.esPar(4), true);',
+      '```',
+      '',
+      '</Exercise>',
+      '',
+    ].join('\n');
+
+    const container = await renderThroughTheShellMap(source);
+
+    await vi.waitFor(() => expect(container.textContent).toContain('Escribe'));
+    // The amber banner is what a broken fence lookup produces.
+    expect(container.textContent, 'the exercise rendered as an authoring error').not.toContain(
+      'espera',
+    );
+    // And the cases stay hidden until the student runs (ADR-0019).
+    expect(container.textContent).not.toContain('check(Solution.esPar(4)');
+  });
+});

--- a/apps/web/src/app/documentFences.test.tsx
+++ b/apps/web/src/app/documentFences.test.tsx
@@ -1,0 +1,92 @@
+import { evaluate } from '@mdx-js/mdx';
+import { render } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { MemoryRouter } from 'react-router-dom';
+import * as runtime from 'react/jsx-runtime';
+import { describe, expect, it, vi } from 'vitest';
+
+import { remarkPlugins } from '../content';
+
+import { mdxComponents } from './mdxComponents';
+
+// The editor is not what is under test here — which renderer a fence reaches is.
+vi.mock('@uiw/react-codemirror', () => ({
+  default: ({ value }: { value: string }) => <textarea readOnly value={value} data-testid="code" />,
+}));
+
+// L4-ish: this binds the content feature to the shell. The `pre` mapping lives
+// in the shell's map (a feature may not import `components/`), so only a test
+// that uses THAT map can say what a document's fences actually become.
+async function renderThroughTheShellMap(source: string): Promise<HTMLElement> {
+  const { default: Content } = await evaluate(source, { ...runtime, remarkPlugins });
+  return render(
+    <MemoryRouter>
+      <Content components={mdxComponents} />
+    </MemoryRouter>,
+  ).container;
+}
+
+// vitest runs with apps/web as its cwd.
+const DOCUMENT = readFileSync(
+  join(process.cwd(), '../../content/courses/sample-course/06-java-desde-cpp.mdx'),
+  'utf8',
+);
+
+/** Every fence in the document, as `[info-string, body]`. */
+function fencesOf(markdown: string): { info: string; body: string }[] {
+  const found: { info: string; body: string }[] = [];
+  const lines = markdown.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const open = /^```(.*)$/.exec(lines[i] ?? '');
+    if (!open) continue;
+    const body: string[] = [];
+    let j = i + 1;
+    for (; j < lines.length && !/^```\s*$/.test(lines[j] ?? ''); j++) body.push(lines[j] ?? '');
+    found.push({ info: (open[1] ?? '').trim(), body: body.join('\n') });
+    i = j;
+  }
+  return found;
+}
+
+describe('the fences of the shipped Java document', () => {
+  const fences = fencesOf(DOCUMENT);
+  const untagged = fences.filter((f) => f.info === '');
+
+  it('found fences at all (guards against a vacuous check)', () => {
+    expect(fences.length).toBeGreaterThan(5);
+  });
+
+  it('the document really does carry language-less fences', () => {
+    // Two ASCII diagrams. If this ever changes, the cases below are measuring
+    // nothing and should be re-pointed rather than deleted.
+    expect(untagged).toHaveLength(2);
+    expect(untagged.every((f) => f.body.includes('→'))).toBe(true);
+  });
+
+  it('leaves an ASCII diagram as a plain pre, loading no editor', async () => {
+    const container = await renderThroughTheShellMap('```\n' + untagged[0]!.body + '\n```\n');
+
+    const pre = container.querySelector('pre');
+    expect(pre, 'the diagram stopped being a pre').not.toBeNull();
+    expect(pre?.textContent).toContain('[g++]');
+    expect(container.querySelector('[data-testid="code"]')).toBeNull();
+  });
+
+  it('turns a Java fence from the same document into the editor', async () => {
+    const java = fences.find((f) => f.info === 'java');
+    expect(java, 'no plain java fence in the document').toBeDefined();
+
+    const container = await renderThroughTheShellMap('```java\n' + java!.body + '\n```\n');
+
+    // Awaited: the editor is lazy, the diagram above is not.
+    await vi.waitFor(() => expect(container.querySelector('.cm-editor, textarea')).not.toBeNull());
+    expect(container.querySelector('pre')).toBeNull();
+  });
+
+  it('leaves a fence in a language the platform cannot run alone', async () => {
+    const container = await renderThroughTheShellMap('```bash\nnpm run build\n```\n');
+
+    expect(container.querySelector('pre')?.textContent).toContain('npm run build');
+  });
+});

--- a/apps/web/src/app/mdxComponents.ts
+++ b/apps/web/src/app/mdxComponents.ts
@@ -1,4 +1,11 @@
-import { LazyCodeEditor, LazyExercise, SectionBreak, SideBySide, Slide } from '../components';
+import {
+  LazyCodeEditor,
+  LazyExercise,
+  MdxPre,
+  SectionBreak,
+  SideBySide,
+  Slide,
+} from '../components';
 import { contentMdxComponents } from '../content';
 
 /**
@@ -8,6 +15,11 @@ import { contentMdxComponents } from '../content';
  */
 export const mdxComponents = {
   ...contentMdxComponents,
+  // Every fence in a language the platform runs becomes the read-only editor.
+  // Registered HERE and not in `content/`: the mapping needs the editor, and
+  // `content → components` is not an allowed edge — composing the map in the
+  // shell is the seam that already exists for exactly this (ADR-0003/0010).
+  pre: MdxPre,
   Slide,
   SectionBreak,
   SideBySide,

--- a/apps/web/src/architecture.test.ts
+++ b/apps/web/src/architecture.test.ts
@@ -144,3 +144,81 @@ describe('architecture: cross-feature dependencies', () => {
     ).toEqual([]);
   });
 });
+
+// The two describes above guard the entry chunk by NAMING the heavy modules.
+// That is per-component, and the invariant is per-graph: ADR-0018's claim is
+// "no CodeMirror, no compiler, no runtime in the entry chunk", and #85 broke it
+// without touching either name — `components/MdxPre` asked the runtime seam
+// which languages exist, and the seam brought the registry, the descriptors and
+// the Java launcher with it. Both allowlist tests stayed green while the eager
+// payload went from 1 chunk / 503kB to 9 / 542kB.
+describe('architecture: what the shell reaches eagerly', () => {
+  /** Resolves an import specifier to a file inside src/, or null. */
+  function moduleOf(fromFile: string, spec: string): string | null {
+    if (!spec.startsWith('.')) return null;
+    const base = resolve(dirname(fromFile), spec);
+    for (const candidate of [
+      base,
+      `${base}.ts`,
+      `${base}.tsx`,
+      join(base, 'index.ts'),
+      join(base, 'index.tsx'),
+    ]) {
+      try {
+        if (statSync(candidate).isFile()) return candidate;
+      } catch {
+        // not this one
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Every module the shell's MDX map pulls in EAGERLY. A `lazy*.tsx` wrapper is
+   * where the graph is cut on purpose (ADR-0018 §7), so the walk stops there —
+   * that is exactly the boundary the invariant is about.
+   */
+  function eagerlyReachable(entry: string): Set<string> {
+    const seen = new Set<string>();
+    const queue = [entry];
+    while (queue.length > 0) {
+      const file = queue.pop()!;
+      if (seen.has(file)) continue;
+      seen.add(file);
+      if (/\/lazy[A-Z]\w*\.tsx$/.test(file)) continue; // the cut
+      const source = readFileSync(file, 'utf8');
+      for (const match of source.matchAll(/(?:from|import)\s*\(?\s*['"]([^'"]+)['"]/g)) {
+        const next = moduleOf(file, match[1] ?? '');
+        if (next) queue.push(next);
+      }
+    }
+    return seen;
+  }
+
+  const reachable = eagerlyReachable(join(SRC, 'app/mdxComponents.ts'));
+
+  it('reaches something at all (guards against a vacuous check)', () => {
+    expect(reachable.size).toBeGreaterThan(5);
+  });
+
+  it('never reaches the runtime feature', () => {
+    // Asking WHICH languages exist is fine and lives in lib/runtimeIds.ts;
+    // reaching `runtime/` drags useRuntime, the registry, every descriptor and
+    // the Java launcher into the payload every reader downloads.
+    const offenders = [...reachable]
+      .filter((file) => relative(SRC, file).startsWith('runtime/'))
+      .map((file) => relative(SRC, file));
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('never reaches CodeMirror or a language grammar', () => {
+    const offenders = [...reachable]
+      .filter((file) =>
+        /@uiw\/react-codemirror|@codemirror\/|@lezer\//.test(readFileSync(file, 'utf8')),
+      )
+      .map((file) => relative(SRC, file));
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/apps/web/src/components/MdxPre.test.tsx
+++ b/apps/web/src/components/MdxPre.test.tsx
@@ -14,6 +14,7 @@ vi.mock('./interactive/lazyCodeEditor', () => ({
       data-language={String(props['language'])}
       data-variant={String(props['variant'])}
       data-source={String(props['defaultValue'])}
+      data-filename={String(props['showFileName'])}
     />
   ),
 }));
@@ -42,6 +43,15 @@ describe('MdxPre', () => {
     render(fence('cpp', 'int main() {}\n'));
 
     expect(screen.getByTestId('editor').dataset['variant']).toBe('snippet');
+  });
+
+  it('claims no filename — a fence is not a file', () => {
+    // `snippet` turns the filename on, which headed a three-line fragment
+    // `Main.java`, two screens from where the document teaches
+    // `Hola.java → [javac] → Hola.class`.
+    render(fence('java', 'import java.util.Scanner;\n'));
+
+    expect(screen.getByTestId('editor').dataset['filename']).toBe('false');
   });
 
   it('keeps the blank lines of the listing, dropping only the fence break', () => {

--- a/apps/web/src/components/MdxPre.test.tsx
+++ b/apps/web/src/components/MdxPre.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MdxPre } from './MdxPre';
+
+// What MdxPre decides is WHICH renderer a fence reaches and with what — the
+// editor's own behaviour is its suite's business, and reaching for it here would
+// drag CodeMirror and a runtime into a test about a seam. So the wrapper is
+// replaced by something that simply reports the props it was handed.
+vi.mock('./interactive/lazyCodeEditor', () => ({
+  LazyCodeEditor: (props: Record<string, unknown>) => (
+    <div
+      data-testid="editor"
+      data-language={String(props['language'])}
+      data-variant={String(props['variant'])}
+      data-source={String(props['defaultValue'])}
+    />
+  ),
+}));
+
+/** What the MDX pipeline hands `pre` — shape verified against the real pipeline. */
+function fence(language: string | undefined, source: string) {
+  return (
+    <MdxPre>
+      <code className={language === undefined ? undefined : `language-${language}`}>{source}</code>
+    </MdxPre>
+  );
+}
+
+describe('MdxPre', () => {
+  it('sends a fence in a language the platform runs to the editor', () => {
+    render(fence('java', 'class A {}\n'));
+
+    const editor = screen.getByTestId('editor');
+    expect(editor.dataset['language']).toBe('java');
+    expect(editor.dataset['source']).toBe('class A {}');
+  });
+
+  it('asks for the reading chrome: numbered and copyable, never runnable', () => {
+    // `snippet` is the variant that was designed for this and wired to nothing
+    // (variants.ts): line numbers and a copy button, no editing, no runtime.
+    render(fence('cpp', 'int main() {}\n'));
+
+    expect(screen.getByTestId('editor').dataset['variant']).toBe('snippet');
+  });
+
+  it('keeps the blank lines of the listing, dropping only the fence break', () => {
+    render(fence('python', 'a = 1\n\nb = 2\n'));
+
+    expect(screen.getByTestId('editor').dataset['source']).toBe('a = 1\n\nb = 2');
+  });
+
+  it('leaves a fence with no language as plain markup', () => {
+    // The two ASCII diagrams in 06-java-desde-cpp.mdx are exactly this.
+    const { container } = render(fence(undefined, 'programa.cpp -> [g++] -> programa\n'));
+
+    expect(container.querySelector('pre')).not.toBeNull();
+    expect(screen.queryByTestId('editor')).not.toBeInTheDocument();
+  });
+
+  it('leaves a fence in a language the platform cannot run as plain markup', () => {
+    const { container } = render(fence('bash', 'npm run build\n'));
+
+    expect(container.querySelector('pre')).not.toBeNull();
+    expect(screen.queryByTestId('editor')).not.toBeInTheDocument();
+  });
+
+  it('keeps a pre that holds something other than a fence', () => {
+    const { container } = render(
+      <MdxPre>
+        <span>no soy una cerca</span>
+      </MdxPre>,
+    );
+
+    expect(container.querySelector('pre')?.textContent).toBe('no soy una cerca');
+    expect(screen.queryByTestId('editor')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/MdxPre.tsx
+++ b/apps/web/src/components/MdxPre.tsx
@@ -30,6 +30,14 @@ function isKnownLanguage(language: string | null): language is RuntimeId {
  * The lazy wrapper, never the editor itself: the shell builds its MDX map
  * eagerly, so naming `CodeEditor` here would put CodeMirror in the entry chunk
  * for every reader of every page (ADR-0018 §7).
+ *
+ * One property was measured rather than assumed, because the editor renders by
+ * viewport and could in principle keep a listing's tail out of the DOM, where
+ * the browser's own `Ctrl+F` would stop finding it: at the sizes a course
+ * document uses it does not. Every line stays in the DOM — including lines
+ * scrolled out of view inside a slide's capped box — so search keeps working
+ * (#85 AC11, measured at 1440px and 390px; the rule for authors is in
+ * `guides/add-a-course-document.md` step 3).
  */
 export function MdxPre({ children }: Props) {
   const fence = fenceOf(children);

--- a/apps/web/src/components/MdxPre.tsx
+++ b/apps/web/src/components/MdxPre.tsx
@@ -1,8 +1,8 @@
 import type { ReactNode } from 'react';
 
 import { fenceOf } from '../lib/codeFences';
-import { RUNTIME_IDS } from '../runtime';
-import type { RuntimeId } from '../runtime';
+import { RUNTIME_IDS } from '../lib/runtimeIds';
+import type { RuntimeId } from '../lib/runtimeIds';
 import { LazyCodeEditor } from './interactive/lazyCodeEditor';
 
 interface Props {
@@ -43,5 +43,16 @@ export function MdxPre({ children }: Props) {
   const fence = fenceOf(children);
   if (!fence || !isKnownLanguage(fence.language)) return <pre>{children}</pre>;
 
-  return <LazyCodeEditor language={fence.language} variant="snippet" defaultValue={fence.source} />;
+  return (
+    <LazyCodeEditor
+      language={fence.language}
+      variant="snippet"
+      // A fence is not a file. `snippet` turns the filename on, which headed a
+      // three-line fragment `Main.java` — two screens from where the document
+      // teaches `Hola.java → [javac] → Hola.class`. An authored <CodeEditor>
+      // still gets one; a quoted listing has no name to claim.
+      showFileName={false}
+      defaultValue={fence.source}
+    />
+  );
 }

--- a/apps/web/src/components/MdxPre.tsx
+++ b/apps/web/src/components/MdxPre.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from 'react';
+
+import { fenceOf } from '../lib/codeFences';
+import { RUNTIME_IDS } from '../runtime';
+import type { RuntimeId } from '../runtime';
+import { LazyCodeEditor } from './interactive/lazyCodeEditor';
+
+interface Props {
+  children?: ReactNode;
+}
+
+/**
+ * Whether the platform can highlight this fence — the registry is the authority,
+ * and asking it is also what narrows the string into a `RuntimeId` without a cast.
+ */
+function isKnownLanguage(language: string | null): language is RuntimeId {
+  return language !== null && (RUNTIME_IDS as readonly string[]).includes(language);
+}
+
+/**
+ * Every `<pre>` a document produces — the seam where a markdown fence becomes a
+ * component.
+ *
+ * Registered on `pre` and never on `code`: `lib/codeFences.ts` identifies an
+ * exercise's `starter` and `test` fences by the literal `code` intrinsic type,
+ * so mapping `code` would leave every `<Exercise>` unable to find its own body.
+ * Mapping the wrapper leaves that walk untouched — it recurses through and still
+ * meets the `code` inside.
+ *
+ * The lazy wrapper, never the editor itself: the shell builds its MDX map
+ * eagerly, so naming `CodeEditor` here would put CodeMirror in the entry chunk
+ * for every reader of every page (ADR-0018 §7).
+ */
+export function MdxPre({ children }: Props) {
+  const fence = fenceOf(children);
+  if (!fence || !isKnownLanguage(fence.language)) return <pre>{children}</pre>;
+
+  return <LazyCodeEditor language={fence.language} variant="snippet" defaultValue={fence.source} />;
+}

--- a/apps/web/src/components/embedded.ts
+++ b/apps/web/src/components/embedded.ts
@@ -1,0 +1,23 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * Whether what renders here is already inside a frame that labels it.
+ *
+ * `<SideBySide>` gives each column a border and a language label, and used to
+ * flatten the bare `<pre>` inside it with `[&_pre]:border-0`. Once a fence is a
+ * component that selector describes nothing, and the column ends up with two
+ * stacked headers and two rounded borders (#85).
+ *
+ * A context rather than a prop because the content is authored as markdown: a
+ * column receives whatever the fence became, and cannot pass it anything.
+ * Same shape as `ModeProvider` — the container states the situation, and the
+ * component decides what to do about it.
+ */
+const EmbeddedContext = createContext(false);
+
+export const EmbeddedProvider = EmbeddedContext.Provider;
+
+/** True when a container already provides the frame and the label. */
+export function useEmbedded(): boolean {
+  return useContext(EmbeddedContext);
+}

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -13,6 +13,9 @@ import { slideCatalogEntry } from './structure/Slide.catalog';
 export { LazyCodeEditor } from './interactive/lazyCodeEditor';
 // Same rule, same reason: Exercise embeds CodeMirror too.
 export { LazyExercise } from './interactive/lazyExercise';
+// Not a document-facing component and deliberately not in the catalog: authors
+// never write it, they write a fence. The shell maps it onto `pre`.
+export { MdxPre } from './MdxPre';
 export { SectionBreak } from './structure/SectionBreak';
 export { SideBySide } from './structure/SideBySide';
 export { Slide } from './structure/Slide';

--- a/apps/web/src/components/interactive/CodeEditor.test.tsx
+++ b/apps/web/src/components/interactive/CodeEditor.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { draftKey, readDraft, saveDraft } from './draft';
+import { EmbeddedProvider } from '../embedded';
 import { ModeProvider } from '../../presentation';
 import type { RunRequest, RuntimeWorker, WorkerMessage } from '../../runtime';
 import { runtimeDescriptors } from '../../runtime';
@@ -12,7 +13,14 @@ import { CodeEditor } from './CodeEditor';
 // contenteditable does not behave in jsdom. The panels, the run flow and the
 // per-mode shape are what the component promises.
 vi.mock('@uiw/react-codemirror', () => ({
-  default: ({ value }: { value: string }) => <textarea readOnly value={value} data-testid="code" />,
+  default: ({ value, basicSetup }: { value: string; basicSetup?: { lineNumbers?: boolean } }) => (
+    <textarea
+      readOnly
+      value={value}
+      data-testid="code"
+      data-line-numbers={String(basicSetup?.lineNumbers)}
+    />
+  ),
 }));
 
 const workers: FakeWorker[] = [];
@@ -346,6 +354,56 @@ describe('CodeEditor', () => {
     await waitFor(() => expect(screen.getAllByTestId('code').length).toBeGreaterThan(0));
 
     expect(container.querySelector('[class*="55vh"]')).not.toBeNull();
+  });
+
+  it('drops its own frame and filename when a container already provides them', async () => {
+    // Inside a SideBySide column the editor used to stack a second header and a
+    // second rounded border inside the column's own — the frame the bare <pre>
+    // never had, because `[&_pre]:border-0` flattened it.
+    const { container } = render(
+      <ModeProvider mode="book">
+        <EmbeddedProvider value={true}>
+          <CodeEditor language="cpp" variant="snippet" defaultValue="int main() {}" />
+        </EmbeddedProvider>
+      </ModeProvider>,
+    );
+    await waitFor(() => expect(screen.getAllByTestId('code').length).toBeGreaterThan(0));
+
+    const shell = container.querySelector('.not-prose');
+    expect(shell?.className).not.toContain('border');
+    expect(shell?.className).not.toContain('rounded');
+    expect(shell?.className).not.toContain('my-6');
+    expect(screen.queryByText('main.cpp')).not.toBeInTheDocument();
+    // The column's label already says which language this is; repeating it
+    // under the label is the second half of the doubled header.
+    expect(screen.queryByText('C++20')).not.toBeInTheDocument();
+    // The gutter goes too, and this is the half that is not cosmetic: it costs
+    // ~22px of a ~376px column, which is exactly the margin the #76 fix lives
+    // on. Measured in a browser at 1440px — 21px of clipping, the closing `);`
+    // of the longest Java line gone — not reasoned about.
+    expect(screen.getByTestId('code').dataset['lineNumbers']).toBe('false');
+  });
+
+  it('keeps the copy button when embedded — the reason a listing is quotable', async () => {
+    render(
+      <ModeProvider mode="book">
+        <EmbeddedProvider value={true}>
+          <CodeEditor language="cpp" variant="snippet" defaultValue="int main() {}" />
+        </EmbeddedProvider>
+      </ModeProvider>,
+    );
+    await waitFor(() => expect(screen.getAllByTestId('code').length).toBeGreaterThan(0));
+
+    expect(screen.getByRole('button', { name: /copiar/i })).toBeInTheDocument();
+  });
+
+  it('keeps its own frame when nothing contains it', async () => {
+    const { container } = renderEditor({ variant: 'snippet' }, 'book');
+    await waitFor(() => expect(screen.getAllByTestId('code').length).toBeGreaterThan(0));
+
+    expect(container.querySelector('.not-prose')?.className).toContain('border');
+    expect(screen.getByText('main.cpp')).toBeInTheDocument();
+    expect(screen.getByTestId('code').dataset['lineNumbers']).toBe('true');
   });
 
   it('still caps an editable editor in the book, which is not a listing', async () => {

--- a/apps/web/src/components/interactive/CodeEditor.test.tsx
+++ b/apps/web/src/components/interactive/CodeEditor.test.tsx
@@ -327,6 +327,35 @@ describe('CodeEditor', () => {
     expect(book.querySelector('.max-h-64')).not.toBeNull();
     expect(slide.querySelector('[class*="55vh"]')).not.toBeNull();
   });
+
+  it('lets a listing take its full height in the book, with no scrollbar of its own', async () => {
+    // A listing that scrolls inside itself while the reader scrolls the page is
+    // the most irritating thing a long document can do — and unlike an editor,
+    // a snippet has no reason to: the page already scrolls.
+    const { container } = renderEditor({ variant: 'snippet' }, 'book');
+    await waitFor(() => expect(screen.getAllByTestId('code').length).toBeGreaterThan(0));
+
+    expect(container.querySelector('.max-h-64')).toBeNull();
+    expect(container.querySelector('.overflow-auto')).toBeNull();
+  });
+
+  it('keeps the slide’s internal scroll for a listing, where the screen does not grow', async () => {
+    // On a slide the box scrolling is not a defect: it is the only way through
+    // code that does not fit without shrinking the type past legibility.
+    const { container } = renderEditor({ variant: 'snippet' }, 'presentation');
+    await waitFor(() => expect(screen.getAllByTestId('code').length).toBeGreaterThan(0));
+
+    expect(container.querySelector('[class*="55vh"]')).not.toBeNull();
+  });
+
+  it('still caps an editable editor in the book, which is not a listing', async () => {
+    // The cap is what stops a long exercise pushing its own Run button off the
+    // screen; only the read-only case gives it up.
+    const { container } = renderEditor({ variant: 'exercise' }, 'book');
+    await waitFor(() => expect(screen.getAllByTestId('code').length).toBeGreaterThan(0));
+
+    expect(container.querySelector('.max-h-64')).not.toBeNull();
+  });
 });
 
 // A Java loop that never ends freezes the tab for good (ADR-0017/ADR-0020), and

--- a/apps/web/src/components/interactive/CodeEditor.test.tsx
+++ b/apps/web/src/components/interactive/CodeEditor.test.tsx
@@ -406,6 +406,48 @@ describe('CodeEditor', () => {
     expect(screen.getByTestId('code').dataset['lineNumbers']).toBe('true');
   });
 
+  it('ignores a stored draft when it is a listing, which nobody could have typed', async () => {
+    // Every markdown fence is an editor now (#85). Reading a draft here let
+    // same-origin storage replace an authored listing - and the copy button
+    // then handed those bytes to the reader.
+    const seeded = fakeStorage();
+    vi.stubGlobal('localStorage', seeded);
+    const key = draftKey(
+      `${globalThis.location?.pathname ?? ''}#cpp#int main() {}`,
+      'int main() {}',
+    );
+    saveDraft(key, 'PLANTADO');
+
+    renderEditor({ variant: 'snippet', defaultValue: 'int main() {}' }, 'book');
+
+    await waitFor(() => expect(screen.getByTestId('code')).toHaveValue('int main() {}'));
+  });
+
+  it('still restores a draft for an editor the student could have typed in', async () => {
+    const seeded = fakeStorage();
+    vi.stubGlobal('localStorage', seeded);
+    const key = draftKey(
+      `${globalThis.location?.pathname ?? ''}#cpp#int main() {}`,
+      'int main() {}',
+    );
+    saveDraft(key, 'lo que escribio el alumno');
+
+    renderEditor({ variant: 'exercise', defaultValue: 'int main() {}' }, 'book');
+
+    await waitFor(() =>
+      expect(screen.getByTestId('code')).toHaveValue('lo que escribio el alumno'),
+    );
+  });
+
+  it('uncaps a read variant too — the rule is about listings, not about a name', async () => {
+    // `variant="read"` ships in 05-codigo-ejecutable.mdx, so this is shipped
+    // behaviour and not a hypothetical: it lost its cap with `snippet`.
+    const { container } = renderEditor({ variant: 'read' }, 'book');
+    await waitFor(() => expect(screen.getAllByTestId('code').length).toBeGreaterThan(0));
+
+    expect(container.querySelector('.max-h-64')).toBeNull();
+  });
+
   it('still caps an editable editor in the book, which is not a listing', async () => {
     // The cap is what stops a long exercise pushing its own Run button off the
     // screen; only the read-only case gives it up.

--- a/apps/web/src/components/interactive/CodeEditor.tsx
+++ b/apps/web/src/components/interactive/CodeEditor.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import { draftKey, readDraft, saveDraft } from './draft';
+import { useEmbedded } from '../embedded';
 import { OUTPUT, Panel } from './Panel';
 import { useMode } from '../../presentation';
 import type { RunResult, RuntimeId, RuntimeModule } from '../../runtime';
@@ -38,7 +39,17 @@ export function CodeEditor({
   ...overrides
 }: CodeEditorProps) {
   const mode = useMode();
+  // A container that already frames and labels this listing (a SideBySide
+  // column). The frame is dropped rather than drawn twice, and the filename
+  // goes with it: the column's own label already says which language this is.
+  const embedded = useEmbedded();
   const flags = resolveFlags(variant, overrides);
+  // Inside a column the line-number gutter costs ~22px of the ~376px the
+  // listing gets, and that is exactly the margin the #76 fix lives on: with the
+  // gutter, `System.out.println("Bienvenidos a EDA");` loses its closing `);`
+  // again — measured at 1440px in the book. Numbers are chrome; a complete line
+  // is the lesson.
+  const gutter = flags.showLineNumbers && !embedded;
 
   const [languageId, setLanguageId] = useState<RuntimeId>(language);
   const [runtimes, setRuntimes] = useState<Partial<Record<RuntimeId, RuntimeModule>>>({});
@@ -195,11 +206,13 @@ export function CodeEditor({
       className={
         expanded
           ? 'fixed inset-0 z-50 flex flex-col bg-zinc-900 text-zinc-100'
-          : 'not-prose my-6 flex flex-col overflow-hidden rounded-lg border border-zinc-700 bg-zinc-900 text-zinc-100'
+          : embedded
+            ? 'not-prose flex flex-col overflow-hidden bg-zinc-900 text-zinc-100'
+            : 'not-prose my-6 flex flex-col overflow-hidden rounded-lg border border-zinc-700 bg-zinc-900 text-zinc-100'
       }
     >
       <header className="flex items-center gap-2 bg-zinc-800 px-3 py-1.5">
-        {flags.showFileName ? (
+        {flags.showFileName && !embedded ? (
           <span className="font-mono text-xs text-zinc-400">
             {descriptor?.fileName ?? `${languageId}…`}
           </span>
@@ -218,7 +231,7 @@ export function CodeEditor({
               </option>
             ))}
           </select>
-        ) : (
+        ) : embedded ? null : (
           <span className="font-mono text-3xs text-zinc-500">{descriptor?.label}</span>
         )}
 
@@ -267,7 +280,7 @@ export function CodeEditor({
             ...(runtime ? [runtime.codeMirrorLanguage()] : []),
             ...(flags.runnable ? [runShortcut] : []),
           ]}
-          basicSetup={{ lineNumbers: flags.showLineNumbers, foldGutter: flags.showFoldGutter }}
+          basicSetup={{ lineNumbers: gutter, foldGutter: flags.showFoldGutter }}
         />
       </div>
 

--- a/apps/web/src/components/interactive/CodeEditor.tsx
+++ b/apps/web/src/components/interactive/CodeEditor.tsx
@@ -173,11 +173,22 @@ export function CodeEditor({
 
   const diagnostics = failure ?? result?.compileLog ?? '';
   const failedToCompile = result !== null && result.exitCode === null;
+  // A listing is code to read, not a surface to type on — and the two want
+  // opposite things from height. In the book it takes whatever it needs and the
+  // PAGE scrolls: a box that scrolls inside a document that also scrolls is the
+  // most irritating thing a long listing can do. On a slide the screen does not
+  // grow, so the internal scroll is the only way through code that does not fit
+  // without shrinking the type past legibility on a projector. An editable
+  // editor keeps its cap in both, or a long exercise pushes its own Run button
+  // out of view.
+  const listing = !flags.editable && !flags.runnable;
   const codeHeight = expanded
     ? 'flex-1 min-h-0 overflow-auto'
     : mode === 'presentation'
       ? 'max-h-[55vh] overflow-auto'
-      : 'max-h-64 overflow-auto';
+      : listing
+        ? ''
+        : 'max-h-64 overflow-auto';
 
   const shell = (
     <div

--- a/apps/web/src/components/interactive/CodeEditor.tsx
+++ b/apps/web/src/components/interactive/CodeEditor.tsx
@@ -86,13 +86,19 @@ export function CodeEditor({
           seed,
         );
         setDraftKeys((current) => ({ ...current, [languageId]: key }));
-        setBuffers((current) =>
+        setBuffers((current) => {
           // A draft only exists if the student ran something here before, and it
-          // is what they had when the tab froze.
-          current[languageId] === undefined
-            ? { ...current, [languageId]: readDraft(key) ?? seed }
-            : current,
-        );
+          // is what they had when the tab froze — so only an editor they could
+          // have typed in reads one. Once every markdown fence became an editor
+          // (#85), an unguarded read meant same-origin storage could replace an
+          // authored listing AND what its copy button hands the reader; on a
+          // GitHub Pages user site that origin is shared with every other repo
+          // of the account. A listing has no draft because it cannot be edited.
+          const restored = flags.editable || flags.runnable ? readDraft(key) : null;
+          return current[languageId] === undefined
+            ? { ...current, [languageId]: restored ?? seed }
+            : current;
+        });
       },
       (error: unknown) => {
         if (!cancelled) setFailure(error instanceof Error ? error.message : String(error));
@@ -101,7 +107,7 @@ export function CodeEditor({
     return () => {
       cancelled = true;
     };
-  }, [languageId, language, defaultValue]);
+  }, [languageId, language, defaultValue, flags.editable, flags.runnable]);
 
   const { run, warmUp, warm, queued, warmStats } = useRuntime({
     runtimeId: flags.runnable && runtime ? languageId : null,

--- a/apps/web/src/components/structure/SideBySide.test.tsx
+++ b/apps/web/src/components/structure/SideBySide.test.tsx
@@ -1,8 +1,22 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 
+import { CodeEditor } from '../interactive/CodeEditor';
 import { ModeProvider } from '../../presentation';
 import { useEmbedded } from '../embedded';
+
+// CodeMirror's editing surface is not the contract here; the basicSetup it is
+// handed IS, because the gutter is what the #76 fix lives on.
+vi.mock('@uiw/react-codemirror', () => ({
+  default: ({ value, basicSetup }: { value: string; basicSetup?: { lineNumbers?: boolean } }) => (
+    <textarea
+      readOnly
+      value={value}
+      data-testid="code"
+      data-line-numbers={String(basicSetup?.lineNumbers)}
+    />
+  ),
+}));
 import { SideBySide } from './SideBySide';
 
 describe('SideBySide', () => {
@@ -117,5 +131,40 @@ describe('SideBySide as a frame', () => {
   it('says nothing of the sort outside a column', () => {
     render(<Probe />);
     expect(screen.getByTestId('probe')).toHaveTextContent('false');
+  });
+});
+
+describe('SideBySide with real listings inside it', () => {
+  // The joint. The two ends were pinned - the column announces the frame, the
+  // editor reacts to it - but nothing put a real editor inside a real column,
+  // and the 21px clipping regression of #76 lives exactly there.
+  it('gives a column one frame, no repeated label, and no gutter', async () => {
+    const { container } = render(
+      <ModeProvider mode="book">
+        <SideBySide left="C++" right="Java">
+          <CodeEditor language="cpp" variant="snippet" defaultValue="int main() {}" />
+          <CodeEditor language="java" variant="snippet" defaultValue="class A {}" />
+        </SideBySide>
+      </ModeProvider>,
+    );
+    await waitFor(() => expect(screen.getAllByTestId('code')).toHaveLength(2));
+
+    const columns = [...container.querySelectorAll('.grid > *')];
+    expect(columns).toHaveLength(2);
+    for (const column of columns) {
+      // The column keeps its own border; the shell inside it must not draw a
+      // second one, which is the doubled frame the browser showed.
+      const shell = column.querySelector('.not-prose');
+      expect(shell, 'no editor shell inside the column').not.toBeNull();
+      expect(shell?.className).not.toContain('border');
+      expect(shell?.className).not.toContain('rounded');
+      expect(shell?.className).not.toContain('my-6');
+      // The gutter is the ~22px the longest Java line needs (#76).
+      expect(column.querySelector('[data-testid="code"]')?.getAttribute('data-line-numbers')).toBe(
+        'false',
+      );
+    }
+    // The column labels it; the editor must not label it again.
+    expect(screen.queryByText('main.cpp')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/structure/SideBySide.test.tsx
+++ b/apps/web/src/components/structure/SideBySide.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
 import { ModeProvider } from '../../presentation';
+import { useEmbedded } from '../embedded';
 import { SideBySide } from './SideBySide';
 
 describe('SideBySide', () => {
@@ -86,5 +87,35 @@ describe('SideBySide', () => {
       </SideBySide>,
     );
     expect(screen.getByText(/espera exactamente dos bloques; recibió 1/)).toBeInTheDocument();
+  });
+});
+
+/** Reports what a column tells whatever lands inside it. */
+function Probe() {
+  return <span data-testid="probe">{String(useEmbedded())}</span>;
+}
+
+describe('SideBySide as a frame', () => {
+  it('tells its columns that they already have a frame and a label', () => {
+    // A fence in a language the platform highlights becomes a component, and a
+    // component brings its own header and border. `[&_pre]` cannot reach inside
+    // one, so the column would show two stacked headers and two rounded borders
+    // — which is exactly what shipped before this was measured in a browser.
+    render(
+      <ModeProvider mode="book">
+        <SideBySide left="C++" right="Java">
+          <Probe />
+          <Probe />
+        </SideBySide>
+      </ModeProvider>,
+    );
+
+    const said = screen.getAllByTestId('probe').map((el) => el.textContent);
+    expect(said).toEqual(['true', 'true']);
+  });
+
+  it('says nothing of the sort outside a column', () => {
+    render(<Probe />);
+    expect(screen.getByTestId('probe')).toHaveTextContent('false');
   });
 });

--- a/apps/web/src/components/structure/SideBySide.tsx
+++ b/apps/web/src/components/structure/SideBySide.tsx
@@ -1,6 +1,7 @@
 import { Children, type ReactNode } from 'react';
 
 import { AuthoringError } from '../AuthoringError';
+import { EmbeddedProvider } from '../embedded';
 import { useMode } from '../../presentation';
 
 export interface SideBySideProps {
@@ -32,11 +33,15 @@ function Column({ label, children }: { label?: string; children: ReactNode }) {
     <div className="min-w-0 overflow-hidden rounded-lg border border-zinc-700">
       {label === undefined ? null : <h4 className={LABEL}>{label}</h4>}
       {/* Each column still scrolls on its own: a long line in one must not widen
-          the page, which is what a two-column layout would otherwise do. */}
+          the page, which is what a two-column layout would otherwise do.
+          The `[&_pre]` rules flatten a BARE fence — one in a language the
+          platform cannot highlight, which stays a <pre> (#85). A fence that
+          became a component is told instead: a CSS selector cannot reach inside
+          one, and the column would end up with two headers and two borders. */}
       <div
         className={`overflow-x-auto ${SCALE[mode]} [&_pre]:my-0 [&_pre]:rounded-none [&_pre]:border-0`}
       >
-        {children}
+        <EmbeddedProvider value={true}>{children}</EmbeddedProvider>
       </div>
     </div>
   );

--- a/apps/web/src/content/index.ts
+++ b/apps/web/src/content/index.ts
@@ -4,4 +4,8 @@ export { DocumentPage } from './DocumentPage';
 export { walkIndex } from './courseIndex';
 export { courseIndex, registry } from './liveContent';
 export { contentMdxComponents } from './mdxComponents';
+// How a document is compiled — the content feature's public statement of it.
+// `vite.config.ts` reaches the module directly (it lives outside `src/`); a real
+// consumer inside `src/` appeared with #85, and it goes through the seam.
+export { remarkPlugins } from './mdxPlugins';
 export { lazyDocumentComponent } from './lazyDoc';

--- a/apps/web/src/lib/codeFences.test.tsx
+++ b/apps/web/src/lib/codeFences.test.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
-import { fencesByMeta, withoutFences } from './codeFences';
+import { fenceOf, fencesByMeta, withoutFences } from './codeFences';
 
 /** What the MDX pipeline hands a component for ```` ```java <meta> ````. */
 function fence(meta: string | undefined, code: string) {
@@ -108,5 +108,46 @@ describe('withoutFences', () => {
       </>,
     );
     expect(text(nodes)).toBe('enunciado');
+  });
+});
+
+describe('fenceOf', () => {
+  it('reads the language and the source of a fenced block', () => {
+    // Exactly what the MDX pipeline hands `pre`: one intrinsic `code` child
+    // carrying `language-*`, and the source with its trailing newline.
+    const read = fenceOf(<code className="language-java">{'class A {}\n'}</code>);
+
+    expect(read).toEqual({ language: 'java', source: 'class A {}' });
+  });
+
+  it('keeps blank lines inside the source, trimming only the fence break', () => {
+    const read = fenceOf(<code className="language-cpp">{'int a;\n\nint b;\n'}</code>);
+
+    expect(read?.source).toBe('int a;\n\nint b;');
+  });
+
+  it('has no language for a fence written without one', () => {
+    // The two ASCII diagrams in 06-java-desde-cpp.mdx are exactly this shape.
+    expect(fenceOf(<code>{'programa.cpp -> [g++] -> programa\n'}</code>)?.language).toBeNull();
+  });
+
+  it('has no language when the class names something else', () => {
+    expect(fenceOf(<code className="highlight">{'x\n'}</code>)?.language).toBeNull();
+  });
+
+  it('reads the language even beside other classes', () => {
+    expect(fenceOf(<code className="foo language-python bar">{'x\n'}</code>)?.language).toBe(
+      'python',
+    );
+  });
+
+  it('is not a fence when the child is not a code element', () => {
+    // `pre` can hold hand-written markup; only a real fence is a fence.
+    expect(fenceOf(<span className="language-java">{'x'}</span>)).toBeNull();
+  });
+
+  it('is not a fence when there is no single child to read', () => {
+    expect(fenceOf(undefined)).toBeNull();
+    expect(fenceOf([<code key="a">{'x'}</code>, <code key="b">{'y'}</code>])).toBeNull();
   });
 });

--- a/apps/web/src/lib/codeFences.ts
+++ b/apps/web/src/lib/codeFences.ts
@@ -2,6 +2,40 @@ import { Children, Fragment, cloneElement, isValidElement, type ReactNode } from
 
 import { textOf } from './reactText';
 
+/** A fenced code block as the MDX pipeline delivers it: its language, and its source. */
+export interface Fence {
+  /** From the `language-*` class; null for a fence written without one. */
+  language: string | null;
+  source: string;
+}
+
+/**
+ * Reads the fence inside a `pre`, or null when there is not one.
+ *
+ * The pipeline hands `pre` exactly one intrinsic `code` child carrying
+ * `className="language-<id>"` and the source with the fence's own trailing
+ * newline. Anything else — hand-written markup, several children — is not a
+ * fence and must keep rendering as whatever it already is.
+ *
+ * Deliberately says nothing about which languages exist: `lib/` imports no
+ * feature, and it is the runtime registry that knows what can be highlighted.
+ */
+export function fenceOf(children: ReactNode): Fence | null {
+  const only = Children.toArray(children);
+  if (only.length !== 1) return null;
+
+  const node = only[0];
+  if (!isValidElement(node) || node.type !== 'code') return null;
+
+  const props = node.props as { className?: unknown; children?: ReactNode };
+  const className = typeof props.className === 'string' ? props.className : '';
+  const language = /(?:^|\s)language-([\w+-]+)(?:\s|$)/.exec(className)?.[1] ?? null;
+
+  // Only the break the fence itself adds — blank lines inside the listing are
+  // the author's and survive.
+  return { language, source: textOf(props.children).replace(/\n$/, '') };
+}
+
 /**
  * The source of every fenced code block in `children`, keyed by its info-string
  * meta — the other half of `remarkCodeMeta`.

--- a/apps/web/src/lib/runtimeIds.ts
+++ b/apps/web/src/lib/runtimeIds.ts
@@ -1,0 +1,19 @@
+/**
+ * Which languages the platform can execute — the name of the set, not the
+ * machinery behind it.
+ *
+ * It lives in `lib/` rather than in `runtime/` because a consumer may need to
+ * ASK the question without paying for the answer. `components/MdxPre` decides
+ * whether a markdown fence is highlightable, and it is reached eagerly through
+ * the shell's MDX map: importing the runtime seam for this pulled `useRuntime`,
+ * the registry, the descriptors and the Java launcher into the eager payload —
+ * 1 eager chunk and 503kB became 9 and 542kB, falsifying ADR-0018's stated
+ * claim to defend ("no CodeMirror, no compiler, no runtime in the entry
+ * chunk"). Guarded now by `architecture.test.ts`.
+ *
+ * Same shape as `lib/catalogEntry.ts` and `lib/componentMeta.ts`: the producing
+ * feature never learns who consumes it (frontend-code-style.md).
+ */
+export const RUNTIME_IDS = ['cpp', 'python', 'java'] as const;
+
+export type RuntimeId = (typeof RUNTIME_IDS)[number];

--- a/apps/web/src/runtime/contract.ts
+++ b/apps/web/src/runtime/contract.ts
@@ -1,15 +1,20 @@
 import type { Extension } from '@codemirror/state';
 
+import type { RuntimeId } from '../lib/runtimeIds';
+
 // The contract every language runtime implements. It is deliberately
 // language-agnostic and transport-agnostic: a runtime is "something that turns
 // source + stdin into output", whether it compiles in a worker (ADR-0001) or,
 // should the Java licence ever force the pivot, behind a network call
 // (ADR-0016). Changing language means changing one worker, nothing else.
 
-/** Every language the platform can execute. */
-export const RUNTIME_IDS = ['cpp', 'python', 'java'] as const;
-
-export type RuntimeId = (typeof RUNTIME_IDS)[number];
+// The id set lives in `lib/` so a consumer can ask which languages exist
+// without importing this feature — `components/MdxPre` is reached eagerly by
+// the shell's MDX map, and importing the runtime seam for it put the whole
+// runtime in the entry chunk (ADR-0018). Re-exported here so every existing
+// consumer of the contract keeps one import.
+export { RUNTIME_IDS } from '../lib/runtimeIds';
+export type { RuntimeId } from '../lib/runtimeIds';
 
 /**
  * The cheap, always-loaded half of a runtime: enough to label a language and

--- a/docs/standards/guides/add-a-course-document.md
+++ b/docs/standards/guides/add-a-course-document.md
@@ -66,6 +66,26 @@ the frontmatter `id`, never the path. v0.1 supports exactly ONE course directory
    for this; it matters only if you add a component of your own — see
    `add-a-content-component.md`.
 
+   **A fence in a language the platform runs is highlighted and copyable.**
+   ```` ```java ````, ```` ```cpp ```` and ```` ```python ```` render through
+   the same editor the runnable blocks use — same colours, a copy button, and
+   not editable or runnable (#85). Write the language whenever the fence holds
+   code. A fence with **no** language, or one the platform has no runtime for
+   (```` ```bash ````), stays plain monospace and loads nothing — which is what
+   an ASCII diagram wants.
+
+   Two consequences worth knowing, both measured rather than assumed:
+
+   - In the book a listing is never given a scrollbar of its own; the page
+     scrolls. On a slide it keeps one, because the screen does not grow.
+   - The reader's own `Ctrl+F` still finds text inside a listing, including
+     lines scrolled out of view on a slide — measured at 1440px and 390px on
+     `06-java-desde-cpp.mdx`. This is worth stating because it is not
+     guaranteed in general: the editor renders by viewport, so a listing of
+     hundreds of lines could hide its tail from the browser's search. Nothing in
+     a course document is near that size (the longest here is 27 lines), and if
+     you ever write one that is, split it.
+
 4. **Mark slides (optional)**: `<Slide title="...">...</Slide>` and
    `<SectionBreak />` are available WITHOUT imports. In the book view a Slide
    renders as its heading + flowing prose and a SectionBreak as a subtle


### PR DESCRIPTION
**Closes #85**

## Summary

Code shown for reading was plain grey monospace; code shown for running was syntax-highlighted. They sat on the same page — sometimes stacked — and looked like they belonged to different products. The clearest case is in `06-java-desde-cpp.mdx`, where two `<SideBySide>` listings sit directly above a `<CodeEditor>` holding the same Java.

Now every fence in a language the platform runs (`java`, `cpp`, `python`) renders through the read-only `snippet` variant of the editor: same colours, a copy button, not editable and not runnable. A fence with no language, or one the platform has no runtime for, stays plain monospace and loads nothing — which is what the document's two ASCII diagrams want.

`snippet` was designed for exactly this in #74 and wired to nothing: `grep -rn 'variant="snippet"'` returned 0.

## Slices completed

All six, one commit each — S1 the fence reader and the `pre` mapping · S2 unknown languages left alone · S3 the `pre`-not-`code` rule pinned · S4 listings uncapped in the book, capped on a slide · S5 `SideBySide` restyled for a component · S6 browser search measured and recorded.

## Acceptance criteria

| # | Evidence |
|---|---|
| 1, 2 | Browser on the built site: 4 distinct token colours, gutter, copy button, `contenteditable="false"`. Clipboard fidelity checked on all 10 copy buttons — 0 mismatches |
| 3 | `documentFences.test.tsx` inventories the shipped document, asserts it really has 2 language-less fences and that they are the ASCII diagrams, then asserts they stay `<pre>` with no editor |
| 4, 5 | **The sharp edge.** Moving the mapping to `code` kills 3 tests, including the one proving an exercise still finds its `starter` and hides its cases — verified to fail at `documentFences.test.tsx:141`, the guard itself |
| 6 | Browser, book and presentation: one border per column, no repeated label, `System.out.println("Bienvenidos a EDA");` complete with its `);`. **This regressed during development** — see below |
| 7, 8 | `CodeEditor.test.tsx`, both directions; browser: 7 listings in the book, none scrolls internally |
| 9 | Browser network log: 18 editors, **0 workers, 0 off-origin requests, 0 toolchain fetches** |
| 10 | **Failed the first review and was fixed** — see below |
| 11 | Measured, recorded in `guides/add-a-course-document.md` §3 |
| 12 | 390px and 1440px, book and presentation, screenshots reviewed. 0 horizontal overflow, 0 console errors |
| 13 | Green at every commit; final: prettier, oxlint, **501 tests / 54 files**, build |

## Tests

**501**, from 465 on `main`.

Worth reviewing hardest: **AC10 failed and I reported it as passing.** I verified there were no heavy network requests — that is AC9 — and never measured the build. `MdxPre` asked the runtime barrel which languages exist, and since the shell reaches `MdxPre` eagerly, the runtime's entire static graph became entry-eager: **1 eager chunk / 503,623 B on `main` → 9 / 542,194 B**, and on the **home page, which contains no code at all**, slow 4G + 4× CPU cost **236 ms of LCP** against a ±20 ms spread.

Round B then found that even that correction was wrong about its own cause: rebuilding each breach in isolation, the runtime import accounts for +10,790 B / +88 ms, and **+27,781 B / +160 ms came from a second one in the same commit** — a single `export { remarkPlugins }` that pulled the build-time MDX compiler and a TOML parser into the browser. ADR-0018 now names both with their own numbers.

## Reviews run

`review-pipeline`, full mode. **Both rounds completed**, including the adversarial verifier and per-fix rechecks (the verifier died to a session limit on the first attempt; it was re-run).

| round | lens | findings |
|---|---|---|
| A | correctness | 8 — incl. a dead assertion of mine and the `Main.java` filename |
| A | architecture | 13 — incl. the entry-chunk regression |
| A | security | 2 — read-only listings read `localStorage` |
| A | performance | 5 — the LCP measurement above; mount cost of 18 editors is **fine** (+8 ms LCP, +6.6% script at 5× throttle) |
| B | agent-readability | 6 — two stale instruction surfaces I created in this branch |
| B | docs-completeness | 11 — incl. one **critical**: the catalog demonstrating the removed rendering |
| B | docs-accuracy | 14 — rebuilt the branch and re-measured every figure the ADR asserts |

**Acted on in round A** (each reverted and its test watched to fail, at the line that encodes it): the entry chunk, the storage read, the filename, the dead assertion, the untested joint, `variant="read"` losing its cap, plus the round-A close — the remark seam export, a rewritten reachability invariant, COR-1/COR-10/COR-11, ARQ-17, ARQ-18.

**Acted on in round B**: `SideBySide`'s catalog entry (it showed authors a `render:` of bare `<pre>` beside a `code:` of fences — those matched before this diff and not after); the two instruction surfaces I broke in this branch (`add-a-language-runtime.md` still sending agents to `runtime/contract.ts` for `RUNTIME_IDS`, and both governance homes still claiming the entry-chunk guard "is per-component, not generic"); the shared-origin residual in `docs/security-notes.md` with its triggers; the L4 inventory; the `useEmbedded` seam registered where seams are inventoried; the fence-alias trap (` ```C++ `, ` ```py ` fall through to grey with nothing to warn the author) documented **and pinned by six cases**; the loading placeholder, which ignored `useEmbedded` and so showed the doubled frame for the whole chunk fetch; and every figure the accuracy lens disagreed with — the misattribution above, `163.9 → 160.5 kB gz` entry, `~153 → ~162 kB gz` per fenced page, an 11-line listing that is 10, a `~22px` gutter that is 20.

**Deferred, complete list** (nothing else was raised):

- `ARQ-2/PER-3` — a ` ```cpp ` fence pulls the 35 kB gz C++ grammar per page. Real, inherent to the feature, and the per-page number is now in the authoring guide.
- `ARQ-3` — `embedded` switches four things through three reasons. Form, not defect.
- `ARQ-7` — `embedded.ts` exports the raw `Context.Provider`, so call sites write `value={true}`. Cosmetic; the guide documents the shape as it is.
- `ARQ-8` — **half acted on.** The doubled frame is fixed. The other half — a fixed 160px placeholder against a listing whose real height is its line count — is a layout-shift question and belongs to **#96**.
- `ARQ-10` — `documentFences.test.tsx` hand-rolls a fence parser and pins a prose fact, so an author editing the shipped document can redden an `app/` unit test. Real maintenance trap, no reader impact.
- `ARQ-11` — the `fence()` test helper is duplicated across two test files.
- `ARQ-6/COR-6/COR-7/ARQ-9/ARQ-12` — standards growth and two surviving mutants in `fenceOf`.
- `PER-5` — CLS on this page is "Poor" and **identical on both branches**. Not this PR's: **#96**.
- The flaky runtime test seen in both #84 and #85: **#98**.
- **ADR-0023** — three lenses argue one is owed for "a markdown fence is a component". Not drafted: ADRs are drafted for the user's approval, not committed by the pipeline. See Notes.

## Manual verification

`npm run build && npm run preview` from `apps/web` (serves under `/nalanda/`; `npm run dev` will not).

- [ ] `/d/java-desde-cpp` — listings are highlighted like the runnable blocks; the two ASCII diagrams are still plain
- [ ] A listing has **no filename header** (an authored `<CodeEditor>` still does) and cannot be typed into
- [ ] `Copiar` on a listing pastes exactly what you see
- [ ] The `SideBySide` pair: one frame per column, no doubled header, and the Java line ends `a EDA");`
- [ ] Same block under `Presentar`
- [ ] Long listings don't scroll inside themselves in the book; on a slide they do
- [ ] `Ctrl+F` finds text inside a listing
- [ ] The home page still feels immediate — this is the one the entry-chunk fix was for

## Notes

`MdxPre` is registered on `pre` in the **shell's** MDX map, not in `content/`: the mapping needs the editor and `content → components` is not an allowed edge. It needs no catalog entry because the catalog invariant covers capitalised keys only — `a`, `table`, `h2`, `h3`, `h4` are the precedent.

`components/embedded.ts` is a context in the shape of `ModeProvider`: a `<SideBySide>` column tells the editor it already has a frame and a label, because a CSS selector cannot reach inside a component — which is how the previous `[&_pre]` rules worked and why they stopped.

**On ADR-0023.** The argument is not the size of the change: it is that ADR-0018 explicitly declares its own prior rejection inapplicable here ("rejected in this ADR for an editing component, and a pure listing is a different premise"), and the reasoning that settled the new premise — one renderer wins the palette-coherence argument against the two listings and the editor on the same slide — lives only in the issue body. Round B also found the prior rejection is thinner than I had described it, which strengthens the case. The decision is the repo owner's.
