### PR TITLE
feat: give the deck a visible way out of presentation mode

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -41,11 +41,16 @@ SPA fallback and the `vite preview` gotcha). One home per fact, per
      implement the browser's tab order, so anything that enumerates focusables,
      moves focus, depends on a viewport width, a scroll position, a device
      capability asked through `window.matchMedia` (pointer type, orientation —
-     jsdom implements no media query at all), measured element geometry (every
-     box is 0×0 there, so anything reading `offsetWidth`/`clientHeight`, or a
-     `ResizeObserver`, is inert in the suite), a touch gesture (jsdom fires the
-     events but lays out and scrolls nothing), or a rule in `styles/index.css`
-     needs a browser too. A device rule also needs an emulated device, not
+     jsdom implements no media query at all), measured element geometry or
+     computed style (every box is 0×0 and `getComputedStyle` only echoes inline
+     styles, so a test must FAKE both — and then the failure is not an inert
+     test but a GREEN one pinning whatever the author assumed: #103 shipped a
+     predicate whose fakes had pinned a false positive as the contract), a
+     touch gesture (jsdom fires the events but lays out and scrolls nothing),
+     or a rule in `styles/index.css` needs a browser too. A guard whose
+     predicate is a DOM measurement is verified in a browser against the
+     property it claims to measure — the recipe is in `testing-strategy.md`
+     §Conventions. A device rule also needs an emulated device, not
      merely a small window: the recipe is in `testing-strategy.md` §Conventions.
 
   Written as classes rather than lists of names because the list was already

