### PR TITLE
fix: take the machine out of the verdict for five test files that raced a lazy boundary

### DIFF
--- a/apps/web/src/app/App.test.tsx
+++ b/apps/web/src/app/App.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 import { courseIndex, registry, walkIndex } from '../content';
 import { AppRoutes } from './AppRoutes';
@@ -10,6 +10,20 @@ import { AppRoutes } from './AppRoutes';
 // Seed convention: each document's h1 equals its frontmatter title.
 const ids = walkIndex(courseIndex);
 const titleOf = (id: string) => registry.get(id)?.meta.title ?? id;
+
+// Every assertion below lives on the far side of `lazy(entry.load)`
+// (`content/lazyDoc.ts`), so each one raced the document module against the
+// 1000ms window `findBy*` gives an assertion. Resolving the modules once, here,
+// takes the machine out of the verdict (#102). Under a simulated 1500ms first
+// load — the shape a busy box produces — this file failed without it.
+//
+// Duplicated in the three app-level files that need it rather than shared: the
+// repo already records that a test double needed by two places is duplicated,
+// not shared (`docs/standards/testing-strategy.md` §Conventions), and three
+// lines are cheaper to read in place than to go and find.
+beforeAll(async () => {
+  await Promise.all(registry.entries.map((entry) => entry.load()));
+});
 
 function renderAt(path: string) {
   render(

--- a/apps/web/src/app/App.test.tsx
+++ b/apps/web/src/app/App.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react';
+import { act, render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeAll, describe, expect, it } from 'vitest';
 
@@ -11,7 +11,7 @@ import { AppRoutes } from './AppRoutes';
 const ids = walkIndex(courseIndex);
 const titleOf = (id: string) => registry.get(id)?.meta.title ?? id;
 
-// Every assertion below lives on the far side of `lazy(entry.load)`
+// Every assertion that reaches document content lives on the far side of `lazy(entry.load)`
 // (`content/lazyDoc.ts`), so each one raced the document module against the
 // 1000ms window `findBy*` gives an assertion. Resolving the modules once, here,
 // takes the machine out of the verdict (#102). Under a simulated 1500ms first
@@ -25,12 +25,22 @@ beforeAll(async () => {
   await Promise.all(registry.entries.map((entry) => entry.load()));
 });
 
-function renderAt(path: string) {
-  render(
-    <MemoryRouter initialEntries={[path]}>
-      <AppRoutes />
-    </MemoryRouter>,
-  );
+/**
+ * Renders at `path` with the first commit flushed.
+ *
+ * `React.lazy` suspends even when the module is already cached, so without the
+ * flush the assertion runs against the Suspense fallback. Step 2 of the
+ * lazy-boundary recipe in `docs/standards/testing-strategy.md` §Conventions
+ * (#102).
+ */
+async function renderAt(path: string): Promise<void> {
+  await act(async () => {
+    render(
+      <MemoryRouter initialEntries={[path]}>
+        <AppRoutes />
+      </MemoryRouter>,
+    );
+  });
 }
 
 describe('routing', () => {
@@ -39,14 +49,16 @@ describe('routing', () => {
   });
 
   it('renders a document by id at /d/:id', async () => {
-    renderAt(`/d/${ids[0]}`);
-    expect(
-      await screen.findByRole('heading', { level: 1, name: titleOf(ids[0]!) }),
-    ).toBeInTheDocument();
+    await renderAt(`/d/${ids[0]}`);
+
+    // The canary (step 3 of the lazy-boundary recipe): `getBy`, which cannot
+    // wait. If the preload above is ever removed this fails on every machine,
+    // instead of reddening in CI at random — which is what #102 was.
+    expect(screen.getByRole('heading', { level: 1, name: titleOf(ids[0]!) })).toBeInTheDocument();
   });
 
   it('renders in-document wiki-links as internal links that resolve', async () => {
-    renderAt(`/d/${ids[0]}`);
+    await renderAt(`/d/${ids[0]}`);
     await screen.findByRole('heading', { level: 1 });
     const article = screen.getByRole('article');
     const internal = within(article)
@@ -59,14 +71,14 @@ describe('routing', () => {
   });
 
   it('redirects the root route to the first index entry (the welcome document)', async () => {
-    renderAt('/');
+    await renderAt('/');
     expect(
       await screen.findByRole('heading', { level: 1, name: titleOf(ids[0]!) }),
     ).toBeInTheDocument();
   });
 
   it('shows prev/next navigation following the index order', async () => {
-    renderAt(`/d/${ids[1]}`);
+    await renderAt(`/d/${ids[1]}`);
     await screen.findByRole('heading', { level: 1 });
     const sequence = screen.getByRole('navigation', { name: 'Documento anterior y siguiente' });
     expect(sequence).toHaveTextContent(titleOf(ids[0]!));
@@ -81,25 +93,25 @@ describe('routing', () => {
     // currently pinned to `auto` as the suite's fixture, not by preference —
     // add-a-course-document.md step 2 (Frontmatter) has the reason.
     const presentableId = ids.find((id) => registry.get(id)?.meta.presentation !== 'none')!;
-    renderAt(`/d/${presentableId}/present`);
+    await renderAt(`/d/${presentableId}/present`);
     expect(
       await screen.findByRole('heading', { name: titleOf(presentableId) }),
     ).toBeInTheDocument();
     expect(screen.queryByRole('article')).not.toBeInTheDocument();
   });
 
-  it('shows the 404 page for an unknown id at /present', () => {
-    renderAt('/d/does-not-exist/present');
+  it('shows the 404 page for an unknown id at /present', async () => {
+    await renderAt('/d/does-not-exist/present');
     expect(screen.getByRole('heading', { name: /not found/i })).toBeInTheDocument();
   });
 
-  it('shows the 404 page for an unknown document id', () => {
-    renderAt('/d/does-not-exist');
+  it('shows the 404 page for an unknown document id', async () => {
+    await renderAt('/d/does-not-exist');
     expect(screen.getByRole('heading', { name: /not found/i })).toBeInTheDocument();
   });
 
-  it('shows the 404 page for an unknown route', () => {
-    renderAt('/nope');
+  it('shows the 404 page for an unknown route', async () => {
+    await renderAt('/nope');
     expect(screen.getByRole('heading', { name: /not found/i })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/documentDrawer.test.tsx
+++ b/apps/web/src/app/documentDrawer.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
-import { courseIndex, walkIndex } from '../content';
+import { courseIndex, registry, walkIndex } from '../content';
 
 import { AppRoutes } from './AppRoutes';
 
@@ -11,20 +11,40 @@ import { AppRoutes } from './AppRoutes';
 // content/Drawer.test.tsx. What only the shell can exercise is the flow: real
 // documents, real routing, and the map that lets a second document render at
 // all when the reader picks it from inside the drawer.
-function renderAt(path: string) {
-  render(
-    <MemoryRouter initialEntries={[path]}>
-      <AppRoutes />
-    </MemoryRouter>,
-  );
+/**
+ * Renders at `path` with the first commit flushed.
+ *
+ * `React.lazy` suspends even when the module is already cached, so without the
+ * flush the assertion runs against the Suspense fallback. Step 2 of the
+ * lazy-boundary recipe in `docs/standards/testing-strategy.md` §Conventions
+ * (#102).
+ */
+async function renderAt(path: string): Promise<void> {
+  await act(async () => {
+    render(
+      <MemoryRouter initialEntries={[path]}>
+        <AppRoutes />
+      </MemoryRouter>,
+    );
+  });
 }
 
 const ids = walkIndex(courseIndex);
+
+// Every assertion that reaches document content lives on the far side of
+// `lazy(entry.load)` (`content/lazyDoc.ts`) — including the `h2[id]` wait in
+// `openDrawer`, which this file's own comment already explains. Resolving the
+// modules once takes the machine out of the verdict (#102). Review measured
+// this file failing the documented slow-load probe; it was the only one left.
+beforeAll(async () => {
+  await Promise.all(registry.entries.map((entry) => entry.load()));
+});
+
 const firstId = ids[0]!;
 
 async function openDrawer() {
   const user = userEvent.setup();
-  renderAt(`/d/${firstId}`);
+  await renderAt(`/d/${firstId}`);
   const article = await screen.findByRole('article');
   // The article element exists before its lazy document does; without this the
   // drawer can open over an empty spine and the section assertions race.
@@ -35,8 +55,13 @@ async function openDrawer() {
 
 describe('the course index drawer', () => {
   it('is not on the page by default — the reading column gets the width', async () => {
-    renderAt(`/d/${firstId}`);
-    await screen.findByRole('article');
+    await renderAt(`/d/${firstId}`);
+
+    // The canary: `getAllBy` cannot wait, and an `h2` exists only once the lazy
+    // document has rendered — `article` does not, it is the shell's and is on
+    // this side of the boundary. If the preload above is removed this fails on
+    // every machine instead of reddening in CI at random (#102, step 3).
+    expect(screen.getAllByRole('heading', { level: 2 }).length).toBeGreaterThan(0);
     // The desktop sidebar still renders and CSS hides it; what must not exist
     // is a second, already-open copy over the document.
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();

--- a/apps/web/src/app/documentFences.test.tsx
+++ b/apps/web/src/app/documentFences.test.tsx
@@ -4,11 +4,20 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { MemoryRouter } from 'react-router-dom';
 import * as runtime from 'react/jsx-runtime';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { remarkPlugins } from '../content/mdxPlugins';
 
 import { mdxComponents } from './mdxComponents';
+
+// Same hazard as #102, different module: the fence renderer is `lazy()`, so the
+// wait below raced the editor chunk against `vi.waitFor`'s default budget.
+// Measured on `main` before this WP touched it — 2 failures in 4 runs of
+// `src/app/`, "expected null not to be null" at the wait. Resolving the module
+// once takes the machine out of the verdict.
+beforeAll(async () => {
+  await import('../components/interactive/CodeEditor');
+});
 
 // The editor is not what is under test here — which renderer a fence reaches is.
 vi.mock('@uiw/react-codemirror', () => ({

--- a/apps/web/src/app/documentSections.test.tsx
+++ b/apps/web/src/app/documentSections.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeAll, describe, expect, it } from 'vitest';
 
@@ -26,12 +26,22 @@ beforeAll(async () => {
 // because <Slide title> renders the h2 the SHELL's MDX map provides. Mounted
 // without that map, every Slide title would be a plain <h2> with no id and the
 // rail would silently list nothing.
-function renderAt(path: string) {
-  render(
-    <MemoryRouter initialEntries={[path]}>
-      <AppRoutes />
-    </MemoryRouter>,
-  );
+/**
+ * Renders at `path` with the first commit flushed.
+ *
+ * `React.lazy` suspends even when the module is already cached, so without the
+ * flush the assertion runs against the Suspense fallback. Step 2 of the
+ * lazy-boundary recipe in `docs/standards/testing-strategy.md` §Conventions
+ * (#102).
+ */
+async function renderAt(path: string): Promise<void> {
+  await act(async () => {
+    render(
+      <MemoryRouter initialEntries={[path]}>
+        <AppRoutes />
+      </MemoryRouter>,
+    );
+  });
 }
 
 const ids = walkIndex(courseIndex);
@@ -89,7 +99,13 @@ describe('the section rail over real documents', () => {
   });
 
   it('lists every section of an auto document, in order', async () => {
-    renderAt(`/d/${autoId}`);
+    await renderAt(`/d/${autoId}`);
+
+    // The canary: `getAllBy` cannot wait, and an `h2` exists only once the lazy
+    // document has rendered — `article` does not, it is the shell's and is on
+    // this side of the boundary. If the preload above is removed this fails on
+    // every machine instead of reddening in CI at random (#102, step 3).
+    expect(screen.getAllByRole('heading', { level: 2 }).length).toBeGreaterThan(0);
     const headings = await headingIdsOf();
     expect(headings.length).toBeGreaterThan(0);
     expect(await railLinkTargets()).toEqual(headings.map((id) => `#${id}`));
@@ -98,14 +114,14 @@ describe('the section rail over real documents', () => {
   it('lists the same spine for an explicit document, whose sections are <Slide> markers', async () => {
     // The equivalence AC4 asks for: two different slide-cutting rules, one
     // section list, because both render the same MDX-mapped h2 in book mode.
-    renderAt(`/d/${explicitId}`);
+    await renderAt(`/d/${explicitId}`);
     const headings = await headingIdsOf();
     expect(headings.length).toBeGreaterThan(0);
     expect(await railLinkTargets()).toEqual(headings.map((id) => `#${id}`));
   });
 
   it('names the sections with the slide titles the reader sees', async () => {
-    renderAt(`/d/${explicitId}`);
+    await renderAt(`/d/${explicitId}`);
     const article = await screen.findByRole('article');
     await waitFor(() => expect(article.querySelector('h2[id]')).not.toBeNull());
     const firstHeading = article.querySelector('h2[id]')!;
@@ -121,7 +137,7 @@ describe('the section rail over real documents', () => {
   it('shows no rail for a document with no sections at all', async () => {
     const flatId = ids.find((id) => registry.get(id)?.meta.presentation === 'none');
     expect(flatId, 'seed course needs a document without sections').toBeDefined();
-    renderAt(`/d/${flatId}`);
+    await renderAt(`/d/${flatId}`);
     const article = await screen.findByRole('article');
     // Wait for the document itself, not just the element that will hold it.
     // Asserting straight after findByRole passed for a document that HAS

--- a/apps/web/src/app/documentSections.test.tsx
+++ b/apps/web/src/app/documentSections.test.tsx
@@ -1,10 +1,24 @@
 import { render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 import { courseIndex, registry, walkIndex } from '../content';
 
 import { AppRoutes } from './AppRoutes';
+
+// Every assertion below lives on the far side of `lazy(entry.load)`
+// (`content/lazyDoc.ts`), so each one raced the document module against the
+// 1000ms window `findBy*` gives an assertion. Resolving the modules once, here,
+// takes the machine out of the verdict (#102). Under a simulated 1500ms first
+// load — the shape a busy box produces — this file failed without it.
+//
+// Duplicated in the three app-level files that need it rather than shared: the
+// repo already records that a test double needed by two places is duplicated,
+// not shared (`docs/standards/testing-strategy.md` §Conventions), and three
+// lines are cheaper to read in place than to go and find.
+beforeAll(async () => {
+  await Promise.all(registry.entries.map((entry) => entry.load()));
+});
 
 // L4-ish: this invariant binds the content feature to the shell and cannot live
 // in either alone. The section rail reads `h2` elements from the rendered

--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -27,6 +27,26 @@ function renderAt(path: string) {
 }
 
 /**
+ * Renders and waits for the document module, so nothing after it is on a timer.
+ *
+ * Every assertion in this file lives on the far side of `lazy(entry.load)`
+ * (`content/lazyDoc.ts`), so each one used to race the module against
+ * `findBy*`'s 1000ms window. On a loaded machine the module lost: the cover
+ * slide case failed three times at ~1400ms, and because CI runs the same
+ * protocol, a green run stopped being reproducible (#102).
+ *
+ * Resolving the module first makes the boundary settle on the first commit.
+ * That is a real fix rather than a bigger number: the wait is over a promise
+ * this function holds, not over a deadline the machine can miss.
+ */
+async function renderPresentation(path: string): Promise<void> {
+  await Promise.all(registry.entries.map((entry) => entry.load()));
+  await act(async () => {
+    renderAt(path);
+  });
+}
+
+/**
  * jsdom implements no Fullscreen API, so after #111 the deck hides its
  * fullscreen control there — correctly, but for a reason no test intended.
  * A test that cares about that control declares the capability first, the way
@@ -46,9 +66,15 @@ async function findCounter() {
 
 describe('PresentationPage viewer', () => {
   it('opens on the cover slide with the document title and a counter', async () => {
-    renderAt(`/d/${firstId}/present`);
-    expect(await screen.findByRole('heading', { name: firstTitle })).toBeInTheDocument();
-    expect(await findCounter()).toHaveTextContent(/^1 \/ \d+$/);
+    await renderPresentation(`/d/${firstId}/present`);
+
+    // `getBy`, deliberately, not `findBy`: once the document is resolved there
+    // is nothing left to wait for, and a query that cannot wait is the only
+    // assertion that can prove it. If this throws, the boundary is being raced
+    // again and every other case in this file is one busy machine away from
+    // failing (#102).
+    expect(screen.getByRole('heading', { name: firstTitle })).toBeInTheDocument();
+    expect(screen.getByText(/^\d+ \/ \d+$/)).toHaveTextContent(/^1 \/ \d+$/);
   });
 
   it('navigates with ArrowRight/ArrowLeft and clamps at the edges', async () => {

--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -18,12 +18,25 @@ const ids = walkIndex(courseIndex);
 const firstId = ids.find((id) => registry.get(id)?.meta.presentation !== 'none')!;
 const firstTitle = registry.get(firstId)?.meta.title ?? firstId;
 
-function renderAt(path: string) {
-  render(
-    <MemoryRouter initialEntries={[path]}>
-      <AppRoutes />
-    </MemoryRouter>,
-  );
+/**
+ * Renders at `path` with the first commit flushed.
+ *
+ * The flush is not decoration. `React.lazy` suspends once even when the module
+ * is already in the ES module cache, so without it the assertion runs against
+ * the Suspense fallback — verified: keep the preload below, drop the `act`, and
+ * the cover-slide case fails with #102's own message.
+ *
+ * It lives in the helper rather than at the call sites because there are 37 of
+ * them, and a step a call site has to remember is a step the 38th will not get.
+ */
+async function renderAt(path: string): Promise<void> {
+  await act(async () => {
+    render(
+      <MemoryRouter initialEntries={[path]}>
+        <AppRoutes />
+      </MemoryRouter>,
+    );
+  });
 }
 
 /**
@@ -44,13 +57,6 @@ beforeAll(async () => {
   await Promise.all(registry.entries.map((entry) => entry.load()));
 });
 
-/** Renders with the first commit flushed, so nothing after it needs a timer. */
-async function renderPresentation(path: string): Promise<void> {
-  await act(async () => {
-    renderAt(path);
-  });
-}
-
 /**
  * jsdom implements no Fullscreen API, so after #111 the deck hides its
  * fullscreen control there — correctly, but for a reason no test intended.
@@ -69,9 +75,14 @@ async function findCounter() {
   return screen.findByText(/^\d+ \/ \d+$/);
 }
 
+/** The counter without waiting — for the canary; see the cover-slide case. */
+function getCounter() {
+  return screen.getByText(/^\d+ \/ \d+$/);
+}
+
 describe('PresentationPage viewer', () => {
   it('opens on the cover slide with the document title and a counter', async () => {
-    await renderPresentation(`/d/${firstId}/present`);
+    await renderAt(`/d/${firstId}/present`);
 
     // `getBy`, deliberately, not `findBy`: once the document is resolved there
     // is nothing left to wait for, and a query that cannot wait is the only
@@ -79,11 +90,11 @@ describe('PresentationPage viewer', () => {
     // again and every other case in this file is one busy machine away from
     // failing (#102).
     expect(screen.getByRole('heading', { name: firstTitle })).toBeInTheDocument();
-    expect(screen.getByText(/^\d+ \/ \d+$/)).toHaveTextContent(/^1 \/ \d+$/);
+    expect(getCounter()).toHaveTextContent(/^1 \/ \d+$/);
   });
 
   it('navigates with ArrowRight/ArrowLeft and clamps at the edges', async () => {
-    renderAt(`/d/${firstId}/present`);
+    await renderAt(`/d/${firstId}/present`);
     const counter = await findCounter();
 
     fireEvent.keyDown(window, { key: 'ArrowLeft' });
@@ -94,7 +105,7 @@ describe('PresentationPage viewer', () => {
   });
 
   it('advances with Space and jumps with Home/End', async () => {
-    renderAt(`/d/${firstId}/present`);
+    await renderAt(`/d/${firstId}/present`);
     const counter = await findCounter();
     const total = Number(counter.textContent!.split('/')[1]);
 
@@ -112,17 +123,17 @@ describe('PresentationPage viewer', () => {
   });
 
   it('deep-links to a slide via ?slide=N and clamps out-of-range values', async () => {
-    renderAt(`/d/${firstId}/present?slide=2`);
+    await renderAt(`/d/${firstId}/present?slide=2`);
     expect(await findCounter()).toHaveTextContent(/^2 \//);
   });
 
   it('survives a crafted non-integer ?slide value', async () => {
-    renderAt(`/d/${firstId}/present?slide=1.5`);
+    await renderAt(`/d/${firstId}/present?slide=1.5`);
     expect(await findCounter()).toHaveTextContent(/^1 \//);
   });
 
   it('returns to the book view on Escape', async () => {
-    renderAt(`/d/${firstId}/present`);
+    await renderAt(`/d/${firstId}/present`);
     await findCounter();
 
     fireEvent.keyDown(window, { key: 'Escape' });
@@ -131,7 +142,7 @@ describe('PresentationPage viewer', () => {
 
   it('offers a fullscreen control that says what pressing it will do', async () => {
     const restore = withFullscreenSupport();
-    renderAt(`/d/${firstId}/present`);
+    await renderAt(`/d/${firstId}/present`);
     await findCounter();
     // Out of fullscreen the button ENTERS it, so the name is the destination.
     expect(screen.getByRole('button', { name: 'Pantalla completa' })).toBeInTheDocument();
@@ -143,7 +154,7 @@ describe('PresentationPage viewer', () => {
     // (ADR-0023), so the control could only ever be a button that does nothing.
     // jsdom is that platform by default, which is exactly why the tests above
     // have to declare the capability rather than inherit it.
-    renderAt(`/d/${firstId}/present`);
+    await renderAt(`/d/${firstId}/present`);
     await findCounter();
 
     const footer = document.querySelector('footer')!;
@@ -159,7 +170,7 @@ describe('PresentationPage viewer', () => {
     // Not only after a click: Escape and the browser's own chrome change the
     // state too, so the name is derived from document.fullscreenElement rather
     // than from what this component last did (#106).
-    renderAt(`/d/${firstId}/present`);
+    await renderAt(`/d/${firstId}/present`);
     await findCounter();
 
     Object.defineProperty(document, 'fullscreenElement', {
@@ -232,7 +243,7 @@ describe('presentation on a phone held in portrait', () => {
 
   it('covers the deck: the panel is shown and no slide is painted', async () => {
     coarsePortrait(true);
-    renderAt(`/d/${firstId}/present`);
+    await renderAt(`/d/${firstId}/present`);
 
     // Waiting for the panel also waits for the lazy document: the deck is what
     // decides, so by now the slides exist and their absence is a decision.
@@ -243,7 +254,7 @@ describe('presentation on a phone held in portrait', () => {
 
   it('leaves nothing but the way out reachable by keyboard', async () => {
     coarsePortrait(true);
-    renderAt(`/d/${firstId}/present`);
+    await renderAt(`/d/${firstId}/present`);
     await screen.findByRole('alertdialog');
 
     // The whole route, not the panel's subtree: the claim is that no control of
@@ -259,7 +270,7 @@ describe('presentation on a phone held in portrait', () => {
 
   it('ignores the slide keys behind the panel, so the position cannot drift', async () => {
     const media = coarsePortrait(true);
-    renderAt(`/d/${firstId}/present?slide=2`);
+    await renderAt(`/d/${firstId}/present?slide=2`);
     await screen.findByRole('alertdialog');
 
     fireEvent.keyDown(window, { key: 'ArrowRight' });
@@ -272,7 +283,7 @@ describe('presentation on a phone held in portrait', () => {
 
   it('still answers Escape behind the panel — a modal has a way out', async () => {
     coarsePortrait(true);
-    renderAt(`/d/${firstId}/present`);
+    await renderAt(`/d/${firstId}/present`);
     await screen.findByRole('alertdialog');
 
     fireEvent.keyDown(window, { key: 'Escape' });
@@ -291,7 +302,7 @@ describe('presentation on a phone held in portrait', () => {
     });
     try {
       coarsePortrait(true);
-      renderAt(`/d/${firstId}/present`);
+      await renderAt(`/d/${firstId}/present`);
       await screen.findByRole('alertdialog');
       expect(exitFullscreen).toHaveBeenCalled();
     } finally {
@@ -302,7 +313,7 @@ describe('presentation on a phone held in portrait', () => {
 
   it('shows the deck at the reader’s slide when the phone is turned, and back', async () => {
     const media = coarsePortrait(true);
-    renderAt(`/d/${firstId}/present?slide=2`);
+    await renderAt(`/d/${firstId}/present?slide=2`);
     await screen.findByRole('alertdialog');
 
     media.turn(false);
@@ -317,7 +328,7 @@ describe('presentation on a phone held in portrait', () => {
 
   it('lets the reader leave the presentation for the book view of the document', async () => {
     coarsePortrait(true);
-    renderAt(`/d/${firstId}/present`);
+    await renderAt(`/d/${firstId}/present`);
     await screen.findByRole('alertdialog');
 
     fireEvent.click(screen.getByRole('link', { name: /leer|libro|volver/i }));
@@ -335,7 +346,7 @@ describe('presentation on a phone held in portrait', () => {
   // cannot evaluate a media query, so no test here can claim it.
   it('renders the deck whenever the phone rule does not match', async () => {
     coarsePortrait(false);
-    renderAt(`/d/${firstId}/present`);
+    await renderAt(`/d/${firstId}/present`);
 
     expect(await findCounter()).toHaveTextContent(/^1 \//);
     expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
@@ -350,7 +361,7 @@ describe('advancing the deck by touch', () => {
   }
 
   it('advances one slide on a leftward swipe and goes back on a rightward one', async () => {
-    renderAt(`/d/${firstId}/present?slide=2`);
+    await renderAt(`/d/${firstId}/present?slide=2`);
     const counter = await findCounter();
 
     swipe(300, 150);
@@ -361,7 +372,7 @@ describe('advancing the deck by touch', () => {
   });
 
   it('clamps at the first slide, as the keyboard does', async () => {
-    renderAt(`/d/${firstId}/present`);
+    await renderAt(`/d/${firstId}/present`);
     const counter = await findCounter();
 
     // The positive control comes first: without it this case is green over a
@@ -377,7 +388,7 @@ describe('advancing the deck by touch', () => {
   });
 
   it('leaves the slide alone on a tap and on a vertical drag', async () => {
-    renderAt(`/d/${firstId}/present?slide=2`);
+    await renderAt(`/d/${firstId}/present?slide=2`);
     const counter = await findCounter();
 
     swipe(200, 200);
@@ -397,7 +408,7 @@ describe('advancing the deck by touch', () => {
     // on the slide wrapper — a box that in a browser has `overflow-x: visible`
     // and cannot scroll. It pinned the wrong contract and never walked a single
     // ancestor (#103 review).
-    renderAt('/d/java-desde-cpp/present?slide=5');
+    await renderAt('/d/java-desde-cpp/present?slide=5');
     const counter = await findCounter();
     const before = counter.textContent;
 
@@ -421,7 +432,7 @@ describe('advancing the deck by touch', () => {
   });
 
   it('forgets a gesture the system cancels', async () => {
-    renderAt(`/d/${firstId}/present?slide=2`);
+    await renderAt(`/d/${firstId}/present?slide=2`);
     const counter = await findCounter();
     const stage = screen.getByTestId('slide-stage');
 
@@ -433,7 +444,7 @@ describe('advancing the deck by touch', () => {
   });
 
   it('ignores a two-finger gesture — a pinch is not a swipe', async () => {
-    renderAt(`/d/${firstId}/present?slide=2`);
+    await renderAt(`/d/${firstId}/present?slide=2`);
     const counter = await findCounter();
     const stage = screen.getByTestId('slide-stage');
 
@@ -500,7 +511,7 @@ describe('fitting a slide to the stage it is shown on', () => {
   }
 
   it('scales the slide by the tighter axis of the stage', async () => {
-    renderAt(`/d/${firstId}/present`);
+    await renderAt(`/d/${firstId}/present`);
     await findCounter();
     // 300/600 is tighter than 800/896.
     expect(slideBox()).toHaveStyle({ transform: 'scale(0.5)' });
@@ -508,7 +519,7 @@ describe('fitting a slide to the stage it is shown on', () => {
 
   it('measures after a rotation, which mounts the deck without changing the slide', async () => {
     const media = coarsePortrait(true);
-    renderAt(`/d/${firstId}/present`);
+    await renderAt(`/d/${firstId}/present`);
     await screen.findByRole('alertdialog');
 
     media.turn(false);
@@ -521,7 +532,7 @@ describe('fitting a slide to the stage it is shown on', () => {
   });
 
   it('measures the slide that is on screen after a slide change, not the one leaving', async () => {
-    renderAt(`/d/${firstId}/present`);
+    await renderAt(`/d/${firstId}/present`);
     await findCounter();
 
     fireEvent.keyDown(window, { key: 'ArrowRight' });
@@ -541,7 +552,7 @@ describe('leaving the presentation from the deck', () => {
     // The capability is declared before the render, because the deck decides
     // whether to paint that neighbour at all (#111).
     const restore = withFullscreenSupport();
-    renderAt(`/d/${firstId}/present`);
+    await renderAt(`/d/${firstId}/present`);
     await findCounter();
     const footer = document.querySelector('footer')!;
     expect([...footer.querySelectorAll('button')].map((b) => b.getAttribute('aria-label'))).toEqual(
@@ -560,7 +571,7 @@ describe('leaving the presentation from the deck', () => {
       value: exitFullscreen,
     });
     try {
-      renderAt(`/d/${firstId}/present`);
+      await renderAt(`/d/${firstId}/present`);
       await findCounter();
       fireEvent.click(screen.getByRole('button', { name: /salir de la presentación/i }));
       await screen.findByRole('article');
@@ -571,7 +582,7 @@ describe('leaving the presentation from the deck', () => {
   });
 
   it('lands on the book view from any slide, including a deep link', async () => {
-    renderAt(`/d/${firstId}/present?slide=3`);
+    await renderAt(`/d/${firstId}/present?slide=3`);
     await findCounter();
 
     fireEvent.click(screen.getByRole('button', { name: /salir de la presentación/i }));
@@ -590,7 +601,7 @@ describe('leaving the presentation from the deck', () => {
       value: exitFullscreen,
     });
     try {
-      renderAt(`/d/${firstId}/present`);
+      await renderAt(`/d/${firstId}/present`);
       await findCounter();
       fireEvent.click(screen.getByRole('button', { name: /salir de la presentación/i }));
       await screen.findByRole('article');
@@ -604,7 +615,7 @@ describe('leaving the presentation from the deck', () => {
   it('is not reachable behind the rotate panel', async () => {
     coarsePortrait(true);
     try {
-      renderAt(`/d/${firstId}/present`);
+      await renderAt(`/d/${firstId}/present`);
       await screen.findByRole('alertdialog');
       expect(
         screen.queryByRole('button', { name: /salir de la presentación/i }),
@@ -619,27 +630,27 @@ describe('presentation: none documents', () => {
   it('redirects /present back to the book view', async () => {
     const noneId = ids.find((id) => registry.get(id)?.meta.presentation === 'none');
     expect(noneId, 'seed course needs a presentation:none document').toBeDefined();
-    renderAt(`/d/${noneId}/present`);
+    await renderAt(`/d/${noneId}/present`);
     expect(await screen.findByRole('article')).toBeInTheDocument();
   });
 });
 
 describe('book-view entry points to presentation', () => {
   it('shows a Presentar toggle in the document header', async () => {
-    renderAt(`/d/${firstId}`);
+    await renderAt(`/d/${firstId}`);
     const toggle = await screen.findByRole('link', { name: /presentar/i });
     expect(toggle).toHaveAttribute('href', `/d/${firstId}/present`);
   });
 
   it('hides the toggle for presentation: none documents', async () => {
     const noneId = ids.find((id) => registry.get(id)?.meta.presentation === 'none')!;
-    renderAt(`/d/${noneId}`);
+    await renderAt(`/d/${noneId}`);
     await screen.findByRole('article');
     expect(screen.queryByRole('link', { name: /presentar/i })).not.toBeInTheDocument();
   });
 
   it('enters presentation with the p key from the book view', async () => {
-    renderAt(`/d/${firstId}`);
+    await renderAt(`/d/${firstId}`);
     await screen.findByRole('article');
     fireEvent.keyDown(window, { key: 'p' });
     expect(await screen.findByText(/^\d+ \/ \d+$/)).toBeInTheDocument();
@@ -684,7 +695,7 @@ describe('explicit-mode documents (real compiled markers)', () => {
   });
 
   it('decks only the marked slides, leaving loose prose book-only', async () => {
-    renderAt(`/d/${explicitId}/present`);
+    await renderAt(`/d/${explicitId}/present`);
     const counter = await findCounter();
     expect(counter).toHaveTextContent('1 / 3');
 
@@ -696,7 +707,7 @@ describe('explicit-mode documents (real compiled markers)', () => {
   });
 
   it('renders marked slides as heading + prose in the book view, with the loose section present', async () => {
-    renderAt(`/d/${explicitId}`);
+    await renderAt(`/d/${explicitId}`);
     const article = await screen.findByRole('article');
     const { within } = await import('@testing-library/react');
     expect(

--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -49,8 +49,8 @@ async function renderAt(path: string): Promise<void> {
  *
  * Resolving the modules once, here, settles every boundary in the file on its
  * first commit. It is done at file level rather than inside a render helper on
- * purpose: 36 renders share this hazard, and a fix a call site has to remember
- * is a fix the 37th will not get. Dynamic imports are cached, so this costs one
+ * purpose: 37 renders share this hazard, and a fix a call site has to remember
+ * is a fix the 38th will not get. Dynamic imports are cached, so this costs one
  * resolution, not one per test.
  */
 beforeAll(async () => {

--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { courseIndex, registry, walkIndex } from '../content';
 
@@ -27,20 +27,25 @@ function renderAt(path: string) {
 }
 
 /**
- * Renders and waits for the document module, so nothing after it is on a timer.
- *
  * Every assertion in this file lives on the far side of `lazy(entry.load)`
- * (`content/lazyDoc.ts`), so each one used to race the module against
- * `findBy*`'s 1000ms window. On a loaded machine the module lost: the cover
- * slide case failed three times at ~1400ms, and because CI runs the same
- * protocol, a green run stopped being reproducible (#102).
+ * (`content/lazyDoc.ts`), so each one raced the document module against the
+ * 1000ms window `findBy*` gives an assertion. On a loaded machine the module
+ * lost: the cover-slide case failed three times, once measured at 1402ms, and
+ * because CI runs the same protocol a green run stopped being reproducible
+ * (#102).
  *
- * Resolving the module first makes the boundary settle on the first commit.
- * That is a real fix rather than a bigger number: the wait is over a promise
- * this function holds, not over a deadline the machine can miss.
+ * Resolving the modules once, here, settles every boundary in the file on its
+ * first commit. It is done at file level rather than inside a render helper on
+ * purpose: 36 renders share this hazard, and a fix a call site has to remember
+ * is a fix the 37th will not get. Dynamic imports are cached, so this costs one
+ * resolution, not one per test.
  */
-async function renderPresentation(path: string): Promise<void> {
+beforeAll(async () => {
   await Promise.all(registry.entries.map((entry) => entry.load()));
+});
+
+/** Renders with the first commit flushed, so nothing after it needs a timer. */
+async function renderPresentation(path: string): Promise<void> {
   await act(async () => {
     renderAt(path);
   });

--- a/docs/standards/testing-strategy.md
+++ b/docs/standards/testing-strategy.md
@@ -199,9 +199,11 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   comment. Worked case (#91): `app/presentationRoute.test.tsx` awaits the rotate
   panel — which only the loaded document can render — before asserting that no
   counter and no slide heading are on the page.
-  The same pre-resolution described below settles the absence case too; reach
-  for the far-side `await` when only one test in a file crosses the boundary,
-  and for the file-wide fix when many do.
+  Steps 1 **and** 2 below settle the absence case too — step 1 alone does not:
+  without the flush the first commit is still the fallback, so `queryBy` passes
+  vacuously, which is the false pass this bullet exists to forbid (verified).
+  Reach for the far-side `await` when one test in a file crosses the boundary,
+  and for the file-wide pair when many do.
 - **Asserting PRESENCE across one has the mirror hazard: the assertion is a
   deadline, and the module is racing it.** `findBy*` waits 1000ms by default,
   which is not a fact about the code but about the machine — on a busy box the
@@ -216,12 +218,23 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   2. Render inside `await act(async () => { render(…) })`. **`React.lazy`
      suspends even when the module is already cached**, so the boundary does
      *not* settle on the first commit — it settles on the retry the flush
-     delivers. Skip this and step 1 buys nothing: verified by mutation, with the
-     preload in place and the flush removed, the assertion still fails.
+     delivers. Skip this and step 3 becomes impossible: with the preload in
+     place and the flush removed, a `getBy` finds the fallback and fails
+     (verified by mutation). A file that stays entirely on `findBy` is already
+     fixed by step 1 alone — the flush is what buys you the canary.
   3. Keep **one canary assertion per file on `getBy`**. A query that cannot wait
      is the only one that can prove the wait is gone; with `findBy` the test
      passes either way and proves nothing. The rest may stay on `findBy` —
      converting them all is churn, and converting them without step 2 is red.
+
+     **Assert something only the loaded module renders.** A canary on the
+     shell's own markup proves nothing: `getByRole('article')` passes with the
+     preload deleted, because the article exists before its lazy document does.
+     An `h2` from the document does not. This was got wrong first here, and the
+     mutation caught it — which is why step 4 exists.
+  4. **Delete the preload and watch the canary fail.** Without this the canary
+     is decoration: two of the four written for #102 asserted shell markup and
+     passed with the preload gone.
 
   **Prove it in both directions rather than asserting it.** Patch each entry so
   its FIRST resolution is delayed and later calls are served from cache, which
@@ -235,17 +248,36 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   }
   ```
 
+  It has to run **before the first render** — `content/lazyDoc.ts` captures
+  `entry.load` when it calls `lazy()` — so put it at the top of the test file
+  (no config needed), or in a scratch setup file pointed at by a throwaway
+  config: `test.setupFiles: ['./vitest.setup.ts', './src/slowLoad.ts']`. Vitest 4
+  has no `--setupFiles` flag.
+
   That turns "seen three times, never reproducible" into one command, and it
   also separates the files genuinely at risk from those that merely look
   similar. Worked case (#102): the cover-slide case in
   `app/presentationRoute.test.tsx` reddened three times on loaded machines, once
   at 1402ms, gating the pre-PR protocol and CI with it. Under the simulation the
-  unfixed shape fails with that same message and the fixed one passes; the same
-  probe found `app/App.test.tsx` and `app/documentSections.test.tsx` exposed and
-  cleared `documentBreadcrumb`, `documentTitle` and `documentDrawer`, whose
-  assertions sit outside the boundary. Apply the three steps to a file when a
-  case there has reddened, or when you want a `getBy` canary — not to every file
-  that contains a `findBy`.
+  unfixed shape fails with that same message and the fixed one passes.
+
+  The same probe found `app/App.test.tsx`, `app/documentSections.test.tsx` and
+  `app/documentDrawer.test.tsx` exposed — the last one waits on `h2[id]`, i.e.
+  *inside* the boundary, on `waitFor`'s same default budget — and cleared
+  `documentBreadcrumb` and `documentTitle`, whose queries hit the shell's nav
+  and `document.title`. **Calibrate the delay before trusting a clearance**: at
+  1500ms `documentDrawer` looked clear and at 4000ms it failed, so the first
+  answer was an artefact of the number, not a property of the file. It was
+  written into this standard as "its assertions sit outside the boundary", which
+  was simply false.
+
+  `app/documentFences.test.tsx` is the same hazard over a different module — the
+  fence renderer, not the document — and was flaky on `main` before this WP:
+  2 failures in 4 runs of `src/app/`. Its fix is the same shape,
+  `await import('../components/interactive/CodeEditor')`.
+
+  Apply the steps to a file when a case there has reddened under the probe, or
+  when you want a `getBy` canary — not to every file that contains a `findBy`.
 - **A per-state browser measurement is not a transition measurement.** Loading
   each state fresh (`?slide=1`, `?slide=2`, …) exercises mount and nothing else;
   the paths BETWEEN states are different code and have to be driven in the same

--- a/docs/standards/testing-strategy.md
+++ b/docs/standards/testing-strategy.md
@@ -199,6 +199,21 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   comment. Worked case (#91): `app/presentationRoute.test.tsx` awaits the rotate
   panel — which only the loaded document can render — before asserting that no
   counter and no slide heading are on the page.
+- **Asserting PRESENCE across one has the mirror hazard: the assertion is a
+  deadline, and the module is racing it.** `findBy*` waits 1000ms by default,
+  which is not a fact about the code but about the machine — on a busy box the
+  chunk arrives later and the case reddens for no reason anyone can reproduce.
+  Do not raise the timeout, which hides this case and the next: **resolve the
+  module before rendering** (`await entry.load()`), so the boundary settles on
+  the first commit and there is nothing left to wait for. Do it once for the
+  file rather than inside a render helper — a fix a call site has to remember is
+  a fix the next render will not get. Then assert with **`getBy`, not `findBy`**:
+  a query that cannot wait is the only one that can prove the wait is gone,
+  because with `findBy` the test passes either way and proves nothing. Worked
+  case (#102): the cover-slide case in `app/presentationRoute.test.tsx` failed
+  three times on loaded machines, once at 1402ms, gating the pre-PR protocol and
+  CI with it; 36 renders in that file shared the hazard and one `beforeAll`
+  closed all of them.
 - **A per-state browser measurement is not a transition measurement.** Loading
   each state fresh (`?slide=1`, `?slide=2`, …) exercises mount and nothing else;
   the paths BETWEEN states are different code and have to be driven in the same

--- a/docs/standards/testing-strategy.md
+++ b/docs/standards/testing-strategy.md
@@ -199,21 +199,53 @@ battery (full tests + integration L6), same rigor as `apps/web`.
   comment. Worked case (#91): `app/presentationRoute.test.tsx` awaits the rotate
   panel — which only the loaded document can render — before asserting that no
   counter and no slide heading are on the page.
+  The same pre-resolution described below settles the absence case too; reach
+  for the far-side `await` when only one test in a file crosses the boundary,
+  and for the file-wide fix when many do.
 - **Asserting PRESENCE across one has the mirror hazard: the assertion is a
   deadline, and the module is racing it.** `findBy*` waits 1000ms by default,
   which is not a fact about the code but about the machine — on a busy box the
   chunk arrives later and the case reddens for no reason anyone can reproduce.
-  Do not raise the timeout, which hides this case and the next: **resolve the
-  module before rendering** (`await entry.load()`), so the boundary settles on
-  the first commit and there is nothing left to wait for. Do it once for the
-  file rather than inside a render helper — a fix a call site has to remember is
-  a fix the next render will not get. Then assert with **`getBy`, not `findBy`**:
-  a query that cannot wait is the only one that can prove the wait is gone,
-  because with `findBy` the test passes either way and proves nothing. Worked
-  case (#102): the cover-slide case in `app/presentationRoute.test.tsx` failed
-  three times on loaded machines, once at 1402ms, gating the pre-PR protocol and
-  CI with it; 36 renders in that file shared the hazard and one `beforeAll`
-  closed all of them.
+  Do not raise the timeout; it hides this case and the next. Three steps, and
+  **the second is the one everybody drops**:
+
+  1. Resolve the modules once for the file —
+     `beforeAll(() => Promise.all(registry.entries.map((e) => e.load())))`.
+     Once per file, not per call site: a step a call site has to remember is a
+     step the next render will not get.
+  2. Render inside `await act(async () => { render(…) })`. **`React.lazy`
+     suspends even when the module is already cached**, so the boundary does
+     *not* settle on the first commit — it settles on the retry the flush
+     delivers. Skip this and step 1 buys nothing: verified by mutation, with the
+     preload in place and the flush removed, the assertion still fails.
+  3. Keep **one canary assertion per file on `getBy`**. A query that cannot wait
+     is the only one that can prove the wait is gone; with `findBy` the test
+     passes either way and proves nothing. The rest may stay on `findBy` —
+     converting them all is churn, and converting them without step 2 is red.
+
+  **Prove it in both directions rather than asserting it.** Patch each entry so
+  its FIRST resolution is delayed and later calls are served from cache, which
+  is how `import()` really behaves:
+
+  ```ts
+  for (const entry of registry.entries) {
+    const real = entry.load;
+    let cached: ReturnType<typeof real> | undefined;
+    entry.load = () => (cached ??= new Promise((r) => setTimeout(() => r(real()), 1500)));
+  }
+  ```
+
+  That turns "seen three times, never reproducible" into one command, and it
+  also separates the files genuinely at risk from those that merely look
+  similar. Worked case (#102): the cover-slide case in
+  `app/presentationRoute.test.tsx` reddened three times on loaded machines, once
+  at 1402ms, gating the pre-PR protocol and CI with it. Under the simulation the
+  unfixed shape fails with that same message and the fixed one passes; the same
+  probe found `app/App.test.tsx` and `app/documentSections.test.tsx` exposed and
+  cleared `documentBreadcrumb`, `documentTitle` and `documentDrawer`, whose
+  assertions sit outside the boundary. Apply the three steps to a file when a
+  case there has reddened, or when you want a `getBy` canary — not to every file
+  that contains a `findBy`.
 - **A per-state browser measurement is not a transition measurement.** Loading
   each state fresh (`?slide=1`, `?slide=2`, …) exercises mount and nothing else;
   the paths BETWEEN states are different code and have to be driven in the same


### PR DESCRIPTION
**Closes #102**

## Summary

`app/presentationRoute.test.tsx` → *"opens on the cover slide with the document title and a counter"* failed intermittently under machine load — `Unable to find role="heading" and name "Bienvenida"`, once measured at 1402ms against `findBy*`'s 1000ms default. Three sightings by two independent parties, none touching `presentation/`.

**It gated the pre-PR protocol, and CI runs that same protocol**, so a green run stopped being reproducible: the same commit could pass locally and fail in CI with nothing to tell the runs apart but load. That is the failure that teaches people to re-run a red suite instead of reading it.

Every assertion in that file lives on the far side of `lazy(entry.load)` (`content/lazyDoc.ts`). Resolving the document modules once per file, and rendering inside `await act(...)`, takes the machine out of the verdict. It is a fix rather than a bigger number: the wait is over a promise the test holds, not a deadline the machine can miss.

**The review then widened it from one case to five files**, and found four false statements I had put in the standard along the way. Both are detailed below, because neither is visible from the diff.

## The measurement that made this tractable

The correctness lens built a deterministic reproduction: patch each registry entry so its **first** module resolution takes 1500ms and every later call is served from cache — which is how `import()` actually behaves. That turned #102 from *"seen three times, never reproducible"* into one command, and it is now recorded in the standard as the verification leg.

Whole suite, both directions:

| | result |
|---|---|
| the five files as they are on `main`, under the probe | **7 failed / 563 passed** — every failure between 1004ms and 1541ms |
| this branch, same probe | **570 passed** |

## Slices

- **S1** — the cover-slide assertion, and the `getBy` canary that proves it
- **S2** — the coupling removed at its source rather than at 36 call sites
- **S3** — the presence half of #91's lazy-boundary rule, which the issue's Notes asked for

## Acceptance criteria

| # | Evidence |
|---|---|
| 1 | The case no longer depends on the 1000ms window: under the 1500ms probe it passes; with the `beforeAll` deleted it fails with the bug's own message |
| 2 | Six full-suite runs with four spinners and a concurrent build: 570 passed, exit 0. **And the control also passed six for six** — synthetic load separates nothing here. The probe above is what does |
| 3 | Not an explicit timeout, so nothing to justify. The chosen fix is design option (1) from the issue, adapted — see Notes |
| 4 | **Widened from "any sibling case in the file" to four other files.** `App.test.tsx`, `documentSections.test.tsx`, `documentDrawer.test.tsx` and `documentFences.test.tsx` had the same hazard; `documentBreadcrumb` and `documentTitle` were measured clear |
| 5 | Per-commit protocol green at every commit (exit status 0, not the summary line); pre-PR protocol green |

## Tests

**570**, exit 0. Four test files fixed, no new test files — this WP repairs existing ones.

Four canaries, one per fixed file, **each verified by deleting its own preload and watching that file redden**.

## Reviews run

`review-pipeline`, full mode, both rounds, per-fix rechecks. Every lens ran in an isolated worktree.

| round | lens | findings |
|---|---|---|
| A | correctness | 4 |
| A | architecture | 6 |
| A | security | not spawned — 50 lines in a test file and one bullet in a standard: no production code, no dependency, no CI, no untrusted input |
| A | performance | not spawned — same reason |
| B | correctness recheck | 4 resolved, 4 new |
| B | docs-accuracy | 7, one **critical** |

**Everything acted on. Nothing deferred.**

I skipped the adversarial verifier and say so rather than omitting it: every finding arrived with executed evidence, and the two that mattered most were raised independently by two lenses running the same mutation.

### The four things I wrote that were false

- **`documentDrawer` was never clear, and the reason I gave was invented.** I wrote that it was cleared "whose assertions sit outside the boundary". They sit *inside* it — the file's own comment says so, and I had read it. It passes the probe at 1500ms and **fails at 4000ms**: my clearance was an artefact of the delay I picked, presented as a property of the file. At that point it was the only failure in all 570 tests under the probe this very branch documents.
- **My canaries were decoration.** Two of the four asserted `getByRole('article')` — the shell's own markup, which exists *before* the lazy document. Deleting the preload left both green. The standard gained a fourth step because of it: delete the preload and watch the canary fail, or it is not a canary.
- **"Skip step 2 and step 1 buys nothing"** is contradicted by two files in the same commit, which got step 1 alone and went from two failures each to green. True only of a `getBy` canary.
- **The rider I added to #91's absence bullet was red as written.** With the preload in place and no flush, `queryBy` passes against the fallback — the exact false pass that bullet forbids. Proven by probe.

The first version of the convention was also unfollowable: it stated that pre-resolving settles the boundary "on the first commit". `React.lazy` suspends even on a cached module, so the flush is load-bearing — and my own code already said so in a docstring I had written. An author following the bullet literally would have got the error the rule exists to prevent.

### A flake nobody had reported

Running `src/app/` repeatedly to check my own work, `documentFences.test.tsx` failed 1 in 3. Control on `main`: **2 in 4**. Pre-existing, same hazard over a different module — the fence renderer is lazy, not the document. Fixed here with the same shape; 6/6 green where `main` was 2-in-4 red.

## Standards grown

`docs/standards/testing-strategy.md` §Conventions, as the mirror of #91's absence rule, in four steps: preload once per file · render inside `await act(...)` (marked as the step everybody drops) · one `getBy` canary asserting something **only the loaded module renders** · delete the preload and watch it fail.

Plus the probe itself, with where to put it and why (`lazyDoc.ts` captures `entry.load` at `lazy()` time, and vitest 4 has no `--setupFiles` flag), and the warning that a clearance is only as good as the delay you calibrated it with.

## Manual verification

Nothing user-facing changed. What is worth checking is the claim:

- [ ] `cd apps/web && npm run test; echo $?` → 570 passed, **exit 0**
- [ ] Break a canary on purpose: delete the `beforeAll` body in `apps/web/src/app/App.test.tsx`. Run again → that file reddens on your machine, immediately, no load needed
- [ ] `git checkout -- apps/web/src/app/App.test.tsx` to restore

## Notes

**The fix is not the one the issue's Design preferred, and the blast radius is wider than its AC4 assumed.** The issue proposed awaiting something on the far side of the boundary inside the failing test; what shipped is a file-level pre-resolution plus an `act` flush, applied to five files rather than to sibling cases within one. AC4 asks for exactly this to be recorded, so it is.

`documentBreadcrumb.test.tsx` and `documentTitle.test.tsx` were measured and left alone: their queries hit the shell's nav and `document.title`, genuinely outside the boundary.
