### PR TITLE
feat: make the slide deck usable on a phone in landscape

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ prefix may not survive the move, so decide before handing URLs to students
   | Site fine, but Ejecutar never finishes or never warms | a runtime CDN is down or blocked (`cjrtnc.leaningtech.com`, `cdn.jsdelivr.net`) | nothing — accepted risk, `docs/security-notes.md` |
   | `/d/<id>/present` blank on an old iPhone | `MediaQueryList.addEventListener` needs Safari/iOS 14 | nothing — accepted baseline, ADR-0023 |
   | `/d/<id>/present` shows "Gira el teléfono" and no slide | working as designed on a touch device held upright; rotate, or use the book view | `presentationRoute.test.tsx`, ADR-0023 |
+  | Slide text renders small, or slide sizes vary across a deck | working as designed — each slide is scaled to fit its stage (ADR-0013 §5.1). If it is unreadable the slide is too dense: split it | `presentation/fit.test.ts` |
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ prefix may not survive the move, so decide before handing URLs to students
   | Deploy job fails on permissions | repo Settings ▸ Pages source must be "GitHub Actions", and the `github-pages` environment must allow `main` | — |
   | Deploy job fails before Vite starts | `prebuild` could not reach Maven Central, or the ECJ checksum did not match | the script's own error; nothing is written on mismatch (ADR-0017) |
   | Site fine, but Ejecutar never finishes or never warms | a runtime CDN is down or blocked (`cjrtnc.leaningtech.com`, `cdn.jsdelivr.net`) | nothing — accepted risk, `docs/security-notes.md` |
+  | `/d/<id>/present` blank on an old iPhone | `MediaQueryList.addEventListener` needs Safari/iOS 14 | nothing — accepted baseline, ADR-0023 |
+  | `/d/<id>/present` shows "Gira el teléfono" and no slide | working as designed on a touch device held upright; rotate, or use the book view | `presentationRoute.test.tsx`, ADR-0023 |
 
 ## Workflow
 

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -37,10 +37,13 @@ SPA fallback and the `vite preview` gotcha). One home per fact, per
   1. _Execution_: every runtime is faked in jsdom, so any change under
      `src/runtime/**`, or to a component that drives a runtime (`CodeEditor`,
      `Exercise`, `harness.ts`) or the draft store, needs a browser too.
-  2. _Layout and focus_: jsdom lays nothing out and does not implement the
-     browser's tab order, so anything that enumerates focusables, moves focus,
-     or depends on a viewport width, a scroll position or a rule in
-     `styles/index.css` needs a browser too.
+  2. _Layout, focus and device shape_: jsdom lays nothing out and does not
+     implement the browser's tab order, so anything that enumerates focusables,
+     moves focus, depends on a viewport width, a scroll position, a device
+     capability asked through `window.matchMedia` (pointer type, orientation —
+     jsdom implements no media query at all), or a rule in `styles/index.css`
+     needs a browser too. A device rule also needs an emulated device, not
+     merely a small window: the recipe is in `testing-strategy.md` §Conventions.
 
   Written as classes rather than lists of names because the list was already
   stale once: `Exercise` arrived with the same shape and the same hazard, and

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -41,7 +41,10 @@ SPA fallback and the `vite preview` gotcha). One home per fact, per
      implement the browser's tab order, so anything that enumerates focusables,
      moves focus, depends on a viewport width, a scroll position, a device
      capability asked through `window.matchMedia` (pointer type, orientation —
-     jsdom implements no media query at all), or a rule in `styles/index.css`
+     jsdom implements no media query at all), measured element geometry (every
+     box is 0×0 there, so anything reading `offsetWidth`/`clientHeight`, or a
+     `ResizeObserver`, is inert in the suite), a touch gesture (jsdom fires the
+     events but lays out and scrolls nothing), or a rule in `styles/index.css`
      needs a browser too. A device rule also needs an emulated device, not
      merely a small window: the recipe is in `testing-strategy.md` §Conventions.
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -58,7 +58,8 @@ src/
 │                         #   section spine hook and its two placements: the rail
 │                         #   at 2xl, the drawer at every width below it
 ├── presentation/         # presentation mode: mode context, slide parser, SlideDeck viewer,
-│                         # and the phone-orientation rule (ADR-0023)
+│                         # the phone-orientation rule (ADR-0023), the swipe gesture
+│                         # and the fit-to-stage scaler (ADR-0013 §5.1/§5.2)
 ├── runtime/              # code execution: worker contract, registry, useRuntime hook,
 │                         # one folder per language (java, cpp, python)
 ├── lib/                  # pure TS utilities + cross-feature contract types
@@ -79,7 +80,14 @@ adding a content component → `docs/standards/guides/add-a-content-component.md
 The site is published under **`/nalanda/`** (GitHub Pages project URL; the
 repo-level story — trigger, rollback — is in the root README).
 
-**Browser baseline: Safari 14+ / iOS 14+** (`MediaQueryList.addEventListener`),
+**Browser baseline: Safari 15.4+ / iOS 15.4+** — raised from 14 by `dvh`
+(#99); `MediaQueryList.addEventListener` (Safari 14) was the previous floor.
+The two fail differently and the difference matters when a student reports
+something: below 14 the `/present` route throws and the page is blank, while
+below 15.4 `dvh` is simply ignored, so the deck silently draws under the mobile
+browser's chrome again, with no error and no test to catch it. Also assumed:
+`ResizeObserver` (Safari 13.1), below both floors. Any browser that can run the
+in-browser runtimes clears all of this by a wide margin — a much heavier bar,
 and in practice any browser that can run the in-browser runtimes — a much
 heavier bar, imposed by ADR-0016/0017 but never written as a version. No legacy
 fallbacks are shipped; the decision and the case that does not hold are in

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -57,7 +57,8 @@ src/
 │                         #   (collapsed to the active path, filterable), breadcrumb,
 │                         #   section spine hook and its two placements: the rail
 │                         #   at 2xl, the drawer at every width below it
-├── presentation/         # presentation mode: mode context, slide parser, SlideDeck viewer
+├── presentation/         # presentation mode: mode context, slide parser, SlideDeck viewer,
+│                         # and the phone-orientation rule (ADR-0023)
 ├── runtime/              # code execution: worker contract, registry, useRuntime hook,
 │                         # one folder per language (java, cpp, python)
 ├── lib/                  # pure TS utilities + cross-feature contract types
@@ -77,6 +78,12 @@ adding a content component → `docs/standards/guides/add-a-content-component.md
 
 The site is published under **`/nalanda/`** (GitHub Pages project URL; the
 repo-level story — trigger, rollback — is in the root README).
+
+**Browser baseline: Safari 14+ / iOS 14+** (`MediaQueryList.addEventListener`),
+and in practice any browser that can run the in-browser runtimes — a much
+heavier bar, imposed by ADR-0016/0017 but never written as a version. No legacy
+fallbacks are shipped; the decision and the case that does not hold are in
+ADR-0023.
 
 - `vite.config.ts` owns the base path: `/nalanda/` for `build` and `preview`,
   `/` for `dev` so local URLs stay short. Runtime code never hardcodes it —

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <!-- The surface colour, so a phone paints its own chrome to match instead
          of framing the page in white. Kept in step with `html` in
          src/styles/index.css by hand: a meta tag cannot read a CSS variable. -->

--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -1,6 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { courseIndex, registry, walkIndex } from '../content';
 
