### PR TITLE
fix: halve what mathematics costs every page, and correct what its docs got wrong

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -3,8 +3,9 @@
 The Nalanda platform frontend: course wiki (book mode), presentation mode, and
 the content-component catalog. React 19 + TypeScript (strict) + Vite + Tailwind
 CSS v4 (+ typography plugin) + framer-motion; course documents compile from MDX
-(ADR-0003) via `@mdx-js/rollup` + remark plugins, sourced from the repo-root
-`content/` tree (ADR-0002, ADR-0012).
+(ADR-0003) via `@mdx-js/rollup` + a **remark and a rehype** plugin list, sourced from the
+repo-root `content/` tree (ADR-0002, ADR-0012, ADR-0027). Mathematics renders at build
+time through remark-math + rehype-katex, so no KaTeX JavaScript ships.
 
 Since #74 it also **executes code in the reader's browser**: CodeMirror 6 editors
 (+ lucide-react icons) driving three runtimes — Java on CheerpJ, C++ on
@@ -56,8 +57,9 @@ src/
 │                         # + MdxPre: the pre→component seam (registered in the SHELL's
 │                         #   map, not a catalog component), embedded.ts: the context by
 │                         #   which a framing container tells its children so
-├── content/              # content pipeline: MDX registry, course index, remark plugin
-│                         # list (wiki-links, fence metadata, GFM), element renderers
+├── content/              # content pipeline: MDX registry, course index, the two plugin
+│                         # lists (remark: wiki-links, fence metadata, GFM, math;
+│                         # rehype: KaTeX), element renderers
 │                         # (links, tables), build-time integrity gate
 │                         # + the reading shell: book-mode page, course-index tree
 │                         #   (collapsed to the active path, filterable), breadcrumb,
@@ -112,6 +114,19 @@ ADR-0023.
   read back by CheerpJ through the deployed base path — `/app/nalanda/…` in
   production, `/app/…` in dev, derived from `BASE_URL` like everything else
   (`src/runtime/java/classPath.ts`).
+- `dist/` also ships **KaTeX's 60 font files** (1072.9 kB; woff2 + woff + ttf, of which
+  only woff2 is ever requested by a browser able to run this app — accepted, Pages storage
+  is free, ADR-0027 §4). They come from our own origin and are fetched only when a page
+  actually renders a glyph: ~42 kB of woff2 for a typical formula, and **nothing at all**
+  for a page without mathematics. `build.assetsInlineLimit: 0` is what keeps that true —
+  at Vite's default one face was small enough to be inlined into the global stylesheet,
+  which made every page in the site pay for it (ADR-0027 §3).
+- **Bumping KaTeX**: `rehype-katex` resolves its **own** copy (`^0.16.0`), so raising the
+  `katex` line in `package.json` alone ships a stylesheet that does not match the markup
+  it styles. #118 did exactly that: 0.18's CSS over 0.16's class names, which looked
+  almost right — `.strut` computed `display: inline` instead of `inline-block`. After any
+  bump, check `npm ls katex` shows a single deduped version and look at a formula in a
+  browser (ADR-0027 §7).
 - The rest of the execution machinery is **not** ours to serve: Pyodide and
   browsercc come from `cdn.jsdelivr.net`, CheerpJ from `cjrtnc.leaningtech.com`
   (ADR-0018 §5). Nothing is fetched until an editor asks for a runtime — the

