### PR TITLE
fix: hide the fullscreen control where the platform has none

### DIFF
--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -18,6 +18,20 @@ function renderAt(path: string) {
   );
 }
 
+/**
+ * jsdom implements no Fullscreen API, so after #111 the deck hides its
+ * fullscreen control there — correctly, but for a reason no test intended.
+ * A test that cares about that control declares the capability first, the way
+ * a browser would present it.
+ */
+function withFullscreenSupport() {
+  Object.defineProperty(document.documentElement, 'requestFullscreen', {
+    configurable: true,
+    value: () => Promise.resolve(),
+  });
+  return () => Reflect.deleteProperty(document.documentElement, 'requestFullscreen');
+}
+
 async function findCounter() {
   return screen.findByText(/^\d+ \/ \d+$/);
 }
@@ -77,13 +91,32 @@ describe('PresentationPage viewer', () => {
   });
 
   it('offers a fullscreen control that says what pressing it will do', async () => {
+    const restore = withFullscreenSupport();
     renderAt(`/d/${firstId}/present`);
     await findCounter();
     // Out of fullscreen the button ENTERS it, so the name is the destination.
     expect(screen.getByRole('button', { name: 'Pantalla completa' })).toBeInTheDocument();
+    restore();
+  });
+
+  it('hides the fullscreen control where the platform has no fullscreen', async () => {
+    // An iPhone: no browser there exposes requestFullscreen for a web page
+    // (ADR-0023), so the control could only ever be a button that does nothing.
+    // jsdom is that platform by default, which is exactly why the tests above
+    // have to declare the capability rather than inherit it.
+    renderAt(`/d/${firstId}/present`);
+    await findCounter();
+
+    const footer = document.querySelector('footer')!;
+    expect([...footer.querySelectorAll('button')].map((b) => b.getAttribute('aria-label'))).toEqual(
+      ['Salir de la presentación'],
+    );
+    // The way out and the counter stay; only the dead control goes.
+    expect(screen.getByText(/^\d+ \/ \d+$/)).toBeInTheDocument();
   });
 
   it('renames the fullscreen control when fullscreen is entered by any means', async () => {
+    const restoreSupport = withFullscreenSupport();
     // Not only after a click: Escape and the browser's own chrome change the
     // state too, so the name is derived from document.fullscreenElement rather
     // than from what this component last did (#106).
@@ -111,6 +144,7 @@ describe('PresentationPage viewer', () => {
       expect(await screen.findByRole('button', { name: 'Pantalla completa' })).toBeInTheDocument();
     } finally {
       Reflect.deleteProperty(document, 'fullscreenElement');
+      restoreSupport();
     }
   });
 });