@@ -80,6 +80,160 @@ describe('PresentationPage viewer', () => {
     renderAt(`/d/${firstId}/present`);
     await findCounter();
     expect(screen.getByRole('button', { name: /pantalla completa/i })).toBeInTheDocument();
+  });
+});
+
+// The phone rule end to end, over the real route and a real document: what the
+// reader gets from /d/<id>/present, not what a component does in isolation.
+// The fake is local rather than shared with presentation/usePortraitPhone.test
+// because a cross-feature import may only go through the feature seam
+// (src/architecture.test.ts), and a test fake is not part of one.
+function coarsePortrait(initial: boolean) {
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+  let matches = initial;
+  window.matchMedia = ((query: string) => {
+    // Answers only the question it was written for. framer-motion asks this
+    // same fake about (prefers-reduced-motion) when the deck mounts, so a fake
+    // that returned `matches` for every query would also be telling it that
+    // reduced motion is on, for the rest of the file (#91 review).
+    const phoneRule = query.includes('pointer: coarse');
+    return {
+      media: query,
+      get matches() {
+        return phoneRule && matches;
+      },
+      addEventListener: (_type: string, listener: (event: MediaQueryListEvent) => void) => {
+        if (phoneRule) listeners.add(listener);
+      },
+      removeEventListener: (_type: string, listener: (event: MediaQueryListEvent) => void) => {
+        listeners.delete(listener);
+      },
+    } as unknown as MediaQueryList;
+  }) as typeof window.matchMedia;
+  return {
+    turn(next: boolean) {
+      matches = next;
+      act(() => {
+        for (const listener of listeners) listener({ matches: next } as MediaQueryListEvent);
+      });
+    },
+  };
+}
+
+describe('presentation on a phone held in portrait', () => {
+  afterEach(() => {
+    Reflect.deleteProperty(window, 'matchMedia');
+  });
+
+  it('covers the deck: the panel is shown and no slide is painted', async () => {
+    coarsePortrait(true);
+    renderAt(`/d/${firstId}/present`);
+
+    // Waiting for the panel also waits for the lazy document: the deck is what
+    // decides, so by now the slides exist and their absence is a decision.
+    expect(await screen.findByRole('alertdialog')).toBeInTheDocument();
+    expect(screen.queryByText(/^\d+ \/ \d+$/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: firstTitle })).not.toBeInTheDocument();
+  });
+
+  it('leaves nothing but the way out reachable by keyboard', async () => {
+    coarsePortrait(true);
+    renderAt(`/d/${firstId}/present`);
+    await screen.findByRole('alertdialog');
+
+    // The whole route, not the panel's subtree: the claim is that no control of
+    // the deck survives anywhere, which asking the panel about itself cannot
+    // show. Enumerated by construction — jsdom has no tab order of its own —
+    // and cross-checked in Chromium, where five Tab presses reach only this
+    // link (testing-strategy.md §Layout and focus).
+    const reachable = [
+      ...document.querySelectorAll<HTMLElement>('a[href], button, [tabindex]:not([tabindex="-1"])'),
+    ];
+    expect(reachable.map((element) => element.textContent)).toEqual(['Leer en el libro']);
+  });
+
+  it('ignores the slide keys behind the panel, so the position cannot drift', async () => {
+    const media = coarsePortrait(true);
+    renderAt(`/d/${firstId}/present?slide=2`);
+    await screen.findByRole('alertdialog');
+
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    fireEvent.keyDown(window, { key: 'End' });
+
+    media.turn(false);
+    expect(await findCounter()).toHaveTextContent(/^2 \//);
+  });
+
+  it('still answers Escape behind the panel — a modal has a way out', async () => {
+    coarsePortrait(true);
+    renderAt(`/d/${firstId}/present`);
+    await screen.findByRole('alertdialog');
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(await screen.findByRole('article')).toBeInTheDocument();
+  });
+
+  it('leaves fullscreen when it takes the deck away, since the ⛶ button goes with it', async () => {
+    const exitFullscreen = vi.fn(() => Promise.resolve());
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      value: document.documentElement,
+    });
+    Object.defineProperty(document, 'exitFullscreen', {
+      configurable: true,
+      value: exitFullscreen,
+    });
+    try {
+      coarsePortrait(true);
+      renderAt(`/d/${firstId}/present`);
+      await screen.findByRole('alertdialog');
+      expect(exitFullscreen).toHaveBeenCalled();
+    } finally {
+      Reflect.deleteProperty(document, 'fullscreenElement');
+      Reflect.deleteProperty(document, 'exitFullscreen');
+    }
+  });
+
+  it('shows the deck at the reader’s slide when the phone is turned, and back', async () => {
+    const media = coarsePortrait(true);
+    renderAt(`/d/${firstId}/present?slide=2`);
+    await screen.findByRole('alertdialog');
+
+    media.turn(false);
+    expect(await findCounter()).toHaveTextContent(/^2 \//);
+
+    media.turn(true);
+    expect(await screen.findByRole('alertdialog')).toBeInTheDocument();
+
+    media.turn(false);
+    expect(await findCounter()).toHaveTextContent(/^2 \//);
+  });
+
+  it('lets the reader leave the presentation for the book view of the document', async () => {
+    coarsePortrait(true);
+    renderAt(`/d/${firstId}/present`);
+    await screen.findByRole('alertdialog');
+
+    fireEvent.click(screen.getByRole('link', { name: /leer|libro|volver/i }));
+
+    // Still a coarse pointer in portrait — and the book view, which was built
+    // for exactly that (#84), is not covered by anything.
+    expect(await screen.findByRole('article')).toBeInTheDocument();
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+  });
+
+  // Named for what it proves: the fake answers `false`, so this shows the route
+  // renders the deck when the rule says no. That the RULE excludes a fine
+  // pointer at any shape is pinned by the query-string assertion in
+  // presentation/usePortraitPhone.test.tsx and by the browser run — jsdom
+  // cannot evaluate a media query, so no test here can claim it.
+  it('renders the deck whenever the phone rule does not match', async () => {
+    coarsePortrait(false);
+    renderAt(`/d/${firstId}/present`);
+
+    expect(await findCounter()).toHaveTextContent(/^1 \//);
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -237,6 +237,60 @@ describe('presentation on a phone held in portrait', () => {
   });
 });
 
+describe('advancing the deck by touch', () => {
+  function swipe(from: number, to: number, y = 200, endY = 205) {
+    const stage = screen.getByTestId('slide-stage');
+    fireEvent.touchStart(stage, { touches: [{ clientX: from, clientY: y }] });
+    fireEvent.touchEnd(stage, { changedTouches: [{ clientX: to, clientY: endY }] });
+  }
+
+  it('advances one slide on a leftward swipe and goes back on a rightward one', async () => {
+    renderAt(`/d/${firstId}/present?slide=2`);
+    const counter = await findCounter();
+
+    swipe(300, 150);
+    expect(counter).toHaveTextContent(/^3 \//);
+
+    swipe(150, 300);
+    expect(counter).toHaveTextContent(/^2 \//);
+  });
+
+  it('clamps at the first slide, as the keyboard does', async () => {
+    renderAt(`/d/${firstId}/present`);
+    const counter = await findCounter();
+
+    swipe(150, 300);
+    expect(counter).toHaveTextContent(/^1 \//);
+  });
+
+  it('leaves the slide alone on a tap and on a vertical drag', async () => {
+    renderAt(`/d/${firstId}/present?slide=2`);
+    const counter = await findCounter();
+
+    swipe(200, 200);
+    expect(counter).toHaveTextContent(/^2 \//);
+
+    swipe(200, 205, 500, 100);
+    expect(counter).toHaveTextContent(/^2 \//);
+  });
+
+  it('ignores a two-finger gesture — a pinch is not a swipe', async () => {
+    renderAt(`/d/${firstId}/present?slide=2`);
+    const counter = await findCounter();
+    const stage = screen.getByTestId('slide-stage');
+
+    fireEvent.touchStart(stage, {
+      touches: [
+        { clientX: 300, clientY: 200 },
+        { clientX: 320, clientY: 260 },
+      ],
+    });
+    fireEvent.touchEnd(stage, { changedTouches: [{ clientX: 150, clientY: 205 }] });
+
+    expect(counter).toHaveTextContent(/^2 \//);
+  });
+});
+
 describe('presentation: none documents', () => {
   it('redirects /present back to the book view', async () => {
     const noneId = ids.find((id) => registry.get(id)?.meta.presentation === 'none');

--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { courseIndex, registry, walkIndex } from '../content';
 
@@ -259,6 +259,14 @@ describe('advancing the deck by touch', () => {
     renderAt(`/d/${firstId}/present`);
     const counter = await findCounter();
 
+    // The positive control comes first: without it this case is green over a
+    // deck that has no touch wiring at all (#99 review).
+    swipe(300, 150);
+    expect(counter).toHaveTextContent(/^2 \//);
+
+    swipe(150, 300);
+    expect(counter).toHaveTextContent(/^1 \//);
+
     swipe(150, 300);
     expect(counter).toHaveTextContent(/^1 \//);
   });
@@ -270,8 +278,12 @@ describe('advancing the deck by touch', () => {
     swipe(200, 200);
     expect(counter).toHaveTextContent(/^2 \//);
 
-    swipe(200, 205, 500, 100);
+    swipe(260, 200, 500, 100);
     expect(counter).toHaveTextContent(/^2 \//);
+
+    // Proves the two above were ignored rather than unheard.
+    swipe(300, 150);
+    expect(counter).toHaveTextContent(/^3 \//);
   });
 
   it('ignores a two-finger gesture — a pinch is not a swipe', async () => {
@@ -288,6 +300,91 @@ describe('advancing the deck by touch', () => {
     fireEvent.touchEnd(stage, { changedTouches: [{ clientX: 150, clientY: 205 }] });
 
     expect(counter).toHaveTextContent(/^2 \//);
+  });
+});
+
+describe('fitting a slide to the stage it is shown on', () => {
+  const STAGE = { width: 800, height: 300 };
+  const CONTENT = { width: 896, height: 600 };
+  let observed: Element[] = [];
+  const originals = new Map<string, PropertyDescriptor | undefined>();
+
+  function fakeGeometry() {
+    // Every box is 0x0 in jsdom, so the sizes are stated rather than laid out;
+    // what is real here is which element each getter is asked about.
+    for (const prop of ['clientWidth', 'clientHeight', 'offsetWidth', 'offsetHeight']) {
+      originals.set(prop, Object.getOwnPropertyDescriptor(HTMLElement.prototype, prop));
+      Object.defineProperty(HTMLElement.prototype, prop, {
+        configurable: true,
+        get(this: HTMLElement) {
+          const stage = this.dataset['testid'] === 'slide-stage';
+          const box = stage ? STAGE : CONTENT;
+          return prop.endsWith('Width') ? box.width : box.height;
+        },
+      });
+    }
+  }
+
+  beforeEach(() => {
+    observed = [];
+    fakeGeometry();
+    // jsdom has no ResizeObserver, so the deck's observer branch would never
+    // run in the suite — and it is the branch that re-measures after a rotation.
+    (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = class {
+      observe(element: Element) {
+        observed.push(element);
+      }
+      unobserve() {}
+      disconnect() {}
+    };
+  });
+
+  afterEach(() => {
+    for (const [prop, descriptor] of originals) {
+      if (descriptor) Object.defineProperty(HTMLElement.prototype, prop, descriptor);
+      else Reflect.deleteProperty(HTMLElement.prototype, prop);
+    }
+    originals.clear();
+    Reflect.deleteProperty(globalThis, 'ResizeObserver');
+    Reflect.deleteProperty(window, 'matchMedia');
+  });
+
+  function slideBox() {
+    return document.querySelector<HTMLElement>('.max-w-4xl');
+  }
+
+  it('scales the slide by the tighter axis of the stage', async () => {
+    renderAt(`/d/${firstId}/present`);
+    await findCounter();
+    // 300/600 is tighter than 800/896.
+    expect(slideBox()).toHaveStyle({ transform: 'scale(0.5)' });
+  });
+
+  it('measures after a rotation, which mounts the deck without changing the slide', async () => {
+    const media = coarsePortrait(true);
+    renderAt(`/d/${firstId}/present`);
+    await screen.findByRole('alertdialog');
+
+    media.turn(false);
+    await findCounter();
+
+    // The index never changed, so an effect keyed on it never re-ran and the
+    // slide stayed at scale(1), overflowing its stage — measured in Chromium
+    // before this fix (#99 review).
+    expect(slideBox()).toHaveStyle({ transform: 'scale(0.5)' });
+  });
+
+  it('measures the slide that is on screen after a slide change, not the one leaving', async () => {
+    renderAt(`/d/${firstId}/present`);
+    await findCounter();
+
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    await findCounter();
+
+    // AnimatePresence mounts the incoming slide after the index changes, so an
+    // effect that runs on the index measures the OUTGOING node and leaves the
+    // new one unobserved for the rest of the deck.
+    expect(observed).toContain(slideBox());
   });
 });
 

--- a/apps/web/src/presentation/RotateNotice.test.tsx
+++ b/apps/web/src/presentation/RotateNotice.test.tsx
@@ -28,6 +28,13 @@ describe('RotateNotice', () => {
     expect(panel).toHaveFocus();
   });
 
+  it('names the gesture the deck will answer to, since a phone has no arrow keys', () => {
+    // The panel is the last thing seen before the deck appears, which is why
+    // the hint lives here instead of as dismissible chrome inside the deck.
+    renderNotice();
+    expect(screen.getByRole('alertdialog')).toHaveTextContent(/desliz[aá]/i);
+  });
+
   it('offers a way out, in Spanish, that lands on the document rather than on history', () => {
     // Not history.back(): a reader who opened /d/<id>/present directly — a link
     // in a message, a bookmark — has nothing behind them to go back to.

--- a/apps/web/src/presentation/RotateNotice.test.tsx
+++ b/apps/web/src/presentation/RotateNotice.test.tsx
@@ -32,7 +32,7 @@ describe('RotateNotice', () => {
     // The panel is the last thing seen before the deck appears, which is why
     // the hint lives here instead of as dismissible chrome inside the deck.
     renderNotice();
-    expect(screen.getByRole('alertdialog')).toHaveTextContent(/desliz[aá]/i);
+    expect(screen.getByRole('alertdialog')).toHaveTextContent(/desliza/i);
   });
 
   it('offers a way out, in Spanish, that lands on the document rather than on history', () => {

--- a/apps/web/src/presentation/RotateNotice.test.tsx
+++ b/apps/web/src/presentation/RotateNotice.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import { RotateNotice } from './RotateNotice';
+
+function renderNotice(docId = 'java-desde-cpp') {
+  render(
+    <MemoryRouter>
+      <RotateNotice docId={docId} />
+    </MemoryRouter>,
+  );
+}
+
+describe('RotateNotice', () => {
+  it('tells the reader, in Spanish, to turn the phone', () => {
+    renderNotice();
+    expect(screen.getByRole('alertdialog')).toHaveTextContent(/gira el (teléfono|celular)/i);
+  });
+
+  it('is announced to assistive technology: a named alert dialog holding the focus', () => {
+    renderNotice();
+    const panel = screen.getByRole('alertdialog');
+    expect(panel).toHaveAccessibleName(/gira el (teléfono|celular)/i);
+    expect(panel).toHaveAttribute('aria-modal', 'true');
+    // Announced on arrival, which is what makes it reachable at all: it appears
+    // without the reader acting, and nothing else on the route is rendered.
+    expect(panel).toHaveFocus();
+  });
+
+  it('offers a way out, in Spanish, that lands on the document rather than on history', () => {
+    // Not history.back(): a reader who opened /d/<id>/present directly — a link
+    // in a message, a bookmark — has nothing behind them to go back to.
+    renderNotice('busqueda-binaria');
+    const out = screen.getByRole('link', { name: /leer|libro|volver/i });
+    expect(out).toHaveAttribute('href', '/d/busqueda-binaria');
+  });
+
+  // What "nothing else is reachable" means is a claim about the whole route,
+  // not about this component, so it is asserted there — app/presentationRoute
+  // .test.tsx, "leaves nothing but the way out reachable by keyboard". Asking
+  // the panel whether it contains its own link proves only that the JSX says so.
+});

--- a/apps/web/src/presentation/RotateNotice.tsx
+++ b/apps/web/src/presentation/RotateNotice.tsx
@@ -35,7 +35,7 @@ export function RotateNotice({ docId }: Props) {
         Gira el teléfono
       </h1>
       <p id="rotate-notice-text" className="text-slate-400">
-        La presentación se ve en horizontal. Deslizá para pasar de diapositiva.
+        La presentación se ve en horizontal. Desliza para pasar de diapositiva.
       </p>
       {/* An absolute route, not history.back(): a reader who opened /present
           from a link or a bookmark has nothing behind them — and a phone with

--- a/apps/web/src/presentation/RotateNotice.tsx
+++ b/apps/web/src/presentation/RotateNotice.tsx
@@ -1,0 +1,51 @@
+import { RotateCwSquare } from 'lucide-react';
+import { useEffect, useRef } from 'react';
+import { Link } from 'react-router-dom';
+
+interface Props {
+  /** Document to fall back to — the way out is the book view of this document. */
+  docId: string;
+}
+
+/**
+ * What a phone held upright gets instead of the deck: slides need the long side
+ * of the screen, and nothing else on this route is rendered behind this panel.
+ */
+export function RotateNotice({ docId }: Props) {
+  const panel = useRef<HTMLDivElement>(null);
+
+  // The panel appears without the reader doing anything, so it takes the focus
+  // to be announced — and there is nothing else on the route to take it from.
+  useEffect(() => {
+    panel.current?.focus();
+  }, []);
+
+  return (
+    <div
+      ref={panel}
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby="rotate-notice-title"
+      aria-describedby="rotate-notice-text"
+      tabIndex={-1}
+      className="fixed inset-0 z-40 flex flex-col items-center justify-center gap-4 bg-slate-950 px-8 text-center text-slate-100"
+    >
+      <RotateCwSquare size={48} aria-hidden="true" className="text-slate-500" />
+      <h1 id="rotate-notice-title" className="text-2xl font-bold tracking-tight">
+        Gira el teléfono
+      </h1>
+      <p id="rotate-notice-text" className="text-slate-400">
+        La presentación se ve en horizontal.
+      </p>
+      {/* An absolute route, not history.back(): a reader who opened /present
+          from a link or a bookmark has nothing behind them — and a phone with
+          rotation locked in the OS needs this to be a real way out. */}
+      <Link
+        to={`/d/${docId}`}
+        className="rounded border border-slate-700 px-4 py-2 text-slate-300 hover:bg-slate-800 hover:text-slate-100"
+      >
+        Leer en el libro
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/presentation/RotateNotice.tsx
+++ b/apps/web/src/presentation/RotateNotice.tsx
@@ -35,7 +35,7 @@ export function RotateNotice({ docId }: Props) {
         Gira el teléfono
       </h1>
       <p id="rotate-notice-text" className="text-slate-400">
-        La presentación se ve en horizontal.
+        La presentación se ve en horizontal. Deslizá para pasar de diapositiva.
       </p>
       {/* An absolute route, not history.back(): a reader who opened /present
           from a link or a bookmark has nothing behind them — and a phone with

--- a/apps/web/src/presentation/RotateNotice.tsx
+++ b/apps/web/src/presentation/RotateNotice.tsx
@@ -28,7 +28,7 @@ export function RotateNotice({ docId }: Props) {
       aria-labelledby="rotate-notice-title"
       aria-describedby="rotate-notice-text"
       tabIndex={-1}
-      className="fixed inset-0 z-40 flex flex-col items-center justify-center gap-4 bg-slate-950 px-8 text-center text-slate-100"
+      className="fixed inset-0 h-[100dvh] z-40 flex flex-col items-center justify-center gap-4 bg-slate-950 px-8 text-center text-slate-100"
     >
       <RotateCwSquare size={48} aria-hidden="true" className="text-slate-500" />
       <h1 id="rotate-notice-title" className="text-2xl font-bold tracking-tight">

--- a/apps/web/src/presentation/SlideDeck.tsx
+++ b/apps/web/src/presentation/SlideDeck.tsx
@@ -160,7 +160,7 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
   if (portraitPhone) return <RotateNotice docId={docId} />;
 
   return (
-    <div className="fixed inset-0 z-40 flex flex-col bg-slate-950 text-slate-100">
+    <div className="fixed inset-0 h-[100dvh] z-40 flex flex-col bg-slate-950 text-slate-100">
       <div
         ref={stage}
         data-testid="slide-stage"

--- a/apps/web/src/presentation/SlideDeck.tsx
+++ b/apps/web/src/presentation/SlideDeck.tsx
@@ -123,12 +123,18 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
   // its design size and scaled down to fit. Measured with offsetWidth/Height,
   // which ignore the transform we are about to apply and so stay the natural
   // size on every pass.
-  const stage = useRef<HTMLDivElement>(null);
-  const content = useRef<HTMLDivElement>(null);
+  // Callback refs in STATE, not useRef, so the effect below can depend on the
+  // identity of the nodes it measures. Keyed on [index] instead, it missed the
+  // two ways this deck actually gets a new content node (#99 review, both
+  // measured in Chromium): rotating out of the rotate panel mounts the whole
+  // deck without changing the index, so nothing was ever measured and the slide
+  // overflowed its stage 3:1; and `AnimatePresence mode="wait"` mounts the
+  // incoming slide AFTER the index changed, so the effect measured the
+  // outgoing node and every slide from the second on kept a stale scale.
+  const [stageNode, setStageNode] = useState<HTMLDivElement | null>(null);
+  const [contentNode, setContentNode] = useState<HTMLDivElement | null>(null);
   const [scale, setScale] = useState(1);
   useLayoutEffect(() => {
-    const stageNode = stage.current;
-    const contentNode = content.current;
     if (!stageNode || !contentNode) return;
     const measure = () =>
       setScale(
@@ -145,7 +151,7 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
     observer.observe(stageNode);
     observer.observe(contentNode);
     return () => observer.disconnect();
-  }, [index, slides.length]);
+  }, [stageNode, contentNode]);
 
   // Fullscreen belongs to the deck, and the deck is about to be gone: the ⛶
   // button is the only control that exits it, so leaving it on would strand the
@@ -162,7 +168,7 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
   return (
     <div className="fixed inset-0 h-[100dvh] z-40 flex flex-col bg-slate-950 text-slate-100">
       <div
-        ref={stage}
+        ref={setStageNode}
         data-testid="slide-stage"
         onTouchStart={onTouchStart}
         onTouchEnd={onTouchEnd}
@@ -175,7 +181,7 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.2 }}
-            ref={content}
+            ref={setContentNode}
             style={{ transform: `scale(${scale})` }}
             className="w-full max-w-4xl"
           >
@@ -188,7 +194,7 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
           </motion.div>
         </AnimatePresence>
       </div>
-      <footer className="flex items-center justify-between px-6 py-3 text-sm text-slate-500">
+      <footer className="flex items-center justify-between px-[max(1.5rem,env(safe-area-inset-left))] py-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] pr-[max(1.5rem,env(safe-area-inset-right))] text-sm text-slate-500">
         <button
           type="button"
           aria-label="Pantalla completa"

--- a/apps/web/src/presentation/SlideDeck.tsx
+++ b/apps/web/src/presentation/SlideDeck.tsx
@@ -1,10 +1,12 @@
 import { AnimatePresence, motion } from 'framer-motion';
-import { useEffect, useMemo } from 'react';
-import type { ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import type { ReactNode, TouchEvent } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { mdxChildrenOf } from './mdxChildren';
 import { computeSlides } from './parser';
+import { swipeDirection } from './swipe';
+import type { Point } from './swipe';
 import { RotateNotice } from './RotateNotice';
 import { usePortraitPhone } from './usePortraitPhone';
 
@@ -48,8 +50,11 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
   const index = Math.min(Math.max(requested - 1, 0), slides.length - 1);
   const slide = slides[index]!;
 
-  useEffect(() => {
-    const go = (target: number) => {
+  // Out of the keydown effect and shared, so the keyboard and the finger reach
+  // the same clamping and the same ?slide contract (ADR-0013) — two paths to
+  // "go to slide N" is two places for the URL to stop being the truth.
+  const go = useCallback(
+    (target: number) => {
       const next = Math.min(Math.max(target, 0), slides.length - 1);
       setSearchParams(
         (prev) => {
@@ -58,7 +63,11 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
         },
         { replace: true },
       );
-    };
+    },
+    [setSearchParams, slides.length],
+  );
+
+  useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       // The panel replaces the deck's markup, not this window-level listener:
       // hooks run above the early return, so behind the panel every slide key
@@ -89,7 +98,23 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [docId, index, navigate, portraitPhone, setSearchParams, slides.length]);
+  }, [docId, go, index, navigate, portraitPhone, slides.length]);
+
+  // The gesture the phone has instead of arrow keys. A single finger only:
+  // a second one means a pinch, and zooming is not navigating.
+  const touchStart = useRef<Point | null>(null);
+  const onTouchStart = (event: TouchEvent<HTMLDivElement>) => {
+    const touch = event.touches.length === 1 ? event.touches[0] : undefined;
+    touchStart.current = touch ? { x: touch.clientX, y: touch.clientY } : null;
+  };
+  const onTouchEnd = (event: TouchEvent<HTMLDivElement>) => {
+    const start = touchStart.current;
+    touchStart.current = null;
+    const touch = event.changedTouches[0];
+    if (!start || !touch) return;
+    const direction = swipeDirection(start, { x: touch.clientX, y: touch.clientY });
+    if (direction) go(index + (direction === 'next' ? 1 : -1));
+  };
 
   // Fullscreen belongs to the deck, and the deck is about to be gone: the ⛶
   // button is the only control that exits it, so leaving it on would strand the
@@ -105,7 +130,12 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
 
   return (
     <div className="fixed inset-0 z-40 flex flex-col bg-slate-950 text-slate-100">
-      <div className="flex flex-1 items-center justify-center overflow-hidden px-16">
+      <div
+        data-testid="slide-stage"
+        onTouchStart={onTouchStart}
+        onTouchEnd={onTouchEnd}
+        className="flex flex-1 items-center justify-center overflow-hidden px-16"
+      >
         <AnimatePresence mode="wait">
           <motion.div
             key={index}

--- a/apps/web/src/presentation/SlideDeck.tsx
+++ b/apps/web/src/presentation/SlideDeck.tsx
@@ -5,6 +5,8 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { mdxChildrenOf } from './mdxChildren';
 import { computeSlides } from './parser';
+import { RotateNotice } from './RotateNotice';
+import { usePortraitPhone } from './usePortraitPhone';
 
 function toggleFullscreen(): void {
   if (document.fullscreenElement) {
@@ -37,6 +39,7 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
   );
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
+  const portraitPhone = usePortraitPhone();
 
   // Math.trunc: a crafted non-integer ?slide (e.g. 1.5) must not become a
   // fractional array index (white-screen crash — review finding, issue #64).
@@ -57,6 +60,13 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
       );
     };
     const onKeyDown = (event: KeyboardEvent) => {
+      // The panel replaces the deck's markup, not this window-level listener:
+      // hooks run above the early return, so behind the panel every slide key
+      // still moved ?slide with nothing painted — measured in Chromium at
+      // 390x844, two ArrowRight took ?slide=2 to 3 and rotating landed on the
+      // wrong slide (#91 review). Escape is deliberately still live: it is the
+      // way out of a modal, and the panel is one.
+      if (portraitPhone && event.key !== 'Escape') return;
       switch (event.key) {
         case 'ArrowRight':
         case ' ':
@@ -79,7 +89,19 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [docId, index, navigate, setSearchParams, slides.length]);
+  }, [docId, index, navigate, portraitPhone, setSearchParams, slides.length]);
+
+  // Fullscreen belongs to the deck, and the deck is about to be gone: the ⛶
+  // button is the only control that exits it, so leaving it on would strand the
+  // panel inside a fullscreen page with no way back out of it.
+  useEffect(() => {
+    if (portraitPhone && document.fullscreenElement) void document.exitFullscreen?.();
+  }, [portraitPhone]);
+
+  // Replaces the deck rather than covering it: no slide is painted, so nothing
+  // of it is readable behind the panel or reachable from it. The reader's
+  // position is safe because it lives in ?slide=N, not in this component.
+  if (portraitPhone) return <RotateNotice docId={docId} />;
 
   return (
     <div className="fixed inset-0 z-40 flex flex-col bg-slate-950 text-slate-100">

--- a/apps/web/src/presentation/SlideDeck.tsx
+++ b/apps/web/src/presentation/SlideDeck.tsx
@@ -1,10 +1,11 @@
 import { AnimatePresence, motion } from 'framer-motion';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode, TouchEvent } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { mdxChildrenOf } from './mdxChildren';
 import { computeSlides } from './parser';
+import { fitScale } from './fit';
 import { swipeDirection } from './swipe';
 import type { Point } from './swipe';
 import { RotateNotice } from './RotateNotice';
@@ -116,6 +117,36 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
     if (direction) go(index + (direction === 'next' ? 1 : -1));
   };
 
+  // A slide is authored at one size and shown at whatever size the device has.
+  // Rather than reflowing it — which changes where every line breaks, so the
+  // slide the author built is not the slide the reader sees — it is laid out at
+  // its design size and scaled down to fit. Measured with offsetWidth/Height,
+  // which ignore the transform we are about to apply and so stay the natural
+  // size on every pass.
+  const stage = useRef<HTMLDivElement>(null);
+  const content = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(1);
+  useLayoutEffect(() => {
+    const stageNode = stage.current;
+    const contentNode = content.current;
+    if (!stageNode || !contentNode) return;
+    const measure = () =>
+      setScale(
+        fitScale(
+          { width: stageNode.clientWidth, height: stageNode.clientHeight },
+          { width: contentNode.offsetWidth, height: contentNode.offsetHeight },
+        ),
+      );
+    measure();
+    // Rotation, the browser chrome appearing, a font finishing loading: all of
+    // them change the stage without changing the slide.
+    if (typeof ResizeObserver !== 'function') return;
+    const observer = new ResizeObserver(measure);
+    observer.observe(stageNode);
+    observer.observe(contentNode);
+    return () => observer.disconnect();
+  }, [index, slides.length]);
+
   // Fullscreen belongs to the deck, and the deck is about to be gone: the ⛶
   // button is the only control that exits it, so leaving it on would strand the
   // panel inside a fullscreen page with no way back out of it.
@@ -131,6 +162,7 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
   return (
     <div className="fixed inset-0 z-40 flex flex-col bg-slate-950 text-slate-100">
       <div
+        ref={stage}
         data-testid="slide-stage"
         onTouchStart={onTouchStart}
         onTouchEnd={onTouchEnd}
@@ -143,6 +175,8 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             transition={{ duration: 0.2 }}
+            ref={content}
+            style={{ transform: `scale(${scale})` }}
             className="w-full max-w-4xl"
           >
             {slide.title ? (

--- a/apps/web/src/presentation/fit.test.ts
+++ b/apps/web/src/presentation/fit.test.ts
@@ -24,4 +24,18 @@ describe('fitScale', () => {
     expect(fitScale({ width: 0, height: 0 }, { width: 0, height: 0 })).toBe(1);
     expect(fitScale({ width: 800, height: 600 }, { width: 0, height: 0 })).toBe(1);
   });
+
+  it('answers 1 for an unmeasured stage rather than collapsing the slide', () => {
+    // Each guard needs a case where the OTHER one cannot cover for it: with a
+    // real content box, dropping the stage guard makes the ratio 0 and the deck
+    // disappears (#99 review — the pair was mutually masking).
+    expect(fitScale({ width: 0, height: 0 }, { width: 896, height: 600 })).toBe(1);
+  });
+
+  it('answers 1 for a detached content box rather than shrinking to fit nothing', () => {
+    // A node removed from the DOM measures 0 on one axis while the other still
+    // reads: without the content guard that is a 0.5 scale computed from a box
+    // that is not on screen.
+    expect(fitScale({ width: 800, height: 600 }, { width: 0, height: 1200 })).toBe(1);
+  });
 });

--- a/apps/web/src/presentation/fit.test.ts
+++ b/apps/web/src/presentation/fit.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { fitScale } from './fit';
+
+describe('fitScale', () => {
+  it('leaves a slide that already fits alone', () => {
+    expect(fitScale({ width: 1200, height: 800 }, { width: 896, height: 600 })).toBe(1);
+  });
+
+  it('never enlarges a small slide to fill a big screen', () => {
+    expect(fitScale({ width: 2000, height: 1400 }, { width: 896, height: 300 })).toBe(1);
+  });
+
+  it('shrinks by the tighter of the two axes', () => {
+    // Height is the scarce one on a phone in landscape; width is on a narrow
+    // window. Taking the smaller ratio is what keeps BOTH inside the stage.
+    expect(fitScale({ width: 800, height: 300 }, { width: 896, height: 600 })).toBeCloseTo(0.5);
+    expect(fitScale({ width: 448, height: 900 }, { width: 896, height: 600 })).toBeCloseTo(0.5);
+  });
+
+  it('renders unscaled where nothing has been laid out', () => {
+    // jsdom: every box is 0x0. A naive ratio would be 0 or NaN and the deck
+    // would vanish in the suite while looking fine in a browser.
+    expect(fitScale({ width: 0, height: 0 }, { width: 0, height: 0 })).toBe(1);
+    expect(fitScale({ width: 800, height: 600 }, { width: 0, height: 0 })).toBe(1);
+  });
+});

--- a/apps/web/src/presentation/fit.ts
+++ b/apps/web/src/presentation/fit.ts
@@ -1,0 +1,19 @@
+/** Size of a box, in CSS pixels. */
+export interface Size {
+  width: number;
+  height: number;
+}
+
+/**
+ * How much a slide must shrink to fit the stage it is shown on. Never enlarges:
+ * a slide designed at desktop size is the reference, and a bigger screen shows
+ * it at its own size rather than blown up.
+ *
+ * Returns 1 for a stage or content the browser has not laid out yet (every box
+ * is 0×0 in jsdom), so the deck renders unscaled instead of collapsing.
+ */
+export function fitScale(stage: Size, content: Size): number {
+  if (stage.width <= 0 || stage.height <= 0) return 1;
+  if (content.width <= 0 || content.height <= 0) return 1;
+  return Math.min(1, stage.width / content.width, stage.height / content.height);
+}

--- a/apps/web/src/presentation/swipe.test.ts
+++ b/apps/web/src/presentation/swipe.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { swipeDirection } from './swipe';
+
+// Pure geometry, so the suite CAN judge it — what jsdom cannot judge is whether
+// a finger on a real screen produces these numbers, which is the browser check.
+describe('swipeDirection', () => {
+  it('reads a leftward drag as the next slide', () => {
+    expect(swipeDirection({ x: 300, y: 200 }, { x: 200, y: 205 })).toBe('next');
+  });
+
+  it('reads a rightward drag as the previous slide', () => {
+    expect(swipeDirection({ x: 200, y: 200 }, { x: 300, y: 195 })).toBe('prev');
+  });
+
+  it('ignores a drag too short to be a swipe', () => {
+    // A tap wobbles. Advancing a slide on 20px would fire while the reader is
+    // steadying the phone.
+    expect(swipeDirection({ x: 200, y: 200 }, { x: 180, y: 200 })).toBeNull();
+  });
+
+  it('ignores a tap that does not move at all', () => {
+    expect(swipeDirection({ x: 200, y: 200 }, { x: 200, y: 200 })).toBeNull();
+  });
+
+  it('ignores a vertical drag, however long', () => {
+    expect(swipeDirection({ x: 200, y: 500 }, { x: 205, y: 100 })).toBeNull();
+  });
+
+  it('ignores a diagonal drag where neither axis clearly wins', () => {
+    // 120px across and 100px down is a smudge, not a decision: acting on it is
+    // how a reader loses their place while trying to do something else.
+    expect(swipeDirection({ x: 300, y: 200 }, { x: 180, y: 300 })).toBeNull();
+  });
+});

--- a/apps/web/src/presentation/swipe.test.ts
+++ b/apps/web/src/presentation/swipe.test.ts
@@ -24,7 +24,10 @@ describe('swipeDirection', () => {
   });
 
   it('ignores a vertical drag, however long', () => {
-    expect(swipeDirection({ x: 200, y: 500 }, { x: 205, y: 100 })).toBeNull();
+    // dx is deliberately over MIN_DISTANCE: with 5px the distance floor
+    // rejected it first and this case proved nothing about the vertical rule
+    // (#99 review).
+    expect(swipeDirection({ x: 200, y: 500 }, { x: 260, y: 100 })).toBeNull();
   });
 
   it('ignores a diagonal drag where neither axis clearly wins', () => {

--- a/apps/web/src/presentation/swipe.ts
+++ b/apps/web/src/presentation/swipe.ts
@@ -1,0 +1,24 @@
+/** A point on the screen, in client coordinates. */
+export interface Point {
+  x: number;
+  y: number;
+}
+
+// Below this the movement is a tap that wobbled, not a swipe.
+const MIN_DISTANCE = 50;
+// How much the horizontal component must beat the vertical one before the
+// gesture counts as deliberate. A drag that is 120px across and 100px down is a
+// smudge: acting on it moves the reader while they were doing something else.
+const HORIZONTAL_DOMINANCE = 1.5;
+
+/**
+ * Which way a touch drag points, or null when it is not a slide gesture at all.
+ * Pure on purpose: this is the half of the interaction the suite can judge.
+ */
+export function swipeDirection(start: Point, end: Point): 'next' | 'prev' | null {
+  const dx = end.x - start.x;
+  const dy = end.y - start.y;
+  if (Math.abs(dx) < MIN_DISTANCE) return null;
+  if (Math.abs(dx) <= Math.abs(dy) * HORIZONTAL_DOMINANCE) return null;
+  return dx < 0 ? 'next' : 'prev';
+}

--- a/apps/web/src/presentation/swipe.ts
+++ b/apps/web/src/presentation/swipe.ts
@@ -4,11 +4,18 @@ export interface Point {
   y: number;
 }
 
-// Below this the movement is a tap that wobbled, not a swipe.
+// Below this the movement is a tap that wobbled, not a swipe. 50 CSS px is
+// ~7% of an iPhone 13's landscape width (750px, measured 2026-08-13): far more
+// than a finger shifts while steadying the phone, far less than a deliberate
+// flick. Lower it and a tap meant for the fullscreen control jumps a slide; a
+// percentage of stage width was the cheaper alternative and is rejected — the
+// same finger travels the same distance whatever the screen is.
 const MIN_DISTANCE = 50;
 // How much the horizontal component must beat the vertical one before the
 // gesture counts as deliberate. A drag that is 120px across and 100px down is a
 // smudge: acting on it moves the reader while they were doing something else.
+// 1.5 is ~34 degrees off horizontal; an angle threshold computes the same thing
+// through an atan2 and is rejected as arithmetic nobody reading this needs.
 const HORIZONTAL_DOMINANCE = 1.5;
 
 /**

--- a/apps/web/src/presentation/usePortraitPhone.test.tsx
+++ b/apps/web/src/presentation/usePortraitPhone.test.tsx
@@ -1,0 +1,100 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { usePortraitPhone } from './usePortraitPhone';
+
+// jsdom does not implement `window.matchMedia` AT ALL — it is undefined, so a
+// hook that calls it unguarded throws here instead of getting `false`
+// (testing-strategy.md §Layout and focus). The fake is therefore both the way
+// to state an answer and the only way this hook can be exercised at all; the
+// real media query is verified in a browser.
+function fakeMatchMedia(initial: boolean) {
+  const listeners = new Set<(event: MediaQueryListEvent) => void>();
+  const asked: string[] = [];
+  let matches = initial;
+
+  window.matchMedia = ((query: string) => {
+    asked.push(query);
+    return {
+      media: query,
+      get matches() {
+        return matches;
+      },
+      addEventListener: (_type: string, listener: (event: MediaQueryListEvent) => void) => {
+        listeners.add(listener);
+      },
+      removeEventListener: (_type: string, listener: (event: MediaQueryListEvent) => void) => {
+        listeners.delete(listener);
+      },
+    } as unknown as MediaQueryList;
+  }) as typeof window.matchMedia;
+
+  return {
+    asked,
+    get listenerCount() {
+      return listeners.size;
+    },
+    /** What the browser does when the phone is turned. */
+    set(next: boolean) {
+      matches = next;
+      act(() => {
+        for (const listener of listeners) listener({ matches: next } as MediaQueryListEvent);
+      });
+    },
+  };
+}
+
+function Harness() {
+  return <span data-testid="answer">{usePortraitPhone() ? 'yes' : 'no'}</span>;
+}
+
+function answer() {
+  return screen.getByTestId('answer').textContent;
+}
+
+afterEach(() => {
+  Reflect.deleteProperty(window, 'matchMedia');
+});
+
+describe('usePortraitPhone', () => {
+  it('asks for a coarse pointer AND portrait, so a narrow desktop window is not a phone', () => {
+    const media = fakeMatchMedia(false);
+    render(<Harness />);
+    // Asserted by construction: jsdom cannot evaluate a media query, so the only
+    // thing the suite can pin is which question is asked. Both halves matter —
+    // dropping `pointer: coarse` tells a laptop user to rotate their screen.
+    expect(media.asked.join(' ')).toContain('pointer: coarse');
+    expect(media.asked.join(' ')).toContain('orientation: portrait');
+  });
+
+  it('is false where the browser cannot answer, rather than throwing', () => {
+    render(<Harness />);
+    expect(answer()).toBe('no');
+  });
+
+  it('is true on a coarse pointer in portrait', () => {
+    fakeMatchMedia(true);
+    render(<Harness />);
+    expect(answer()).toBe('yes');
+  });
+
+  it('follows the phone when it is turned, both ways', () => {
+    const media = fakeMatchMedia(true);
+    render(<Harness />);
+
+    media.set(false);
+    expect(answer()).toBe('no');
+
+    media.set(true);
+    expect(answer()).toBe('yes');
+  });
+
+  it('stops listening when it unmounts', () => {
+    const media = fakeMatchMedia(true);
+    const { unmount } = render(<Harness />);
+    expect(media.listenerCount).toBe(1);
+
+    unmount();
+    expect(media.listenerCount).toBe(0);
+  });
+});

--- a/apps/web/src/presentation/usePortraitPhone.ts
+++ b/apps/web/src/presentation/usePortraitPhone.ts
@@ -1,0 +1,38 @@
+import { useSyncExternalStore } from 'react';
+
+// Coarse pointer AND portrait, in one query. The pointer half is what keeps a
+// narrow or tall window on a laptop out of it: that is not a phone, and telling
+// its user to turn their screen sideways is worse than the layout ever was.
+const PHONE_IN_PORTRAIT = '(pointer: coarse) and (orientation: portrait)';
+
+function ask(): MediaQueryList | null {
+  // jsdom does not implement matchMedia at all, so the guard is what keeps the
+  // suite from throwing on a question the browser is the only one who can
+  // answer (testing-strategy.md §Layout and focus).
+  return typeof window.matchMedia === 'function' ? window.matchMedia(PHONE_IN_PORTRAIT) : null;
+}
+
+function subscribe(onChange: () => void): () => void {
+  const query = ask();
+  if (!query) return () => {};
+  query.addEventListener('change', onChange);
+  return () => query.removeEventListener('change', onChange);
+}
+
+function matches(): boolean {
+  return ask()?.matches ?? false;
+}
+
+/**
+ * True while the reader holds a touch device upright. False anywhere it cannot
+ * be asked.
+ *
+ * useSyncExternalStore rather than useState + an effect: React re-reads the
+ * snapshot after subscribing, which closes the render-to-effect gap by
+ * construction. Doing it by hand needs an extra re-read whose only possible
+ * test asserts render/effect ordering — an implementation detail, which
+ * `apps/web/CLAUDE.md` rules out of component tests (#91 review).
+ */
+export function usePortraitPhone(): boolean {
+  return useSyncExternalStore(subscribe, matches);
+}

--- a/docs/decisions/0013-presentation-pipeline.md
+++ b/docs/decisions/0013-presentation-pipeline.md
@@ -61,6 +61,23 @@ can drive it.
    keyboard `p`/`←`/`→`/`Space`/`Home`/`End`/`Esc`, fullscreen via
    `requestFullscreen`, minimal framer-motion fade).
 
+   **5.1 A slide is fit, not reflowed** (#99). It is laid out at its design
+   size and uniformly scaled down (`presentation/fit.ts`, capped at 1 so a big
+   screen shows design size rather than a blown-up slide) so that it fits its
+   stage. Reflowing was the alternative and is rejected: it moves every line
+   break, so the slide the author built is not the slide the reader sees.
+   Clipping was the status quo and is what this replaces — measured 2026-08-13,
+   slide 9 of `java-desde-cpp` lost 69px at 1440x900 and more on a phone. The
+   consequence an author feels: nothing is cut any more, but a dense slide
+   shrinks, and below roughly half scale it stops being readable on a phone.
+
+   **5.2 Touch is a second input path** (#99): a one-finger horizontal swipe
+   moves one slide (a second finger is a pinch, and zooming is not navigating).
+   Keyboard and finger funnel through one clamped `go()`, so `?slide` stays the
+   single source of truth. Unlike a key, the swipe needs no portrait gate: it
+   hangs off the slide stage, which the rotate panel replaces rather than
+   covers. A new input author should know which of those two shapes theirs is.
+
    **Constrained by ADR-0023** (#91): on a coarse pointer in portrait the deck
    is replaced by a rotate panel — a second case where `/present` paints no
    slide, and unlike `presentation: none` it does not redirect. While that panel

--- a/docs/decisions/0013-presentation-pipeline.md
+++ b/docs/decisions/0013-presentation-pipeline.md
@@ -61,6 +61,14 @@ can drive it.
    keyboard `p`/`←`/`→`/`Space`/`Home`/`End`/`Esc`, fullscreen via
    `requestFullscreen`, minimal framer-motion fade).
 
+   **Constrained by ADR-0023** (#91): on a coarse pointer in portrait the deck
+   is replaced by a rotate panel — a second case where `/present` paints no
+   slide, and unlike `presentation: none` it does not redirect. While that panel
+   is up every slide key above is silenced at the window listener (`Esc` alone
+   stays live) and fullscreen is exited. A new deck shortcut wired at window
+   level inherits that gate or it will move `?slide` behind a panel showing no
+   slide.
+
 ## Alternatives considered
 
 - **Compile-time slide splitting** as the primary mechanism (mdx-deck style):

--- a/docs/decisions/0023-presentation-requires-landscape-on-a-phone.md
+++ b/docs/decisions/0023-presentation-requires-landscape-on-a-phone.md
@@ -114,6 +114,20 @@ Three things this fixes in place:
   in Chromium: enter fullscreen in landscape, rotate, `document.fullscreenElement`
   is null and the panel is up. This does not touch the button itself, which the
   WP put out of scope.
+- **The deck asks for the viewport the browser actually gives, not the one it
+  claims (#99).** `fixed inset-0` resolves against the *large* viewport, the one
+  a mobile browser overlays with its own chrome, so the deck was drawing under
+  the URL bar. It now also carries `h-[100dvh]` (dynamic viewport) and the page
+  declares `viewport-fit=cover`; `theme-color` was already `#020617`, the deck's
+  own background, so where a bar cannot be removed it at least stops being a
+  stripe of a different colour. Measured 2026-08-13 in Chromium with an iPhone 13
+  context: the deck's box is exactly `innerHeight` at 844x390, 390x844 and
+  1440x900, with nothing scrollable behind it.
+  **What emulation cannot answer**: whether a given mobile browser hides its
+  chrome, keeps it, or changes on rotation. Headless Chromium has no URL bar, so
+  that is a real-device observation and belongs here as one, with the browser and
+  the date. Fullscreen remains rejected as the answer for the reasons above — this
+  is what can be done without it.
 - The reader's position survives rotation for free: it lives in `?slide=N`, not
   in the component.
 - **jsdom implements no `matchMedia` at all**, so the suite can pin which

--- a/docs/decisions/0023-presentation-requires-landscape-on-a-phone.md
+++ b/docs/decisions/0023-presentation-requires-landscape-on-a-phone.md
@@ -1,0 +1,126 @@
+# ADR-0023: Presentation requires landscape on a phone
+
+**Status:** Accepted
+**Date:** 2026-08-13
+**Decision-makers:** Miguel Rodriguez
+**Covers:** why the deck refuses portrait on a touch device · why the pointer
+half of the query is load-bearing · what the panel must offer as a way out
+**Source:** Issue #91 (require landscape for presentation mode on a phone),
+found verifying #90. Constrains ADR-0013 (presentation pipeline) §2 and §5.
+
+## Context
+
+The slide deck is a landscape form: one idea per screen, a comfortable measure,
+a counter in a corner. Held upright on a phone it stops being that. Measured in
+Chromium on `/d/java-desde-cpp`, slide 2, at 390x844: the paragraph is squeezed
+into a 262px column (the viewer's `px-16` leaves 64px of gutter on each side,
+at any width) and runs so far past the bottom that the `h2` sits 164px above
+the top of the screen — clipped by the viewer's `overflow-hidden`, with nothing
+telling the reader that anything is wrong. A student who taps `Presentar` on
+their phone gets that by default (#91, found verifying #90).
+
+At 844x390 the same slide reads in nine lines of body instead of twenty-six,
+and it is usable. **It is not, however, whole**: measured again during this
+WP's review, the heading sits at `y = -61` there too and the closing paragraph
+falls below the fold — both clipped by the same `overflow-hidden`. The issue
+this ADR comes from said the landscape rendering "reads correctly"; re-measured,
+that is true only of the paragraphs that fit. The remaining clipping is slide
+typography, deliberately out of scope here and recorded in the last Consequence.
+
+The book view already serves reading on a phone in portrait, by design (#84), so
+the platform is not missing a way to read the material there — only a way to
+stop the deck from being the thing that answers.
+
+## Decision
+
+**A slide is never painted on a coarse pointer in portrait.** The viewer asks
+one media query — `(pointer: coarse) and (orientation: portrait)` — and when it
+matches it renders a panel in place of the deck: a rotate icon, one line in
+Spanish, and a link to the document's book view.
+
+Three things this fixes in place:
+
+- **The pointer half is load-bearing.** A narrow or tall window on a laptop is
+  not a phone; telling its user to turn their screen sideways is worse than the
+  layout ever was.
+- **The panel replaces the deck, it does not sit over it, and it is modal.** No
+  slide is painted, the only control reachable by keyboard is the way out, and
+  the deck's slide keys are silenced at the window listener. `Escape` is the
+  deliberate exception — a modal has a way out, and this one lands where the
+  panel's own link lands. (Why the listener needs silencing at all is a
+  React mechanic; it lives in the code comment that guards it.)
+- **The way out is an absolute route** (`/d/<id>`), not `history.back()`: a
+  reader who opened `/d/<id>/present` from a message or a bookmark has nothing
+  behind them to go back to.
+
+## Alternatives considered
+
+- **`screen.orientation.lock('landscape')`** — the first idea, and the reason
+  this ADR exists. It only works inside fullscreen, and **iPhone Safari has no
+  Fullscreen API for a web page at all** (only native `<video>` gets it — which
+  is why YouTube can rotate an iPhone and a web page cannot imitate it). It would
+  deliver three different behaviours across browsers and a maintenance burden for
+  each, and would still leave the iPhone case unsolved. Rejected with that in
+  hand. `SlideDeck`'s existing `toggleFullscreen()` is where such a lock would
+  hang if a later WP ever wants it on the browsers that do support it.
+- **Requesting fullscreen automatically on entering presentation** — same
+  dependency, plus it takes a decision away from the reader. Rejected.
+- **Redesigning slide typography for narrow portrait** — makes the deck a second
+  reading surface competing with the book view, for a shape nobody presents in.
+  The decision is landscape, not "make portrait work".
+- **A "view it anyway" escape** — the way out is out (the book view), not
+  through. Two ways of reading the same document on a phone is the confusion the
+  book view exists to prevent.
+- **Doing nothing and documenting it** — the failure is silent, and silence is
+  what the WP was opened to fix.
+
+## Consequences
+
+- A phone with rotation locked in the OS cannot reach the deck at all. That is
+  accepted: the panel's link to the book view is the answer for it, which is why
+  the way out is a requirement of the rule and not a courtesy.
+- The rule lives in the viewer (`presentation/SlideDeck.tsx` + `RotateNotice`),
+  so every entry point to presentation inherits it — the `Presentar` button, the
+  `p` shortcut, and a deep link straight into `/present`. It sits in the viewer
+  rather than in `PresentationPage` because the document is then already loaded:
+  turning the phone shows the deck immediately, with no second fetch.
+- **Any coarse pointer in portrait gets the panel, tablets included.** An iPad
+  held upright has room for a slide and will still be told to turn — accepted,
+  because the WP asked for one mechanism, identical on every device, and a width
+  term would mean choosing a breakpoint nobody has measured. The panel says
+  "Gira el teléfono" there; if that ever grates, the fix is the wording, not a
+  second rule.
+- **Browser baseline: Safari 14+ / iOS 14+, and no legacy fallback.**
+  `MediaQueryList.addEventListener` landed in Safari 14 (MDN browser-compat-data,
+  checked 2026-08-13; `addListener` goes back to 5.1), so on older WebKit the
+  hook throws and takes the whole `/present` route down — a blank page, worse
+  than the layout this WP fixes, on the device class it targets. Shipping it
+  anyway is the decision, not an oversight, and the case that does NOT hold is
+  named: **a pre-14 iOS phone loses presentation entirely, silently, and no test
+  guards it.** No other ADR states a browser floor — 0016/0017 impose a much
+  heavier one in practice (a browser that runs CheerpJ and WebAssembly) but never
+  wrote it down, so this is the repo's first recorded baseline and the operator
+  surface for it is `apps/web/README.md` §Deployed shape.
+- **Live sessions (ADR-0008) are not exempted, and that is not yet a decision.**
+  ADR-0013 makes `/present` + `?slide=N` the seam a session drives, so a student
+  following the class from a phone held upright will get this panel instead of
+  the slide the professor is on, while `?slide` keeps advancing behind it. The
+  rule is deliberately unconditional today — follower mode does not exist yet —
+  and whether it should stay that way is a question for whoever implements
+  ADR-0008 in v0.3, not one this ADR answers.
+- **Fullscreen is left when the rule takes over.** The `⛶` button is the only
+  control that exits fullscreen and it lives in the deck being removed, so the
+  panel would otherwise sit inside a fullscreen page with no way back. Verified
+  in Chromium: enter fullscreen in landscape, rotate, `document.fullscreenElement`
+  is null and the panel is up. This does not touch the button itself, which the
+  WP put out of scope.
+- The reader's position survives rotation for free: it lives in `?slide=N`, not
+  in the component.
+- **jsdom implements no `matchMedia` at all**, so the suite can pin which
+  question is asked and fake the answer, but never evaluate the query. The
+  behaviour is verified in a real browser at 390x844 and 844x390, with a coarse
+  pointer emulated and again without one (`testing-strategy.md`).
+- The deck's own behaviour on a short landscape phone screen is untouched by this
+  decision: a slide taller than the viewport is still clipped by the viewer's
+  `overflow-hidden`, as it is on any short window. That is slide typography, and
+  it is deliberately out of scope here.

--- a/docs/decisions/0023-presentation-requires-landscape-on-a-phone.md
+++ b/docs/decisions/0023-presentation-requires-landscape-on-a-phone.md
@@ -134,7 +134,14 @@ Three things this fixes in place:
   question is asked and fake the answer, but never evaluate the query. The
   behaviour is verified in a real browser at 390x844 and 844x390, with a coarse
   pointer emulated and again without one (`testing-strategy.md`).
-- The deck's own behaviour on a short landscape phone screen is untouched by this
-  decision: a slide taller than the viewport is still clipped by the viewer's
-  `overflow-hidden`, as it is on any short window. That is slide typography, and
-  it is deliberately out of scope here.
+- **Corrected by #99.** This ADR claimed, as behaviour and as a scope boundary,
+  that a slide taller than the viewport is still clipped by the viewer's
+  `overflow-hidden` — "that is slide typography, and it is deliberately out of
+  scope here". Measuring all ten slides of `java-desde-cpp` while fixing the
+  phone deck falsified the boundary rather than the observation: slide 9
+  overflowed its stage by 69px at **1440x900**, so the clipping was never a
+  phone problem and calling it phone-side typography was wrong. The deck now
+  fits a slide to its stage instead of clipping it (ADR-0013 §5.1), so nothing
+  is silently cut on any screen. The failure mode moved rather than vanishing:
+  a slide too dense to fit is now too small to read, which is visible instead
+  of invisible, and belongs to the author (`guides/add-a-course-document.md`).

--- a/docs/standards/frontend-code-style.md
+++ b/docs/standards/frontend-code-style.md
@@ -160,7 +160,32 @@ src/
 - Design tokens (colors, spacing, fonts beyond Tailwind defaults) are declared in
   `styles/index.css` via Tailwind v4 `@theme` — components never hardcode hex
   values or magic pixel sizes.
-- `style={{ ... }}` only for genuinely dynamic values (computed positions).
+- `style={{ ... }}` only for genuinely dynamic values (computed positions,
+  and a measured transform — see the fit-to-stage rule below).
+- **Content that must not reflow is laid out at its design size and scaled**,
+  never re-typeset per screen. The scale is computed by a pure, unit-tested
+  helper rather than inline in the component, because jsdom lays nothing out
+  and the arithmetic is the only half a suite can judge. Two invariants make it
+  work: measure with `offsetWidth`/`offsetHeight`, which ignore the transform
+  about to be applied, so a re-measure sees the natural size instead of
+  compounding; and observe BOTH boxes, because a font finishing loading changes
+  the content without changing the stage. Cap the scale at 1 — a big screen
+  shows design size, not a blown-up slide. And **hold the measured nodes in
+  state via callback refs, so the effect can depend on their identity**: keyed
+  on an index instead, it does not re-run when the same index gets a new node —
+  which is what `AnimatePresence mode="wait"` does on every slide change, and
+  what an early return does when the deck replaces another view. Worked case:
+  `presentation/fit.ts` + `SlideDeck` (#99, where both defects shipped past a
+  green suite and a thirty-point browser pass); the decision and its
+  consequences are ADR-0013 §5.1.
+- **A full-viewport overlay carries `h-[100dvh]` beside `fixed inset-0`.**
+  `inset-0` resolves against the LARGE viewport — the one a mobile browser
+  overlays with its own chrome — so the overlay draws under the URL bar. The
+  page-level half is `viewport-fit=cover`, declared once in `index.html`, which
+  is therefore load-bearing for this rule despite sitting outside `src/`.
+  Worked case: `SlideDeck` and `RotateNotice` (#99), a failure invisible to the
+  suite and to any desktop browser. Note the version floor in
+  `apps/web/README.md`: `dvh` degrades silently below it rather than throwing.
 
 - **The reading measure is a global rule, and components opt out of it by name**
   (ADR-0022). The document `<article>` carries `.measured-prose`, and in

--- a/docs/standards/frontend-code-style.md
+++ b/docs/standards/frontend-code-style.md
@@ -195,14 +195,33 @@ src/
   icon-only control inside a component's own dense chrome (`CodeEditor`'s
   expand). 16px for an icon-only control on the PAGE chrome, where the button is
   a touch target rather than part of a text row — the drawer toggle and its
-  close button (#84) are the only two. Adding a second icon set
-  needs the same discussion a dependency does (root `CLAUDE.md`).
+  close button (#84) are the only two. 48px when the icon is the illustration of
+  a full-screen panel rather than a control — it carries the message at a
+  glance, is `aria-hidden` because the text beside it says the same thing, and
+  is not clickable (worked case: `presentation/RotateNotice.tsx`, #91). Adding a
+  second icon set needs the same discussion a dependency does (root `CLAUDE.md`).
 
 ## State
 
 - Local `useState`/`useReducer` first; React context for genuinely cross-cutting
   concerns (e.g., presentation mode). No global state library — introducing one
   requires an ADR.
+- **A browser store is subscribed with `useSyncExternalStore`, not `useState` +
+  an effect.** A `MediaQueryList`, `document.fullscreenElement`, a storage
+  event: React re-reads the snapshot after subscribing, so the gap between the
+  first render and the effect closes by construction. Doing it by hand needs an
+  extra re-read for that gap, and the only test that can prove the re-read
+  asserts render/effect ordering — an implementation detail, which component
+  tests may not assert (`apps/web/CLAUDE.md`). Worked case:
+  `presentation/usePortraitPhone.ts` (#91), where the hand-rolled version
+  shipped in the first slice and was replaced in review, once the review
+  measured that no permitted test could kill its re-read.
+- **Layout breakpoints stay in Tailwind classes; a media query is only asked
+  from JS when device shape decides BEHAVIOUR** — what gets rendered at all,
+  not how wide it is. It belongs in a hook colocated in the feature that owns
+  the behaviour (`presentation/usePortraitPhone.ts`), never in a shared
+  `lib/useMediaQuery`, and the call is guarded with `typeof window.matchMedia`
+  so the suite gets `false` instead of a throw.
 
 ## Imports
 

--- a/docs/standards/guides/add-a-course-document.md
+++ b/docs/standards/guides/add-a-course-document.md
@@ -213,7 +213,10 @@ themselves rather than maintained by hand.
    `/nalanda/d/<id>`) and run every exercise you added: no amber authoring
    banner, the cases pass against a correct solution, and they fail against the
    starter. If a `<SideBySide>` or a `<Slide>` is involved, look at it in
-   presentation mode too — `/d/<id>/present`.
+   presentation mode too — `/d/<id>/present`. **Slides are checked in
+   landscape**: on a phone or tablet held upright the viewer deliberately shows
+   a "Gira el teléfono" panel instead of the deck (ADR-0023), so an empty
+   presentation there is the platform working, not a fault in your document.
 
 9. **Publish**: merging to `main` republishes
    <https://so77id.github.io/nalanda/> automatically — `content/**` is a deploy

--- a/docs/standards/guides/add-a-course-document.md
+++ b/docs/standards/guides/add-a-course-document.md
@@ -217,6 +217,14 @@ themselves rather than maintained by hand.
    landscape**: on a phone or tablet held upright the viewer deliberately shows
    a "Gira el teléfono" panel instead of the deck (ADR-0023), so an empty
    presentation there is the platform working, not a fault in your document.
+   **What you are checking is legibility, not completeness** (ADR-0013 §5.1):
+   a slide too tall or too wide is no longer clipped, it is scaled down whole,
+   so nothing disappears and instead everything shrinks. Measured on a phone in
+   landscape (2026-08-13, iPhone 13 at 750x342): below roughly half scale the
+   body text stops being readable. If a slide gets there, the fix is yours and
+   not the viewer's — split it at a `<SectionBreak/>`, or shorten the listing.
+   The same applies to width: an over-wide `<SideBySide>` column now shrinks
+   the ENTIRE slide rather than overflowing on its own.
 
 9. **Publish**: merging to `main` republishes
    <https://so77id.github.io/nalanda/> automatically — `content/**` is a deploy

--- a/docs/standards/testing-strategy.md
+++ b/docs/standards/testing-strategy.md
@@ -144,14 +144,16 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   skips and `focus()` silently refuses. So a test can assert a focus trap, a
   roving tabindex, an active-section rule or a breakpoint and stay green over
   code that fails on the page. Any change that enumerates focusable elements,
-  moves focus, depends on a viewport width or a scroll position, or is enforced
-  by a rule in `styles/index.css`, MUST also be verified in a real browser
-  against `npm run build && npm run preview`, at the widths that matter, judged
-  from a screenshot. In the suite these cases are asserted **by construction** —
-  place the headings and dispatch a scroll (`content/useSections.test.tsx`),
-  assert the list a trap computed through where focus lands
-  (`content/Drawer.test.tsx`) — and the construction must be checked against a
-  browser at least once, because it encodes an assumption jsdom cannot refute.
+  moves focus, depends on a viewport width, a scroll position or a device
+  capability asked through `window.matchMedia` (pointer type, orientation), or
+  is enforced by a rule in `styles/index.css`, MUST also be verified in a real
+  browser against `npm run build && npm run preview`, at the widths that matter,
+  judged from a screenshot. In the suite these cases are asserted **by
+  construction** — place the headings and dispatch a scroll
+  (`content/useSections.test.tsx`), assert the list a trap computed through
+  where focus lands (`content/Drawer.test.tsx`) — and the construction must be
+  checked against a browser at least once, because it encodes an assumption
+  jsdom cannot refute.
   Three worked cases, all from #84 and all green in jsdom at the time:
   an `IntersectionObserver` active-section rule that left the rail unmarked
   through 70% of a document (an observer fires on crossings; a reader inside a
@@ -159,6 +161,36 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   the toggle behind the drawer; and the first fix for it, a visibility filter on
   `offsetParent`, which under jsdom matched *nothing*, emptied the trap's list
   and made its own tests pass while proving nothing.
+- **A media query is the sharpest case of it**: the suite can pin **which
+  question is asked** and fake the answer, never evaluate it, so what is
+  asserted is the query string plus the behaviour that follows from a faked
+  match (worked case: `presentation/usePortraitPhone.test.tsx`, #91 — dropping
+  `pointer: coarse` from the query tells a laptop user to rotate their screen,
+  and the string assertion is the only thing in the suite that can catch it).
+  Two riders, both earned in #91's review. **Guard the call**:
+  `window.matchMedia` is universal in browsers, so the `typeof` check exists
+  purely so jsdom answers `false` instead of throwing, and `vitest.setup.ts` is
+  confirmation-gated (`apps/web/CLAUDE.md`), which is why the accommodation
+  lives in the code. **Make the fake answer only its own query**: one that
+  returns the same `matches` for every question also answers framer-motion's
+  `(prefers-reduced-motion)` when the component under test mounts, silently
+  changing it — worked case `app/presentationRoute.test.tsx`, whose fake scopes
+  its answer to `pointer: coarse`, which the hook's own fake does not need
+  because its harness renders no motion component.
+- **A browser-API fake needed by two features is duplicated, not shared.** The
+  seam invariant in `src/architecture.test.ts` has no `.test.` exemption for the
+  "goes through the feature root seam" case, so a shell test cannot import a
+  helper out of a feature folder, and `lib/` is for shipped pure code, not test
+  doubles. Worked case (#91): the `matchMedia` fake exists in
+  `app/presentationRoute.test.tsx` and in `presentation/usePortraitPhone.test.tsx`,
+  and they are not identical — only the second tracks which queries were asked.
+- **Asserting ABSENCE inside a lazy boundary needs a synchronisation point.**
+  `queryBy…` returns nothing while a `Suspense` child is still loading, so the
+  assertion passes before the code under test has run at all. First `await` an
+  element that can only exist on the far side of the boundary, and say so in a
+  comment. Worked case (#91): `app/presentationRoute.test.tsx` awaits the rotate
+  panel — which only the loaded document can render — before asserting that no
+  counter and no slide heading are on the page.
 - **A fix is not done until its test has been seen to fail.** Revert the fix,
   watch the new test go red, restore it — and name the failing test in the
   commit message. Reviewing a test by reading it is how a test that cannot fail
@@ -178,6 +210,23 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   `-- --port <n>` when something already holds 4173.
   `guides/add-a-language-runtime.md` §7 keeps the runtime-specific checks and
   points here for the mechanics.
+  **A device rule needs an emulated device, not a small window.** A desktop
+  context reports `pointer: fine` at any size, so resizing Chromium to 390x844
+  proves nothing about a phone — the check silently passes over code that never
+  ran. Use a touch context (`browser.newContext({ ...devices['iPhone 13'] })`,
+  or `{ viewport, hasTouch: true, isMobile: true }`), rotate by swapping width
+  and height **in the same context** so the page is not remounted, and run the
+  same page once in a default desktop context to prove the rule does NOT fire on
+  a narrow laptop window. Two mechanics worth knowing before they cost an hour
+  (#91): on a **fullscreen** page the driver's resize call rejects
+  (`Browser.setWindowBounds`: "To resize minimized/maximized/fullscreen window,
+  restore it to normal state first") *after* the metrics override has already
+  landed — so the page has rotated, the app has reacted, and the script dies
+  holding a state it thinks it never reached. Rotate a fullscreen page through
+  `Emulation.setDeviceMetricsOverride` on a CDP session instead. And the
+  emulated rotation is what makes `matchMedia` fire, so assert the query's own
+  value in the page (`matchMedia('(pointer: coarse)').matches`) rather than
+  trusting the preset.
 - **Env-derived values go through a pure helper**: extract the transformation
   into a colocated, unit-tested module rather than inlining it in a component
   the suite cannot exercise. Worked case: `app/basename.ts` derives the router

--- a/docs/standards/testing-strategy.md
+++ b/docs/standards/testing-strategy.md
@@ -191,6 +191,23 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   comment. Worked case (#91): `app/presentationRoute.test.tsx` awaits the rotate
   panel — which only the loaded document can render — before asserting that no
   counter and no slide heading are on the page.
+- **A per-state browser measurement is not a transition measurement.** Loading
+  each state fresh (`?slide=1`, `?slide=2`, …) exercises mount and nothing else;
+  the paths BETWEEN states are different code and have to be driven in the same
+  page — press the key, dispatch the gesture, rotate the context. Worked case
+  (#99): thirty fresh-load measurements across ten slides and three viewports
+  reported "no overflow anywhere" while the deck was broken on every path a
+  reader actually takes — rotating into it left the slide at scale 1 overflowing
+  its stage 3:1, and pressing an arrow key measured the outgoing slide. One run
+  that pressed ArrowRight instead of reloading showed it immediately.
+- **A measure-and-observe effect is keyed on the identity of the node it
+  measures**, never on a scalar that merely correlates with it (an index, a
+  length). And this class IS reachable from jsdom, which is what makes it worth
+  a test: stub `ResizeObserver`, define `clientWidth`/`offsetHeight` getters on
+  `HTMLElement.prototype`, and assert WHICH element was measured and observed —
+  jsdom cannot lay out, but it can answer that. Worked case (#99):
+  `app/presentationRoute.test.tsx` §"fitting a slide to the stage it is shown
+  on", where the rotation case fails against the index-keyed version.
 - **A fix is not done until its test has been seen to fail.** Revert the fix,
   watch the new test go red, restore it — and name the failing test in the
   commit message. Reviewing a test by reading it is how a test that cannot fail


### PR DESCRIPTION
**Closes #99**

## Summary

After #91 a phone could *reach* the presentation; it still could not be used.
This makes it usable in landscape: a horizontal swipe moves through the deck,
the rotate panel says the gesture exists, the slide is fit to the screen instead
of clipped, and the deck takes the viewport the browser actually gives rather
than the one it claims.

Two things changed shape during the work, both from measurement:

- **The clipping was never a phone problem.** Measuring all ten slides of
  `java-desde-cpp` showed slide 9 overflowing its stage by 69px at **1440x900**.
  So the fix is not phone typography but the model deck tools use: a slide is
  laid out at its design size and scaled down to fit, never reflowed — reflowing
  moves every line break, so the slide the author built is not the slide the
  reader sees. Recorded as ADR-0013 §5.1.
- **My first verification method was wrong**, and the review caught it. Loading
  each slide fresh (`?slide=N`) measures mount and nothing else. Driven through
  transitions instead, the deck was broken on every path a reader takes.

## Slices completed

- [x] S1 — advance and go back with a horizontal swipe (`6d62072`)
- [x] S2 — name the gesture on the rotate panel (`efe3e37`)
- [x] S3 — fit a slide to the screen it is shown on (`a459825`)
- [x] S4 — give the deck the viewport the browser offers (`9410705`)

Plus `380fb0c` (review fixes) and `db84dab` (docs).

## Acceptance criteria

Browser evidence: Playwright/Chromium, an emulated iPhone 13 and a desktop
context, against `npm run build && npm run preview`, driving transitions.

1. **Swipe moves one slide each way, clamped** — `presentation/swipe.ts` +
   handlers on the stage; tests in `swipe.test.ts` and four route cases, each
   with a positive control. Browser: swipes gave `10 / 10` then `9 / 10`.
2. **A vertical drag, a tap and a pinch leave the slide alone** — three cases,
   each proven by a real swipe afterwards in the same test.
3. **Position stays in `?slide=N`** — the gesture goes through the same clamped
   `go()` as the keyboard; unchanged deep-link and reload tests still pass.
4. **Desktop behaviour unchanged** — arrows, Space, Home/End, Escape, `⛶`, and
   `p` from the book: existing tests green, and re-driven in the browser.
5. **The panel names the gesture, in Spanish** — "Desliza para pasar de
   diapositiva", one register with "Gira el teléfono" (review finding).
6. **At 844x390 the title is visible and nothing falls below the fold** — all
   ten slides at 750x342, 844x390 and 1440x900: zero overflow, screenshots
   looked at. After the review fixes, also true when rotating in and swiping.
7. **The deck fills the viewport the browser gives** — `h-[100dvh]` +
   `viewport-fit=cover`; measured: the deck's box equals `innerHeight` at all
   three sizes with nothing scrollable. **Real-device half is yours** (below).
8. **1440x900 perceptibly unchanged** — nine of ten slides scale by exactly 1.
   The tenth (slide 9) now shows whole at 0.83 instead of losing 69px, which
   you approved as better than clipped.
9. **What each browser does with its chrome is recorded** — ADR-0023 carries the
   emulated measurement and says plainly that a real browser's bar behaviour is
   a device observation, not something headless Chromium can settle.
10. **Book view and the portrait rule unaffected** — untouched; #91's tests green.
11. **Protocols green** — before every commit and again after the review round:
    format ✓ lint ✓ 488/488 ✓ build ✓.

## Tests

488 green (was 483 on `main`). New: `presentation/swipe.test.ts` (6),
`presentation/fit.test.ts` (6), four route swipe cases and three route scaling
cases that stub `ResizeObserver` and state the geometry, so the suite can assert
*which* node was measured — the exact defect class the review found.

Mutations run: the index-keyed dependency array fails two scaling cases;
removing the touch wiring fails the swipe case; dropping the dominance guard
fails the diagonal case; each `fitScale` guard now has a case that kills it
alone.

## Reviews run

Reduced pipeline (your call, to keep the cost down): mechanical gate + one code
lens + one docs lens, no verifier.

- **Code lens** — 8 findings: 2 critical, 3 important, 2 suggestions, 1 pattern.
  Both criticals were real, reproduced in Chromium, and are what made this WP
  actually work. All acted on.
- **Docs lens** — 12 findings: 2 critical, 7 important, 3 suggestions. All acted
  on, including a claim from #91's own ADR that this diff falsified.

## Manual verification

On your phone, in Brave:

1. Open a document, tap `Presentar`, rotate to landscape.
2. **Swipe left and right** — the deck should move one slide per swipe, and stop
   at the first and last rather than wrapping.
3. A tap, and a vertical drag, should do nothing.
4. Rotate back to portrait and forward again: same slide, still fitting.
5. **The chrome question (#94)**: does Brave still show its bar over the deck?
   This is the one thing I could not measure — headless Chromium has no bar.
   Whatever you see goes into ADR-0023 with your device and the date.
6. On a notched iPhone if you have one: the `⛶` button and the counter should be
   clear of the notch and the home indicator in landscape.
7. On the laptop: nothing should look different, except that the dense slide
   ("Entrada y salida") now shows whole instead of cut.

## Notes

- **A dense slide is now small rather than cut.** Slide 9 on a phone lands at
  0.28 scale — everything visible, but a signal that the slide is too dense to
  present. That is authoring, not the viewer: the guide now says so, with the
  measured floor (below roughly half scale it stops being readable).
- **The browser baseline rises to Safari/iOS 15.4** because of `dvh`. Unlike
  `matchMedia` (which throws), `dvh` degrades silently: on an older phone the
  deck simply draws under the browser chrome again, with no error and no test.
- Pre-existing flake, unrelated: `presentationRoute.test.tsx > "opens on the
  cover slide…"` can exceed the 1000ms `findBy` default under parallel load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s8pBXNvdMc6th4rxfZ9MW