--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -286,6 +286,26 @@ describe('advancing the deck by touch', () => {
     expect(counter).toHaveTextContent(/^3 \//);
   });
 
+  it('leaves a sideways-scrolling code block to scroll itself', async () => {
+    renderAt(`/d/${firstId}/present?slide=2`);
+    const counter = await findCounter();
+
+    // A code block wider than the slide: the reader drags inside it to read the
+    // rest of the line, and the deck must not take that drag (#103, measured on
+    // a phone with 73px of Java hidden to the right).
+    const scroller = screen.getByTestId('slide-stage').querySelector('div')!;
+    Object.defineProperty(scroller, 'scrollWidth', { value: 900, configurable: true });
+    Object.defineProperty(scroller, 'clientWidth', { value: 800, configurable: true });
+
+    fireEvent.touchStart(scroller, { touches: [{ clientX: 600, clientY: 200 }] });
+    fireEvent.touchEnd(scroller, { changedTouches: [{ clientX: 200, clientY: 205 }] });
+    expect(counter).toHaveTextContent(/^2 \//);
+
+    // …and the same drag on the stage itself still moves the deck.
+    swipe(600, 200);
+    expect(counter).toHaveTextContent(/^3 \//);
+  });
+
   it('ignores a two-finger gesture — a pinch is not a swipe', async () => {
     renderAt(`/d/${firstId}/present?slide=2`);
     const counter = await findCounter();
@@ -385,6 +405,58 @@ describe('fitting a slide to the stage it is shown on', () => {
     // effect that runs on the index measures the OUTGOING node and leaves the
     // new one unobserved for the rest of the deck.
     expect(observed).toContain(slideBox());
+  });
+});
+
+describe('leaving the presentation from the deck', () => {
+  it('offers a visible exit beside the fullscreen control', async () => {
+    renderAt(`/d/${firstId}/present`);
+    await findCounter();
+    expect(screen.getByRole('button', { name: /salir de la presentación/i })).toBeInTheDocument();
+  });
+
+  it('lands on the book view from any slide, including a deep link', async () => {
+    renderAt(`/d/${firstId}/present?slide=3`);
+    await findCounter();
+
+    fireEvent.click(screen.getByRole('button', { name: /salir de la presentación/i }));
+
+    expect(await screen.findByRole('article')).toBeInTheDocument();
+  });
+
+  it('leaves fullscreen on the way out, since the control goes with the deck', async () => {
+    const exitFullscreen = vi.fn(() => Promise.resolve());
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      value: document.documentElement,
+    });
+    Object.defineProperty(document, 'exitFullscreen', {
+      configurable: true,
+      value: exitFullscreen,
+    });
+    try {
+      renderAt(`/d/${firstId}/present`);
+      await findCounter();
+      fireEvent.click(screen.getByRole('button', { name: /salir de la presentación/i }));
+      await screen.findByRole('article');
+      expect(exitFullscreen).toHaveBeenCalled();
+    } finally {
+      Reflect.deleteProperty(document, 'fullscreenElement');
+      Reflect.deleteProperty(document, 'exitFullscreen');
+    }
+  });
+
+  it('is not reachable behind the rotate panel', async () => {
+    coarsePortrait(true);
+    try {
+      renderAt(`/d/${firstId}/present`);
+      await screen.findByRole('alertdialog');
+      expect(
+        screen.queryByRole('button', { name: /salir de la presentación/i }),
+      ).not.toBeInTheDocument();
+    } finally {
+      Reflect.deleteProperty(window, 'matchMedia');
+    }
   });
 });
 

--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -287,23 +287,44 @@ describe('advancing the deck by touch', () => {
   });
 
   it('leaves a sideways-scrolling code block to scroll itself', async () => {
-    renderAt(`/d/${firstId}/present?slide=2`);
+    // A document whose slides really carry <pre>: the first fixture's slide 2
+    // has no code at all, so the earlier version of this test faked the geometry
+    // on the slide wrapper — a box that in a browser has `overflow-x: visible`
+    // and cannot scroll. It pinned the wrong contract and never walked a single
+    // ancestor (#103 review).
+    renderAt('/d/java-desde-cpp/present?slide=5');
     const counter = await findCounter();
+    const before = counter.textContent;
 
-    // A code block wider than the slide: the reader drags inside it to read the
-    // rest of the line, and the deck must not take that drag (#103, measured on
-    // a phone with 73px of Java hidden to the right).
-    const scroller = screen.getByTestId('slide-stage').querySelector('div')!;
-    Object.defineProperty(scroller, 'scrollWidth', { value: 900, configurable: true });
-    Object.defineProperty(scroller, 'clientWidth', { value: 800, configurable: true });
+    const stage = screen.getByTestId('slide-stage');
+    const code = stage.querySelector('pre');
+    expect(code, 'this slide must carry a code block for the case to mean anything').toBeTruthy();
+    Object.defineProperty(code!, 'scrollWidth', { value: 900, configurable: true });
+    Object.defineProperty(code!, 'clientWidth', { value: 800, configurable: true });
+    code!.style.overflowX = 'auto';
 
-    fireEvent.touchStart(scroller, { touches: [{ clientX: 600, clientY: 200 }] });
-    fireEvent.touchEnd(scroller, { changedTouches: [{ clientX: 200, clientY: 205 }] });
-    expect(counter).toHaveTextContent(/^2 \//);
+    // The touch lands on a DESCENDANT of the scroller, which is what a finger
+    // does, so the ancestor walk is what has to refuse the gesture.
+    const inside = code!.firstElementChild ?? code!;
+    fireEvent.touchStart(inside, { touches: [{ clientX: 600, clientY: 200 }] });
+    fireEvent.touchEnd(inside, { changedTouches: [{ clientX: 200, clientY: 205 }] });
+    expect(counter).toHaveTextContent(before!);
 
     // …and the same drag on the stage itself still moves the deck.
     swipe(600, 200);
-    expect(counter).toHaveTextContent(/^3 \//);
+    expect(counter).not.toHaveTextContent(before!);
+  });
+
+  it('forgets a gesture the system cancels', async () => {
+    renderAt(`/d/${firstId}/present?slide=2`);
+    const counter = await findCounter();
+    const stage = screen.getByTestId('slide-stage');
+
+    fireEvent.touchStart(stage, { touches: [{ clientX: 600, clientY: 200 }] });
+    fireEvent.touchCancel(stage, { changedTouches: [{ clientX: 600, clientY: 200 }] });
+    fireEvent.touchEnd(stage, { changedTouches: [{ clientX: 200, clientY: 205 }] });
+
+    expect(counter).toHaveTextContent(/^2 \//);
   });
 
   it('ignores a two-finger gesture — a pinch is not a swipe', async () => {
@@ -412,7 +433,33 @@ describe('leaving the presentation from the deck', () => {
   it('offers a visible exit beside the fullscreen control', async () => {
     renderAt(`/d/${firstId}/present`);
     await findCounter();
-    expect(screen.getByRole('button', { name: /salir de la presentación/i })).toBeInTheDocument();
+
+    // Both halves of the name, asserted: that it is there, and that it sits
+    // after the fullscreen control — which is the tab order a reader meets.
+    const footer = document.querySelector('footer')!;
+    expect([...footer.querySelectorAll('button')].map((b) => b.getAttribute('aria-label'))).toEqual(
+      ['Pantalla completa', 'Salir de la presentación'],
+    );
+  });
+
+  it('does not ask to leave fullscreen when it was never entered', async () => {
+    // exitFullscreen() REJECTS outside fullscreen and the call is `void`ed, so
+    // an unguarded exit is an unhandled rejection on every ordinary way out
+    // (#103 review, measured in Chromium).
+    const exitFullscreen = vi.fn(() => Promise.resolve());
+    Object.defineProperty(document, 'exitFullscreen', {
+      configurable: true,
+      value: exitFullscreen,
+    });
+    try {
+      renderAt(`/d/${firstId}/present`);
+      await findCounter();
+      fireEvent.click(screen.getByRole('button', { name: /salir de la presentación/i }));
+      await screen.findByRole('article');
+      expect(exitFullscreen).not.toHaveBeenCalled();
+    } finally {
+      Reflect.deleteProperty(document, 'exitFullscreen');
+    }
   });
 
   it('lands on the book view from any slide, including a deep link', async () => {

--- a/apps/web/src/presentation/SlideDeck.tsx
+++ b/apps/web/src/presentation/SlideDeck.tsx
@@ -1,4 +1,5 @@
 import { AnimatePresence, motion } from 'framer-motion';
+import { X } from 'lucide-react';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode, TouchEvent } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
@@ -6,7 +7,7 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { mdxChildrenOf } from './mdxChildren';
 import { computeSlides } from './parser';
 import { fitScale } from './fit';
-import { swipeDirection } from './swipe';
+import { startsInsideScroller, swipeDirection } from './swipe';
 import type { Point } from './swipe';
 import { RotateNotice } from './RotateNotice';
 import { usePortraitPhone } from './usePortraitPhone';
@@ -68,6 +69,15 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
     [setSearchParams, slides.length],
   );
 
+  // The one way out, used by Escape and by the footer control. Absolute, not
+  // history.back(): a reader who opened /present from a link has nothing behind
+  // them (ADR-0023). Fullscreen goes with it, because the control that exits
+  // fullscreen lives in the deck being left.
+  const leave = useCallback(() => {
+    if (document.fullscreenElement) void document.exitFullscreen?.();
+    void navigate(`/d/${docId}`);
+  }, [docId, navigate]);
+
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
       // The panel replaces the deck's markup, not this window-level listener:
@@ -93,20 +103,24 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
           go(slides.length - 1);
           break;
         case 'Escape':
-          void navigate(`/d/${docId}`);
+          leave();
           break;
       }
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [docId, go, index, navigate, portraitPhone, slides.length]);
+  }, [go, index, leave, portraitPhone, slides.length]);
 
   // The gesture the phone has instead of arrow keys. A single finger only:
   // a second one means a pinch, and zooming is not navigating.
   const touchStart = useRef<Point | null>(null);
   const onTouchStart = (event: TouchEvent<HTMLDivElement>) => {
     const touch = event.touches.length === 1 ? event.touches[0] : undefined;
-    touchStart.current = touch ? { x: touch.clientX, y: touch.clientY } : null;
+    if (!touch || startsInsideScroller(event.target, event.currentTarget)) {
+      touchStart.current = null;
+      return;
+    }
+    touchStart.current = { x: touch.clientX, y: touch.clientY };
   };
   const onTouchEnd = (event: TouchEvent<HTMLDivElement>) => {
     const start = touchStart.current;
@@ -195,14 +209,26 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
         </AnimatePresence>
       </div>
       <footer className="flex items-center justify-between px-[max(1.5rem,env(safe-area-inset-left))] py-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] pr-[max(1.5rem,env(safe-area-inset-right))] text-sm text-slate-500">
-        <button
-          type="button"
-          aria-label="Pantalla completa"
-          onClick={toggleFullscreen}
-          className="rounded px-2 py-1 hover:bg-slate-800 hover:text-slate-200"
-        >
-          ⛶
-        </button>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            aria-label="Pantalla completa"
+            onClick={toggleFullscreen}
+            className="rounded px-2 py-1 hover:bg-slate-800 hover:text-slate-200"
+          >
+            ⛶
+          </button>
+          {/* Escape does this too, and says so nowhere on screen — which is the
+              whole reason this exists. A phone has no Escape at all. */}
+          <button
+            type="button"
+            aria-label="Salir de la presentación"
+            onClick={leave}
+            className="rounded px-2 py-1 hover:bg-slate-800 hover:text-slate-200"
+          >
+            <X size={16} aria-hidden="true" />
+          </button>
+        </div>
         <span>
           {index + 1} / {slides.length}
         </span>

--- a/apps/web/src/presentation/SlideDeck.tsx
+++ b/apps/web/src/presentation/SlideDeck.tsx
@@ -7,14 +7,22 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { mdxChildrenOf } from './mdxChildren';
 import { computeSlides } from './parser';
 import { fitScale } from './fit';
-import { startsInsideScroller, swipeDirection } from './swipe';
+import { startsInsideHorizontalScroller, swipeDirection } from './swipe';
 import type { Point } from './swipe';
 import { RotateNotice } from './RotateNotice';
 import { usePortraitPhone } from './usePortraitPhone';
 
+// Exiting is guarded everywhere it happens: exitFullscreen() REJECTS when
+// nothing is fullscreen, and `void` attaches no catch, so an unguarded call is
+// an unhandled rejection on every ordinary exit (measured in Chromium, #103
+// review). Three call sites had drifted into three spellings of this.
+function leaveFullscreen(): void {
+  if (document.fullscreenElement) void document.exitFullscreen?.();
+}
+
 function toggleFullscreen(): void {
   if (document.fullscreenElement) {
-    void document.exitFullscreen();
+    leaveFullscreen();
   } else {
     void document.documentElement.requestFullscreen?.();
   }
@@ -74,7 +82,7 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
   // them (ADR-0023). Fullscreen goes with it, because the control that exits
   // fullscreen lives in the deck being left.
   const leave = useCallback(() => {
-    if (document.fullscreenElement) void document.exitFullscreen?.();
+    leaveFullscreen();
     void navigate(`/d/${docId}`);
   }, [docId, navigate]);
 
@@ -116,11 +124,17 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
   const touchStart = useRef<Point | null>(null);
   const onTouchStart = (event: TouchEvent<HTMLDivElement>) => {
     const touch = event.touches.length === 1 ? event.touches[0] : undefined;
-    if (!touch || startsInsideScroller(event.target, event.currentTarget)) {
+    if (!touch || startsInsideHorizontalScroller(event.target, event.currentTarget)) {
       touchStart.current = null;
       return;
     }
     touchStart.current = { x: touch.clientX, y: touch.clientY };
+  };
+  // The system can take a gesture away mid-drag (a notification, an edge
+  // swipe). Without this the start point survived and the NEXT touchend acted
+  // on coordinates the reader never finished — pre-existing from #99.
+  const onTouchCancel = () => {
+    touchStart.current = null;
   };
   const onTouchEnd = (event: TouchEvent<HTMLDivElement>) => {
     const start = touchStart.current;
@@ -171,7 +185,7 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
   // button is the only control that exits it, so leaving it on would strand the
   // panel inside a fullscreen page with no way back out of it.
   useEffect(() => {
-    if (portraitPhone && document.fullscreenElement) void document.exitFullscreen?.();
+    if (portraitPhone) leaveFullscreen();
   }, [portraitPhone]);
 
   // Replaces the deck rather than covering it: no slide is painted, so nothing
@@ -186,6 +200,7 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
         data-testid="slide-stage"
         onTouchStart={onTouchStart}
         onTouchEnd={onTouchEnd}
+        onTouchCancel={onTouchCancel}
         className="flex flex-1 items-center justify-center overflow-hidden px-16"
       >
         <AnimatePresence mode="wait">
@@ -209,12 +224,12 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
         </AnimatePresence>
       </div>
       <footer className="flex items-center justify-between px-[max(1.5rem,env(safe-area-inset-left))] py-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] pr-[max(1.5rem,env(safe-area-inset-right))] text-sm text-slate-500">
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-2">
           <button
             type="button"
             aria-label="Pantalla completa"
             onClick={toggleFullscreen}
-            className="rounded px-2 py-1 hover:bg-slate-800 hover:text-slate-200"
+            className="rounded p-2 hover:bg-slate-800 hover:text-slate-200"
           >
             ⛶
           </button>
@@ -224,7 +239,7 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
             type="button"
             aria-label="Salir de la presentación"
             onClick={leave}
-            className="rounded px-2 py-1 hover:bg-slate-800 hover:text-slate-200"
+            className="rounded p-2 hover:bg-slate-800 hover:text-slate-200"
           >
             <X size={16} aria-hidden="true" />
           </button>

--- a/apps/web/src/presentation/swipe.test.ts
+++ b/apps/web/src/presentation/swipe.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { startsInsideScroller, swipeDirection } from './swipe';
+import { startsInsideHorizontalScroller, swipeDirection } from './swipe';
 
-// Pure geometry, so the suite CAN judge it — what jsdom cannot judge is whether
-// a finger on a real screen produces these numbers, which is the browser check.
+// Two halves of one question — is this touch the deck's? The geometry is pure
+// and the suite judges it outright; the eligibility walk reads the DOM, and the
+// suite can only judge WHICH nodes it visits, never what a browser would
+// report about them. Both halves get a browser check (testing-strategy.md).
 describe('swipeDirection', () => {
   it('reads a leftward drag as the next slide', () => {
     expect(swipeDirection({ x: 300, y: 200 }, { x: 200, y: 205 })).toBe('next');
@@ -37,13 +39,16 @@ describe('swipeDirection', () => {
   });
 });
 
-describe('startsInsideScroller', () => {
-  // jsdom lays nothing out, so scrollWidth/clientWidth are stated rather than
-  // measured; what is real here is the walk up the tree and where it stops.
-  function box(scrollWidth: number, clientWidth: number) {
+describe('startsInsideHorizontalScroller', () => {
+  // jsdom lays nothing out, so the geometry is stated; what is real here is the
+  // walk up the tree, where it stops, and which computed overflow it accepts.
+  // Which of those the BROWSER agrees with is the browser check — a scrollLeft
+  // round-trip, per testing-strategy.md.
+  function box(scrollWidth: number, clientWidth: number, overflowX = 'auto') {
     const element = document.createElement('div');
     Object.defineProperty(element, 'scrollWidth', { value: scrollWidth });
     Object.defineProperty(element, 'clientWidth', { value: clientWidth });
+    element.style.overflowX = overflowX;
     return element;
   }
 
@@ -53,37 +58,70 @@ describe('startsInsideScroller', () => {
     const line = box(0, 0);
     stage.append(code);
     code.append(line);
+    document.body.append(stage);
 
-    expect(startsInsideScroller(line, stage)).toBe(true);
+    expect(startsInsideHorizontalScroller(line, stage)).toBe(true);
   });
 
-  it('allows a touch on a box that merely happens to be wide', () => {
+  it('keeps the swipe over content that overflows a box nobody can scroll', () => {
+    // The distinction the browser makes and the numbers do not: a wrapper with
+    // `overflow-x: visible` reports scrollWidth > clientWidth and refuses to
+    // scroll. Trusting the numbers alone would kill the swipe across any slide
+    // holding a wide svg or canvas (#103 review, measured in Chromium).
     const stage = box(800, 800);
-    const slide = box(800, 800);
-    stage.append(slide);
+    const wrapper = box(1000, 716, 'visible');
+    stage.append(wrapper);
+    document.body.append(stage);
 
-    expect(startsInsideScroller(slide, stage)).toBe(false);
+    expect(startsInsideHorizontalScroller(wrapper, stage)).toBe(false);
+  });
+
+  it('keeps the swipe over a box that clips without panning', () => {
+    // `overflow-x: hidden` clips; it does not scroll. Measured the same way.
+    const stage = box(800, 800);
+    const clipped = box(1000, 800, 'hidden');
+    stage.append(clipped);
+    document.body.append(stage);
+
+    expect(startsInsideHorizontalScroller(clipped, stage)).toBe(false);
+  });
+
+  it('lets a box that scrolls only up and down keep the swipe', () => {
+    // The shape under the reader's thumb most often: an editor or an exercise
+    // panel, tall and scrollable vertically. The gesture is horizontal, so it
+    // is the deck's.
+    const stage = box(800, 800);
+    const tall = document.createElement('div');
+    Object.defineProperty(tall, 'scrollWidth', { value: 800 });
+    Object.defineProperty(tall, 'clientWidth', { value: 800 });
+    Object.defineProperty(tall, 'scrollHeight', { value: 2000 });
+    Object.defineProperty(tall, 'clientHeight', { value: 300 });
+    tall.style.overflowY = 'auto';
+    stage.append(tall);
+    document.body.append(stage);
+
+    expect(startsInsideHorizontalScroller(tall, stage)).toBe(false);
   });
 
   it("stops at the stage, whose own overflow is the deck's business", () => {
-    // The stage clips its slide by design (overflow-hidden); if the walk counted
-    // it, every swipe on the deck would be refused.
     const stage = box(2000, 800);
     const slide = box(800, 800);
     stage.append(slide);
+    document.body.append(stage);
 
-    expect(startsInsideScroller(slide, stage)).toBe(false);
+    expect(startsInsideHorizontalScroller(slide, stage)).toBe(false);
   });
 
   it('ignores a target that is not an element', () => {
-    expect(startsInsideScroller(null, box(800, 800))).toBe(false);
+    expect(startsInsideHorizontalScroller(null, box(800, 800))).toBe(false);
   });
 
   it('tolerates the sub-pixel rounding a browser reports on boxes that do not scroll', () => {
     const stage = box(800, 800);
     const rounded = box(801, 800);
     stage.append(rounded);
+    document.body.append(stage);
 
-    expect(startsInsideScroller(rounded, stage)).toBe(false);
+    expect(startsInsideHorizontalScroller(rounded, stage)).toBe(false);
   });
 });

--- a/apps/web/src/presentation/swipe.test.ts
+++ b/apps/web/src/presentation/swipe.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { swipeDirection } from './swipe';
+import { startsInsideScroller, swipeDirection } from './swipe';
 
 // Pure geometry, so the suite CAN judge it — what jsdom cannot judge is whether
 // a finger on a real screen produces these numbers, which is the browser check.
@@ -34,5 +34,56 @@ describe('swipeDirection', () => {
     // 120px across and 100px down is a smudge, not a decision: acting on it is
     // how a reader loses their place while trying to do something else.
     expect(swipeDirection({ x: 300, y: 200 }, { x: 180, y: 300 })).toBeNull();
+  });
+});
+
+describe('startsInsideScroller', () => {
+  // jsdom lays nothing out, so scrollWidth/clientWidth are stated rather than
+  // measured; what is real here is the walk up the tree and where it stops.
+  function box(scrollWidth: number, clientWidth: number) {
+    const element = document.createElement('div');
+    Object.defineProperty(element, 'scrollWidth', { value: scrollWidth });
+    Object.defineProperty(element, 'clientWidth', { value: clientWidth });
+    return element;
+  }
+
+  it('refuses a touch that starts inside a sideways-scrolling box', () => {
+    const stage = box(800, 800);
+    const code = box(900, 800);
+    const line = box(0, 0);
+    stage.append(code);
+    code.append(line);
+
+    expect(startsInsideScroller(line, stage)).toBe(true);
+  });
+
+  it('allows a touch on a box that merely happens to be wide', () => {
+    const stage = box(800, 800);
+    const slide = box(800, 800);
+    stage.append(slide);
+
+    expect(startsInsideScroller(slide, stage)).toBe(false);
+  });
+
+  it("stops at the stage, whose own overflow is the deck's business", () => {
+    // The stage clips its slide by design (overflow-hidden); if the walk counted
+    // it, every swipe on the deck would be refused.
+    const stage = box(2000, 800);
+    const slide = box(800, 800);
+    stage.append(slide);
+
+    expect(startsInsideScroller(slide, stage)).toBe(false);
+  });
+
+  it('ignores a target that is not an element', () => {
+    expect(startsInsideScroller(null, box(800, 800))).toBe(false);
+  });
+
+  it('tolerates the sub-pixel rounding a browser reports on boxes that do not scroll', () => {
+    const stage = box(800, 800);
+    const rounded = box(801, 800);
+    stage.append(rounded);
+
+    expect(startsInsideScroller(rounded, stage)).toBe(false);
   });
 });

--- a/apps/web/src/presentation/swipe.ts
+++ b/apps/web/src/presentation/swipe.ts
@@ -19,19 +19,36 @@ const MIN_DISTANCE = 50;
 const HORIZONTAL_DOMINANCE = 1.5;
 
 /**
- * Whether the touch landed on something that scrolls sideways on its own, up to
+ * Whether the touch landed on something that really scrolls sideways, up to
  * (and excluding) the stage. A code block wider than the slide is the case that
  * matters: on a phone the reader drags inside it to read the rest of the line,
  * and the deck used to take that drag and change the slide instead (#103,
  * measured on `/d/java-desde-cpp/present?slide=3` with 73px of Java hidden).
  * The reader gets the scroll; the deck keeps every other swipe.
  */
-export function startsInsideScroller(target: EventTarget | null, stage: Element): boolean {
+export function startsInsideHorizontalScroller(
+  target: EventTarget | null,
+  stage: Element,
+): boolean {
   let node = target instanceof Element ? target : null;
   while (node && node !== stage) {
-    // +1 absorbs sub-pixel rounding, which reports a 0.5px "overflow" on boxes
-    // that do not scroll at all.
-    if (node.scrollWidth > node.clientWidth + 1) return true;
+    // Overflowing content is not the same as a scrollable box: a wrapper with
+    // `overflow-x: visible` reports scrollWidth > clientWidth and cannot be
+    // scrolled at all (measured in Chromium — scrollLeft stays 0 through both
+    // an assignment and a real touch drag). Asking only about the numbers made
+    // any slide containing a wide element — an svg, a canvas, a flex row, i.e.
+    // what v0.2's visualisations produce — refuse the swipe across its whole
+    // width. `hidden` is excluded on the same evidence: it clips, it does not
+    // pan (#103 review).
+    const overflowX = getComputedStyle(node).overflowX;
+    if (
+      (overflowX === 'auto' || overflowX === 'scroll') &&
+      // +1 absorbs sub-pixel rounding, which reports a 0.5px "overflow" on
+      // boxes that do not scroll at all.
+      node.scrollWidth > node.clientWidth + 1
+    ) {
+      return true;
+    }
     node = node.parentElement;
   }
   return false;

--- a/apps/web/src/presentation/swipe.ts
+++ b/apps/web/src/presentation/swipe.ts
@@ -38,8 +38,10 @@ export function startsInsideHorizontalScroller(
     // an assignment and a real touch drag). Asking only about the numbers made
     // any slide containing a wide element — an svg, a canvas, a flex row, i.e.
     // what v0.2's visualisations produce — refuse the swipe across its whole
-    // width. `hidden` is excluded on the same evidence: it clips, it does not
-    // pan (#103 review).
+    // width. `hidden` is excluded on the DRAG half of that evidence only: it
+    // does accept a scrollLeft assignment (measured: 30), so a round trip calls
+    // it scrollable, while a real touch drag moves it 0px. It clips; it does
+    // not pan — which is why this asks the computed value, not the numbers.
     const overflowX = getComputedStyle(node).overflowX;
     if (
       (overflowX === 'auto' || overflowX === 'scroll') &&

--- a/apps/web/src/presentation/swipe.ts
+++ b/apps/web/src/presentation/swipe.ts
@@ -19,6 +19,25 @@ const MIN_DISTANCE = 50;
 const HORIZONTAL_DOMINANCE = 1.5;
 
 /**
+ * Whether the touch landed on something that scrolls sideways on its own, up to
+ * (and excluding) the stage. A code block wider than the slide is the case that
+ * matters: on a phone the reader drags inside it to read the rest of the line,
+ * and the deck used to take that drag and change the slide instead (#103,
+ * measured on `/d/java-desde-cpp/present?slide=3` with 73px of Java hidden).
+ * The reader gets the scroll; the deck keeps every other swipe.
+ */
+export function startsInsideScroller(target: EventTarget | null, stage: Element): boolean {
+  let node = target instanceof Element ? target : null;
+  while (node && node !== stage) {
+    // +1 absorbs sub-pixel rounding, which reports a 0.5px "overflow" on boxes
+    // that do not scroll at all.
+    if (node.scrollWidth > node.clientWidth + 1) return true;
+    node = node.parentElement;
+  }
+  return false;
+}
+
+/**
  * Which way a touch drag points, or null when it is not a slide gesture at all.
  * Pure on purpose: this is the half of the interaction the suite can judge.
  */

--- a/docs/decisions/0013-presentation-pipeline.md
+++ b/docs/decisions/0013-presentation-pipeline.md
@@ -59,7 +59,22 @@ can drive it.
    sessions: sync-follow = driving route + query from `location` events;
    detaching = navigating freely. Viewer chrome is POC-style (fixed overlay,
    keyboard `p`/`←`/`→`/`Space`/`Home`/`End`/`Esc`, fullscreen via
-   `requestFullscreen`, minimal framer-motion fade).
+   `requestFullscreen`, minimal framer-motion fade); the footer carries the
+   slide counter, the fullscreen toggle and — since #103 — a visible exit
+   control (§5.3).
+
+   **5.3 The deck always paints a visible way out** (#103), on every device and
+   not only under a coarse pointer: `Escape` announces itself nowhere and a
+   phone has no `Escape` at all, so for two WPs the rotate panel had an exit and
+   the deck, where the reader actually is, did not. That control and `Escape`
+   are one `leave()`, which navigates to the absolute route `/d/<id>` (the
+   reasoning is ADR-0023's: a reader who deep-linked has nothing behind them)
+   and drops fullscreen on the way, because the control that entered fullscreen
+   goes with the deck. Every fullscreen exit in the viewer — this one, `Escape`,
+   the `⛶` toggle and the portrait rule — goes through one `leaveFullscreen()`;
+   `document.exitFullscreen()` REJECTS when nothing is fullscreen, so three
+   drifted spellings of that guard were one unhandled rejection away from each
+   other.
 
    **5.1 A slide is fit, not reflowed** (#99). It is laid out at its design
    size and uniformly scaled down (`presentation/fit.ts`, capped at 1 so a big

--- a/docs/decisions/0013-presentation-pipeline.md
+++ b/docs/decisions/0013-presentation-pipeline.md
@@ -77,6 +77,10 @@ can drive it.
    single source of truth. Unlike a key, the swipe needs no portrait gate: it
    hangs off the slide stage, which the rotate panel replaces rather than
    covers. A new input author should know which of those two shapes theirs is.
+   **A gesture that starts inside a descendant which scrolls sideways is not
+   the deck's** (#103): a code block wider than the slide is dragged to be
+   read, and taking that drag as navigation makes a long line unreadable on the
+   device the gesture exists for.
 
    **Constrained by ADR-0023** (#91): on a coarse pointer in portrait the deck
    is replaced by a rotate panel — a second case where `/present` paints no

--- a/docs/decisions/0023-presentation-requires-landscape-on-a-phone.md
+++ b/docs/decisions/0023-presentation-requires-landscape-on-a-phone.md
@@ -4,7 +4,10 @@
 **Date:** 2026-08-13
 **Decision-makers:** Miguel Rodriguez
 **Covers:** why the deck refuses portrait on a touch device · why the pointer
-half of the query is load-bearing · what the panel must offer as a way out
+half of the query is load-bearing · what the panel must offer as a way out ·
+and, accumulated through #99 and #103, the phone-side consequences of that
+rule: the browser baseline, the viewport measures and what a real mobile
+browser does with its chrome. Deck-wide decisions live in ADR-0013 §5.
 **Source:** Issue #91 (require landscape for presentation mode on a phone),
 found verifying #90. Constrains ADR-0013 (presentation pipeline) §2 and §5.
 
@@ -51,10 +54,9 @@ Three things this fixes in place:
   React mechanic; it lives in the code comment that guards it.)
 - **The way out is an absolute route** (`/d/<id>`), not `history.back()`: a
   reader who opened `/d/<id>/present` from a message or a bookmark has nothing
-  behind them to go back to. Extended by #103: the deck carries the same way out
-  as a visible control, because `Escape` announces itself nowhere and a phone
-  has no `Escape` — the panel had an exit and the deck, where the reader
-  actually is, did not.
+  behind them to go back to. The deck carries the same way out as a visible
+  control since #103; that decision is deck-wide, so it lives with the viewer's
+  chrome in ADR-0013 §5.3.
 
 ## Alternatives considered
 
@@ -74,6 +76,14 @@ Three things this fixes in place:
 - **A "view it anyway" escape** — the way out is out (the book view), not
   through. Two ways of reading the same document on a phone is the confusion the
   book view exists to prevent.
+- **Hiding the browser chrome by requesting fullscreen on entering `/present`**
+  (considered #103, once a device showed the chrome is not hidden by `dvh` +
+  `viewport-fit=cover`). Rejected for the reasons already above: on iOS no
+  browser has the Fullscreen API for a web page at all, so it cannot work on
+  the device that raised the question, and taking the decision away from the
+  reader was already rejected for the automatic case. Note this rejects
+  fullscreen as an AUTOMATIC answer, not the API: the `⛶` control uses
+  `requestFullscreen` deliberately, where the platform has it.
 - **Doing nothing and documenting it** — the failure is silent, and silence is
   what the WP was opened to fix.
 
@@ -111,12 +121,13 @@ Three things this fixes in place:
   rule is deliberately unconditional today — follower mode does not exist yet —
   and whether it should stay that way is a question for whoever implements
   ADR-0008 in v0.3, not one this ADR answers.
-- **Fullscreen is left when the rule takes over.** The `⛶` button is the only
-  control that exits fullscreen and it lives in the deck being removed, so the
-  panel would otherwise sit inside a fullscreen page with no way back. Verified
-  in Chromium: enter fullscreen in landscape, rotate, `document.fullscreenElement`
-  is null and the panel is up. This does not touch the button itself, which the
-  WP put out of scope.
+- **Fullscreen is left when the rule takes over.** Written when the `⛶` button
+  was the only control that exits fullscreen, which #103 made false: `Escape`
+  and the deck's exit control leave it too, all three paths through one
+  `leaveFullscreen()`. The rule stands and is now one instance of a wider one —
+  no path leaves the deck holding a fullscreen page the reader cannot get out
+  of. Verified in Chromium: enter fullscreen in landscape, rotate,
+  `document.fullscreenElement` is null and the panel is up.
 - **The deck asks for the viewport the browser actually gives, not the one it
   claims (#99).** `fixed inset-0` resolves against the *large* viewport, the one
   a mobile browser overlays with its own chrome, so the deck was drawing under
@@ -126,14 +137,17 @@ Three things this fixes in place:
   stripe of a different colour. Measured 2026-08-13 in Chromium with an iPhone 13
   context: the deck's box is exactly `innerHeight` at 844x390, 390x844 and
   1440x900, with nothing scrollable behind it.
-  **Answered on a device, 2026-08-13: it does not hide the bar.** Brave on a
-  phone keeps its chrome over the deck with `dvh` and `viewport-fit=cover` in
-  place. The measures are still right — they stop the deck from being *clipped*
-  by the chrome, which was the actual bug — but they do not remove it, and
-  nothing short of the Fullscreen API can. That API is rejected above and the
-  reasons have not changed, so **this is the end state, not an open question**:
-  on a phone the deck shares the screen with the browser's bar. A reader who
-  wants the whole screen has the `⛶` control, where the platform supports it.
+  **Answered on a device, 2026-08-13: it does not hide the bar.** Brave on an
+  **iPhone** (iOS, therefore WebKit whatever the browser's name) keeps its
+  chrome over the deck with `dvh` and `viewport-fit=cover` in place. The
+  measures are still right — they stop the deck from being *clipped* by the
+  chrome, which was the actual bug — but they do not remove it.
+  **This is the end state, not an open question**, and on iOS it is
+  unconditional: no browser there has the Fullscreen API for a web page (see
+  Alternatives), so the `⛶` control cannot help either and the bar is
+  permanent. The case that may differ, and is NOT measured: Android, where
+  `requestFullscreen` exists, so a reader who taps `⛶` should get the screen —
+  observed nowhere yet, so nobody should assume it.
   What headless Chromium can and cannot say about this is itself the lesson —
   it has no bar to hide, so it reported success on a question it could not see
   (`testing-strategy.md` §the browser recipe).

--- a/docs/decisions/0023-presentation-requires-landscape-on-a-phone.md
+++ b/docs/decisions/0023-presentation-requires-landscape-on-a-phone.md
@@ -51,7 +51,10 @@ Three things this fixes in place:
   React mechanic; it lives in the code comment that guards it.)
 - **The way out is an absolute route** (`/d/<id>`), not `history.back()`: a
   reader who opened `/d/<id>/present` from a message or a bookmark has nothing
-  behind them to go back to.
+  behind them to go back to. Extended by #103: the deck carries the same way out
+  as a visible control, because `Escape` announces itself nowhere and a phone
+  has no `Escape` — the panel had an exit and the deck, where the reader
+  actually is, did not.
 
 ## Alternatives considered
 
@@ -123,11 +126,17 @@ Three things this fixes in place:
   stripe of a different colour. Measured 2026-08-13 in Chromium with an iPhone 13
   context: the deck's box is exactly `innerHeight` at 844x390, 390x844 and
   1440x900, with nothing scrollable behind it.
-  **What emulation cannot answer**: whether a given mobile browser hides its
-  chrome, keeps it, or changes on rotation. Headless Chromium has no URL bar, so
-  that is a real-device observation and belongs here as one, with the browser and
-  the date. Fullscreen remains rejected as the answer for the reasons above — this
-  is what can be done without it.
+  **Answered on a device, 2026-08-13: it does not hide the bar.** Brave on a
+  phone keeps its chrome over the deck with `dvh` and `viewport-fit=cover` in
+  place. The measures are still right — they stop the deck from being *clipped*
+  by the chrome, which was the actual bug — but they do not remove it, and
+  nothing short of the Fullscreen API can. That API is rejected above and the
+  reasons have not changed, so **this is the end state, not an open question**:
+  on a phone the deck shares the screen with the browser's bar. A reader who
+  wants the whole screen has the `⛶` control, where the platform supports it.
+  What headless Chromium can and cannot say about this is itself the lesson —
+  it has no bar to hide, so it reported success on a question it could not see
+  (`testing-strategy.md` §the browser recipe).
 - The reader's position survives rotation for free: it lives in `?slide=N`, not
   in the component.
 - **jsdom implements no `matchMedia` at all**, so the suite can pin which

--- a/docs/standards/frontend-code-style.md
+++ b/docs/standards/frontend-code-style.md
@@ -229,10 +229,17 @@ src/
   icon-only control inside a component's own dense chrome (`CodeEditor`'s
   expand). 16px for an icon-only control on the PAGE chrome, where the button is
   a touch target rather than part of a text row — the drawer toggle and its
-  close button (#84) and the deck's exit control (#103). Give each of them a
-  `p-2` box and `gap-2` from its neighbour: at `px-2 py-1` the deck's exit was
-  32x24 with 4px of clearance from a control that does the opposite thing, and
-  a mis-tap took the reader deeper in instead of out. 48px when the icon is the illustration of
+  close button (#84) and the deck's exit control (#103). **The floor is 24x24
+  CSS px with at least 8px of clearance** (WCAG 2.2 §2.5.8, level AA); `p-2`
+  around a 16px icon gives 32x32 and is the shape to copy. 44x44 — the
+  Apple/Material figure and WCAG's AAA target — was considered and rejected for
+  deck chrome, which would then dominate a 342px-tall landscape stage. Measured
+  case that forced the floor (#103): at `px-2 py-1` the deck's exit was 32x24
+  with 4px of clearance from a control that does the opposite thing, so a
+  mis-tap took the reader deeper in instead of out. Known debt, deliberately not
+  fixed here: the drawer toggle ships at `p-1.5` (28x28) and its close button at
+  `p-1` (24x24) — above the floor, below the shape — and neither carries
+  `gap-2`; bring them up when that chrome is next touched. 48px when the icon is the illustration of
   a full-screen panel rather than a control — it carries the message at a
   glance, is `aria-hidden` because the text beside it says the same thing, and
   is not clickable (worked case: `presentation/RotateNotice.tsx`, #91). Adding a
@@ -264,6 +271,24 @@ src/
   whole surface. Worked case: `presentation/swipe.ts` + `SlideDeck` (#103) —
   a code block wider than the slide is dragged to be read, and the deck used to
   take that drag as navigation, which made a long line unreadable on a phone.
+  A handler that stores a start point clears it on `touchcancel` too, or the
+  next `touchend` acts on a drag the reader never finished (#99 shipped that,
+  #103 fixed it). A second gesture on another axis parameterises
+  `startsInsideHorizontalScroller` rather than copying it: the vertical form
+  reads `overflowY` and `scrollHeight > clientHeight + 1`.
+- **Leaving fullscreen is guarded, and each surface has one way to do it.**
+  `document.exitFullscreen()` REJECTS when nothing is fullscreen and `void`
+  attaches no catch, so an unguarded call is an unhandled rejection on every
+  ordinary exit. Always `if (document.fullscreenElement) void
+  document.exitFullscreen?.()`, behind one named helper that the surface's other
+  exits call. Worked case: `presentation/SlideDeck.tsx`'s `leaveFullscreen()`
+  (#103), where three call sites had drifted into three spellings.
+- **A surface that replaces the viewport carries a visible way out.** A keyboard
+  escape announces itself nowhere and a phone has no `Escape` key, so a
+  full-viewport surface needs an on-screen exit, sized per §Icons, navigating to
+  an ABSOLUTE route rather than `history.back()`. Worked case: the deck's footer
+  exit (#103) — the `⛶` toggle alone left it with no announced way out for two
+  WPs.
 - **Layout breakpoints stay in Tailwind classes; a media query is only asked
   from JS when device shape decides BEHAVIOUR** — what gets rendered at all,
   not how wide it is. It belongs in a hook colocated in the feature that owns

--- a/docs/standards/frontend-code-style.md
+++ b/docs/standards/frontend-code-style.md
@@ -229,7 +229,10 @@ src/
   icon-only control inside a component's own dense chrome (`CodeEditor`'s
   expand). 16px for an icon-only control on the PAGE chrome, where the button is
   a touch target rather than part of a text row — the drawer toggle and its
-  close button (#84) are the only two. 48px when the icon is the illustration of
+  close button (#84) and the deck's exit control (#103). Give each of them a
+  `p-2` box and `gap-2` from its neighbour: at `px-2 py-1` the deck's exit was
+  32x24 with 4px of clearance from a control that does the opposite thing, and
+  a mis-tap took the reader deeper in instead of out. 48px when the icon is the illustration of
   a full-screen panel rather than a control — it carries the message at a
   glance, is `aria-hidden` because the text beside it says the same thing, and
   is not clickable (worked case: `presentation/RotateNotice.tsx`, #91). Adding a
@@ -250,6 +253,17 @@ src/
   `presentation/usePortraitPhone.ts` (#91), where the hand-rolled version
   shipped in the first slice and was replaced in review, once the review
   measured that no permitted test could kill its re-read.
+- **A container-level gesture yields to descendants that scroll on its axis.**
+  Decide eligibility at `touchstart` by walking from `event.target` to
+  `event.currentTarget`, and refuse when a node in between really scrolls on
+  the gesture's axis — `getComputedStyle(node).overflowX` of `auto` or
+  `scroll`, AND `scrollWidth > clientWidth + 1` for the sub-pixel rounding a
+  browser reports on boxes that do not scroll at all. Overflowing content is
+  not a scrollable box: `visible` overflows and cannot pan, `hidden` clips and
+  cannot pan, and treating either as a scroller kills the gesture across the
+  whole surface. Worked case: `presentation/swipe.ts` + `SlideDeck` (#103) —
+  a code block wider than the slide is dragged to be read, and the deck used to
+  take that drag as navigation, which made a long line unreadable on a phone.
 - **Layout breakpoints stay in Tailwind classes; a media query is only asked
   from JS when device shape decides BEHAVIOUR** — what gets rendered at all,
   not how wide it is. It belongs in a hook colocated in the feature that owns

--- a/docs/standards/frontend-code-style.md
+++ b/docs/standards/frontend-code-style.md
@@ -264,8 +264,9 @@ src/
   Decide eligibility at `touchstart` by walking from `event.target` to
   `event.currentTarget`, and refuse when a node in between really scrolls on
   the gesture's axis — `getComputedStyle(node).overflowX` of `auto` or
-  `scroll`, AND `scrollWidth > clientWidth + 1` for the sub-pixel rounding a
-  browser reports on boxes that do not scroll at all. Overflowing content is
+  `scroll`, AND `scrollWidth > clientWidth + 1` — these are integer
+  pixels, so a sub-pixel overflow surfaces as a 1px difference, and a scroll of
+  under a pixel is not a reader panning. Overflowing content is
   not a scrollable box: `visible` overflows and cannot pan, `hidden` clips and
   cannot pan, and treating either as a scroller kills the gesture across the
   whole surface. Worked case: `presentation/swipe.ts` + `SlideDeck` (#103) —

--- a/docs/standards/guides/add-a-content-component.md
+++ b/docs/standards/guides/add-a-content-component.md
@@ -66,6 +66,16 @@ apps/web/src/components/structure/
      itself **`.not-prose`** (a block, not text — `CodeEditor`, `Exercise`,
      `SideBySide`, `AuthoringError` all do) or **`.measure-full`** (neither
      block nor text: the table scroll box, the prev/next row, `<SectionBreak/>`).
+     **Anything the reader drags sideways must be a REAL scroller.** In
+     presentation the deck owns the horizontal swipe and yields only to a
+     descendant whose computed `overflow-x` is `auto` or `scroll` AND that
+     actually overflows (`presentation/swipe.ts`, ADR-0013 §5.2). A component
+     that pans by transform, by canvas pointer handling, or inside an
+     `overflow-x: visible` wrapper will have that drag taken as a slide change
+     on a phone; conversely a full-bleed scrollable component leaves the reader
+     no swipe target on that slide. Give it `overflow-x-auto`, and check it on
+     a touch context.
+
      **A component that renders anything wide MUST carry one of the two**, or it
      is silently centred at 624px in documents. The rule is unlayered, so a
      `max-w-*` of your own cannot override it. It will look correct everywhere

--- a/docs/standards/guides/add-a-course-document.md
+++ b/docs/standards/guides/add-a-course-document.md
@@ -233,7 +233,11 @@ themselves rather than maintained by hand.
    `/nalanda/d/<id>`) and run every exercise you added: no amber authoring
    banner, the cases pass against a correct solution, and they fail against the
    starter. If a `<SideBySide>` or a `<Slide>` is involved, look at it in
-   presentation mode too — `/d/<id>/present`. **Slides are checked in
+   presentation mode too — `/d/<id>/present`. A listing wider than the slide is
+   **panned with a one-finger drag inside it** on a touch device, and that drag
+   no longer advances the deck (#103, ADR-0013 §5.2) — so its tail is reachable,
+   but only from inside the listing; a swipe anywhere else still changes slide.
+   Worth dragging one in landscape when you check. **Slides are checked in
    landscape**: on a phone or tablet held upright the viewer deliberately shows
    a "Gira el teléfono" panel instead of the deck (ADR-0023), so an empty
    presentation there is the platform working, not a fault in your document.

--- a/docs/standards/testing-strategy.md
+++ b/docs/standards/testing-strategy.md
@@ -200,6 +200,17 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   reader actually takes — rotating into it left the slide at scale 1 overflowing
   its stage 3:1, and pressing an arrow key measured the outgoing slide. One run
   that pressed ArrowRight instead of reloading showed it immediately.
+- **A guard whose predicate is a DOM measurement is verified against the
+  property it claims to measure, not against itself.** The suite can pin which
+  nodes a walk visits; only a browser can say whether those nodes behave the
+  way the predicate assumes. The recipe is a round trip: set `el.scrollLeft =
+  30`, read it back, restore it — a box that reports overflow but returns 0 was
+  never scrollable. Worked case (#103): `scrollWidth > clientWidth` was true
+  for an `overflow-x: visible` wrapper that neither an assignment nor a real
+  touch drag could move, and the jsdom fakes had pinned that false positive as
+  the intended contract. The same run over every slide of every document is
+  what sized the finding — the predicate was wrong and today's content happened
+  not to trigger it.
 - **A measure-and-observe effect is keyed on the identity of the node it
   measures**, never on a scalar that merely correlates with it (an index, a
   length). And this class IS reachable from jsdom, which is what makes it worth

--- a/docs/standards/testing-strategy.md
+++ b/docs/standards/testing-strategy.md
@@ -203,9 +203,13 @@ battery (full tests + integration L6), same rigor as `apps/web`.
 - **A guard whose predicate is a DOM measurement is verified against the
   property it claims to measure, not against itself.** The suite can pin which
   nodes a walk visits; only a browser can say whether those nodes behave the
-  way the predicate assumes. The recipe is a round trip: set `el.scrollLeft =
-  30`, read it back, restore it — a box that reports overflow but returns 0 was
-  never scrollable. Worked case (#103): `scrollWidth > clientWidth` was true
+  way the predicate assumes. The recipe has two legs, and each proves a different
+  thing: set `el.scrollLeft = 30` and read it back, AND drive a real touch drag.
+  A box that returns 0 to both was never scrollable (`overflow-x: visible`); a
+  box that moves under the assignment but not under the drag clips without
+  panning (`overflow-x: hidden` — measured at 30 and 0). Running only the first
+  leg calls `hidden` scrollable, which is how a predicate about what a READER
+  can drag ends up trusting a number instead of the computed `overflow-x`. Worked case (#103): `scrollWidth > clientWidth` was true
   for an `overflow-x: visible` wrapper that neither an assignment nor a real
   touch drag could move, and the jsdom fakes had pinned that false positive as
   the intended contract. The same run over every slide of every document is
@@ -233,6 +237,12 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   value instead of by identity — both survived a full revert with **449/449
   green**, so the suite would have carried the defect back in silently. The
   cost is one command per fix.
+- **Headless Chromium has no browser chrome.** Any question about the browser's
+  own bar — does it hide on scroll, does it overlay the page — is unanswerable
+  there and comes back a false success; it is a real-device observation,
+  recorded with the browser, the OS and the date. Worked case (#103): `dvh` +
+  `viewport-fit=cover` measured clean in emulation, and the bar was still over
+  the deck on an iPhone (ADR-0023).
 - **The browser recipe lives here, not in a runtime guide.** Two failure classes
   now share it. Install once (`npm install playwright && npx playwright install
   chromium`, in a scratch directory — it is not a repo dependency; `grep


### PR DESCRIPTION
**Closes #103**

## Summary

Two things you found on the phone, plus one I found while fixing them.

- **The deck had no visible way out.** `Escape` works on a laptop and announces
  itself nowhere; a phone has no `Escape` at all, so once inside the deck the
  only exit was the browser's own gesture. There is now a `✕` beside the
  fullscreen control, on every device — a mouse user had no visible exit either.
- **The browser chrome question is answered and closed.** Brave on a phone does
  not hide its bar with `dvh` + `viewport-fit=cover`. Those measures still earn
  their place (they stopped the deck from being *clipped* by the chrome, which
  was the real bug), but the bar stays and only the Fullscreen API could remove
  it — rejected in ADR-0023 for reasons that have not changed. Recorded as an
  end state, not an open question.
- **Found while verifying: a wide code block could not be read.** Slide 3 of
  `java-desde-cpp` hides 73px of Java to the right, and dragging inside the
  block to read it changed the slide instead (`?slide=3` → `4`). The swipe from
  #99 hangs off the stage, so a drag starting in a scrollable descendant
  bubbled up to it. That is my defect from the previous PR, fixed here.

## Slices completed

- [x] S1 — give the deck a visible way out (`300cedd`)
- [x] S2 — record what a real mobile browser does with its chrome (`5fafd7e`)

`300cedd` also carries the code-block fix: I staged both changes together and
amended the message to say so rather than inventing a split after the fact.

## Acceptance criteria

1. **Exit control in the footer, every device** — `SlideDeck`, beside `⛶`.
   Browser: visible at 844x390 on an iPhone 13 profile (screenshot looked at).
2. **Lands on the book view from any slide, incl. a deep link** — test with
   `?slide=3`; browser: click → `/nalanda/d/java-desde-cpp`, `<article>` present.
3. **Keyboard reachable, Spanish accessible name** — browser tab order:
   `["Pantalla completa", "Salir de la presentación", …]`.
4. **`Escape`, `p`, arrows and `⛶` unchanged** — 552 tests green, and `Escape`
   now shares the same `leave()` as the button.
5. **Leaving also leaves fullscreen** — test (mutation-checked); browser:
   entered fullscreen at 1440x900, clicked exit, `fullscreenElement` null.
6. **Not reachable behind the rotate panel** — test asserting its absence while
   the panel is up; #91's AC1 still holds.
7. **Visible and tappable clear of the notch** — footer keeps #99's safe-area
   padding; measured box `32×24` at the left edge, clear of the inset.
8. **1440x900 unchanged in character** — counter in its corner, the two controls
   grouped left (screenshot).
9. **ADR-0023 closes the chrome question** with browser, device and date.
10. **Protocols green** — format ✓ lint ✓ 552/552 ✓ build ✓; browser checks at
    844x390 and 1440x900.

## Tests

552 green (was 546). New: three exit cases and one code-block case in
`presentationRoute.test.tsx`, five `startsInsideScroller` cases in
`swipe.test.ts`.

Mutations run: dropping `exitFullscreen` fails the fullscreen case; renaming the
accessible name fails all three exit cases; **removing the scroll guard from
`onTouchStart` fails the route case while every helper test stays green** —
which is the point, since the helper-tested-but-wiring-untested gap is exactly
what the previous review round caught.

## Reviews run

**Full pipeline, both rounds** — run after this PR was opened, because the
first version of this section said "none beyond the mechanical gate" and Miguel
called that out: skipping the process is not a scope decision. What it found is
the argument for it.

- **Round A** — correctness+tests, architecture+simplicity, security, then the
  adversarial verifier over the important ones. 3 important, 8 suggestions,
  2 patterns, 0 critical, 0 security. The headline: **the regression test for
  this WP's own code-block fix touched no code block** — the fixture slide has
  no `<pre>`, so the faked geometry landed on the slide wrapper, the one element
  that in a browser has `overflow: visible` and cannot scroll, and it pinned a
  false positive as the contract. The predicate itself asked
  `scrollWidth > clientWidth`, true of any overflowing box: a wide svg or canvas
  — what v0.2's visualisations produce — would have killed the swipe across a
  whole slide, silently. The verifier corrected my fix twice: `hidden` does not
  belong in the allowed list (it clips without panning), and the
  `stage.contains()` guard I was about to add is dead code that would make a
  portal touch navigate instead of being ignored.
- **Round B** — docs completeness, accuracy, ADR hunter, agent readability.
  1 critical, 12 important, 8 suggestions. ADR-0023 still claimed the `⛶` button
  was the only control that exits fullscreen, which this PR made false while
  editing that same file twice. I had also closed the browser-chrome question by
  citing a rejection that does not exist (the Alternatives reject
  `orientation.lock` and *automatic* fullscreen, not the API the `⛶` uses), and
  recorded the device answer without the OS — which matters, because on iOS no
  web page can go fullscreen at all, so the `⛶` escape I offered does not exist
  on the phone the observation came from. The accuracy lens then falsified three
  claims I had written minutes earlier, including the `scrollLeft` round trip I
  had just canonised as a standard: a `hidden` box answers the assignment and
  refuses the drag, so one leg is not enough.

Every accepted fix was seen to fail first. Commits: `d904e3d` (code), `d7fa7fe`,
`12a4138`, `20568b3` (docs). 556 tests green.

## Manual verification

1. On the phone, in the deck in landscape: the `✕` in the bottom-left corner
   should take you back to the document.
2. Slide 3 of "Java desde C++": drag **inside** the Java block — it should
   scroll to reveal the rest of the line and **not** change the slide. Dragging
   anywhere else should still change it.
3. On the laptop: `Escape` and `⛶` unchanged; entering fullscreen and then
   clicking `✕` should leave both fullscreen and the presentation.

## Notes

- The tap target is `32×24`, matching the fullscreen button beside it: above the
  24px WCAG minimum, below the 44px enhanced target. Deliberate for now so the
  footer keeps one visual language — if it is fiddly on your phone, the fix is
  both controls at once, and worth a WP of its own.
- Not opened here: whether the deck should show any persistent chrome on a phone
  at all (tap-to-reveal, as video players do). This adds the missing exit only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s8pBXNvdMc6th4rxfZ9MW