@@ -463,15 +497,18 @@ describe('fitting a slide to the stage it is shown on', () => {
 
 describe('leaving the presentation from the deck', () => {
   it('offers a visible exit beside the fullscreen control', async () => {
-    renderAt(`/d/${firstId}/present`);
-    await findCounter();
-
     // Both halves of the name, asserted: that it is there, and that it sits
     // after the fullscreen control — which is the tab order a reader meets.
+    // The capability is declared before the render, because the deck decides
+    // whether to paint that neighbour at all (#111).
+    const restore = withFullscreenSupport();
+    renderAt(`/d/${firstId}/present`);
+    await findCounter();
     const footer = document.querySelector('footer')!;
     expect([...footer.querySelectorAll('button')].map((b) => b.getAttribute('aria-label'))).toEqual(
       ['Pantalla completa', 'Salir de la presentación'],
     );
+    restore();
   });
 
   it('does not ask to leave fullscreen when it was never entered', async () => {

--- a/apps/web/src/presentation/SlideDeck.tsx
+++ b/apps/web/src/presentation/SlideDeck.tsx
@@ -41,6 +41,16 @@ function isFullscreen(): boolean {
   return document.fullscreenElement != null;
 }
 
+/**
+ * Whether this browser can put a web page in fullscreen at all. On iOS none
+ * can (ADR-0023 — the same fact that ruled out an orientation lock), so the
+ * control would be a button that answers nothing. Read at render: a browser
+ * does not grow the API mid-session, so there is no store to subscribe to.
+ */
+function canGoFullscreen(): boolean {
+  return typeof document.documentElement.requestFullscreen === 'function';
+}
+
 function toggleFullscreen(): void {
   if (document.fullscreenElement) {
     leaveFullscreen();
@@ -247,14 +257,16 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
       </div>
       <footer className="flex items-center justify-between px-[max(1.5rem,env(safe-area-inset-left))] py-3 pb-[max(0.75rem,env(safe-area-inset-bottom))] pr-[max(1.5rem,env(safe-area-inset-right))] text-sm text-slate-500">
         <div className="flex items-center gap-2">
-          <button
-            type="button"
-            aria-label={fullscreen ? 'Salir de pantalla completa' : 'Pantalla completa'}
-            onClick={toggleFullscreen}
-            className="rounded p-2 hover:bg-slate-800 hover:text-slate-200"
-          >
-            ⛶
-          </button>
+          {canGoFullscreen() ? (
+            <button
+              type="button"
+              aria-label={fullscreen ? 'Salir de pantalla completa' : 'Pantalla completa'}
+              onClick={toggleFullscreen}
+              className="rounded p-2 hover:bg-slate-800 hover:text-slate-200"
+            >
+              ⛶
+            </button>
+          ) : null}
           {/* Escape does this too, and says so nowhere on screen — which is the
               whole reason this exists. A phone has no Escape at all. */}
           <button

--- a/docs/standards/frontend-code-style.md
+++ b/docs/standards/frontend-code-style.md
@@ -253,10 +253,10 @@ src/
   mis-tap took the reader deeper in instead of out. All three obey it since
   #106 — measured on a phone profile at 34x34, 32x32 and 32x32, each with at
   least 12px of clearance from its neighbour (`gap-3`, `gap-4`, `mb-3`), which
-  is the half the retired debt note had named. Known and deliberately not fixed
-  in #106: where `requestFullscreen` is absent the deck's `⛶` is inert while
-  still naming an action, so the control promises what it cannot do — hide or
-  disable it when that surface is next touched. 48px when the icon is the illustration of
+  is the half the retired debt note had named. A control the platform cannot honour is
+  not shown at all: where `requestFullscreen` is absent — every browser on iOS —
+  the deck omits its `⛶` rather than painting a button that answers nothing
+  (#111). The check is a capability, never a device. 48px when the icon is the illustration of
   a full-screen panel rather than a control — it carries the message at a
   glance, is `aria-hidden` because the text beside it says the same thing, and
   is not clickable (worked case: `presentation/RotateNotice.tsx`, #91). Adding a


### PR DESCRIPTION
**Closes #111**

## Summary

En tu iPhone el `⛶` era un botón que no hacía nada: en iOS ningún navegador
expone `requestFullscreen` para una página web — el mismo hecho que en ADR-0023
descartó el bloqueo de orientación. Ahora no se dibuja donde la plataforma no
puede honrarlo.

Es una comprobación de **capacidad, no de dispositivo**: un Android conserva el
control, un iPhone lo pierde, y el contador y la salida se quedan donde están.

## Slices completed

- [x] S1 — esconder el control donde no hay pantalla completa (`ebb6bac`)

## Acceptance criteria

1. **Sin la API, el pie muestra solo la salida** — verificado en Chromium
   borrando `requestFullscreen` antes de que monte React (que es lo que ve un
   iPhone): `["Salir de la presentación"]`, contador `2 / 10` intacto.
2. **Con la API, nada cambia** respecto de #106: `["Pantalla completa", "Salir
   de la presentación"]`.
3. **Los tests declaran la capacidad** en vez de heredar la ausencia de jsdom.
4. **El resto del deck sin tocar** — teclado, swipe, escalado, regla de vertical:
   570 tests verdes.
5. **La salida sigue funcionando** sin el control: clic → vista libro.
6. §Icons deja de registrar esto como deuda.

## Tests

570 verdes (eran 569). Un caso nuevo — el pie sin la capacidad — y tres casos
existentes que ahora **declaran** que la plataforma tiene fullscreen.

Eso último es lo que más importa de este PR: sin declararlo, los tres habrían
seguido pasando por el motivo equivocado. El botón habría estado ausente porque
jsdom no es un navegador, no porque el código lo decidiera, y nadie se habría
enterado.

Mutación: forzar el control a renderizarse siempre mata el caso nuevo.

## Reviews run

Gate mecánico verde. Reducida y anunciada: el diff es una comprobación de
capacidad y sus tests. Si querés una lente antes de mergear, decime y la corro.

## Manual verification

En el iPhone, en presentación horizontal: en el pie ahora debería haber **solo**
la ✕. Antes había un `⛶` a su izquierda que no respondía.

## Notes

- Sin plan B para iOS: la barra del navegador no se puede esconder ahí y eso ya
  es estado final en ADR-0023. Este PR quita la promesa falsa, no intenta
  cumplirla.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s8pBXNvdMc6th4rxfZ9MW
