### PR TITLE
fix: make the abandoned-run test deterministic, and close the window that exits 1 while printing green

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,8 @@ rules live in the plugin's `docs/defaults.md`. Engineering-practice doctrine
 
 ### References
 
-- Workflow conventions (kanban, labels, branches, commits, PR template, worktrees):
+- Workflow conventions (kanban, labels, branches, commits, slice planning, PR
+  template, worktrees):
   `docs/conventions.md`
 - ADR format and when to write one: `docs/standards/documentation.md` (§Rules 2 + §ADR format)
 

--- a/apps/web/src/runtime/useRuntime.test.ts
+++ b/apps/web/src/runtime/useRuntime.test.ts
@@ -55,18 +55,28 @@ function resultFor(id: number, overrides: Partial<ResultMessage> = {}): ResultMe
   };
 }
 
-/** Spawns fake workers and records every one it made. */
-/**
- * A pause longer than any short budget a test hands the hook.
- *
- * The flake this guards was not a race in the code: it was a test that asked a
- * loaded machine to answer inside a 20ms real timer. Waiting here on purpose
- * makes that dependency explicit — a test that survives this survives a busy
- * CI box, and one that does not fails on every machine instead of one in
- * however many (#98).
- */
-const underLoad = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 30));
+/** The start budget the abandoned-run test gives its FIRST run, in ms. */
+const SHORT_START_BUDGET_MS = 20;
 