--- a/apps/web/src/components/structure/Slide.catalog.tsx
+++ b/apps/web/src/components/structure/Slide.catalog.tsx
@@ -15,7 +15,8 @@ export const slideCatalogEntry: CatalogEntry = {
     {
       name: 'title',
       type: 'string',
-      description: 'Section heading in the book; slide title in the presentation.',
+      description:
+        'Section heading in the book; slide title in the presentation. PLAIN TEXT — it is a JSX attribute, so markdown and mathematics are not processed: a `$$…$$` here ships literal dollar signs to the reader, projected, past a green build (#118). Put a formula in the slide body instead.',
     },
     {
       name: 'children',

--- a/apps/web/src/content/mdxHeading.tsx
+++ b/apps/web/src/content/mdxHeading.tsx
@@ -27,6 +27,13 @@ export function headingFor(level: 2 | 3 | 4) {
   function MdxHeading({ children }: HeadingProps) {
     const text = textOf(children);
     const slug = slugify(text);
+    // No text to slug: render the heading, but with no id and no self-anchor.
+    // Since #118 (2026-08-14) this is reachable from ordinary authoring — a
+    // heading that is entirely a formula (`## $$\log_2 n$$`) has no text at all,
+    // because `textOf` sees no strings — and it fails silently: no deep link, no
+    // rail entry, green build, green suite. Contradicts ADR-0021 and ADR-0002
+    // knowingly; the fix moves published slugs, so it needs its own migration
+    // (ADR-0027 §8). The authoring guide tells authors to put text in a heading.
     if (!slug) return <Tag>{children}</Tag>;
     return (
       <Tag id={slug} className="group scroll-mt-8">

--- a/apps/web/src/lib/reactText.ts
+++ b/apps/web/src/lib/reactText.ts
@@ -1,6 +1,20 @@
 import type { ReactNode } from 'react';
 
-/** Concatenated text content of a node tree (elements contribute nothing themselves). */
+/**
+ * Concatenated text content of a node tree (elements contribute nothing themselves).
+ *
+ * That last clause is load-bearing and costs something, since #118 (2026-08-14).
+ * A heading whose content is entirely an element — a formula, `## $$\log_2 n$$` —
+ * yields an empty string here, so `mdxHeading` produces no slug, no id, no
+ * self-anchor and no entry in the section rail, silently and with a green suite.
+ * The auto-mode slide-title path in `presentation/parser.ts` has the same hole.
+ *
+ * **Do not "fix" it by recursing into elements without a migration.** Recursing
+ * changes slugs that are already published: `06-java-desde-cpp.mdx` has a heading
+ * whose live anchor is `la-trampa-de-seguido-de` and would become
+ * `la-trampa-de-nextint-seguido-de-nextline`. ADR-0027 records that a published
+ * anchor is frozen, and why this was left alone.
+ */
 export function textOf(node: ReactNode): string {
   if (typeof node === 'string' || typeof node === 'number') return String(node);
   if (Array.isArray(node)) return node.map(textOf).join('');

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -1,14 +1,17 @@
 @import 'tailwindcss';
 /* KaTeX's own stylesheet and @font-face rules.
 
-   Global, and it is DEBT rather than a design (ADR-0027 §3). Every page pays
-   8.27 kB gzip whether or not it has mathematics. Scoping it per document was
+   Global, and it is DEBT rather than a design (ADR-0027 §3): every page pays
+   3.94 kB gzip whether or not it has mathematics. Scoping it per document was
    measured and works — Vite splits it cleanly and the app stylesheet returns to
    its exact pre-math size — so the reason this is global is speed of delivery,
    not a build limitation. Taken knowingly; the ADR carries the exit.
 
-   The fonts are not part of that debt: a browser fetches a face only for glyphs
-   something renders, so a document with no formula downloads none of them. */
+   The fonts are not part of that debt — a browser fetches a face only for glyphs
+   something renders — but only because `build.assetsInlineLimit: 0` is set in
+   vite.config.ts. At Vite's default, one face was small enough to be inlined
+   here as base64 and cost every page 4.34 kB gz on its own, more than half the
+   total. Do not raise that limit without re-measuring this file. */
 @import 'katex/dist/katex.min.css';
 
 @plugin '@tailwindcss/typography';

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -22,6 +22,19 @@ export default defineConfig(({ command, isPreview }) => ({
   // the built dist, whose asset URLs already carry the prefix — while dev keeps
   // the root so local URLs stay short.
   base: command === 'build' || isPreview ? '/nalanda/' : '/',
+  build: {
+    // Never inline an asset into the stylesheet. Vite's default inlines anything
+    // under 4096 bytes, and exactly one asset in this app qualifies: KaTeX's
+    // `Size3-Regular.woff2` at 3,624 bytes. Being in the CSS made it
+    // unconditional — every page in the site downloaded a font for large
+    // delimiters, whether or not it had a formula, at 4,343 bytes gzip: **52% of
+    // the whole cost of shipping mathematics** (#118 review, ADR-0027 §3).
+    //
+    // Zero rather than a smaller threshold because the tradeoff inlining buys —
+    // one fewer request — is worthless for a font the page usually does not
+    // need, and this app has no other asset near the limit.
+    assetsInlineLimit: 0,
+  },
   plugins: [
     contentIntegrity(contentDir),
     spaFallback(),
@@ -30,7 +43,7 @@ export default defineConfig(({ command, isPreview }) => ({
       enforce: 'pre',
       // Both lists live in src/content/ so the suite can compile MDX through the
       // same ones the build uses, instead of scraping this file for plugin
-      // names. Math needs one from each tree: remark to parse `$…$`, rehype to
+      // names. Math needs one from each tree: remark to parse `$$…$$`, rehype to
       // render it.
       ...mdx({ remarkPlugins, rehypePlugins, providerImportSource: '@mdx-js/react' }),
     },

--- a/docs/decisions/0002-content-model-graph-index-stable-ids.md
+++ b/docs/decisions/0002-content-model-graph-index-stable-ids.md
@@ -4,6 +4,10 @@
 **Date:** 2026-08-05
 **Decision-makers:** Miguel Rodriguez
 **Source:** Redesign session (D1, D3, D4, D6, D7, D8)
+**Amended by:** ADR-0027 §8 — a *published* slug is frozen. Every `h2`–`h4` is still
+deep-linkable, with one reachable exception: a heading whose content is entirely an
+element (a formula, since #118) produces no text, so no id and no anchor. The fix
+changes slugs that are already live and therefore needs a migration.
 
 ## Context
 

--- a/docs/decisions/0012-content-pipeline-implementation.md
+++ b/docs/decisions/0012-content-pipeline-implementation.md
@@ -5,6 +5,10 @@
 **Decision-makers:** Miguel Rodriguez
 **Source:** Issue #63 (WP2, content model). Extends ADR-0002 (which deferred the
 index format to v0.1) and ADR-0003 (which chose MDX but not the toolchain).
+**Amended by:** ADR-0027 — the pipeline now carries a **second, rehype tree**
+(`src/content/rehypePlugins.ts`), and both lists are handed to `@mdx-js/rollup`
+together. `remark-gfm` (#83) and `remark-math` also joined the remark list, so the
+toolchain enumeration in §2 below is no longer live — the two source files are.
 
 ## Context
 

--- a/docs/decisions/0018-runtime-feature-and-editor-layer.md
+++ b/docs/decisions/0018-runtime-feature-and-editor-layer.md
@@ -167,6 +167,11 @@ ADR-0014's fifth decision reserves for an ADR extending ADR-0010; `/catalog/gove
   the component — and the grammar is not optional chrome, it is the
   highlighter. Measured from a network trace of `03-busqueda-binaria.mdx`, prose
   plus a single 10-line Java listing: **160.7 → 323.7 kB gz, +163.0 kB (+101%)**.
+  (Superseded as a *page total* by #118 on 2026-08-14: that same document now
+  also carries mathematics, so it pays +3.94 kB gz of unconditional stylesheet —
+  as does every other page in the site — plus ~42 kB of fonts for its own
+  formulas. The fence figures below are unchanged; ADR-0027 §Consequences holds
+  the math side and states the comparison from both directions.)
   Of that, **161.2 is five lazy chunks** — 95.6 core + 36.4 wrapper + 17.7 java
   grammar + 8.6 `@lezer/lr` + 2.9 the editor chunk itself — and the remaining
   1.7 is the entry chunk's own growth. (Two earlier drafts got this wrong in the

--- a/docs/decisions/0021-rendered-h2-is-the-section-boundary.md
+++ b/docs/decisions/0021-rendered-h2-is-the-section-boundary.md
@@ -6,6 +6,9 @@
 **Covers:** where a document's section spine comes from · why it is read from the DOM
 rather than from the source · what a structural component must render to stay navigable
 **Source:** Issue #84 (WP: the reading shell on a phone and inside a document).
+**Amended by:** ADR-0027 §8 — an `h2` that is entirely a formula paints but contributes
+no section, because it has no text to slug. Accepted knowingly; the fix moves published
+anchors.
 Extends ADR-0013 (presentation pipeline) and ADR-0010 (component contract);
 constrained by the import direction in `frontend-code-style.md`.
 

--- a/docs/decisions/0027-mathematics-is-rendered-before-it-ships.md
+++ b/docs/decisions/0027-mathematics-is-rendered-before-it-ships.md
@@ -84,59 +84,70 @@ is pinned by a test rather than left to the guide.
 ### 3. The stylesheet is global — and that is debt, taken knowingly
 
 `katex.min.css` is imported once, in `styles/index.css`, so every page carries it:
-**+8.26 kB gzip on every page in the site, whether or not it contains mathematics.**
+**+3.94 kB gzip on every page in the site, whether or not it contains mathematics.**
 
-The fonts are not part of that. They are the expensive half — 20 faces — and a browser
-fetches a face only for glyphs something actually renders. Verified in a browser: a
-document with one formula requests exactly two woff2 files, and a document with no
-mathematics requests **none**.
+The fonts are demand-loaded and are not part of that — a browser fetches a face only for
+glyphs something actually renders. Verified in a browser: a document with one formula
+requests exactly two woff2 files, and a document with no mathematics requests **none**.
 
-**The first draft of this ADR justified the global import by saying that scoping it per
-document "would fight Vite's CSS splitting". That was false, and it was measured false
-during review.** Importing the stylesheet from a document module splits cleanly and
-returns the app stylesheet to its exact pre-math size:
+**That sentence was false when this ADR was first written, and the way it was false is
+the more useful record.** `KaTeX_Size3-Regular.woff2` is 3,624 bytes, under Vite's default
+`assetsInlineLimit` of 4096 — so Vite inlined it as a base64 data URI *inside the global
+stylesheet*. One font for large delimiters was therefore downloaded by every page in the
+site, math or not, at **4,343 bytes gzip: 52% of the entire cost of shipping
+mathematics.** The build emitted 19 woff2 files where KaTeX has 20, and nobody noticed
+the missing one.
 
-    dist/assets/03-busqueda-binaria-*.css   30.20 kB │ gzip: 7.95 kB
-    dist/assets/index-*.css                 49.37 kB │ gzip: 8.55 kB   ← the baseline
+`build.assetsInlineLimit: 0` in `vite.config.ts` fixes it, and the measurement is the
+whole argument:
+
+| | Inlined (as merged) | `assetsInlineLimit: 0` |
+|---|---|---|
+| App CSS | 77.29 kB → 16.70 kB gz | 72.48 kB → **12.36 kB gz** |
+| Cost to every page | 8.28 kB gz | **3.94 kB gz** |
+| woff2 emitted as files | 19 | **20** |
+
+**The remaining 3.94 kB is still debt**, and the exit for it is different and larger:
+scoping the stylesheet per document. That was also measured, after a first draft of this
+ADR claimed — falsely — that it "would fight Vite's CSS splitting". It does not. Importing
+the stylesheet from a document module splits cleanly and returns the app stylesheet to
+its exact pre-math size:
+
+    dist/assets/03-busqueda-binaria-*.css   29.30 kB │ gzip: 7.93 kB
+    dist/assets/index-*.css                 47.98 kB │ gzip: 8.42 kB   ← the baseline
 
 with a browser trace confirming the consequence: the math-free page loads one stylesheet
 and no fonts, the math page loads two and the same two woff2. So "a page without
-mathematics pays nothing" is **literally achievable**, not merely approachable.
+mathematics pays nothing" is **literally achievable**, not merely approachable. It is
+global anyway, for speed of delivery: this WP unblocks #120, and one unconditional
+stylesheet is the shortest path there. Tracked rather than narrated — see the issue
+linked from this ADR's header.
 
-It is global anyway, and the reason is speed of delivery rather than a build constraint:
-this WP unblocks #120, and one unconditional stylesheet is the shortest path there. **The
-debt is recorded here rather than hidden behind a technical claim, and the exit is
-known**: inject the import from a remark plugin when a document contains a math node
-(an alias is needed, because `content/` resolves outside `apps/web`). Worth paying down
-when a second measurement says 8.26 kB matters, or when the catalog of math-free
-documents grows enough that the ratio embarrasses.
-
-Recording the false version of this reasoning is deliberate. This repo has already
-shipped one regression behind unverified build-weight reasoning (#83, and the 5.8 kB gz
-that #104 had to chase), and the failure mode is exactly a plausible sentence nobody
-re-measures.
+Recording both false versions is deliberate. This repo has already shipped one regression
+behind unverified build-weight reasoning (#83, and the 5.8 kB gz that #104 had to chase),
+and the failure mode is exactly this: a plausible sentence nobody re-measures. Here it
+happened twice in one WP, and the second one hid more than half the cost.
 
 ### 4. All three font formats are published
 
-KaTeX declares each face in woff2, woff and ttf; the build emits all 59 files, **1047.8
-kB** (19 woff2 / 250.2 kB, 20 woff / 296.0 kB, 20 ttf / 501.6 kB). A browser picks the
-first format it understands, which for anything able to run this app is woff2, so
-**797.6 kB is published and never requested**. **Accepted knowingly by the repo owner**:
-the host is GitHub Pages, where that storage is free.
+KaTeX declares each face in woff2, woff and ttf; the build emits all 60 files, **1072.9
+kB** (20 woff2 / 256.2 kB, 20 woff / 303.1 kB, 20 ttf / 513.7 kB — decimal kB, matching
+Vite's own output). A browser picks the first format it understands, which for anything
+able to run this app is woff2, so **816.8 kB is published and never requested**.
+**Accepted knowingly by the repo owner**: the host is GitHub Pages, where that storage is
+free, and dropping formats is a compatibility decision rather than an inherited one.
 
-**One exception, and it is not hypothetical for an algorithms course**: `KaTeX_Size3-Regular`
-ships no woff2 at all. A formula using size-3 delimiters — a `\left(` around a tall
-fraction, a display-size `\sum` — fetches its 13.2 kB `.woff`.
+What the dead formats cost every *reader* is **511 bytes gzip** — 6.2% of the CSS delta
+as merged, measured by stripping every `woff`/`truetype` `url()` from the built
+stylesheet: 16,678 B gz → 16,167 B gz. The `@font-face` blocks as a whole are 64% of that
+delta, so even a woff2-only build would carry 4,822 B of them.
 
-What the dead formats cost every reader is **474 bytes gzip**, which is 5.8% of the CSS
-delta. Measured by stripping every `woff`/`truetype` `url()` from the built stylesheet:
-16,613 B gz → 16,139 B gz. The `@font-face` blocks as a whole are 65% of the delta, so
-even a woff2-only build would carry 4,807 B of them.
-
-An earlier draft of this section explained the delta by saying hashed asset paths do not
-compress. Measured, de-hashing every font filename saves 445 B gz — about 5% of the
-delta, so the explanation was directionally right and quantitatively backwards. The
-delta is mostly the stylesheet itself.
+An earlier draft explained the delta by saying hashed asset paths do not compress.
+Measured, de-hashing every font filename saves 445 B gz — about 5%, so the explanation
+was directionally right and quantitatively backwards. And an earlier draft claimed
+`KaTeX_Size3-Regular` "ships no woff2 at all", which was wrong in both direction and
+magnitude: the woff2 exists and was being *inlined into the stylesheet* rather than
+omitted. §3 carries what that cost and how it was fixed.
 
 ### 5. A malformed formula renders wrong; it does not fail the build
 
@@ -158,9 +169,11 @@ syntax. The symptom to recognise is "the document ends here", not "one formula i
 `rehypeKatex` is passed `{ trust: false }`. That is already KaTeX's default, and it is
 stated explicitly because it is the one option whose flip is a direct injection: with
 `trust: true`, `\href`, `\url` and the `\html*` family emit real attributes out of
-author-written LaTeX — verified during review, `\href{javascript:alert(1)}{x}` becomes a
-live anchor. Enabling it, or adding `macros` that reach those commands, needs a security
-review. Pinned by a test so the flip cannot be made quietly.
+author-written LaTeX. Verified during review: with `trust: true`, `\href{javascript:…}{x}`
+emits a real `<a href>` **and** an `href` on the MathML `<mrow>`. React neutralises a
+`javascript:` URL specifically — so that exact payload is defanged — but the attribute
+channel is open and any other scheme rides it, which is why the flip needs a security
+review rather than why it is survivable. Pinned by a test so it cannot be made quietly.
 
 The default was attacked before being trusted: ten hostile documents compiled through the
 real build path produced red error text for every trust-gated command, and never an
@@ -170,19 +183,53 @@ refuses non-`http(s)`/`mailto`/local schemes.
 
 ### 7. Which KaTeX renders
 
-`rehype-katex@7` declares `katex: ^0.16.0`, so it cannot use a 0.18. The direct
-dependency is therefore pinned to **`^0.16.47`**, and npm dedupes to a single copy that
-both renders the formulas and supplies their stylesheet.
+`rehype-katex@7` declares `katex: ^0.16.0`, so it cannot use a 0.18. The direct dependency
+is pinned to **`^0.16.47`** and npm dedupes to a single copy that both renders the
+formulas and supplies their stylesheet. The postmortem of getting this wrong — and the
+symptom that made it nearly invisible — is a dated note in `apps/web/README.md`, where a
+dependency bump actually happens.
 
-This is written down because the first version of this WP got it wrong in a way nothing
-caught: it pinned `katex@^0.18.4`, which supplied the CSS while 0.16.47 — nested under
-`rehype-katex` — did the rendering. The class names differ between them (0.18 defines
-`.katex-base`/`.katex-strut`; the markup emits `.base`/`.strut`), so formulas shipped
-styled by a stylesheet that had no rules for them: measured in a browser, `.strut`
-computed `display: inline` instead of `inline-block` and `.base` `position: static`
-instead of `relative` — the two things KaTeX uses for vertical alignment. It looked
-almost right, which is why only a class-by-class comparison found it. **When bumping
-KaTeX, bump what `rehype-katex` resolves, not just this manifest line.**
+### 8. A published anchor is frozen
+
+Heading slugs come from `lib/reactText.ts`, which contributes nothing for an element. A
+heading that is *entirely* a formula therefore has no text, gets no slug, and ships with
+**no id, no self-anchor and no entry in the section spine** — silently. That contradicts
+ADR-0021 (every `h2` the page paints becomes a section) and ADR-0002 (every `h2`–`h4` is
+deep-linkable), and it is reachable from ordinary authoring only since this WP.
+
+The fix is three lines: make `textOf` recurse into elements. **It is not taken, and the
+reason is the decision.** Recursing changes slugs that already exist:
+`06-java-desde-cpp.mdx` has a heading published at `la-trampa-de-seguido-de` which would
+become `la-trampa-de-nextint-seguido-de-nextline`. The site is live and its documents are
+handed to students as links.
+
+So: **a slug that has been published is frozen.** Changing `slugify` or `textOf` is a
+migration — it needs anchor aliases or redirects, and it needs to be decided as such
+rather than arriving as a side effect of a heading fix. Until then, an author writes a
+heading with text in it, and the guide says so. The same root cause gives a sibling limit:
+a `<Slide title>` is a JSX attribute, so a formula there ships literal `$$`; that one is
+authoring-visible and lives in the guide and the catalog entry.
+
+## Alternatives considered
+
+- **Single-dollar delimiters** (`$…$`), the LaTeX convention — rejected. Prose about
+  prices parses as mathematics, and a pasted formula with braces is silently corrupted or
+  fails the build. §2 carries the measurements.
+- **`\(…\)` / `\[…\]`**, LaTeX's other pair — not adopted: `remark-math` does not offer
+  them, and adopting them would mean a second syntax for the same thing.
+- **Per-document stylesheet scoping** — measured, works, and **deferred rather than
+  rejected**. It is the exit condition for §3's remaining debt, not a road not taken.
+- **`throwOnError: true`**, failing the build on a bad formula — rejected. The content
+  gate refuses documents for structural faults; a typo inside a formula is authoring
+  feedback, and a broken wiki-link already renders visibly wrong on purpose (§5).
+- **MathJax** (`rehype-mathjax`) — not adopted. Its package is 3× the size and its usual
+  deployment renders client-side, which is the property that makes KaTeX-at-build-time
+  cheap here. Not benchmarked; if mathematics ever needs what MathJax has and KaTeX
+  lacks, that is the measurement to run.
+- **KaTeX in the browser** — rejected on the cost that motivated the whole WP: it would
+  ship ~90 kB gzip of JavaScript to do at runtime what the build already did once.
+- **Authoring MathML directly** — rejected. It is unwritable by hand for a professor
+  drafting a class, which is the actual user.
 
 ## Consequences
 
@@ -193,25 +240,26 @@ overstated the document chunk.
 
 | | Before | After |
 |---|---|---|
-| App CSS | 47.98 kB → 8.42 kB gz | 77.29 kB → **16.70 kB gz** |
+| App CSS | 47.98 kB → 8.42 kB gz | 72.48 kB → **12.36 kB gz** |
 | JavaScript shipped | — | **unchanged; zero** |
 | `03-busqueda-binaria` chunk | 2.07 kB → 1.03 kB gz | 5.17 kB → **1.66 kB gz** |
-| Font files in `dist/` | 0 | 59, 1047.8 kB |
+| Font files in `dist/` | 0 | 60, 1072.9 kB |
 | Fonts a formula requests | — | 2 woff2, 42,712 B |
 | Fonts a math-free page requests | — | **0** |
 | Build time | 3.17–3.95 s | 3.20–3.67 s (within noise) |
 
-The CSS row is measured against the baseline *after* #109's two-theme system
-landed, by building this branch with and without the `@import` — the honest form,
-since a rebase moved the ground under the first reading. The delta is +8.28 kB
-gz, unchanged in substance from the +8.26 measured before the rebase.
+The CSS row is measured against the baseline *after* #109's two-theme system landed, by
+building this branch with and without the `@import` — the honest form, since a rebase
+moved the ground under the first reading, and since one number in an earlier version of
+this table was taken from a tree with a stray `dist*` directory that Tailwind scanned.
 
 The zero-JavaScript claim is hard-verified, not inferred: the entry chunk is
 byte-identical across the change, and `grep` for KaTeX's own runtime strings over
 `dist/assets/*.js` returns nothing. The document chunk contains only the class names.
 
-So: **+8.26 kB gz on every page**, and +0.63 kB gz of markup plus ~42 kB of fonts on the
-pages with a formula.
+So: **+3.94 kB gz on every page**, and +0.63 kB gz of markup plus ~42 kB of fonts on the
+pages with a formula. As first merged it was 8.28 kB, of which 4.34 was a font Vite had
+inlined into the stylesheet — §3.
 
 **The comparison with ADR-0018, stated fairly.** #86 asked for it and the first draft
 gave a single flattering ratio. Two numbers is the honest form, because the axis that
@@ -219,17 +267,20 @@ matters is conditionality — and ADR-0018 is precisely the decision that establ
 
 - A page **with** mathematics pays ~51 kB, against ~162 kB gz for a page with a code
   fence. Cheaper, and it runs no script at all.
-- A page **without** mathematics pays 8.26 kB gz. A page without a fence pays **zero**.
+- A page **without** mathematics pays 3.94 kB gz. A page without a fence pays **zero**.
 
 The second line is the one that makes §3's debt visible instead of hiding it inside a
 ratio.
 
-**On a slide**, measured against the production build: scale 1.00 at 1024×768, and 0.895
-on an iPhone 13 in landscape. Both are above the 0.8 floor and far above the ~0.5 point
-where the authoring guide records body text ceasing to be readable. **Caveat**: measured
-on a temporary slide, because no shipped document currently puts a formula in a deck —
-`03-busqueda-binaria.mdx` keeps its cost section book-only. Reproducing these numbers
-means adding one, and #120 is where a deck with mathematics first ships for real.
+**On a slide**: a formula renders and scales like anything else, and the binary-search
+cost formula specifically does not shrink the slide at all — scale 1.00 at both 1024×768
+and iPhone 13 landscape, re-measured during review. Two caveats, because the first
+version of this paragraph carried neither. It cited "the 0.8 floor", **a threshold that
+does not exist anywhere in this repo** — the only recorded one is the guide's "below
+roughly half scale the body text stops being readable". And no shipped document puts a
+formula in a deck, so there is no reproducible example: `03-busqueda-binaria.mdx` keeps
+its cost section book-only, and #120 is where a deck with mathematics first ships. The
+hazard worth checking is a *long* display equation, which this one is not.
 
 **Layout shift.** Mathematics adds none of its own: KaTeX bakes build-time metrics into
 inline styles, so blocking the woff2 files versus loading them leaves every formula box
@@ -238,9 +289,11 @@ because the pre-existing unexplained shifts of #96 scale with document height an
 page got taller. All three shifts fire at ~375 ms, before any font could arrive — a
 datapoint for #96, which is still open.
 
-**DOM weight.** Two trivial formulas add 53 elements to a 251-element page, ~26 elements
-and ~1.5 kB raw each. No measurable cost at this size; recorded so #120 has a baseline
-before a slide carries a dozen.
+**DOM weight.** Two trivial formulas are 55 elements and 1,905 B of markup on a
+235-element page at 1440×900 — ~28 elements and ~950 B each. No measurable cost at this
+size; recorded so #120 has a baseline before a slide carries a dozen. The element count
+of the page itself varies with viewport width, so the per-formula figures are the ones
+that travel.
 
 **Build-time resource use.** KaTeX now runs in Node on author-controlled content.
 Expansion bombs and deep recursion are bounded — `maxExpand` stops `\def` loops, and a

--- a/docs/security-notes.md
+++ b/docs/security-notes.md
@@ -192,9 +192,36 @@ Decisions: ADR-0019 §3b/§7, ADR-0020 §6, ADR-0028 §6/§7.
   MDX itself compiles content into arbitrary components (ADR-0003 by design).
   Both are safe only while every `.mdx` that reaches the build comes from the
   repo-controlled `content/` tree, reviewed like code.
+- **Since #118 (2026-08-14), a third**: KaTeX renders author-written LaTeX in
+  Node during the Vite transform (`src/content/rehypePlugins.ts`, ADR-0027).
+  Injection was attacked and held — ten hostile documents produced red error text
+  for every trust-gated command, never an anchor or an attribute — but **output
+  size is unbounded**: an 80 kB `\begin{matrix}` produced 40 MB of compiled JSX
+  in 29 s. Expansion bombs and deep recursion ARE bounded (`maxExpand`, and a
+  stack overflow is caught and degraded). The realistic worst case today is burnt
+  CI minutes or a wedged local build, not a compromise — CI runs on
+  `pull_request` with `contents: read` and no secrets in the web job.
 - **Why currently safe**: content ships exclusively via git + PR review; there is
   no runtime ingestion, no user-contributed documents, no CMS.
 - **Review trigger**: the moment ANY non-repo-authored content path appears —
   v0.2 authoring-agent output that bypasses PR review, a future in-platform
   editor (vision phase C), or user-submitted material. At that point the MDX
-  pipeline and this adapter must be re-reviewed as an injection surface.
+  pipeline and this adapter must be re-reviewed as an injection surface — and
+  since #118 there is a second reason to re-review at that same moment: the
+  LaTeX renderer above is a resource-exhaustion sink in the build.
+
+### KaTeX runs with `trust: false` (recorded 2026-08-14, #118)
+
+- **What relies on it**: `rehypeKatex` is passed `{ trust: false }` explicitly
+  (`apps/web/src/content/rehypePlugins.ts`). It is KaTeX's own default, stated
+  because flipping it is a direct attribute-injection: verified, `trust: true`
+  makes `\href{javascript:…}{x}` emit a real `<a href>` **and** an `href` on the
+  MathML `<mrow>`. React neutralises `javascript:` specifically, but the
+  attribute channel is open and any other scheme rides it.
+- **Why currently safe**: the default holds, it is pinned by a test
+  (`mdxPipeline.test.tsx`, "refuses to build a link out of a formula"), and
+  KaTeX-emitted elements resolve through the MDX component map where `a` is
+  `MdxLink`, which already refuses non-`http(s)`/`mailto`/local schemes.
+- **Review trigger**: anyone setting `trust` to anything but `false`, or adding
+  `macros` that reach `\href`, `\url` or the `\html*` family. Decision and the
+  attack record: ADR-0027 §6.

--- a/docs/standards/design-system.md
+++ b/docs/standards/design-system.md
@@ -79,6 +79,20 @@ something to allow; it is something nobody should write.
 - **Third-party components that own their colours** take the theme through
   `lib/useResolvedTheme.ts`. That hook exists for CodeMirror and should stay
   rare: anything we style ourselves takes tokens and needs no hook.
+- **A third party that draws in `currentColor` needs no hook at all**, and that
+  is the better shape when you get to choose it. Worked case: KaTeX (#118). A
+  formula inherits `--tw-prose-body` like the paragraph around it, so it is
+  correct in both themes by construction and cannot drift when the palette
+  changes — measured, 8.90:1 on dark and 7.02:1 on light, identical to the prose
+  in each. Check this before reaching for `useResolvedTheme`.
+- **A vendor colour we do not control is exempt from §The one rule only when it
+  is recorded here, with its measured pairs.** One exists: KaTeX paints a
+  malformed formula in its own `#cc0000`, which measures **3.24:1 on the dark
+  `ground`** — above the 3:1 for large text, below the 4.5:1 the tokens hold text
+  to. Accepted: it is an authoring error state that should look wrong in either
+  theme and is never a reading surface. `architecture.test.ts` cannot see it —
+  it greps our class names, not vendor CSS or inline styles — so this note is
+  the only guard.
 
 ## Verifying a colour change
 

--- a/docs/standards/frontend-code-style.md
+++ b/docs/standards/frontend-code-style.md
@@ -201,7 +201,14 @@ src/
 - **Tailwind only**, utility classes inline in JSX. No CSS modules, no CSS-in-JS,
   no new `.css` files beyond `styles/` globals.
 - **A third-party stylesheet is imported once, in `styles/index.css`, and only
-  when the package's own CSS is the sole source of the rules.** Check before
+  when the package's own CSS is the sole source of the rules** — *unless* it is
+  conditional on a feature only some documents use, in which case scoping the
+  import to the module that needs it is preferred and Vite splits it cleanly
+  (measured: ADR-0027 §3). `katex.min.css` is global today as recorded debt, not
+  as the pattern. Check also what the bundler does with the assets it references:
+  Vite inlines anything under `assetsInlineLimit` into the stylesheet, which
+  turns a conditional asset into an unconditional one (#118 shipped a font that
+  way and it was 52% of the feature's cost). Check before
   importing that it is class-scoped: a vendor rule on a bare element leaks into
   the whole product. Worked case — `katex.min.css`, whose only unscoped rule is
   `body{counter-reset:…}`, and whose weight is recorded with the decision that
@@ -252,7 +259,12 @@ src/
   `CodeEditor`, `Exercise`, `SideBySide`, `AuthoringError`), or marks itself
   `.measure-full` (neither block nor text: the scroll box around a table, the
   prev/next row, the `<SectionBreak/>` rule). **A component that renders
-  anything wide MUST carry one of the two.** The rule is unlayered on purpose,
+  anything wide MUST carry one of the two.** There is a third case, for markup
+  the author cannot mark because a vendor emits it: **keep the cap and give the
+  block its own scroll box** in this stylesheet, beside the rule. Worked case:
+  `.katex-display`, which KaTeX sets `white-space: nowrap` on and ships no
+  overflow rule for, so a long recurrence would widen the page instead of
+  scrolling inside itself (#118, ADR-0027). The rule is unlayered on purpose,
   so a child's own `max-w-*` or `w-full` cannot win — the opt-out is the marker
   class, deliberately, and this also binds new element renderers registered in
   `content/mdxComponents.ts` (worked case: `MdxTable`), not only catalog

--- a/docs/standards/guides/add-a-course-document.md
+++ b/docs/standards/guides/add-a-course-document.md
@@ -176,28 +176,58 @@ the frontmatter `id`, never the path. v0.1 supports exactly ONE course directory
    sees nothing, because it checks frontmatter and the index, not body syntax.
    The symptom to recognise is *"the document ends here"*.
 
+   **A decimal comma needs braces.** This one will bite a Spanish-language
+   course immediately, and it is silent. In mathematics a comma is *punctuation*,
+   so `0,25` renders as `0, 25` — with a gap — and its MathML comes out as three
+   tokens (number, operator, number) instead of one number, which is what a
+   screen reader reads aloud. Write `0{,}25`:
+
+   ```mdx
+   $$
+   N_p = 0{,}25\,S_1 + 0{,}25\,S_2 + 0{,}25\,N_{TC} + 0{,}25\,N_L
+   $$
+   ```
+
+   The `\,` between the number and the symbol is a thin space, which is how
+   multiplication is conventionally set. Neither is optional if you want the
+   formula to read as mathematics rather than as a list.
+
    **A heading wants text in it.** `## $$\log_2 n$$` — a heading that is only a
    formula — gets no id, no anchor and no entry in the section list, silently.
-   Write `## El costo, $$\log_2 n$$` instead. And a `<Slide title="...">` cannot
-   hold a formula at all: the title is a JSX attribute, so the `$$` ship to the
-   reader as literal characters.
+   Write `## El costo, $$\log_2 n$$` instead.
+
+   **A `<Slide title="...">` cannot hold a formula**: the title is a JSX
+   attribute, so the `$$` ship to the reader as literal characters, projected.
+   Put the formula in the slide **body** instead, with a blank line above and
+   below the `$$` block like any markdown inside JSX, and keep the title plain:
+
+   ```mdx
+   <Slide title="Cómo se calcula tu nota">
+
+   $$
+   N_p = 0{,}25\,S_1 + 0{,}25\,S_2
+   $$
+
+   </Slide>
+   ```
 
    Three things worth knowing, all measured rather than assumed:
 
    - **No JavaScript is shipped.** KaTeX renders during the build, so a formula
      costs the reader a stylesheet and the font faces its own glyphs use — about
      42 kB for a typical formula, against ~162 kB gzip of editor for the first
-     highlighted fence on a page (ADR-0018). The 3.6 kB stylesheet is global, so
-     it is the one thing a page without mathematics also pays; it downloads **no
-     fonts at all**.
+     highlighted fence on a page (ADR-0018). The stylesheet is global — **3.94 kB
+     gzip on every page in the site**, including pages with no mathematics
+     (measured 2026-08-14; ADR-0027 §3 carries the figure and why it is debt). A
+     page without a formula downloads **no fonts at all**.
    - **A malformed formula does not fail the build.** It renders in KaTeX's
      error colour, like a broken wiki-link renders visibly broken. Nothing stops
      you publishing it — look at the page.
-   - **On a slide it is fine but not free.** Measured on the binary-search cost
-     formula: scale 1.00 at 1024×768 and 0.895 on a phone in landscape. A long
-     display equation is wide, and ADR-0013 scales the whole slide down rather
-     than clipping — so a formula that does not fit shrinks the prose beside it.
-     Check any slide carrying one, in landscape.
+   - **On a slide it is fine but not free.** A long display equation is wide, and
+     ADR-0013 scales the whole slide down rather than clipping — so a formula
+     that does not fit shrinks the prose beside it. No shipped document puts a
+     formula in a deck yet, so there is no measured example to copy: check any
+     slide carrying one, in landscape, and judge it yourself.
 
    Screen readers are covered: KaTeX emits MathML beside the visual rendering,
    so a formula is read as mathematics rather than skipped as decoration.


### PR DESCRIPTION
Follow-up to #126 (issue #118). The **documentation round** of the review pipeline was
skipped before that PR merged. Run afterwards, its four lenses produced **39 findings**.
This is what they were worth.

## Mathematics now costs every page half what it did

`KaTeX_Size3-Regular.woff2` is 3,624 bytes — under Vite's default `assetsInlineLimit` of
4096 — so Vite inlined it as base64 **into the global stylesheet**. A font for large
delimiters was downloaded by every page in the site, math or not, at **4,343 bytes gzip:
52% of the entire cost of shipping mathematics.** The build emitted 19 woff2 where KaTeX
has 20, and nothing noticed the missing one.

`build.assetsInlineLimit: 0` (confirmed — `vite.config.ts` is gated):

| | Before | After |
|---|---|---|
| App CSS | 77.29 kB → 16.70 kB gz | 72.48 kB → **12.36 kB gz** |
| Cost to **every** page | 8.28 kB gz | **3.94 kB gz** |
| woff2 emitted as files | 19 | **20** |

Verified in a browser: a formula still fetches only its two faces; a math-free page still
fetches none. The ADR had asserted the opposite — that Size3 "ships no woff2 at all", and
that "the fonts are not part of" the per-page cost. Both were wrong, and more than half
the debt was hiding behind them.

## Two things an author needed and did not have

**Decimal commas.** In mathematics a comma is punctuation, so `0,25` renders as `0, 25`
and its MathML comes out as three tokens instead of one number — which is what a screen
reader reads aloud. **Every grade formula in #120 is built from Spanish decimals**; all
of them would have shipped wrong, past a green build, on the most-read slide of the first
class. The repo already knew the idiom — this WP's own test writes `0{,}25` — and it never
reached the guide.

**A formula on a slide.** The guide forbade `<Slide title>` without giving the
alternative. It now shows it, and the prohibition also lands in `Slide.catalog.tsx`,
which is where prop behaviour is supposed to live. That was the one real catalog
obligation this WP created.

## What the docs said that was not true

- The guide priced the stylesheet at **3.6 kB** (the raw npm file) where the ADR said 8.26
  and the CSS comment said 8.27 — three homes, three numbers, none of them the measured
  8.28. Now one number, 3.94, everywhere.
- *"Both are above the 0.8 floor"* cited a slide-scale threshold that **does not exist
  anywhere in this repo**.
- *"`trust: true` makes it a live anchor"* — it emits the anchor and the attribute, but
  React neutralises `javascript:` specifically. Corrected without weakening the argument,
  which is about the attribute channel being open to every other scheme.
- Font totals were KiB labelled kB, in a table whose other rows are Vite's decimal kB.
- The dead-format cost (474 B) and the DOM-weight baseline (53 elements / 251) were from
  older builds; measured now, 511 B and 55 / 235.
- §3's evidence block quoted a pre-rebase baseline that contradicted the table in the same
  document.

## What was decided but never recorded as a decision

The deep-link call is now **§8, a numbered decision**: *a published slug is frozen*, so
fixing the math-only heading is a migration rather than a heading fix. **ADR-0002** and
**ADR-0021** — which it contradicts — now carry `**Amended by:**` lines, which is this
repo's own two-sided convention and was not followed. `reactText.ts` and `mdxHeading.tsx`
carry the warning inline, where someone would otherwise "fix" it in three lines and break
a live student link.

ADR-0027 also gains the **`## Alternatives considered`** section the format mandates and
all 26 prior ADRs have — including the one alternative that is *deferred* rather than
rejected.

## Homes that were skipped

- **`security-notes.md`** is the declared home for accepted risk with review triggers, and
  the merge never touched it. It now carries the build-time resource sink (an 80 kB
  `\begin{matrix}` → 40 MB of JSX in 29 s) and the `trust: false` invariant, each with its
  trigger.
- **ADR-0012** said the pipeline has "no extra rehype dependency". **ADR-0018** is the
  page-cost ledger and its trace is for the very document this WP edited. Both amended.
- **`apps/web/README.md`** described a remark-only pipeline, listed no fonts among emitted
  artifacts, and is where a dependency bump actually happens — so the KaTeX version trap is
  recorded there rather than only in an ADR.
- **`frontend-code-style.md`**'s measure rule enumerated three ways out of the 39rem cap;
  `.katex-display` takes a fourth. And the vendor-stylesheet rule this WP added
  contradicted the ADR's own exit — it now says global is the debt, not the pattern.
- **`design-system.md`** gains the general case worth having: a third party that draws in
  `currentColor` needs no theme hook at all. Plus KaTeX's `#cc0000` error red at a
  measured **3.24:1** on dark, accepted explicitly as an error state.

## Tests

743 passing (70 files), unchanged in count by this PR — it corrects documentation and one
build setting. The behaviour it changes is verified in a browser rather than by the suite,
which cannot see asset inlining.

## Manual verification

- [ ] `/d/busqueda-binaria` still renders the formula, in both themes.
- [ ] DevTools → Network on a page with **no** mathematics: no KaTeX font is requested.
- [ ] `dist/assets/` contains `KaTeX_Size3-Regular-*.woff2` as a real file, and the built
      CSS contains no `base64`.

## Not acted on

The catalog's blindness to non-component authoring capabilities — fences (#85),
mathematics (#118), images (#119) — is **Discussion #127**. It is a design question about
what `/catalog` *is*, not two missing entries, and the standard currently decides it the
other way with an explicit precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RBsd3QsDEe7soC371r1mme
