### PR TITLE
fix: pay the two accessibility debts #103 recorded

### DIFF
--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -95,10 +95,20 @@ describe('PresentationPage viewer', () => {
       value: document.documentElement,
     });
     try {
-      fireEvent(document, new Event('fullscreenchange'));
+      // Dispatched where the browser dispatches it: at the element that entered
+      // fullscreen, bubbling — not directly at `document`, which would only
+      // prove the listener's address.
+      fireEvent(document.documentElement, new Event('fullscreenchange', { bubbles: true }));
       expect(
         await screen.findByRole('button', { name: 'Salir de pantalla completa' }),
       ).toBeInTheDocument();
+
+      // …and back. One crossing is satisfied by a latch: an implementation that
+      // never returns the name survived the enter-only assertion across 569
+      // tests (#106 review).
+      Reflect.deleteProperty(document, 'fullscreenElement');
+      fireEvent(document.documentElement, new Event('fullscreenchange', { bubbles: true }));
+      expect(await screen.findByRole('button', { name: 'Pantalla completa' })).toBeInTheDocument();
     } finally {
       Reflect.deleteProperty(document, 'fullscreenElement');
     }

--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -76,10 +76,32 @@ describe('PresentationPage viewer', () => {
     expect(await screen.findByRole('article')).toBeInTheDocument();
   });
 
-  it('offers a fullscreen control', async () => {
+  it('offers a fullscreen control that says what pressing it will do', async () => {
     renderAt(`/d/${firstId}/present`);
     await findCounter();
-    expect(screen.getByRole('button', { name: /pantalla completa/i })).toBeInTheDocument();
+    // Out of fullscreen the button ENTERS it, so the name is the destination.
+    expect(screen.getByRole('button', { name: 'Pantalla completa' })).toBeInTheDocument();
+  });
+
+  it('renames the fullscreen control when fullscreen is entered by any means', async () => {
+    // Not only after a click: Escape and the browser's own chrome change the
+    // state too, so the name is derived from document.fullscreenElement rather
+    // than from what this component last did (#106).
+    renderAt(`/d/${firstId}/present`);
+    await findCounter();
+
+    Object.defineProperty(document, 'fullscreenElement', {
+      configurable: true,
+      value: document.documentElement,
+    });
+    try {
+      fireEvent(document, new Event('fullscreenchange'));
+      expect(
+        await screen.findByRole('button', { name: 'Salir de pantalla completa' }),
+      ).toBeInTheDocument();
+    } finally {
+      Reflect.deleteProperty(document, 'fullscreenElement');
+    }
   });
 });
 