+/**
+ * A pause that certainly outlives `budgetMs`, for the gap right after a run
+ * starts.
+ *
+ * It does not simulate a busy machine — 30ms is nothing to a CI box, and the
+ * second phase survives on a 10s budget, not on this. What it does is turn a
+ * load-dependent flake into a deterministic failure: if the budget in force
+ * during the gap is still the short one, its timer fires inside the pause and
+ * the test reddens on every machine instead of one run in however many (#98).
+ *
+ * Takes the budget rather than hard-coding a number, because the two were
+ * coupled by prose alone and raising the budget past the pause disarmed the
+ * guard in total silence — verified: with the budget at 50 the guard's own
+ * mutation went 13/13 green.
+ */
+const outlasting = (budgetMs: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, budgetMs * 2));
+
+/** Spawns fake workers and records every one it made. */
 function workerFactory() {
   const created: FakeWorker[] = [];
   return {
@@ -236,11 +246,12 @@ describe('useRuntime', () => {
     act(() => {
       slowStart = result.current.run('int main(){}', '');
     });
-    await waitFor(() => expect(factory.created).toHaveLength(1));
-
     // Downloading a toolchain, booting a JVM or queueing behind another editor
     // is not an infinite loop, and must not be reported as one.
-    await expect(slowStart).rejects.toThrow(/runtime no estuvo listo/i);
+    const rejected = expect(slowStart).rejects.toThrow(/runtime no estuvo listo/i);
+    await waitFor(() => expect(factory.created).toHaveLength(1));
+
+    await rejected;
   });
 
   it('starts measuring the program only once the runtime says it has started', async () => {
@@ -258,13 +269,14 @@ describe('useRuntime', () => {
     act(() => {
       stuck = result.current.run('while(true){}', '');
     });
+    const rejected = expect(stuck).rejects.toThrow(/bucle infinito/i);
     await waitFor(() => expect(factory.created).toHaveLength(1));
     const worker = factory.last();
     await waitFor(() => expect(worker.posted).toHaveLength(1));
 
     act(() => worker.emit({ id: worker.posted[0]!.id, type: 'started' }));
 
-    await expect(stuck).rejects.toThrow(/bucle infinito/i);
+    await rejected;
     expect(factory.created[0]!.terminated).toBe(true);
   });
 
@@ -326,14 +338,14 @@ describe('useRuntime', () => {
     // 20ms made the second one a race against whatever else the box was doing
     // (#98).
     const { result, rerender } = renderHook(
-      ({ startTimeoutMs }: { startTimeoutMs: number }) =>
+      ({ timeoutMs, startTimeoutMs }: { timeoutMs: number; startTimeoutMs: number }) =>
         useRuntime({
           runtimeId: 'cpp',
           createWorker: factory.createWorker,
-          timeoutMs: 20,
+          timeoutMs,
           startTimeoutMs,
         }),
-      { initialProps: { startTimeoutMs: 20 } },
+      { initialProps: { timeoutMs: 10_000, startTimeoutMs: SHORT_START_BUDGET_MS } },
     );
 
     let stuck!: Promise<unknown>;
@@ -341,15 +353,20 @@ describe('useRuntime', () => {
       // The student's `while (true)`: the worker never replies.
       stuck = result.current.run('while(true){}', '');
     });
+    // Attached before the gap, not after. The budget is armed inside `run()`,
+    // so a promise left bare across an `await` can reject with nobody
+    // listening — vitest then exits 1 while printing every test green (#98).
+    const abandoned = expect(stuck).rejects.toThrow(/no estuvo listo/i);
+    await outlasting(SHORT_START_BUDGET_MS);
     await waitFor(() => expect(factory.created).toHaveLength(1));
 
-    await expect(stuck).rejects.toThrow(/no estuvo listo|bucle infinito/i);
+    await abandoned;
     // A stranded worker holds a whole compiler in memory, so it must go.
     expect(factory.created[0]!.terminated).toBe(true);
 
     // Nothing is being timed now — the point of what follows is that a fresh
     // run works after a discard, not how fast it is.
-    rerender({ startTimeoutMs: 10_000 });
+    rerender({ timeoutMs: 10_000, startTimeoutMs: 10_000 });
 
     let next!: Promise<unknown>;
     act(() => {
@@ -357,7 +374,7 @@ describe('useRuntime', () => {
     });
     await waitFor(() => expect(factory.created).toHaveLength(2));
     // The second run must not inherit the first run's impatience.
-    await underLoad();
+    await outlasting(SHORT_START_BUDGET_MS);
     const fresh = factory.last();
     act(() => fresh.emit(resultFor(fresh.posted[0]!.id, { output: 'ok' })));
     await expect(next).resolves.toMatchObject({ output: 'ok' });

--- a/apps/web/src/runtime/useRuntime.test.ts
+++ b/apps/web/src/runtime/useRuntime.test.ts
@@ -56,6 +56,17 @@ function resultFor(id: number, overrides: Partial<ResultMessage> = {}): ResultMe
 }
 
 /** Spawns fake workers and records every one it made. */
+/**
+ * A pause longer than any short budget a test hands the hook.
+ *
+ * The flake this guards was not a race in the code: it was a test that asked a
+ * loaded machine to answer inside a 20ms real timer. Waiting here on purpose
+ * makes that dependency explicit — a test that survives this survives a busy
+ * CI box, and one that does not fails on every machine instead of one in
+ * however many (#98).
+ */
+const underLoad = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 30));
+
 function workerFactory() {
   const created: FakeWorker[] = [];
   return {
@@ -309,13 +320,20 @@ describe('useRuntime', () => {
 
   it('abandons a run that never finishes and frees its toolchain', async () => {
     const factory = workerFactory();
-    const { result } = renderHook(() =>
-      useRuntime({
-        runtimeId: 'cpp',
-        createWorker: factory.createWorker,
-        timeoutMs: 20,
-        startTimeoutMs: 20,
-      }),
+    // Two budgets, because the two halves of this test want opposite things:
+    // the abandoned run needs a deadline it will actually hit, and the run
+    // after it needs one the machine cannot blow through. Handing both halves
+    // 20ms made the second one a race against whatever else the box was doing
+    // (#98).
+    const { result, rerender } = renderHook(
+      ({ startTimeoutMs }: { startTimeoutMs: number }) =>
+        useRuntime({
+          runtimeId: 'cpp',
+          createWorker: factory.createWorker,
+          timeoutMs: 20,
+          startTimeoutMs,
+        }),
+      { initialProps: { startTimeoutMs: 20 } },
     );
 
     let stuck!: Promise<unknown>;
@@ -329,11 +347,17 @@ describe('useRuntime', () => {
     // A stranded worker holds a whole compiler in memory, so it must go.
     expect(factory.created[0]!.terminated).toBe(true);
 
+    // Nothing is being timed now — the point of what follows is that a fresh
+    // run works after a discard, not how fast it is.
+    rerender({ startTimeoutMs: 10_000 });
+
     let next!: Promise<unknown>;
     act(() => {
       next = result.current.run('int main(){}', '');
     });
     await waitFor(() => expect(factory.created).toHaveLength(2));
+    // The second run must not inherit the first run's impatience.
+    await underLoad();
     const fresh = factory.last();
     act(() => fresh.emit(resultFor(fresh.posted[0]!.id, { output: 'ok' })));
     await expect(next).resolves.toMatchObject({ output: 'ok' });

--- a/apps/web/src/runtime/useRuntime.test.ts
+++ b/apps/web/src/runtime/useRuntime.test.ts
@@ -58,12 +58,15 @@ function resultFor(id: number, overrides: Partial<ResultMessage> = {}): ResultMe
 /** The start budget the abandoned-run test gives its FIRST run, in ms. */
 const SHORT_START_BUDGET_MS = 20;
 
+/** The start budget `does not blame the program for a slow start` uses, in ms. */
+const SLOW_START_BUDGET_MS = 30;
+
 /**
  * A pause that certainly outlives `budgetMs`, for the gap right after a run
  * starts.
  *
- * It does not simulate a busy machine — 30ms is nothing to a CI box, and the
- * second phase survives on a 10s budget, not on this. What it does is turn a
+ * It does not simulate a busy machine — twice a 20ms budget is nothing to a
+ * CI box, and the second phase survives on its 10s budget, not on this. What it does is turn a
  * load-dependent flake into a deterministic failure: if the budget in force
  * during the gap is still the short one, its timer fires inside the pause and
  * the test reddens on every machine instead of one run in however many (#98).
@@ -238,7 +241,7 @@ describe('useRuntime', () => {
         createWorker: factory.createWorker,
         // The program gets almost no budget; getting started gets plenty.
         timeoutMs: 10_000,
-        startTimeoutMs: 30,
+        startTimeoutMs: SLOW_START_BUDGET_MS,
       }),
     );
 
@@ -247,9 +250,12 @@ describe('useRuntime', () => {
       slowStart = result.current.run('int main(){}', '');
     });
     // Downloading a toolchain, booting a JVM or queueing behind another editor
-    // is not an infinite loop, and must not be reported as one.
+    // is not an infinite loop, and must not be reported as one. Handled before
+    // the gap (testing-strategy.md §Conventions), and the pause is what proves
+    // it: move this line after `outlasting` and the run exits 1.
     const rejected = expect(slowStart).rejects.toThrow(/runtime no estuvo listo/i);
-    await waitFor(() => expect(factory.created).toHaveLength(1));
+    expect(factory.created).toHaveLength(1);
+    await outlasting(SLOW_START_BUDGET_MS);
 
     await rejected;
   });
@@ -332,20 +338,23 @@ describe('useRuntime', () => {
 
   it('abandons a run that never finishes and frees its toolchain', async () => {
     const factory = workerFactory();
-    // Two budgets, because the two halves of this test want opposite things:
-    // the abandoned run needs a deadline it will actually hit, and the run
-    // after it needs one the machine cannot blow through. Handing both halves
-    // 20ms made the second one a race against whatever else the box was doing
-    // (#98).
+    // Two START budgets, one per half — not the program-vs-start pair the hook
+    // itself calls "two budgets". The abandoned run needs a deadline it will
+    // actually hit; the run after it needs one the machine cannot blow through.
+    // Handing both halves 20ms made the second a race against whatever else the
+    // box was doing (#98).
     const { result, rerender } = renderHook(
-      ({ timeoutMs, startTimeoutMs }: { timeoutMs: number; startTimeoutMs: number }) =>
+      ({ startTimeoutMs }: { startTimeoutMs: number }) =>
         useRuntime({
           runtimeId: 'cpp',
           createWorker: factory.createWorker,
-          timeoutMs,
+          // Generous and never varied: the program budget is not what this test
+          // is about, and a short one here is armed by nothing (no run emits
+          // `started`) while still misleading whoever makes this run realistic.
+          timeoutMs: 10_000,
           startTimeoutMs,
         }),
-      { initialProps: { timeoutMs: 10_000, startTimeoutMs: SHORT_START_BUDGET_MS } },
+      { initialProps: { startTimeoutMs: SHORT_START_BUDGET_MS } },
     );
 
     let stuck!: Promise<unknown>;
@@ -357,8 +366,12 @@ describe('useRuntime', () => {
     // so a promise left bare across an `await` can reject with nobody
     // listening — vitest then exits 1 while printing every test green (#98).
     const abandoned = expect(stuck).rejects.toThrow(/no estuvo listo/i);
+    // `createWorker` runs synchronously inside `run()`, so this is a fact by
+    // the time the `act` returns — asserted here, before the pause, where it
+    // still means something. After it, the budget has fired and the worker is
+    // already discarded.
+    expect(factory.created).toHaveLength(1);
     await outlasting(SHORT_START_BUDGET_MS);
-    await waitFor(() => expect(factory.created).toHaveLength(1));
 
     await abandoned;
     // A stranded worker holds a whole compiler in memory, so it must go.
@@ -366,18 +379,22 @@ describe('useRuntime', () => {
 
     // Nothing is being timed now — the point of what follows is that a fresh
     // run works after a discard, not how fast it is.
-    rerender({ timeoutMs: 10_000, startTimeoutMs: 10_000 });
+    rerender({ startTimeoutMs: 10_000 });
 
     let next!: Promise<unknown>;
     act(() => {
       next = result.current.run('int main(){}', '');
     });
-    await waitFor(() => expect(factory.created).toHaveLength(2));
+    // Handled before its own gap, for the same reason as above: inert today
+    // because this phase's budget is 10s, and the next person to shorten it
+    // would get an unhandled rejection rather than a failing assertion.
+    const resolved = expect(next).resolves.toMatchObject({ output: 'ok' });
+    expect(factory.created).toHaveLength(2);
     // The second run must not inherit the first run's impatience.
     await outlasting(SHORT_START_BUDGET_MS);
     const fresh = factory.last();
     act(() => fresh.emit(resultFor(fresh.posted[0]!.id, { output: 'ok' })));
-    await expect(next).resolves.toMatchObject({ output: 'ok' });
+    await resolved;
   });
 
   it('never creates a worker when the runtime is disabled', async () => {

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -62,6 +62,13 @@ One commit per slice. Every commit must pass the touched app's **per-commit
 protocol** (see `docs/standards/testing-strategy.md`); every PR passes the
 **pre-PR protocol** before publishing.
 
+**A slice that pins a defect cannot be its own commit**, and this constrains
+how a WP is planned, not only how it is committed. Such a slice ends red by
+construction — a test written to fail is the whole point of it — so plan the
+pin and the fix as ONE slice; the red step still happens, inside it, and the
+commit lands green. Worked case (#98), where they were refined as S1 and S2 and
+had to be merged mid-development after S1 was committed red and reverted.
+
 ```
 <type>(issue-<N>): S<n> <slice description>
 

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,6 +1,6 @@
 # Conventions — Nalanda
 
-This document is the source of truth for development conventions: kanban columns, labels, branch naming, commit format, PR template, and worktree setup. The `agentic-workflow` plugin skills reference this file and `.claude/workflow-bindings.md` (which owns the machine-readable IDs).
+This document is the source of truth for development conventions: kanban columns, labels, branch naming, commit format, **slice planning**, PR template, and worktree setup. The `agentic-workflow` plugin skills reference this file and `.claude/workflow-bindings.md` (which owns the machine-readable IDs).
 
 ## Project board IDs
 
@@ -67,7 +67,17 @@ how a WP is planned, not only how it is committed. Such a slice ends red by
 construction — a test written to fail is the whole point of it — so plan the
 pin and the fix as ONE slice; the red step still happens, inside it, and the
 commit lands green. Worked case (#98), where they were refined as S1 and S2 and
-had to be merged mid-development after S1 was committed red and reverted.
+had to be merged mid-development after S1 was committed red and the commit
+dropped with `git reset` — there is no revert commit, and after the mandatory
+squash merge nothing in this repository records it, which is itself the reason
+the rule is written here rather than left as a war story.
+
+**A slice whose product is evidence rather than code has no diff.** Commit it
+with `git commit --allow-empty` and put the runs, the counts and the mutations
+in the message — or fold it into the slice it verifies. Do not manufacture a
+change to carry it. Worked case: #98's S4, twenty consecutive suite runs and a
+load experiment whose control also passed, which is a result worth keeping
+precisely because it proved nothing.
 
 ```
 <type>(issue-<N>): S<n> <slice description>
@@ -195,6 +205,8 @@ Every refined issue body must contain, in this order:
 
 1. **Header:** `**Type:** ...`, `**Area:** ...`, `**Source:** ...`
 2. **Structured summary:** Problem / Goals / Non-goals / Design / Acceptance criteria / Slices / Notes
+   — when writing Slices, note that a slice which only pins a defect cannot be
+   its own commit (§Commit format); plan the pin and its fix as one.
 3. **Full artefacts appended:** `## Original specification`, `## Original plan`, `## Original todo` containing the complete content of any artefact produced during refinement
 
 The issue is the single source of truth for the WP. `develop-task` must have everything it needs in the body — no "see file X" references.

--- a/docs/standards/documentation.md
+++ b/docs/standards/documentation.md
@@ -19,7 +19,7 @@ finished until its documentation exists, and review verifies it (ADR-0005).
 | Design narratives | `docs/design/` | 2026-08 redesign |
 | Content-component usage (what authors see) | The **catalog** (`/catalog` in-app) | when to use `<Slide>`, props, examples |
 | Component governance (contract, how-to-add, doc + review checklists) | The **catalog governance page** (`/catalog/governance`, authored in `apps/web/src/catalog/GovernancePage.tsx`) — the operational home authors and agents read; ADR-0010/0014 hold the decisions and win on disagreement, `guides/add-a-content-component.md` maps them onto repo paths | the component contract points |
-| Workflow conventions (kanban, branches, PRs) | `docs/conventions.md` | commit format |
+| Workflow conventions (kanban, branches, PRs, slice planning) | `docs/conventions.md` | commit format |
 | How an app is published & operated | Root `README.md` §Deployment (repo-level: URL, trigger, rollback, what to verify) + that app's `README.md` (app-level build shape: base path, emitted artifacts, gotchas) | Pages publication of `apps/web` (#66) |
 | Security deferrals / advisory dispositions | `docs/security-notes.md` | accepted-risk records with review triggers |
 | Course planning material | `docs/course-graph.md` + `docs/graphs/` | topic dependencies, topology diagrams |

--- a/docs/standards/testing-strategy.md
+++ b/docs/standards/testing-strategy.md
@@ -208,6 +208,22 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   jsdom cannot lay out, but it can answer that. Worked case (#99):
   `app/presentationRoute.test.tsx` §"fitting a slide to the stage it is shown
   on", where the rotation case fails against the index-keyed version.
+- **A test that hands the code a short real timeout is racing the machine.**
+  A budget the production code arms with `setTimeout` is wall clock, so any
+  assertion that must happen INSIDE it is a bet on how busy the box is. Give
+  each phase of a test the budget its own question needs — the phase that must
+  time out gets a small one, the phase that must succeed gets a large one — and
+  make the load explicit by waiting longer than the small budget where the gap
+  opens. Worked case (#98): one test handed both its runs 20ms, so the second
+  one, the one that had to succeed, failed whenever review agents were building
+  in parallel and passed 10/10 on an idle machine. A flake that only appears
+  under load cannot be chased by re-running the suite; the pause makes it fail
+  everywhere or nowhere.
+- **A slice that pins a defect cannot be its own commit.** Such a slice ends
+  RED by construction, and the per-commit protocol has to pass before every
+  commit (`CLAUDE.md`). Plan the pin and the fix as ONE slice — the red step
+  still happens, inside it. Worked case (#98), where they were planned as S1 and
+  S2 and had to be merged mid-WP.
 - **A negative test about a KEY needs a positive twin.** When a test asserts
   that something stored under a computed key is *ignored* — a draft, a cache
   entry, a query param — it passes identically when the guard works and when the

--- a/docs/standards/testing-strategy.md
+++ b/docs/standards/testing-strategy.md
@@ -9,7 +9,8 @@ app must define. Decisions recorded here were agreed with Miguel (2026-08-06).
 protocols in this document:**
 
 1. **Per-commit protocol** — runs before EVERY commit (one commit = one slice).
-   Nothing is committed in red. Ever.
+   Nothing is committed in red. Ever. A slice that only pins a defect therefore
+   cannot stand alone — see `docs/conventions.md` §Commit format.
 2. **Pre-PR protocol** — runs before publishing ANY pull request. The full battery.
    CI mirrors this protocol exactly; a PR is not opened if any step fails locally.
 
@@ -55,6 +56,13 @@ npm run build          # tsc -b + vite build (type gate + content/ integrity gat
                        # index.yaml validated by contentIntegrity)
 npm run test           # vitest run — at minimum the touched scope, in green
 ```
+
+**Green means exit status 0, not the summary line.** An unhandled rejection
+makes vitest exit 1 while counting every test as passed; the cause appears only
+in its `Unhandled Errors` block and an `Errors 1 error` line, both of which scroll
+past. Check `echo $?`, or run the protocol under `set -e`. See §Conventions,
+"a promise that can reject". Worked case #98, where the mode was discovered by a
+review rather than by the protocol that is supposed to catch it.
 
 **Pre-PR** (from `apps/web/`):
 
@@ -215,25 +223,37 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   time out gets a small one, the phase that must succeed gets a large one — and
   make the load explicit by waiting longer than the small budget where the gap
   opens. Worked case (#98): one test handed both its runs 20ms, so the second
-  one, the one that had to succeed, failed whenever review agents were building
-  in parallel and passed 10/10 on an idle machine. A flake that only appears
-  under load cannot be chased by re-running the suite; the pause makes it fail
-  everywhere or nowhere — and it is only deterministic while it outlives the
-  budget, so derive it from that constant instead of writing a number that
-  agrees with it by luck. **Fake timers are the other answer**
-  (`vi.useFakeTimers({ shouldAdvanceTime: true })`, as in
-  `content/useSections.test.tsx`) and are preferable when the timers can be
-  advanced directly; #98 kept real ones because the fix had to stay inside one
-  test rather than migrate a file whose two neighbours also arm real budgets.
-- **A promise that can reject is given its handler before the next `await`,
-  not after.** A budget armed inside the call means the rejection can land
-  while the test is parked on a `waitFor`, with nobody listening — vitest then
-  exits 1 while printing every test green, which reads as a false pass and is
-  really a flaky red with a lying summary. Capture
-  `const rejected = expect(p).rejects.toThrow(...)` on the line after the call
-  and `await rejected` at the end. Worked case (#98): three tests in
-  `runtime/useRuntime.test.ts` had this window, two of them older than the WP
-  that found it.
+  one, the one that had to succeed, failed on the two occasions it was seen —
+  both with review agents building in parallel — and passed 10/10 on an idle
+  machine. Synthetic load reproduces it only sometimes (1 run in 10 under a
+  12-way load, measured in review), which is exactly why the pause and not a
+  re-run is the gate. A flake that only appears
+  under load cannot be chased by re-running the suite. Pin the split with a
+  pause that certainly outlives the small budget — `outlasting(BUDGET)`, twice
+  the constant. **The pause does not simulate load**: 40ms is nothing to a busy
+  box. What it does is make the wrong budget fail deterministically, which is
+  also what keeps the guard mutation-detectable. Derive it from the constant:
+  #98 first wrote the two as separate numbers and, with the budget raised to 50,
+  the guard's own mutation went 13/13 green with no signal at all.
+  **For a NEW test, or a file that arms no other real budget, fake timers are
+  the default** — `vi.useFakeTimers({ shouldAdvanceTime: true })`, as in
+  `content/useSections.test.tsx` — and none of the juggling above is needed.
+  Keep real timers only when the file already has real-budget tests you are not
+  converting in this WP (worked case #98, whose two neighbours arm 30ms budgets).
+- **When a call arms its own rejection on a timer, the promise it returns is
+  given its handler before the next `await`.** That is the trigger, and it is
+  narrow: a promise that can only reject because the test itself emits something
+  is not this shape, so this is not a licence to rewrite every assertion. When a
+  budget is armed *inside* the call, the rejection can land while the test is
+  parked on a `waitFor` with nobody listening; vitest then exits 1 with every
+  test counted as passed, and names the cause only in its `Unhandled Errors`
+  block and an `Errors 1 error` line — a red run whose pass counts read green.
+  Capture `const rejected = expect(p).rejects.toThrow(...)` on the line after
+  the call and `await rejected` at the end. Prove it the same way as any fix:
+  move the handler back after the gap and the run must exit 1. Worked case
+  (#98): two tests in `runtime/useRuntime.test.ts` had this window, both older
+  than the WP that found it; a third was aligned prophylactically, its budget
+  being armed 10s wide and unable to fire inside the gap.
 - **A negative test about a KEY needs a positive twin.** When a test asserts
   that something stored under a computed key is *ignored* — a draft, a cache
   entry, a query param — it passes identically when the guard works and when the

--- a/docs/standards/testing-strategy.md
+++ b/docs/standards/testing-strategy.md
@@ -218,12 +218,22 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   one, the one that had to succeed, failed whenever review agents were building
   in parallel and passed 10/10 on an idle machine. A flake that only appears
   under load cannot be chased by re-running the suite; the pause makes it fail
-  everywhere or nowhere.
-- **A slice that pins a defect cannot be its own commit.** Such a slice ends
-  RED by construction, and the per-commit protocol has to pass before every
-  commit (`CLAUDE.md`). Plan the pin and the fix as ONE slice — the red step
-  still happens, inside it. Worked case (#98), where they were planned as S1 and
-  S2 and had to be merged mid-WP.
+  everywhere or nowhere — and it is only deterministic while it outlives the
+  budget, so derive it from that constant instead of writing a number that
+  agrees with it by luck. **Fake timers are the other answer**
+  (`vi.useFakeTimers({ shouldAdvanceTime: true })`, as in
+  `content/useSections.test.tsx`) and are preferable when the timers can be
+  advanced directly; #98 kept real ones because the fix had to stay inside one
+  test rather than migrate a file whose two neighbours also arm real budgets.
+- **A promise that can reject is given its handler before the next `await`,
+  not after.** A budget armed inside the call means the rejection can land
+  while the test is parked on a `waitFor`, with nobody listening — vitest then
+  exits 1 while printing every test green, which reads as a false pass and is
+  really a flaky red with a lying summary. Capture
+  `const rejected = expect(p).rejects.toThrow(...)` on the line after the call
+  and `await rejected` at the end. Worked case (#98): three tests in
+  `runtime/useRuntime.test.ts` had this window, two of them older than the WP
+  that found it.
 - **A negative test about a KEY needs a positive twin.** When a test asserts
   that something stored under a computed key is *ignored* — a draft, a cache
   entry, a query param — it passes identically when the guard works and when the


### PR DESCRIPTION
**Closes #98**

## Summary

A test in `apps/web/src/runtime/useRuntime.test.ts` — *"abandons a run that never finishes and frees its toolchain"* — failed intermittently in the full suite and always passed alone. It had reddened in the pre-PR protocol of #84 and again of #85, both of which left `src/runtime/**` untouched.

**Nothing was wrong with the code under test.** `startTimeoutMs` arms a real `setTimeout` per run, and the test handed both of its runs 20ms. The second run — the one that must *succeed* — had those 20ms between `waitFor` seeing its worker created and the test emitting a result. On a busy machine that gap opens wider and the run dies on its own start timeout. The test was asking a loaded box to answer in 20ms.

The two halves want opposite things, so they now get opposite budgets, through the `rerender` idiom this file already used. A pause derived from the budget (`outlasting(SHORT_START_BUDGET_MS)`) sits permanently at the gap, which is what converts a load-dependent flake into a failure that is deterministic on any machine.

**The review then found a second, older defect** that this WP did not introduce and would not have found without it: a promise left bare across an `await` can reject with nobody listening, and vitest exits 1 while counting every test as passed. It affected two tests, both predating this WP.

## Slices

- **S1+S2** (merged during development) — pin the flake so it fails everywhere, and give each phase the budget its own question needs
- **S3** — close the unhandled-rejection question
- **S4** — twenty consecutive suite runs, recorded with what they do and do not prove

S1 and S2 were refined as separate slices and could not be: a slice that pins a defect ends red by construction, and green-before-commit is a hard rule. S1 was committed red for about a minute before this was caught, and the commit was dropped with `git reset`. **The lesson is now a convention in `docs/conventions.md` §Commit format**, where slices are planned — not left as a war story.

## Acceptance criteria

| # | Evidence |
|---|---|
| 1 | Cause named and measured, not guessed. `startTimeoutMs` arms a real timer at `useRuntime.ts:208`; the test gave both runs 20ms (`git show 7f8fac4:…useRuntime.test.ts:316`). Reproduced deterministically by inserting a 30ms pause at the gap. **The first draft of this issue blamed a different cause and was wrong** |
| 2 | **The gate.** Removing the fix reddens `useRuntime.test.ts` at the assertion that encodes it, with the original message verbatim. Round B added the reverse check for the second defect: move a handler back after its gap → `Errors 1 error`, exit 1, in each of the three tests |
| 3 | **20/20** full-suite runs green on the post-review tree, each one `554 passed`, `exit=0`, `FAIL=0`. Necessary, not sufficient: the unfixed baseline also passes on an idle machine, which is why AC2 is the real gate |
| 4 | Zero unhandled rejections in all twenty — grepped for `Unhandled` and `Errors N error`, and confirmed by exit status, which is the check this WP added to the protocol |
| 5 | Behaviour still asserted: reverting `discardWorker()` in the start-timeout path reddens `useRuntime.test.ts:286` and `:378`, both `expect(…terminated).toBe(true)` |
| 6 | Per-commit protocol green at every commit; pre-PR protocol green |

## Tests

**554**, exit 0. No new test files — this WP repairs and hardens existing ones.

**The honest state of the measurements**, because three of them changed during review:

- My own load experiment in S4 **proved nothing**: the control — `main`'s version under identical load — also passed 5/5. Recorded rather than dropped, because a green result whose control also passed is exactly the kind of number that reads as proof.
- The docs-accuracy lens later **did** reproduce the original flake: **1 run in 10** with the pre-WP shape under a 12-way load on a 10-core box, with a control that separates the two trees. That is the only genuine reproduction anyone managed.
- "Roughly 1 in 8", which the first draft of the issue claimed, does not survive measurement: 10/10 green on an idle machine. The trigger is machine load, not a fixed probability.

## Reviews run

`review-pipeline`, full mode, both rounds, with per-fix rechecks. All lenses ran in isolated worktrees after the security lens found that three panel members mutating one shared checkout had cross-contaminated each other's baselines.

| round | lens | findings |
|---|---|---|
| A | correctness | 7 |
| A | architecture | 5 |
| A | security | **0**, and it earned that — four mutations establishing that the `terminated` assertion still fires under a budget that expires, that three other tests independently cover `terminate()`, and that a future weakening hangs rather than passing vacuously |
| A | performance | not spawned — no production code, no hot path, no perf goal in the issue |
| B | correctness recheck | 7 resolved, 3 new |
| B | architecture recheck | 5 resolved, 5 new |
| B | docs-accuracy | 8 |
| B | agent-readability | 6 |

**Everything was acted on. Nothing deferred.**

The verifier confirmed the two structural findings, refuted one hazard outright (a claimed 30-vs-30 timer coin flip: `outlasting` has one call site in the relevant phase, and Node fires equal-duration timers in arming order anyway), and deflated three to suggestion.

**The largest group of findings was my own false statements**, and they are corrected in the commits rather than quietly repaired:

- I told the reviewer twice that the unhandled-rejection finding did not reproduce. **It did.** My mutation searched for a string that occurs twice in the file and `replace(…, 1)` took the first — a different test, whose budget is 10s, where no pause could ever fire. Widening the window to 200ms did not help because I was measuring the wrong test. Every replacement since asserts the match is **unique**, not merely present.
- The S3 commit concluded the unhandled rejection was "a consequence of the failure, not an independent defect. Nothing further is owed." False: it fires while no assertion fails.
- I wrote "three tests had this window, two older than the WP". All three are older; only two had the window.
- The docstring I rewrote **to remove a prose-coupled number** stated 30ms when the helper waits 40.
- The round-A commit message was wrong about its own fix: `outlasting` has two call sites, and it added the first.
- `git reset` is not a revert.

## Standards grown

Four conventions, each with its worked case:

- **A test that hands the code a short real timeout is racing the machine** — per-phase budgets, and a pause derived from the constant. With the two written as separate numbers, raising the budget to 50 disarmed the guard silently: its own mutation went 13/13 green.
- **Fake timers are the default for a new test**; real ones only when the file already has real-budget tests you are not converting.
- **When a call arms its own rejection on a timer, the promise gets its handler before the next `await`** — stated with its trigger, because read unconditionally it would rewrite a dozen assertions in this file alone.
- **Green means exit status 0, not the summary line** (`docs/standards/testing-strategy.md` §Protocols). This WP found the mode where the two disagree and had left both protocols defining green by the summary.

Plus, in `docs/conventions.md`: a slice that pins a defect cannot be its own commit, and a slice whose product is evidence has no diff — commit it `--allow-empty` rather than manufacturing a change to carry it.

## Manual verification

Nothing user-facing changed; this is test and documentation work. What is worth checking is the claim, not the UI:

- [ ] `cd apps/web && npm run test; echo $?` → 554 passed, **exit 0**
- [ ] Break it on purpose: delete `await outlasting(SHORT_START_BUDGET_MS);` at `useRuntime.test.ts:374` and move `const abandoned = …` (line 371) down to just above `await abandoned;`. Run again → `Errors 1 error`, **exit 1**, with the summary still reading 13 passed. That is the defect this PR closes, and the reason `echo $?` is now in the protocol
- [ ] `git checkout -- apps/web/src/runtime/useRuntime.test.ts` to restore

## Notes

**COR-6 stays open, deliberately.** The correctness lens saw four consecutive runs fail `expect(factory.created[0]!.terminated).toBe(true)` at two lines under real load, and could not reproduce it in 30+ later attempts, including a 12-vs-12 controlled comparison. It is recorded in the issue as an open observation, not closed. The two lines involved are precisely the two `await expect(…).rejects` this PR moved, which raises the prior that it was the same defect — but that is a hypothesis, not a finding.

Also passed on, out of scope: under a load average near 100 the **full suite** flaked in `App.test.tsx`, `deployedApp.test.tsx`, `documentFences.test.tsx` and `presentationRoute.test.tsx`, all green in isolation. Same "racing the machine" class as the new convention, but through `waitFor`'s 1s default rather than a budget armed by the code. Worth its own issue.
