### PR TITLE
chore: declare presentation explicitly in every course document

### DIFF
--- a/apps/web/src/app/App.test.tsx
+++ b/apps/web/src/app/App.test.tsx
@@ -60,10 +60,12 @@ describe('routing', () => {
   });
 
   it('renders the presentation viewer at /d/:id/present', async () => {
-    // A PRESENTABLE document, not simply the first one (#108): `ids[0]` is the
-    // course's opening document, and a landing page declaring
-    // `presentation: none` is a legitimate choice that redirects /present back
-    // to the book — which reads here as "the viewer did not render".
+    // A PRESENTABLE document, not simply the first one (#108). Today the two
+    // resolve to the same document; this guards the case where they stop doing
+    // so, because a `none` document redirects /present back to the book, which
+    // reads here as "the viewer did not render". Note the opening document is
+    // currently pinned to `auto` as the suite's fixture, not by preference —
+    // add-a-course-document.md §presentation has the reason.
     const presentableId = ids.find((id) => registry.get(id)?.meta.presentation !== 'none')!;
     renderAt(`/d/${presentableId}/present`);
     expect(

--- a/apps/web/src/app/App.test.tsx
+++ b/apps/web/src/app/App.test.tsx
@@ -65,7 +65,7 @@ describe('routing', () => {
     // so, because a `none` document redirects /present back to the book, which
     // reads here as "the viewer did not render". Note the opening document is
     // currently pinned to `auto` as the suite's fixture, not by preference —
-    // add-a-course-document.md §presentation has the reason.
+    // add-a-course-document.md step 2 (Frontmatter) has the reason.
     const presentableId = ids.find((id) => registry.get(id)?.meta.presentation !== 'none')!;
     renderAt(`/d/${presentableId}/present`);
     expect(

--- a/apps/web/src/app/App.test.tsx
+++ b/apps/web/src/app/App.test.tsx
@@ -60,8 +60,15 @@ describe('routing', () => {
   });
 
   it('renders the presentation viewer at /d/:id/present', async () => {
-    renderAt(`/d/${ids[0]}/present`);
-    expect(await screen.findByRole('heading', { name: titleOf(ids[0]!) })).toBeInTheDocument();
+    // A PRESENTABLE document, not simply the first one (#108): `ids[0]` is the
+    // course's opening document, and a landing page declaring
+    // `presentation: none` is a legitimate choice that redirects /present back
+    // to the book — which reads here as "the viewer did not render".
+    const presentableId = ids.find((id) => registry.get(id)?.meta.presentation !== 'none')!;
+    renderAt(`/d/${presentableId}/present`);
+    expect(
+      await screen.findByRole('heading', { name: titleOf(presentableId) }),
+    ).toBeInTheDocument();
     expect(screen.queryByRole('article')).not.toBeInTheDocument();
   });
 

--- a/apps/web/src/app/documentSections.test.tsx
+++ b/apps/web/src/app/documentSections.test.tsx
@@ -21,8 +21,22 @@ function renderAt(path: string) {
 }
 
 const ids = walkIndex(courseIndex);
-const autoId = ids.find((id) => (registry.get(id)?.meta.presentation ?? 'auto') === 'auto')!;
-const explicitId = ids.find((id) => registry.get(id)?.meta.presentation === 'explicit')!;
+
+// Named, not discovered (#108). Picking "the first auto document" and "the first
+// explicit one" reads as robust and is the opposite: it silently follows the
+// index. When 02-intro-estructuras declared `explicit` it became the first one,
+// and the explicit case moved off busqueda-binaria — the only document here that
+// INTERLEAVES a markdown `##` with `<Slide title>` h2s, which is the whole point
+// of the equivalence asserted below. The suite stayed green while the case
+// stopped testing what it is named for.
+//
+// `presentation` is no longer defaulted in either selector either: since #108
+// every document declares it, so `?? 'auto'` could only ever fire for an id the
+// registry does not have — selecting a document that does not exist.
+const AUTO_FIXTURE = 'bienvenida';
+const EXPLICIT_FIXTURE = 'busqueda-binaria';
+const autoId = ids.find((id) => id === AUTO_FIXTURE);
+const explicitId = ids.find((id) => id === EXPLICIT_FIXTURE);
 
 /**
  * The h2 ids the article actually painted — the answer key for the rail. The
@@ -41,9 +55,23 @@ async function railLinkTargets(): Promise<string[]> {
 }
 
 describe('the section rail over real documents', () => {
-  it('the seed course provides both an auto and an explicit document', () => {
-    expect(autoId, 'no presentation: auto document').toBeDefined();
-    expect(explicitId, 'no presentation: explicit document').toBeDefined();
+  it('the seed course still provides the two fixtures these cases describe', () => {
+    expect(
+      autoId,
+      `${AUTO_FIXTURE} left the index. It is the seed course's only \`presentation: auto\` document (see add-a-course-document.md §presentation) — declare another document auto and name it here, or these cases stop covering the markdown-h2 rail path.`,
+    ).toBeDefined();
+    expect(
+      registry.get(autoId!)?.meta.presentation,
+      `${AUTO_FIXTURE} no longer declares auto`,
+    ).toBe('auto');
+    expect(
+      explicitId,
+      `${EXPLICIT_FIXTURE} left the index. Repoint this block at another document that interleaves a markdown \`##\` with <Slide title> headings — not merely at any explicit document, or the equivalence below stops being tested.`,
+    ).toBeDefined();
+    expect(
+      registry.get(explicitId!)?.meta.presentation,
+      `${EXPLICIT_FIXTURE} no longer declares explicit`,
+    ).toBe('explicit');
   });
 
   it('lists every section of an auto document, in order', async () => {

--- a/apps/web/src/app/documentSections.test.tsx
+++ b/apps/web/src/app/documentSections.test.tsx
@@ -25,10 +25,10 @@ const ids = walkIndex(courseIndex);
 // Named, not discovered (#108). Picking "the first auto document" and "the first
 // explicit one" reads as robust and is the opposite: it silently follows the
 // index. When 02-intro-estructuras declared `explicit` it became the first one,
-// and the explicit case moved off busqueda-binaria — the only document here that
-// INTERLEAVES a markdown `##` with `<Slide title>` h2s, which is the whole point
-// of the equivalence asserted below. The suite stayed green while the case
-// stopped testing what it is named for.
+// and the explicit case moved onto it — a document whose h2s are ALL
+// `<Slide title>`, so the equivalence asserted below (both heading sources, one
+// section list) stopped being exercised. busqueda-binaria carries both. The
+// suite stayed green while the case stopped testing what it is named for.
 //
 // `presentation` is no longer defaulted in either selector either: since #108
 // every document declares it, so `?? 'auto'` could only ever fire for an id the
@@ -58,7 +58,7 @@ describe('the section rail over real documents', () => {
   it('the seed course still provides the two fixtures these cases describe', () => {
     expect(
       autoId,
-      `${AUTO_FIXTURE} left the index. It is the seed course's only \`presentation: auto\` document (see add-a-course-document.md §presentation) — declare another document auto and name it here, or these cases stop covering the markdown-h2 rail path.`,
+      `${AUTO_FIXTURE} left the index. It is the seed course's only \`presentation: auto\` document (see add-a-course-document.md step 2 (Frontmatter)) — declare another document auto and name it here, or these cases stop covering the markdown-h2 rail path.`,
     ).toBeDefined();
     expect(
       registry.get(autoId!)?.meta.presentation,
@@ -66,7 +66,7 @@ describe('the section rail over real documents', () => {
     ).toBe('auto');
     expect(
       explicitId,
-      `${EXPLICIT_FIXTURE} left the index. Repoint this block at another document that interleaves a markdown \`##\` with <Slide title> headings — not merely at any explicit document, or the equivalence below stops being tested.`,
+      `${EXPLICIT_FIXTURE} left the index. Repoint this block at another document carrying BOTH heading sources — a markdown "##" and <Slide title> h2s — not merely at any explicit document, or the equivalence below stops being tested.`,
     ).toBeDefined();
     expect(
       registry.get(explicitId!)?.meta.presentation,

--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -7,7 +7,12 @@ import { courseIndex, registry, walkIndex } from '../content';
 import { AppRoutes } from './AppRoutes';
 
 const ids = walkIndex(courseIndex);
-const firstId = ids[0]!;
+// The first PRESENTABLE document, not simply the first one (#108). These cases
+// need a deck to drive; `ids[0]` only happened to have one, and the day the
+// course's opening document declared `presentation: none` — the right call for a
+// landing page — 33 cases here went red for a reason with nothing to do with the
+// viewer they test.
+const firstId = ids.find((id) => registry.get(id)?.meta.presentation !== 'none')!;
 const firstTitle = registry.get(firstId)?.meta.title ?? firstId;
 
 function renderAt(path: string) {
@@ -574,10 +579,21 @@ describe('book-view entry points to presentation', () => {
 // these tests guard the real compiled <Slide> path through the mdxChildrenOf
 // adapter — the alarm the adapter's docs promise.
 describe('explicit-mode documents (real compiled markers)', () => {
-  const explicitId = ids.find((id) => registry.get(id)?.meta.presentation === 'explicit');
+  // Named, not discovered (#108). The assertions below are this document's own
+  // words — "La idea", "Costo", "prosa de libro" — so "the first explicit
+  // document" was never what these cases meant; it merely resolved to the right
+  // one while `busqueda-binaria` happened to come first in the index. The day
+  // another document ahead of it declared `explicit`, both cases failed against
+  // a fixture whose content they never claimed to know.
+  const EXPLICIT_FIXTURE = 'busqueda-binaria';
+  const explicitId = ids.find((id) => id === EXPLICIT_FIXTURE);
 
-  it('the seed course provides an explicit fixture', () => {
-    expect(explicitId).toBeDefined();
+  it('the seed course still provides the explicit fixture these cases describe', () => {
+    expect(
+      explicitId,
+      `${EXPLICIT_FIXTURE} is gone from the index — repoint this block at a document whose sections are <Slide> markers, and update the headings asserted below to its own`,
+    ).toBeDefined();
+    expect(registry.get(explicitId!)?.meta.presentation).toBe('explicit');
   });
 
   it('decks only the marked slides, leaving loose prose book-only', async () => {

--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -8,10 +8,13 @@ import { AppRoutes } from './AppRoutes';
 
 const ids = walkIndex(courseIndex);
 // The first PRESENTABLE document, not simply the first one (#108). These cases
-// need a deck to drive; `ids[0]` only happened to have one, and the day the
-// course's opening document declared `presentation: none` — the right call for a
-// landing page — 33 cases here went red for a reason with nothing to do with the
-// viewer they test.
+// need a deck to drive, and `ids[0]` only happens to have one. Today the two
+// resolve to the same document, so this is a no-op — it is here because the
+// course's opening document is a landing page whose content argues for
+// `presentation: none`, and it declares `auto` only to stay the suite's auto
+// fixture (add-a-course-document.md §presentation). Were that to change, `ids[0]`
+// would redirect /present back to the book and these cases would go red for a
+// reason with nothing to do with the viewer they test.
 const firstId = ids.find((id) => registry.get(id)?.meta.presentation !== 'none')!;
 const firstTitle = registry.get(firstId)?.meta.title ?? firstId;
 
@@ -594,6 +597,22 @@ describe('explicit-mode documents (real compiled markers)', () => {
       `${EXPLICIT_FIXTURE} is gone from the index — repoint this block at a document whose sections are <Slide> markers, and update the headings asserted below to its own`,
     ).toBeDefined();
     expect(registry.get(explicitId!)?.meta.presentation).toBe('explicit');
+  });
+
+  // What #108 actually bought, pinned. Reverting content/ to its pre-#108 state
+  // left the whole suite green except the declaration invariant — nothing was
+  // watching the behaviour the WP exists for. `intro-estructuras` used to end
+  // its deck on the book's own closing navigation sentence, projected alone,
+  // because in `auto` there is no way to keep loose prose out of a deck.
+  it('keeps the book’s closing navigation sentence out of intro-estructuras’ deck', async () => {
+    renderAt('/d/intro-estructuras/present');
+    expect(await findCounter()).toHaveTextContent('1 / 4');
+
+    fireEvent.keyDown(window, { key: 'End' });
+    expect(
+      await screen.findByRole('heading', { name: 'Operaciones y costos' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Cuando termines/)).not.toBeInTheDocument();
   });
 
   it('decks only the marked slides, leaving loose prose book-only', async () => {

--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -12,7 +12,7 @@ const ids = walkIndex(courseIndex);
 // resolve to the same document, so this is a no-op — it is here because the
 // course's opening document is a landing page whose content argues for
 // `presentation: none`, and it declares `auto` only to stay the suite's auto
-// fixture (add-a-course-document.md §presentation). Were that to change, `ids[0]`
+// fixture (add-a-course-document.md step 2). Were that to change, `ids[0]`
 // would redirect /present back to the book and these cases would go red for a
 // reason with nothing to do with the viewer they test.
 const firstId = ids.find((id) => registry.get(id)?.meta.presentation !== 'none')!;

--- a/apps/web/src/content/architecture.test.ts
+++ b/apps/web/src/content/architecture.test.ts
@@ -1,5 +1,6 @@
-import { readdirSync, readFileSync } from 'node:fs';
-import { join, relative } from 'node:path';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
 
@@ -7,26 +8,29 @@ import { walkIndex } from './courseIndex';
 import { parseFrontmatterBlock } from './documentMeta';
 import { courseIndex, registry } from './liveContent';
 
-// Read from disk, not through the registry and not through a `?raw` glob.
+// The document list comes from the same glob `liveContent.ts` uses, so this
+// invariant covers exactly the set the app ships — no more and no less. A
+// directory walk of its own drifts from that set in both directions: it follows
+// a symlinked directory out of the tree, and it drops a symlinked `.mdx` the
+// glob (and therefore the registry) does publish.
 //
-// Two reasons, and each one was measured rather than assumed:
+// The BODY still reads the file, and two measured facts say it has to:
 //   - `parseDocumentMeta` normalises an absent `presentation` to 'auto', so the
 //     parsed meta cannot tell "declared auto" from "never declared" — and that
-//     difference is the entire point of the invariant below.
+//     difference is the entire point of the invariant below. The `?frontmatter`
+//     virtual module goes through the same normaliser, so it is no better.
 //   - `import.meta.glob(..., { query: '?raw' })` does NOT return the source
 //     here: the MDX plugin claims the file first, so the glob hands back the
 //     compiled `MDXContent` function. A frontmatter regex over that finds
 //     nothing and every case fails with "no frontmatter block", which looks
 //     like the invariant working and is not.
-// Resolved from the Vitest root (apps/web), not from import.meta.url: under
-// Vite's SSR transform that is an http: URL, and fileURLToPath rejects it.
-const COURSES = join(process.cwd(), '../../content/courses');
-
-function mdxFilesUnder(dir: string): string[] {
-  return readdirSync(dir, { withFileTypes: true, recursive: true })
-    .filter((e) => e.isFile() && e.name.endsWith('.mdx'))
-    .map((e) => join(e.parentPath, e.name));
-}
+//
+// Glob keys are relative to the Vite root, so they are resolved against this
+// file rather than the cwd. `fileURLToPath(import.meta.url)` is fine on its own
+// — it is the `new URL(x, import.meta.url)` PATTERN that Vite rewrites into an
+// asset URL, and only that pattern throws.
+const APP_ROOT = join(dirname(fileURLToPath(import.meta.url)), '../..');
+const documents = Object.keys(import.meta.glob('@content/courses/**/*.mdx'));
 
 // L4 invariants over the live content/ tree (testing-strategy.md): unique ids
 // and index integrity. Importing liveContent re-runs all fail-fast validation.
@@ -52,29 +56,26 @@ describe('architecture: content invariants', () => {
   // should be presentable wants it); this invariant is about authored intent, and
   // it is the only thing that can tell the two apart.
   //
-  // Registry-driven per testing-strategy.md: one case per document found, so a
-  // new document is gated the moment it lands, with the non-vacuity guard naming
-  // what to do if it ever trips.
+  // Registry-driven per testing-strategy.md: one case per document the glob
+  // finds, so a new document is gated the moment it lands, with the non-vacuity
+  // guard naming what to do if it ever trips.
   describe('every course document declares how it presents', () => {
-    const files = mdxFilesUnder(COURSES);
-
     it('finds documents to check', () => {
       expect(
-        files.length,
-        'no .mdx found under content/courses — the tree moved; repoint COURSES before trusting the cases below',
+        documents.length,
+        'the @content glob matched no .mdx — the content tree moved; repoint it before trusting the cases below',
       ).toBeGreaterThan(0);
     });
 
-    it.each(files)('%s declares `presentation`', (file) => {
-      const where = relative(COURSES, file);
-      const front = parseFrontmatterBlock(readFileSync(file, 'utf8')) as Record<
+    it.each(documents)('%s declares `presentation`', (key) => {
+      const front = parseFrontmatterBlock(readFileSync(join(APP_ROOT, key), 'utf8')) as Record<
         string,
         unknown
       > | null;
-      expect(front, `no frontmatter block in ${where}`).not.toBeNull();
+      expect(front, `no frontmatter block in ${key}`).not.toBeNull();
       expect(
         Object.hasOwn(front!, 'presentation'),
-        `${where} does not declare "presentation". It still ships a deck (the default is 'auto') — one nobody chose. Declare auto, explicit or none.`,
+        `${key} does not declare "presentation". It still ships a deck (the default is 'auto') — one nobody chose. Declare auto, explicit or none.`,
       ).toBe(true);
     });
   });

--- a/apps/web/src/content/architecture.test.ts
+++ b/apps/web/src/content/architecture.test.ts
@@ -1,7 +1,32 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import { walkIndex } from './courseIndex';
+import { parseFrontmatterBlock } from './documentMeta';
 import { courseIndex, registry } from './liveContent';
+
+// Read from disk, not through the registry and not through a `?raw` glob.
+//
+// Two reasons, and each one was measured rather than assumed:
+//   - `parseDocumentMeta` normalises an absent `presentation` to 'auto', so the
+//     parsed meta cannot tell "declared auto" from "never declared" — and that
+//     difference is the entire point of the invariant below.
+//   - `import.meta.glob(..., { query: '?raw' })` does NOT return the source
+//     here: the MDX plugin claims the file first, so the glob hands back the
+//     compiled `MDXContent` function. A frontmatter regex over that finds
+//     nothing and every case fails with "no frontmatter block", which looks
+//     like the invariant working and is not.
+// Resolved from the Vitest root (apps/web), not from import.meta.url: under
+// Vite's SSR transform that is an http: URL, and fileURLToPath rejects it.
+const COURSES = join(process.cwd(), '../../content/courses');
+
+function mdxFilesUnder(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true, recursive: true })
+    .filter((e) => e.isFile() && e.name.endsWith('.mdx'))
+    .map((e) => join(e.parentPath, e.name));
+}
 
 // L4 invariants over the live content/ tree (testing-strategy.md): unique ids
 // and index integrity. Importing liveContent re-runs all fail-fast validation.
@@ -19,5 +44,38 @@ describe('architecture: content invariants', () => {
     for (const id of ids) {
       expect(registry.get(id), `index references unknown doc "${id}"`).toBeDefined();
     }
+  });
+
+  // Issue #108. `presentation` is optional in the schema and defaults to 'auto',
+  // so a document that never declares it still ships a deck — one its author has
+  // never seen. The schema keeps the default (a platform where most documents
+  // should be presentable wants it); this invariant is about authored intent, and
+  // it is the only thing that can tell the two apart.
+  //
+  // Registry-driven per testing-strategy.md: one case per document found, so a
+  // new document is gated the moment it lands, with the non-vacuity guard naming
+  // what to do if it ever trips.
+  describe('every course document declares how it presents', () => {
+    const files = mdxFilesUnder(COURSES);
+
+    it('finds documents to check', () => {
+      expect(
+        files.length,
+        'no .mdx found under content/courses — the tree moved; repoint COURSES before trusting the cases below',
+      ).toBeGreaterThan(0);
+    });
+
+    it.each(files)('%s declares `presentation`', (file) => {
+      const where = relative(COURSES, file);
+      const front = parseFrontmatterBlock(readFileSync(file, 'utf8')) as Record<
+        string,
+        unknown
+      > | null;
+      expect(front, `no frontmatter block in ${where}`).not.toBeNull();
+      expect(
+        Object.hasOwn(front!, 'presentation'),
+        `${where} does not declare "presentation". It still ships a deck (the default is 'auto') — one nobody chose. Declare auto, explicit or none.`,
+      ).toBe(true);
+    });
   });
 });

--- a/content/courses/sample-course/01-bienvenida.mdx
+++ b/content/courses/sample-course/01-bienvenida.mdx
@@ -1,6 +1,7 @@
 ---
 id: bienvenida
 title: Bienvenida
+presentation: auto
 ---
 
 # Bienvenida

--- a/content/courses/sample-course/02-intro-estructuras.mdx
+++ b/content/courses/sample-course/02-intro-estructuras.mdx
@@ -1,27 +1,28 @@
 ---
 id: intro-estructuras
 title: ¿Qué es una estructura de datos?
+presentation: explicit
 ---
 
 # ¿Qué es una estructura de datos?
 
+<Slide>
 Una **estructura de datos** es una forma de organizar información en memoria
 para que ciertas operaciones sean eficientes. Elegir la estructura correcta es
 la mitad de resolver el problema.
+</Slide>
 
-## Un ejemplo cotidiano
-
+<Slide title="Un ejemplo cotidiano">
 Una fila en la caja del supermercado es una _cola_: la primera persona en
 llegar es la primera en ser atendida. Una pila de platos es exactamente eso,
 una _pila_: el último plato en llegar es el primero en salir.
+</Slide>
 
-## Operaciones y costos
-
+<Slide title="Operaciones y costos">
 Cada estructura ofrece un contrato: qué operaciones existen y cuánto cuestan.
 Por ejemplo, buscar en una lista desordenada cuesta tiempo lineal, mientras que
 [[busqueda-binaria|la búsqueda binaria]] sobre un arreglo ordenado cuesta
 tiempo logarítmico.
-
-<SectionBreak />
+</Slide>
 
 Cuando termines, vuelve a la [[bienvenida]] o continúa con el recorrido.

--- a/docs/decisions/0013-presentation-pipeline.md
+++ b/docs/decisions/0013-presentation-pipeline.md
@@ -32,6 +32,35 @@ can drive it.
    contentIntegrity gate. `none` hides the Presentar toggle and `/present`
    redirects to the book view. Extends the ADR-0012 frontmatter contract.
 
+   **2.1 The default stays; omitting it does not** (#108, 2026-08-14). Every
+   document in this repository MUST declare `presentation`, including when the
+   value it wants is the default. The schema is unchanged — `absent = auto`
+   remains the runtime contract — but an omission here is a CI failure.
+
+   The reason is that the default is silent in the one direction that matters:
+   omitting the field does not mean "no slides", it means slides nobody chose,
+   and nothing surfaces them. An undeclared deck is never clipped, never
+   unreadable and never invalid, so neither the build nor the suite could say it
+   was wrong — only that it existed. Two of the six seed documents were in that
+   state, and one projected the book's own closing navigation sentence alone on
+   a slide. Walking the deck was the only way to find it.
+
+   **Enforcement moves off the build gate**, which departs from the sentence
+   above and from ADR-0012 §3. Invalid _values_ still fail `vite build` through
+   contentIntegrity; a _missing_ field does not, because requiring it there
+   would change the schema for every future consumer rather than record a rule
+   for this repository. It is enforced instead by an L4 invariant
+   (`apps/web/src/content/architecture.test.ts`), which reads the frontmatter
+   from source — every seam that returns a parsed model has already applied the
+   default, so none of them can tell "declared auto" from "never declared".
+   Consequence for an author: `npm run build` stays green on a violation and
+   `npm run test` does not, so editing `content/` requires both.
+
+   The parenthetical rationale above — _"every document is presentable for
+   now"_ — no longer describes the tree. After #108 one document of six declares
+   `auto`, and it does so to remain the suite's only `auto` fixture rather than
+   because its content wants a deck. That coupling is ADR-0025.
+
 3. **Boundary identity travels as static metadata** (`lib/componentMeta.ts`:
    `withMeta`/`metaOf` — components declare `slideBoundary` / `headingLevel`).
    The parser dispatches on metadata, never on component-identity imports.
@@ -49,7 +78,7 @@ can drive it.
    a slides metadata export) — swap the adapter; parser and viewer unchanged.
    This departs from ADR-0012's suggestion that the `?frontmatter`
    virtual-module pattern could serve slide metadata: that pattern serves
-   build-time metadata well, but slides need the *rendered element stream*,
+   build-time metadata well, but slides need the _rendered element stream_,
    which only exists at runtime under option A's model.
 
 5. **Mode is set by the route; the URL is the sync seam**: `/d/:id` = book,

--- a/docs/decisions/0025-content-is-also-the-fixture-set.md
+++ b/docs/decisions/0025-content-is-also-the-fixture-set.md
@@ -1,0 +1,101 @@
+# ADR-0025: `content/` is also the test suite's fixture set
+
+**Status:** Accepted
+**Date:** 2026-08-14
+**Decision-makers:** Miguel Rodriguez
+**Source:** Issue #108. Extends ADR-0013 §4 and qualifies ADR-0002 (content as a
+separate domain) and `repository-structure.md` §Fixed taxonomy.
+
+## Context
+
+v0.1 has exactly one course directory and no synthetic content. Every test that
+needs a real document — a real deck, a real section rail, a real `h2` — reaches
+into `content/courses/sample-course/` through the live registry, because there is
+nothing else to reach into.
+
+That was already true and already accepted in a narrow form: ADR-0013 §4 leans on
+a real document as the explicit-marker fixture guarding the compiled-MDX adapter.
+There the arrangement costs nothing, because the fixture role and the content's
+own intent agree — `busqueda-binaria` genuinely wants marked slides, and would be
+written the same way if no test existed.
+
+Issue #108 made every document declare its `presentation` mode and broke that
+agreement. Walking the decks showed `01-bienvenida.mdx` for what it is: a landing
+page about the platform, whose two sections are "Cómo navegar" and "Qué
+encontrarás". Projected on a wall it is site navigation. Its content argues for
+`presentation: none`.
+
+It cannot have it. After #108 it is the only `auto` document in the tree, and the
+markdown-`h2` path of the section rail — the primary path of ADR-0021's
+decision — has no other real content to run over. Declaring `none` on it leaves
+that path untested.
+
+Two further couplings surfaced in the same review, both invisible from the
+documents themselves:
+
+- `documentSections.test.tsx` and `presentationRoute.test.tsx` were selecting
+  their fixtures **positionally** ("the first `explicit` document"). Declaring
+  `explicit` on a document earlier in the index silently moved one of them onto a
+  document with no markdown `##` at all, so the case asserting that both heading
+  sources produce one section list stopped exercising the mixed document it was
+  written for. The suite stayed green at 576 tests while the case stopped testing
+  what it is named for.
+- `presentationRoute.test.tsx` drives `java-desde-cpp` at a **fixed slide index**
+  (`?slide=5`). Nothing names it a fixture; it is a bare URL in a test.
+
+## Decision
+
+**In v0.1, `content/` serves two masters — published course material and the test
+suite's fixture set — and where they conflict, the suite wins and the conflict is
+recorded at the document.**
+
+Concretely:
+
+1. `01-bienvenida.mdx` declares `presentation: auto` although its content argues
+   for `none`, to remain the suite's only `auto` fixture.
+2. **Fixtures are named, never discovered.** A test that knows a document's
+   content names that document, with a non-vacuity guard whose message says what
+   to repoint and why. Positional selection is banned — recorded as a convention
+   in `testing-strategy.md`.
+3. **Editing `content/` requires the full suite, not the build.** A declaration
+   change can redden a test that never mentions the document. Recorded in
+   `guides/add-a-course-document.md` step 2 and in its checklist.
+
+## Alternatives considered
+
+- **Declare `none` on `bienvenida` and accept the coverage loss.** Rejected: the
+  markdown-`h2` rail is the _default_ authoring path — the one every `auto`
+  document uses — and it would have no coverage over real content while the
+  `<Slide title>` path kept it. The cheaper-looking option removes the test for
+  the more common case.
+- **Declare `none` and add a synthetic MDX fixture under `src/` now.** Rejected
+  for scope, not for correctness: this is the right end state and it is the exit
+  condition below, but it is a WP, and #108 is a chore about frontmatter.
+- **Take the exit immediately** (fixture course + registry injection). Rejected
+  on cost. `buildRegistry(metaModules, loaders)` is already parameterised, so the
+  registry half is nearly free; what blocks it is that the shell reaches the live
+  singleton at module scope (`DocumentPage.tsx`, `Toc.tsx`, `MdxLink.tsx`,
+  `content/index.ts`), and the tests that need fixtures render `AppRoutes`. This
+  rejection is the decision actually being made here.
+- **Leave it undocumented**, as it had been until now. Rejected: the constraint
+  is invisible from `content/`, and an author following
+  `repository-structure.md`'s claim that content "is edited without entering any
+  `src/`" would hit a red suite with no way to know why.
+
+## Consequences
+
+- An authoring decision in this repository may be overridden by a test. That is
+  a real cost paid by the reader of `01-bienvenida.mdx`, whose deck exists for
+  the suite.
+- `repository-structure.md`'s "edited without entering any `src/`" is qualified:
+  still true for _writing_, no longer true for _verifying_.
+- The invariant added by #108 reads frontmatter from source rather than through
+  any of the app's seams, because each of them applies the default. Worth
+  keeping visible: an `import.meta.glob` with `query: '?raw'` does not return the
+  source either — the MDX plugin claims the file first and returns the compiled
+  `MDXContent` function, so a frontmatter regex over it fails every case in a way
+  indistinguishable from the invariant working.
+- **Exit condition**: a dedicated fixture course plus registry injection through
+  the shell. When a second course exists (multi-course is already a planned WP)
+  much of this dissolves on its own, because a fixture course stops being a
+  special case.

--- a/docs/standards/guides/add-a-course-document.md
+++ b/docs/standards/guides/add-a-course-document.md
@@ -56,7 +56,7 @@ the frontmatter `id`, never the path. v0.1 supports exactly ONE course directory
    The field defaults to `auto`, so a document that omits it still ships a deck;
    omitting it does not mean "no slides", it means slides nobody chose. Two of
    the five documents here had exactly that, and one of them projected the book's
-   own navigation sentence — *"Cuando termines, vuelve a la bienvenida"* — alone
+   own navigation sentence — _"Cuando termines, vuelve a la bienvenida"_ — alone
    on a slide.
 
    Deciding is cheap and takes one walk through `/d/<id>/present`. Note that the
@@ -65,13 +65,17 @@ the frontmatter `id`, never the path. v0.1 supports exactly ONE course directory
    only that it exists.
 
    > **The seed course is also the suite's fixture set**, and that constrains
-   > what you may declare here. `documentSections.test.tsx` needs one `auto`
-   > document and one `explicit` one; `presentationRoute.test.tsx` needs a
-   > presentable one and names `busqueda-binaria` for its explicit cases. That is
-   > why `01-bienvenida.mdx` declares `auto` rather than the `none` its content
-   > would suggest — it is the only `auto` document left, and the rail's
-   > markdown-`h2` path has no other real content to run over. Change a
-   > declaration here and run the full suite, not just the build (#108).
+   > what you may declare here. Two tests name the documents they need:
+   > `documentSections.test.tsx` names `bienvenida` (its `auto` fixture) and
+   > `busqueda-binaria` (its `explicit` one, the only document that interleaves a
+   > markdown `##` with `<Slide title>` headings); `presentationRoute.test.tsx`
+   > names `busqueda-binaria` too, and drives `intro-estructuras`.
+   >
+   > That is why `01-bienvenida.mdx` declares `auto` rather than the `none` its
+   > content would suggest: it is the only `auto` document left, and the rail's
+   > markdown-`h2` path has no other real content to run over. Changing a
+   > declaration here can therefore break a test that never mentions your
+   > document — **run the full suite, not just the build** (#108).
 
 3. **Write prose in Markdown.** Headings h2–h4 get automatic slug anchors
    (deep-linkable). Code fences render book-style.
@@ -89,16 +93,16 @@ the frontmatter `id`, never the path. v0.1 supports exactly ONE course directory
    `add-a-content-component.md`.
 
    **A fence in a language the platform runs is highlighted and copyable.**
-   ```` ```java ````, ```` ```cpp ```` and ```` ```python ```` render through
+   ` ```java `, ` ```cpp ` and ` ```python ` render through
    the same editor the runnable blocks use — same colours, a copy button, and
    not editable or runnable (#85, ADR-0024). Write the language whenever the fence holds
    code. A fence with **no** language, or one the platform has no runtime for
-   (```` ```bash ````), stays plain monospace and loads nothing — which is what
+   (` ```bash `), stays plain monospace and loads nothing — which is what
    an ASCII diagram wants.
 
    **The three ids are matched exactly**, so an alias is silently a different
-   language: ```` ```C++ ````, ```` ```c++ ````, ```` ```py ```` and
-   ```` ```Java ```` all fall through to plain monospace. Nothing warns you —
+   language: ` ```C++ `, ` ```c++ `, ` ```py ` and
+   ` ```Java ` all fall through to plain monospace. Nothing warns you —
    the page renders, it just renders grey. If a fence you expected to be
    coloured is not, check its tag before anything else.
 
@@ -154,77 +158,77 @@ the frontmatter `id`, never the path. v0.1 supports exactly ONE course directory
    compiler at all.
 
 5b. **Add an exercise (optional)**: `<Exercise>` gives the reader a problem to
-   solve, checked automatically in their browser. The statement is ordinary
-   prose; two annotated fences carry the rest:
+solve, checked automatically in their browser. The statement is ordinary
+prose; two annotated fences carry the rest:
 
-   ````mdx
-   <Exercise title="¿Es par?">
+````mdx
+<Exercise title="¿Es par?">
 
-   Escribe `esPar`, que devuelve `true` si el número es par.
+Escribe `esPar`, que devuelve `true` si el número es par.
 
-   ```java starter
-   class Solution {
-       static boolean esPar(int n) {
-           return false;
-       }
-   }
-   ```
+```java starter
+class Solution {
+    static boolean esPar(int n) {
+        return false;
+    }
+}
+```
 
-   ```java test
-   check(Solution.esPar(4), true);
-   check(Solution.esPar(7), false);
-   ```
+```java test
+check(Solution.esPar(4), true);
+check(Solution.esPar(7), false);
+```
 
-   </Exercise>
-   ````
+</Exercise>
+````
 
-   The `test` fence is inlined as the body of a generated `main` (in class
-   `NalandaCheck`), which is compiled beside the student's class and calls it —
-   so what is checked is the method, not what the program printed. Two
-   consequences worth knowing before you write one:
+The `test` fence is inlined as the body of a generated `main` (in class
+`NalandaCheck`), which is compiled beside the student's class and calls it —
+so what is checked is the method, not what the program printed. Two
+consequences worth knowing before you write one:
 
-   - **Statements only.** No method or field declarations: they are legal in a
-     class body and illegal in a method body. Get it wrong and the *student*
-     sees compiler errors for code they never wrote.
-   - **`check(obtenido, esperado)`** — the student's value first, the expected
-     value second. Reversed, it still compiles and the feedback reads backwards.
-     `check` is the only helper available, overloaded for `int`, `long`,
-     `double` (compared with a 1e-9 tolerance, never `==`), `boolean`, `char`,
-     `Object` (arrays compared by contents) and `int[]`, `long[]`, `char[]`,
-     `boolean[]`.
+- **Statements only.** No method or field declarations: they are legal in a
+  class body and illegal in a method body. Get it wrong and the _student_
+  sees compiler errors for code they never wrote.
+- **`check(obtenido, esperado)`** — the student's value first, the expected
+  value second. Reversed, it still compiles and the feedback reads backwards.
+  `check` is the only helper available, overloaded for `int`, `long`,
+  `double` (compared with a 1e-9 tolerance, never `==`), `boolean`, `char`,
+  `Object` (arrays compared by contents) and `int[]`, `long[]`, `char[]`,
+  `boolean[]`.
 
-   The class named in `starter` and the one the cases call must agree.
-   **Only Java validates**; C++ and Python refuse an exercise rather than report
-   a pass for something they never checked. Two class names are reserved by the
-   platform — `NalandaLauncher` and `NalandaCheck` — and a Java program using
-   either is refused before it compiles, in an exercise or a plain editor alike.
+The class named in `starter` and the one the cases call must agree.
+**Only Java validates**; C++ and Python refuse an exercise rather than report
+a pass for something they never checked. Two class names are reserved by the
+platform — `NalandaLauncher` and `NalandaCheck` — and a Java program using
+either is refused before it compiles, in an exercise or a plain editor alike.
 
-   Editing a shipped `starter` fence changes the key its drafts are stored
-   under: every student's saved attempt at that exercise becomes unreachable
-   (ADR-0020 §3). Fixing a typo in a starter is cheap; rewriting one after a
-   class has used it is not.
+Editing a shipped `starter` fence changes the key its drafts are stored
+under: every student's saved attempt at that exercise becomes unreachable
+(ADR-0020 §3). Fixing a typo in a starter is cheap; rewriting one after a
+class has used it is not.
 
-   The cases are hidden until the first run — pacing, not secrecy. Everything
-   under `content/` is published, so the page source reveals them to anyone who
-   looks: never author an exercise whose cases must stay private.
+The cases are hidden until the first run — pacing, not secrecy. Everything
+under `content/` is published, so the page source reveals them to anyone who
+looks: never author an exercise whose cases must stay private.
 
-   Worked example: `06-java-desde-cpp.mdx` (four exercises).
+Worked example: `06-java-desde-cpp.mdx` (four exercises).
 
 5c. **Compare two listings (optional)**: `<SideBySide left="C++" right="Java">`
-   places exactly two blocks next to each other, stacking on a narrow screen.
-   For a course whose students already program, the comparison is often the
-   lesson itself. Half the page is all a column gets: check the longest line of
-   both listings on a slide, not only in the book.
-   Worked example: `06-java-desde-cpp.mdx`.
+places exactly two blocks next to each other, stacking on a narrow screen.
+For a course whose students already program, the comparison is often the
+lesson itself. Half the page is all a column gets: check the longest line of
+both listings on a slide, not only in the book.
+Worked example: `06-java-desde-cpp.mdx`.
 
 Full usage docs, props and live examples for every document-facing component
 live in the catalog — browse `/catalog`, which is generated from the components
 themselves rather than maintained by hand.
 
 5d. **External links**: write them as explicit `https://`. Markdown now parses
-   GFM, so a bare URL becomes a link on its own — and a bare `www.host` resolves
-   to **`http://`**, a cleartext link the reader can be downgraded on. Tables,
-   strikethrough (`~~`), task lists and footnotes also work now.
+GFM, so a bare URL becomes a link on its own — and a bare `www.host` resolves
+to **`http://`**, a cleartext link the reader can be downgraded on. Tables,
+strikethrough (`~~`), task lists and footnotes also work now.
 
 6. **Cross-reference with wiki-links**: `[[otro-id]]` renders that document's
    link, `[[otro-id|texto visible]]` overrides the label. A target that doesn't
@@ -264,7 +268,7 @@ themselves rather than maintained by hand.
 
    **A build cannot see inside an exercise.** The fence labels are matched when
    the component renders, and the cases are Java compiled in the reader's
-   browser — so a mistyped ```` ```java Starter ```` or a `test` fence that does
+   browser — so a mistyped ` ```java Starter ` or a `test` fence that does
    not compile ships with a green build and a green suite. Open the document
    before the PR (`npm run build && npm run preview`, then
    `/nalanda/d/<id>`) and run every exercise you added: no amber authoring
@@ -304,7 +308,10 @@ themselves rather than maintained by hand.
       unless the value is `none`.
 - [ ] Wiki-links point at real ids (or are intentional forward links).
 - [ ] Listed in `index.yaml` if it belongs to the recorrido.
-- [ ] `npm run build` green from `apps/web/` (content integrity gate).
+- [ ] `npm run build` **and** `npm run test` green from `apps/web/`. The build
+      runs the content integrity gate; the declaration invariant and the fixture
+      guards live in the suite, so the build alone goes green on content CI
+      rejects (#108).
 - [ ] Every exercise opened in `npm run preview` and actually run: no authoring
       banner, cases pass against a correct solution and fail against the starter.
       Nothing in the build or the suite can check this for you.

--- a/docs/standards/guides/add-a-course-document.md
+++ b/docs/standards/guides/add-a-course-document.md
@@ -16,8 +16,8 @@ The seed course `content/courses/sample-course/` exercises everything:
 
 ```
 content/courses/sample-course/
-├── 01-bienvenida.mdx          # id: bienvenida        (presentation: auto — h2 slicing)
-├── 02-intro-estructuras.mdx   # id: intro-estructuras (auto, uses <SectionBreak/>)
+├── 01-bienvenida.mdx          # id: bienvenida        (auto — h2 slicing; the suite's `auto` fixture)
+├── 02-intro-estructuras.mdx   # id: intro-estructuras (explicit, uses <Slide>)
 ├── 03-busqueda-binaria.mdx    # id: busqueda-binaria  (presentation: explicit, uses <Slide>)
 ├── 04-apuntes.mdx             # id: apuntes-del-curso (presentation: none — book-only)
 ├── 05-codigo-ejecutable.mdx   # id: codigo-ejecutable (explicit, uses <CodeEditor>)
@@ -41,7 +41,7 @@ the frontmatter `id`, never the path. v0.1 supports exactly ONE course directory
    ---
    id: busqueda-binaria # kebab-case, UNIQUE across the whole content/ tree
    title: Búsqueda binaria # shown in the TOC, prev/next, and lookups
-   presentation: explicit # OPTIONAL: auto (default) | explicit | none
+   presentation: explicit # auto | explicit | none — declare it, always
    ---
    ```
 
@@ -50,6 +50,28 @@ the frontmatter `id`, never the path. v0.1 supports exactly ONE course directory
    ONLY content marked with `<Slide>` / `<SectionBreak/>` (loose prose stays
    book-only); `none` means book-only — no Presentar toggle, `/present`
    redirects back.
+
+   **Optional in the schema, required in practice — declare it even when you
+   want the default** (#108, enforced by `src/content/architecture.test.ts`).
+   The field defaults to `auto`, so a document that omits it still ships a deck;
+   omitting it does not mean "no slides", it means slides nobody chose. Two of
+   the five documents here had exactly that, and one of them projected the book's
+   own navigation sentence — *"Cuando termines, vuelve a la bienvenida"* — alone
+   on a slide.
+
+   Deciding is cheap and takes one walk through `/d/<id>/present`. Note that the
+   walk is the only way to find this: an undeclared deck is never clipped or
+   unreadable, so nothing in the build or the suite can tell you it is wrong —
+   only that it exists.
+
+   > **The seed course is also the suite's fixture set**, and that constrains
+   > what you may declare here. `documentSections.test.tsx` needs one `auto`
+   > document and one `explicit` one; `presentationRoute.test.tsx` needs a
+   > presentable one and names `busqueda-binaria` for its explicit cases. That is
+   > why `01-bienvenida.mdx` declares `auto` rather than the `none` its content
+   > would suggest — it is the only `auto` document left, and the rail's
+   > markdown-`h2` path has no other real content to run over. Change a
+   > declaration here and run the full suite, not just the build (#108).
 
 3. **Write prose in Markdown.** Headings h2–h4 get automatic slug anchors
    (deep-linkable). Code fences render book-style.
@@ -275,8 +297,11 @@ themselves rather than maintained by hand.
 
 ## Checklist
 
-- [ ] Frontmatter has kebab-case `id` (unique) + `title` (+ `presentation` if
-      the default `auto` doesn't fit).
+- [ ] Frontmatter has kebab-case `id` (unique) + `title` + `presentation` —
+      declared even when the value is the default (`architecture.test.ts` fails
+      otherwise).
+- [ ] The deck the chosen value produces was walked once in `/d/<id>/present`,
+      unless the value is `none`.
 - [ ] Wiki-links point at real ids (or are intentional forward links).
 - [ ] Listed in `index.yaml` if it belongs to the recorrido.
 - [ ] `npm run build` green from `apps/web/` (content integrity gate).

--- a/docs/standards/guides/add-a-course-document.md
+++ b/docs/standards/guides/add-a-course-document.md
@@ -16,12 +16,12 @@ The seed course `content/courses/sample-course/` exercises everything:
 
 ```
 content/courses/sample-course/
-├── 01-bienvenida.mdx          # id: bienvenida        (auto — h2 slicing; the suite's `auto` fixture)
-├── 02-intro-estructuras.mdx   # id: intro-estructuras (explicit, uses <Slide>)
-├── 03-busqueda-binaria.mdx    # id: busqueda-binaria  (presentation: explicit, uses <Slide>)
-├── 04-apuntes.mdx             # id: apuntes-del-curso (presentation: none — book-only)
-├── 05-codigo-ejecutable.mdx   # id: codigo-ejecutable (explicit, uses <CodeEditor>)
-├── 06-java-desde-cpp.mdx      # id: java-desde-cpp    (explicit, uses <Exercise> + <SideBySide>)
+├── 01-bienvenida.mdx          # presentation: auto     — h2 slicing; the suite's `auto` fixture
+├── 02-intro-estructuras.mdx   # presentation: explicit — uses <Slide>
+├── 03-busqueda-binaria.mdx    # presentation: explicit — uses <Slide>, plus a markdown ## (both h2 sources)
+├── 04-apuntes.mdx             # presentation: none     — book-only
+├── 05-codigo-ejecutable.mdx   # presentation: explicit — uses <CodeEditor>
+├── 06-java-desde-cpp.mdx      # presentation: explicit — uses <Exercise> + <SideBySide>
 └── index.yaml                 # the ordered teaching path
 ```
 
@@ -55,7 +55,7 @@ the frontmatter `id`, never the path. v0.1 supports exactly ONE course directory
    want the default** (#108, enforced by `src/content/architecture.test.ts`).
    The field defaults to `auto`, so a document that omits it still ships a deck;
    omitting it does not mean "no slides", it means slides nobody chose. Two of
-   the five documents here had exactly that, and one of them projected the book's
+   the six documents here had exactly that, and one of them projected the book's
    own navigation sentence — _"Cuando termines, vuelve a la bienvenida"_ — alone
    on a slide.
 
@@ -65,11 +65,19 @@ the frontmatter `id`, never the path. v0.1 supports exactly ONE course directory
    only that it exists.
 
    > **The seed course is also the suite's fixture set**, and that constrains
-   > what you may declare here. Two tests name the documents they need:
-   > `documentSections.test.tsx` names `bienvenida` (its `auto` fixture) and
-   > `busqueda-binaria` (its `explicit` one, the only document that interleaves a
-   > markdown `##` with `<Slide title>` headings); `presentationRoute.test.tsx`
-   > names `busqueda-binaria` too, and drives `intro-estructuras`.
+   > what you may declare here. Several tests bind to real documents; three
+   > constrain the presentation declaration:
+   >
+   > - `documentSections.test.tsx` names `bienvenida` (its `auto` fixture) and
+   >   `busqueda-binaria` (its `explicit` one, chosen because it carries BOTH
+   >   heading sources — `<Slide title>` h2s and a markdown `##` — which is the
+   >   equivalence those cases assert).
+   > - `presentationRoute.test.tsx` names `busqueda-binaria` too and drives
+   >   `intro-estructuras`.
+   > - `presentationRoute.test.tsx` also drives `java-desde-cpp` at a **fixed
+   >   slide index** (`?slide=5`), so that document must stay presentable and
+   >   keep its shape there. Nothing names it as a fixture; it is a bare URL in a
+   >   test.
    >
    > That is why `01-bienvenida.mdx` declares `auto` rather than the `none` its
    > content would suggest: it is the only `auto` document left, and the rail's

--- a/docs/standards/repository-structure.md
+++ b/docs/standards/repository-structure.md
@@ -47,28 +47,43 @@ nalanda/
    - `content/` — course material (Material domain). Not app code: it has its own
      lifecycle (authoring), its own future (database, per ADR-0002), and is edited
      without entering any `src/`.
+
+     **In v0.1 it is also the test suite's fixture set, and that is a real
+     constraint on authoring, not just a note.** Several tests assert over the
+     live registry because there is no other real content to assert over. The
+     cost has already been paid once: since #108, `01-bienvenida.mdx` declares
+     `presentation: auto` rather than the `none` its content argues for, purely
+     because it is the suite's only `auto` document. A declaration chosen for the
+     suite rather than for the reader is the line this crosses — ADR-0013 §4
+     accepts content-as-fixture, but there the fixture role and the content's
+     intent agreed. Editing `content/` therefore requires the full suite, not
+     only the build (`guides/add-a-course-document.md` §presentation). The exit
+     is a dedicated fixture course plus registry injection — `buildRegistry` is
+     already parameterised; what blocks it is that the shell reaches
+     `liveContent` at module scope. Its own WP when the cost justifies it.
+
    - `docs/` — knowledge: standards, design, decisions, conventions.
    - `infra/` — running the system around the apps:
      - `infra/local/` — local orchestration (docker-compose, multi-app Makefile)
        and runnable dev mocks of external services.
      - `infra/deploy/` — host provisioning, reverse-proxy/systemd config,
-       production compose. Apps package themselves; infra *places* them.
+       production compose. Apps package themselves; infra _places_ them.
 
 ## Placement criteria — "where does X go"
 
-| Thing | Where | Why |
-|---|---|---|
-| Local orchestration (docker-compose / multi-app Makefile) | `infra/local/` | Coordinates apps; belongs to none |
-| Runnable dev mock of an external service (fake university API, fake OAuth server) | `infra/local/mocks/` | Exists to run the system locally, not to test |
-| Test fakes/mocks (in-process, used by tests) | Next to the tests, inside their app | Test code |
-| Dockerfile / packaging of one app | Inside that app | The app packages itself; infra places it |
-| VPS provisioning, systemd/proxy config, production compose | `infra/deploy/` | Belongs to the host, not to an app |
-| One app's integration tests | In that app | They verify ITS behavior |
-| Cross-app e2e (browser → web → server) | Top-level `e2e/` (created when it first exists) | Verifies the whole |
-| Course assets (images/video) | `content/`, next to their documents | Material domain |
-| Test mocks needed by a second app | Promote to `packages/` | Shared-code rule |
-| Build script (fetches or generates a build input) | `apps/<app>/scripts/`, wired to an npm lifecycle hook (`prebuild`/`predev`) | Neither source nor runtime code; must run before the bundler, and in CI |
-| Fetched or generated build input (jar, wasm blob) | That app's `public/`, gitignored, digest pinned in the fetching script | Reproducible without carrying binaries in git — worked case `public/java-compiler.jar` (ADR-0017) |
+| Thing                                                                             | Where                                                                       | Why                                                                                               |
+| --------------------------------------------------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Local orchestration (docker-compose / multi-app Makefile)                         | `infra/local/`                                                              | Coordinates apps; belongs to none                                                                 |
+| Runnable dev mock of an external service (fake university API, fake OAuth server) | `infra/local/mocks/`                                                        | Exists to run the system locally, not to test                                                     |
+| Test fakes/mocks (in-process, used by tests)                                      | Next to the tests, inside their app                                         | Test code                                                                                         |
+| Dockerfile / packaging of one app                                                 | Inside that app                                                             | The app packages itself; infra places it                                                          |
+| VPS provisioning, systemd/proxy config, production compose                        | `infra/deploy/`                                                             | Belongs to the host, not to an app                                                                |
+| One app's integration tests                                                       | In that app                                                                 | They verify ITS behavior                                                                          |
+| Cross-app e2e (browser → web → server)                                            | Top-level `e2e/` (created when it first exists)                             | Verifies the whole                                                                                |
+| Course assets (images/video)                                                      | `content/`, next to their documents                                         | Material domain                                                                                   |
+| Test mocks needed by a second app                                                 | Promote to `packages/`                                                      | Shared-code rule                                                                                  |
+| Build script (fetches or generates a build input)                                 | `apps/<app>/scripts/`, wired to an npm lifecycle hook (`prebuild`/`predev`) | Neither source nor runtime code; must run before the bundler, and in CI                           |
+| Fetched or generated build input (jar, wasm blob)                                 | That app's `public/`, gitignored, digest pinned in the fetching script      | Reproducible without carrying binaries in git — worked case `public/java-compiler.jar` (ADR-0017) |
 
 **Growth rule:** when a new case has no row in this table, propose a placement in
 the PR that introduces it and record the outcome here in the same PR. The standard

--- a/docs/standards/repository-structure.md
+++ b/docs/standards/repository-structure.md
@@ -57,7 +57,7 @@ nalanda/
      suite rather than for the reader is the line this crosses — ADR-0013 §4
      accepts content-as-fixture, but there the fixture role and the content's
      intent agreed. Editing `content/` therefore requires the full suite, not
-     only the build (`guides/add-a-course-document.md` §presentation). The exit
+     only the build (`guides/add-a-course-document.md` step 2 (Frontmatter)). The exit
      is a dedicated fixture course plus registry injection — `buildRegistry` is
      already parameterised; what blocks it is that the shell reaches
      `liveContent` at module scope. Its own WP when the cost justifies it.

--- a/docs/standards/repository-structure.md
+++ b/docs/standards/repository-structure.md
@@ -45,22 +45,19 @@ nalanda/
    - `packages/` — code shared by two or more apps. Nothing is "promoted" here
      speculatively; a second consumer is the admission ticket.
    - `content/` — course material (Material domain). Not app code: it has its own
-     lifecycle (authoring), its own future (database, per ADR-0002), and is edited
-     without entering any `src/`.
+     lifecycle (authoring), its own future (database, per ADR-0002), and is
+     **written** without entering any `src/` — but see below: verifying it is
+     another matter.
 
-     **In v0.1 it is also the test suite's fixture set, and that is a real
-     constraint on authoring, not just a note.** Several tests assert over the
-     live registry because there is no other real content to assert over. The
-     cost has already been paid once: since #108, `01-bienvenida.mdx` declares
-     `presentation: auto` rather than the `none` its content argues for, purely
-     because it is the suite's only `auto` document. A declaration chosen for the
-     suite rather than for the reader is the line this crosses — ADR-0013 §4
-     accepts content-as-fixture, but there the fixture role and the content's
-     intent agreed. Editing `content/` therefore requires the full suite, not
-     only the build (`guides/add-a-course-document.md` step 2 (Frontmatter)). The exit
-     is a dedicated fixture course plus registry injection — `buildRegistry` is
-     already parameterised; what blocks it is that the shell reaches
-     `liveContent` at module scope. Its own WP when the cost justifies it.
+     **In v0.1 it is also the test suite's fixture set** (ADR-0025), and that is
+     a constraint on authoring rather than a note. Several tests assert over the
+     live registry because there is no other real content to assert over, so a
+     declaration can be forced by a test instead of by the reader: since #108,
+     `01-bienvenida.mdx` declares `presentation: auto` rather than the `none` its
+     content argues for, purely because it is the suite's only `auto` document.
+     Editing `content/` therefore requires the full suite, not only the build
+     (`guides/add-a-course-document.md` step 2). ADR-0025 carries the
+     alternatives that were rejected and the exit condition.
 
    - `docs/` — knowledge: standards, design, decisions, conventions.
    - `infra/` — running the system around the apps:

--- a/docs/standards/testing-strategy.md
+++ b/docs/standards/testing-strategy.md
@@ -318,11 +318,12 @@ playwright package.json` finds nothing by design), then drive `npm run build
   and all mean "whatever the index happens to put first". Name the fixture
   whenever the assertions know its content, and give the guard a message saying
   what to repoint. Worked case (#108): declaring `explicit` on a document earlier
-  in the index moved `documentSections.test.tsx` off the only document that
-  interleaves a markdown `##` with `<Slide title>` headings — the exact
-  equivalence that case exists to assert. The suite stayed green at 576 while the
-  case stopped testing what it is named for, and the diff that caused it did not
-  touch that file or either document it selects.
+  in the index moved `documentSections.test.tsx` onto one whose `h2`s all come
+  from `<Slide title>`, so the case asserting that BOTH heading sources produce
+  one section list stopped exercising the mixed document it was written for. The
+  suite stayed green at 576 while the case stopped testing what it is named for,
+  and the diff that caused it touched neither that file nor either document it
+  selects.
 - **Registry-driven invariants**: when a standard applies to every member of a
   live registry, iterate the registry at module scope and generate one case per
   entry, so a new entry is gated the moment it is registered — never hand-write

--- a/docs/standards/testing-strategy.md
+++ b/docs/standards/testing-strategy.md
@@ -24,16 +24,16 @@ the add-new-app checklist in `repository-structure.md`).
 
 ## Test levels
 
-| Level | Verifies | Tool | When |
-|---|---|---|---|
-| L1 Static | Types, lint, format | `tsc` + oxlint + prettier | Every commit |
-| L2 Unit | Pure logic: parsers, registries, index walks | Vitest | Every commit (TDD red→green per slice) |
-| L3 Component | Components honor their contract (e.g., per-mode rendering) | Vitest + Testing Library (jsdom) | Every commit, touched scope |
-| L4 Architecture | System invariants: import direction + feature edges (`src/architecture.test.ts`), content ids (`src/content/architecture.test.ts`), catalog entry shape (`src/catalog/architecture.test.tsx`), entry-chunk isolation — a per-component case for each lazily-registered heavy component, **plus** a walk of everything the shell reaches eagerly from `app/main.tsx` (both in `src/architecture.test.ts`): it never reaches `runtime/`, and it pulls in no bare package outside `SHIPS_EAGERLY`, MDX map ↔ catalog completeness (`src/app/mdxComponents.test.ts`), deployed build shape (`src/app/deployedApp.test.tsx`, `src/app/spaFallback.test.ts`) | Vitest (pattern imported from DocumentBuddy) | Pre-PR + CI |
-| L5 Browser smoke | The real app boots; key flows render in a real browser | **Playwright** (decided 2026-08-06; introduced with the first real smoke, WP2+) | Pre-PR + CI |
-| L6 Backend integration | Go handlers against real SQLite + fakes | Go testing | Defined when `apps/server` is born (v0.3) |
-| L7 Cross-app e2e | browser → web → server | Top-level `e2e/` | v0.3+ |
-| L8 Manual | Human visual/functional verification | PR checklist | Pre-PR |
+| Level                  | Verifies                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               | Tool                                                                            | When                                      |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------- | ----------------------------------------- |
+| L1 Static              | Types, lint, format                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | `tsc` + oxlint + prettier                                                       | Every commit                              |
+| L2 Unit                | Pure logic: parsers, registries, index walks                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | Vitest                                                                          | Every commit (TDD red→green per slice)    |
+| L3 Component           | Components honor their contract (e.g., per-mode rendering)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | Vitest + Testing Library (jsdom)                                                | Every commit, touched scope               |
+| L4 Architecture        | System invariants: import direction + feature edges (`src/architecture.test.ts`), content ids (`src/content/architecture.test.ts`), catalog entry shape (`src/catalog/architecture.test.tsx`), entry-chunk isolation — a per-component case for each lazily-registered heavy component, **plus** a walk of everything the shell reaches eagerly from `app/main.tsx` (both in `src/architecture.test.ts`): it never reaches `runtime/`, and it pulls in no bare package outside `SHIPS_EAGERLY`, MDX map ↔ catalog completeness (`src/app/mdxComponents.test.ts`), deployed build shape (`src/app/deployedApp.test.tsx`, `src/app/spaFallback.test.ts`) | Vitest (pattern imported from DocumentBuddy)                                    | Pre-PR + CI                               |
+| L5 Browser smoke       | The real app boots; key flows render in a real browser                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | **Playwright** (decided 2026-08-06; introduced with the first real smoke, WP2+) | Pre-PR + CI                               |
+| L6 Backend integration | Go handlers against real SQLite + fakes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | Go testing                                                                      | Defined when `apps/server` is born (v0.3) |
+| L7 Cross-app e2e       | browser → web → server                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | Top-level `e2e/`                                                                | v0.3+                                     |
+| L8 Manual              | Human visual/functional verification                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | PR checklist                                                                    | Pre-PR                                    |
 
 **TDD is the default working mode**: for any slice with logic, the test comes
 first (red), then the implementation (green). Internal refactors lean on the
@@ -77,7 +77,7 @@ battery (full tests + integration L6), same rigor as `apps/web`.
 
 - Tests are colocated: `Thing.test.ts(x)` next to `Thing.ts(x)`.
 - **Ordering invariants are asserted with the call still in flight.** When what a
-  slice buys is *when* something happens relative to a blocking call — saved
+  slice buys is _when_ something happens relative to a blocking call — saved
   before the run, warmed before the click, discarded before the switch — assert
   against the intermediate state, never after the round trip: by then both
   orderings look identical. Worked case (#76): a test named "saves the editor
@@ -159,7 +159,7 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   through 70% of a document (an observer fires on crossings; a reader inside a
   long section crosses nothing); a focus trap that let Tab escape in Chromium to
   the toggle behind the drawer; and the first fix for it, a visibility filter on
-  `offsetParent`, which under jsdom matched *nothing*, emptied the trap's list
+  `offsetParent`, which under jsdom matched _nothing_, emptied the trap's list
   and made its own tests pass while proving nothing.
 - **A media query is the sharpest case of it**: the suite can pin **which
   question is asked** and fake the answer, never evaluate it, so what is
@@ -224,7 +224,7 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   `app/presentationRoute.test.tsx` §"fitting a slide to the stage it is shown
   on", where the rotation case fails against the index-keyed version.
 - **A negative test about a KEY needs a positive twin.** When a test asserts
-  that something stored under a computed key is *ignored* — a draft, a cache
+  that something stored under a computed key is _ignored_ — a draft, a cache
   entry, a query param — it passes identically when the guard works and when the
   test simply computed the wrong key and planted nothing the code would ever
   read. Pair it with a test that plants under the SAME key and expects it to be
@@ -244,7 +244,7 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   WHICH line reddened: an assertion sitting after a `waitFor` whose condition the
   same mutation also breaks can never fire. Worked case (#85): a guard against an
   exercise rendering its authoring banner sat behind
-  `await waitFor(… toContain('Escribe'))`, and the banner *replaces* the
+  `await waitFor(… toContain('Escribe'))`, and the banner _replaces_ the
   statement — so the mutation reddened the file at the wait, and the guard was
   dead through two rounds of review before a recheck named the line. Do this on a
   **committed** tree and restore with `git checkout --`: that command reverts
@@ -266,9 +266,9 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   the deck on an iPhone (ADR-0023).
 - **The browser recipe lives here, not in a runtime guide.** Two failure classes
   now share it. Install once (`npm install playwright && npx playwright install
-  chromium`, in a scratch directory — it is not a repo dependency; `grep
-  playwright package.json` finds nothing by design), then drive `npm run build
-  && npm run preview` (which serves under `/nalanda/`, like production — the
+chromium`, in a scratch directory — it is not a repo dependency; `grep
+playwright package.json` finds nothing by design), then drive `npm run build
+&& npm run preview` (which serves under `/nalanda/`, like production — the
   dev server serves at `/` and exercises different paths, ADR-0015). Add
   `-- --port <n>` when something already holds 4173.
   **Stop it by port, never by pattern**: `lsof -ti tcp:<n> | xargs kill`. Other
@@ -287,7 +287,7 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   a narrow laptop window. Two mechanics worth knowing before they cost an hour
   (#91): on a **fullscreen** page the driver's resize call rejects
   (`Browser.setWindowBounds`: "To resize minimized/maximized/fullscreen window,
-  restore it to normal state first") *after* the metrics override has already
+  restore it to normal state first") _after_ the metrics override has already
   landed — so the page has rotated, the app has reacted, and the script dies
   holding a state it thinks it never reached. Rotate a fullscreen page through
   `Emulation.setDeviceMetricsOverride` on a CDP session instead. And the
@@ -298,6 +298,31 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   into a colocated, unit-tested module rather than inlining it in a component
   the suite cannot exercise. Worked case: `app/basename.ts` derives the router
   basename from `BASE_URL` (#66).
+- **An invariant about what an author DECLARED reads the source.** Every layer
+  that hands you a model has already normalised the distinction away — that is
+  what a normaliser is for — so asking one of them what the author wrote returns
+  what the author _meant after defaults_. Worked case (#108): `presentation` is
+  optional and defaults to `auto`, and the invariant is that every document
+  declares it. Three seams were candidates and two are structurally blind — the
+  registry and the `?frontmatter` virtual module both run `parseDocumentMeta`,
+  which applies the default. The third, an `import.meta.glob` with
+  `query: '?raw'`, is worse than blind: the MDX plugin claims the file first, so
+  the glob returns the compiled `MDXContent` function and a frontmatter regex
+  over it fails EVERY case with "no frontmatter block" — indistinguishable from
+  the invariant working. Read the file. Take the file _list_ from the same glob
+  the app ships from, so the set checked is the set published: a directory walk
+  of your own drifts from it in both directions, following a symlinked directory
+  out of the tree while dropping a symlinked `.mdx` the registry does publish.
+- **A fixture picked positionally silently follows the content.** `ids[0]`, "the
+  first `explicit` document", "the first presentable one" — all read as robust
+  and all mean "whatever the index happens to put first". Name the fixture
+  whenever the assertions know its content, and give the guard a message saying
+  what to repoint. Worked case (#108): declaring `explicit` on a document earlier
+  in the index moved `documentSections.test.tsx` off the only document that
+  interleaves a markdown `##` with `<Slide title>` headings — the exact
+  equivalence that case exists to assert. The suite stayed green at 576 while the
+  case stopped testing what it is named for, and the diff that caused it did not
+  touch that file or either document it selects.
 - **Registry-driven invariants**: when a standard applies to every member of a
   live registry, iterate the registry at module scope and generate one case per
   entry, so a new entry is gated the moment it is registered — never hand-write
@@ -308,7 +333,7 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   non-vacuity guard carries a **message naming the test to write when it trips**,
   not a bare check — the day it fires, whoever hits it is not the person who knew
   why it was there. Worked case (#87): `expect(empty, 'every family now has
-  components — cover the empty branch with a direct FamilyPage test')`.
+components — cover the empty branch with a direct FamilyPage test')`.
 - **Assert where the fact belongs, not that it appears somewhere.** A page-wide
   `getAllByText(...)` proves a string exists on the page; it does not tie the
   string to the row that must carry it. Scope with `within(...)` on the element
@@ -320,7 +345,7 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   family. The same shape hid a swapped component count.
   Second worked case (#87): four tests written across S3–S7 stayed green through
   the exact defect each was named for — every one asserted that a string appeared
-  *somewhere* rather than in the place that had to carry it — and the slice that
+  _somewhere_ rather than in the place that had to carry it — and the slice that
   fixed them exists only because a review lens mutated the code instead of
   reading it.
 - **An invariant with a deliberate exception splits by level.** Put the


### PR DESCRIPTION
**Closes #108**

## Summary

Every course document now states how it presents, and an L4 invariant keeps it
that way. `presentation` is optional in the schema and defaults to `auto`, so a
document that never declared it still shipped a deck — one nobody chose, and one
nothing could flag: an undeclared deck is never clipped, never unreadable and
never invalid, so neither the build nor the suite could say it was wrong, only
that it existed. Walking it was the only way to find out.

Two of the six documents were in that state. One of them,
`02-intro-estructuras.mdx`, ended its deck on the book's own closing navigation
sentence — *"Cuando termines, vuelve a la bienvenida"* — projected alone on a
slide.

The field stays optional in the schema on purpose. What changed is that omitting
it is a CI failure **here**, which is a departure from ADR-0013 §2 and is
recorded as an amendment to it rather than left as a contradiction.

## Slices completed

- [x] **S1** — walked the four decks in a browser and decided curate vs `none`
      for each (decisions recorded in [the issue](https://github.com/so77id/nalanda/issues/108#issuecomment-5287991089); no diff, by nature)
- [x] **S2** — applied the declarations and updated the authoring guide

## Acceptance criteria

1. **All course documents declare `presentation` explicitly, including where the
   value equals the old default.** ✅

   ```
   01-bienvenida.mdx          presentation: auto
   02-intro-estructuras.mdx   presentation: explicit
   03-busqueda-binaria.mdx    presentation: explicit
   04-apuntes.mdx             presentation: none
   05-codigo-ejecutable.mdx   presentation: explicit
   06-java-desde-cpp.mdx      presentation: explicit
   ```

   Enforced by `apps/web/src/content/architecture.test.ts`, mutation-checked:
   deleting the declaration from `01-bienvenida.mdx` reddens exactly that case
   with its authored message.

2. **Every deck left alive was walked end to end; nothing clipped, unreadable or
   below 0.8 scale at 1024×768.** ✅ Driven with `ArrowRight` rather than
   reloading `?slide=N`, per `testing-strategy.md` — a per-state measurement only
   exercises mount (#99).

   | Deck | Slides | Scale |
   |---|---|---|
   | `bienvenida` | 3 | 1 |
   | `intro-estructuras` | 4 | 1 |
   | `busqueda-binaria` | 3 | 1 |
   | `codigo-ejecutable` | 4 | 1 |

   `intro-estructuras` before: 4 slides ending on the navigation sentence. After:
   4 slides ending on "Operaciones y costos". The book keeps the sentence.

3. **The authoring guide recommends declaring the field and says why.** ✅
   `docs/standards/guides/add-a-course-document.md` step 2, plus the fixture
   constraint and a checklist that now requires `npm run test`.

4. **`npm run build` green.** ✅ And `npm run test`: **59 files / 577 tests**.

## Tests

- New L4 invariant over every document the `@content` glob finds — the same seam
  `liveContent.ts` ships from, so the set checked is the set published.
- New behavioural case pinning that the closing navigation sentence stays
  book-only. Seen red at `presentationRoute.test.tsx:613` against the document's
  pre-#108 form.
- Three fixture selections changed from positional to named.

Both new cases were mutation-checked on a committed tree, with the failing line
named in the commit message.

## Reviews run

Full pipeline, both rounds.

**Round A** — `lens-correctness-tests`, `lens-arch-simplicity`, `lens-security`,
each in its own worktree. `lens-performance` deliberately not spawned: the diff
touches no render or compute path and the issue declares no perf goal. 18
findings → 4 groups after dedup → adversarial verifier on the important ones.

Verifier outcome: 2 CONFIRMED, 3 DEFLATED, 1 dismissed. It **corrected the fix I
was about to apply**: `Object.keys(import.meta.glob(...))` returns keys relative
to the Vite root, not absolute paths, so the proposed change would have broken
the test from the repo root.

**Round B** — `lens-docs-accuracy` and `lens-adr-hunter`. Narrowed from four
lenses by explicit decision; `lens-docs-completeness` and
`lens-agent-readability` were not run.

Per-fix recheck was **skipped by explicit decision**: every fix was verified by
executing it rather than by re-reading — 9/9 from both working directories, the
new case seen red at its own line, the full gate at exit 0.

What the review caught that five green gates did not:

| | Found by |
|---|---|
| The walker diverged from the published set in both directions (followed a symlinked dir out of the tree, dropped a symlinked `.mdx` the registry publishes) | security |
| A coverage regression in a file the diff never touched: a positionally-picked fixture moved, and its case stopped asserting the equivalence it is named for | correctness |
| A load-bearing comment of mine was factually false about *why* `import.meta.url` failed | arch + correctness |
| Four false claims in the docs, including a uniqueness assertion repeated in three files | docs-accuracy |
| **This WP contradicted Accepted ADR-0013 §2 and never touched `docs/decisions/`** | adr-hunter |

## Manual verification

- [ ] `/d/intro-estructuras/present` — 4 slides, ends on "Operaciones y costos",
      no navigation sentence anywhere in the deck.
- [ ] `/d/intro-estructuras` — book still shows both `##` sections and the
      closing sentence.
- [ ] `/d/bienvenida/present` — still 3 slides (it stays `auto` for the suite).
- [ ] Read **ADR-0013 §2.1** and **ADR-0025** and confirm they say what you want
      said. ADR-0025 accepts a real cost — a document declares a mode for the
      test suite rather than for its reader — and that is the kind of thing that
      should carry your name, not mine.

## Notes

- **`01-bienvenida.mdx` declares `auto` against what its content argues for.** It
  is a landing page; `none` is what it wants. It stays `auto` because it is the
  suite's only `auto` fixture and the markdown-`h2` rail path has no other real
  content. Recorded in ADR-0025 with the alternatives and the exit condition.
- The `<SectionBreak/>` in `intro-estructuras` was removed, not moved: in
  `explicit` that marker opens a group for the prose after it, which is exactly
  how the navigation sentence reached the deck.
- Not acted on: splitting the auto→explicit conversion into its own commit
  (deflated — no repo-local change-sizing doctrine, and the conversion was
  approved before being made); the pre-existing `nanoid` advisory (not this WP's,
  lockfile untouched); and a finding that the fixture predicate should encode
  "a deck with ≥3 slides" rather than "presentable" — real, more invasive, worth
  its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wrv7feTtV1h61A2vWmVXr8