--- a/apps/web/src/content/DocumentPage.tsx
+++ b/apps/web/src/content/DocumentPage.tsx
@@ -124,7 +124,7 @@ export function DocumentPage({ notFound }: Props) {
               type="button"
               onClick={() => setDrawerOpen(true)}
               aria-label="Abrir la navegación"
-              className={`shrink-0 rounded border border-slate-700 p-1.5 text-slate-300 hover:bg-slate-800 hover:text-slate-100 ${toggleHiddenAt}`}
+              className={`shrink-0 rounded border border-slate-700 p-2 text-slate-300 hover:bg-slate-800 hover:text-slate-100 ${toggleHiddenAt}`}
             >
               <Menu size={16} aria-hidden="true" />
             </button>

--- a/apps/web/src/content/Drawer.tsx
+++ b/apps/web/src/content/Drawer.tsx
@@ -126,7 +126,7 @@ export function Drawer({ open, onClose, label, children }: Props) {
           type="button"
           onClick={onClose}
           aria-label="Cerrar"
-          className="mb-3 self-end rounded p-1 text-slate-400 hover:bg-slate-800 hover:text-slate-100"
+          className="mb-3 self-end rounded p-2 text-slate-400 hover:bg-slate-800 hover:text-slate-100"
         >
           <X size={16} aria-hidden="true" />
         </button>

--- a/apps/web/src/presentation/SlideDeck.tsx
+++ b/apps/web/src/presentation/SlideDeck.tsx
@@ -1,6 +1,14 @@
 import { AnimatePresence, motion } from 'framer-motion';
 import { X } from 'lucide-react';
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
 import type { ReactNode, TouchEvent } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
@@ -18,6 +26,19 @@ import { usePortraitPhone } from './usePortraitPhone';
 // review). Three call sites had drifted into three spellings of this.
 function leaveFullscreen(): void {
   if (document.fullscreenElement) void document.exitFullscreen?.();
+}
+
+// The browser owns this state and changes it behind our back — Escape, the
+// browser's own chrome, the portrait rule. useSyncExternalStore re-reads after
+// subscribing, which is the shape frontend-code-style.md §State fixes for a
+// browser store.
+function subscribeToFullscreen(onChange: () => void): () => void {
+  document.addEventListener('fullscreenchange', onChange);
+  return () => document.removeEventListener('fullscreenchange', onChange);
+}
+
+function isFullscreen(): boolean {
+  return document.fullscreenElement != null;
 }
 
 function toggleFullscreen(): void {
@@ -52,6 +73,7 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
   const portraitPhone = usePortraitPhone();
+  const fullscreen = useSyncExternalStore(subscribeToFullscreen, isFullscreen);
 
   // Math.trunc: a crafted non-integer ?slide (e.g. 1.5) must not become a
   // fractional array index (white-screen crash — review finding, issue #64).
@@ -227,7 +249,7 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
         <div className="flex items-center gap-2">
           <button
             type="button"
-            aria-label="Pantalla completa"
+            aria-label={fullscreen ? 'Salir de pantalla completa' : 'Pantalla completa'}
             onClick={toggleFullscreen}
             className="rounded p-2 hover:bg-slate-800 hover:text-slate-200"
           >

--- a/docs/standards/frontend-code-style.md
+++ b/docs/standards/frontend-code-style.md
@@ -250,10 +250,8 @@ src/
   deck chrome, which would then dominate a 342px-tall landscape stage. Measured
   case that forced the floor (#103): at `px-2 py-1` the deck's exit was 32x24
   with 4px of clearance from a control that does the opposite thing, so a
-  mis-tap took the reader deeper in instead of out. Known debt, deliberately not
-  fixed here: the drawer toggle ships at `p-1.5` (28x28) and its close button at
-  `p-1` (24x24) — above the floor, below the shape — and neither carries
-  `gap-2`; bring them up when that chrome is next touched. 48px when the icon is the illustration of
+  mis-tap took the reader deeper in instead of out. All three obey it since
+  #106 — measured on a phone profile at 34x34, 32x32 and 32x32. 48px when the icon is the illustration of
   a full-screen panel rather than a control — it carries the message at a
   glance, is `aria-hidden` because the text beside it says the same thing, and
   is not clickable (worked case: `presentation/RotateNotice.tsx`, #91). Adding a
@@ -297,6 +295,14 @@ src/
   document.exitFullscreen?.()`, behind one named helper that the surface's other
   exits call. Worked case: `presentation/SlideDeck.tsx`'s `leaveFullscreen()`
   (#103), where three call sites had drifted into three spellings.
+- **A toggle's accessible name says what pressing it will DO**, and derives
+  that from the state itself rather than from what the component last did.
+  `aria-label="Pantalla completa"` on a button that also leaves fullscreen
+  announces the opposite of the truth half the time; the browser changes such
+  state behind the component's back (a key, its own chrome, another rule), so
+  read it through `useSyncExternalStore` and let the name follow. Worked cases:
+  `CodeEditor`'s expand control (`Expandir a pantalla completa` / `Cerrar
+  pantalla completa`) and the deck's `⛶` (#106).
 - **A surface that replaces the viewport carries a visible way out.** A keyboard
   escape announces itself nowhere and a phone has no `Escape` key, so a
   full-viewport surface needs an on-screen exit, sized per §Icons, navigating to

--- a/docs/standards/frontend-code-style.md
+++ b/docs/standards/frontend-code-style.md
@@ -251,7 +251,12 @@ src/
   case that forced the floor (#103): at `px-2 py-1` the deck's exit was 32x24
   with 4px of clearance from a control that does the opposite thing, so a
   mis-tap took the reader deeper in instead of out. All three obey it since
-  #106 — measured on a phone profile at 34x34, 32x32 and 32x32. 48px when the icon is the illustration of
+  #106 — measured on a phone profile at 34x34, 32x32 and 32x32, each with at
+  least 12px of clearance from its neighbour (`gap-3`, `gap-4`, `mb-3`), which
+  is the half the retired debt note had named. Known and deliberately not fixed
+  in #106: where `requestFullscreen` is absent the deck's `⛶` is inert while
+  still naming an action, so the control promises what it cannot do — hide or
+  disable it when that surface is next touched. 48px when the icon is the illustration of
   a full-screen panel rather than a control — it carries the message at a
   glance, is `aria-hidden` because the text beside it says the same thing, and
   is not clickable (worked case: `presentation/RotateNotice.tsx`, #91). Adding a
@@ -298,11 +303,13 @@ src/
 - **A toggle's accessible name says what pressing it will DO**, and derives
   that from the state itself rather than from what the component last did.
   `aria-label="Pantalla completa"` on a button that also leaves fullscreen
-  announces the opposite of the truth half the time; the browser changes such
-  state behind the component's back (a key, its own chrome, another rule), so
-  read it through `useSyncExternalStore` and let the name follow. Worked cases:
+  announces the opposite of the truth half the time. Worked cases:
   `CodeEditor`'s expand control (`Expandir a pantalla completa` / `Cerrar
-  pantalla completa`) and the deck's `⛶` (#106).
+  pantalla completa`) and the deck's `⛶` (#106). **When the state belongs to the
+  browser rather than to the component**, read it through
+  `useSyncExternalStore` so the name follows a change made by a key, by the
+  browser's own chrome or by another rule — the deck's `⛶` alone, since
+  `CodeEditor`'s expansion is its own `useState` over a CSS overlay.
 - **A surface that replaces the viewport carries a visible way out.** A keyboard
   escape announces itself nowhere and a phone has no `Escape` key, so a
   full-viewport surface needs an on-screen exit, sized per §Icons, navigating to

--- a/docs/standards/testing-strategy.md
+++ b/docs/standards/testing-strategy.md
@@ -231,6 +231,12 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   honoured; the pair is the proof. Worked case (#85): "a listing ignores a
   stored draft" is trustworthy only because "an editor still restores one"
   plants the identical key and gets it back.
+- **A test for a state-derived NAME asserts the round trip**, not one crossing.
+  "A becomes B" passes identically over code that derives the value and over
+  code that latches on the first transition, so one crossing proves nothing
+  about the second. Worked case (#106): the deck's fullscreen `aria-label`,
+  where a latched implementation stayed green across all 569 tests and the
+  return assertion is what killed it.
 - **Nothing — a fix or a guard — is done before its test has been seen to fail,
   at the assertion that encodes it.** Revert the fix (or introduce the defect the
   guard names), watch the test go red, restore it — and name the failing test,


### PR DESCRIPTION
**Closes #106**

## Summary

Las dos deudas que #103 dejó anotadas, pagadas — y la anotación borrada, que era
la otra mitad del pedido.

- **Los tres controles de 16px cumplen la regla que los cita.** El toggle del
  drawer pasa de `p-1.5` (28x28) a `p-2`, su botón de cerrar de `p-1` (24x24, el
  mínimo pelado) a `p-2`. Un estándar cuyos propios casos citados lo violan
  enseña lo contrario de lo que dice.
- **El `⛶` dice lo que va a hacer.** `aria-label="Pantalla completa"` en un
  botón que alterna es correcto en un estado y exactamente lo opuesto en el
  otro. Ahora la etiqueta sale de `document.fullscreenElement` vía
  `useSyncExternalStore`, no de un estado propio: el navegador cambia eso por su
  cuenta (Escape, su propia barra, la regla de vertical), y un nombre que solo
  se actualiza al hacer clic estaría mal justo entonces.

## Slices completed

- [x] S1 — subir los dos controles del drawer a la regla que los cita (`14aa62d`)
- [x] S2 — que el toggle de pantalla completa anuncie lo que hará (`28e40c4`)

Más `00a371b` (el estándar deja de registrar la deuda) y `0094149` (review fixes).

## Acceptance criteria

1. **Ambos controles ≥32x32 con separación** — medido en Chromium con perfil de
   iPhone 13: toggle **34x34** (el borde suma un píxel por lado), cerrar
   **32x32**, con `gap-3`/`gap-4`/`mb-3` de separación (≥12px).
2. **El nombre sigue al estado en ambas direcciones** — test del viaje de ida y
   vuelta; en navegador, entrar a pantalla completa deja el pie en
   `["Salir de pantalla completa", "Salir de la presentación"]`.
3. **El drawer sigue funcionando** como lo dejó #84 — sus tests intactos.
4. **§Icons ya no registra deuda**, porque no la hay: dice las tres medidas.
5. **Protocolos verdes** — formato, lint, 569 tests, build.

## Tests

569 verdes (eran 556). El test de la etiqueta afirma el viaje completo y
despacha el evento donde lo despacha el navegador (`document.documentElement`,
burbujeando), no directamente en `document`.

## Reviews run

**Reducida y anunciada como tal**: gate mecánico + una lente (correctness+tests),
sin panel completo ni verificador — el diff son dos clases de Tailwind, una
etiqueta derivada de estado y sus tests.

6 hallazgos (1 important, 4 sugerencias, 1 patrón), todos aplicados. El
important vale el PR entero: **yo había probado solo la ida**, y una
implementación que "latchea" el nombre —que nunca vuelve a "Pantalla completa"—
sobrevivía los 569 tests. La lente lo midió mutando el código; el test del
viaje de vuelta es lo que lo mata.

## Manual verification

1. En el teléfono, abrí el índice con el botón de arriba a la izquierda y cerralo
   con la ✕: ambos deberían acertarse sin pelear.
2. En el escritorio, en presentación: entrá a pantalla completa con `⛶` y
   revisá con el lector de pantalla (o el inspector) que el botón ahora se
   llame "Salir de pantalla completa"; salí con `Escape` y confirmá que vuelve
   a llamarse "Pantalla completa".

## Notes

- Deuda nueva, nombrada y no pagada: donde no existe `requestFullscreen` el `⛶`
  queda inerte pero sigue anunciando una acción. Está registrado en §Icons para
  cuando se toque esa chrome, en vez de descubrirse después.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s8pBXNvdMc6th4rxfZ9MW
