### PR TITLE
feat: support images and visual composition in course documents (#119)

### DIFF
--- a/apps/web/src/app/catalogRoute.test.tsx
+++ b/apps/web/src/app/catalogRoute.test.tsx
@@ -137,19 +137,20 @@ describe('/catalog', () => {
   });
 
   it('does not site an empty family in a folder that is not there', async () => {
-    // src/components/semantic/ and media/ do not exist: the first component
-    // added to a family creates it. "Components live in ..." was a claim the
-    // repo contradicted.
+    // src/components/semantic/ does not exist: the first component added to a
+    // family creates it. "Components live in ..." was a claim the repo
+    // contradicted. Repointed from media in #119, which gave that family its
+    // first habitant — the message below is what said where to move it.
     expect(
-      catalog.byFamily('media').length,
-      'media has components now — point this test at a family that is still empty, ' +
+      catalog.byFamily('semantic').length,
+      'semantic has components now — point this test at a family that is still empty, ' +
         "and make sure that family's page is in the rendered-English path list below",
     ).toBe(0);
 
-    renderAt('/catalog/media');
-    await screen.findByRole('heading', { level: 1, name: 'Media' });
+    renderAt('/catalog/semantic');
+    await screen.findByRole('heading', { level: 1, name: 'Semantic' });
     // The path sits in its own <code>; the tense is on the paragraph around it.
-    expect(screen.getByText(/src\/components\/media\//).parentElement).toHaveTextContent(
+    expect(screen.getByText(/src\/components\/semantic\//).parentElement).toHaveTextContent(
       /components will live in/i,
     );
   });
@@ -278,17 +279,23 @@ describe('the catalog writes English', () => {
   // Exercise and CodeEditor, whose chrome addresses students in Spanish, and
   // the snippets are course content. Root CLAUDE.md §Language exempts exactly
   // that, so scanning it would flag the one Spanish the WP decided to keep.
-  it.each(['/catalog', '/catalog/structure', '/catalog/media', '/catalog/governance'])(
-    'renders no Spanish orthography at %s',
-    async (path) => {
-      renderAt(path);
-      const main = await screen.findByRole('main');
-      const offenders = (main.textContent ?? '')
-        .split('\n')
-        .filter((line) => SPANISH_ORTHOGRAPHY.test(line));
-      expect(offenders, `Spanish rendered at ${path}`).toEqual([]);
-    },
-  );
+  // Three families and the index: `structure` and `media` are populated (media
+  // since #119), `semantic` is the one still empty — the tense branch and the
+  // component list both get scanned.
+  it.each([
+    '/catalog',
+    '/catalog/structure',
+    '/catalog/media',
+    '/catalog/semantic',
+    '/catalog/governance',
+  ])('renders no Spanish orthography at %s', async (path) => {
+    renderAt(path);
+    const main = await screen.findByRole('main');
+    const offenders = (main.textContent ?? '')
+      .split('\n')
+      .filter((line) => SPANISH_ORTHOGRAPHY.test(line));
+    expect(offenders, `Spanish rendered at ${path}`).toEqual([]);
+  });
 });
 
 describe('/catalog/governance', () => {

--- a/apps/web/src/app/mdxComponents.ts
+++ b/apps/web/src/app/mdxComponents.ts
@@ -1,11 +1,14 @@
 import {
+  Figure,
   LazyCodeEditor,
   LazyExercise,
   LazyMemoryDiagram,
   MdxPre,
+  Mosaic,
   SectionBreak,
   SideBySide,
   Slide,
+  Split,
 } from '../components';
 import { contentMdxComponents } from '../content';
 
@@ -24,6 +27,9 @@ export const mdxComponents = {
   Slide,
   SectionBreak,
   SideBySide,
+  Split,
+  Mosaic,
+  Figure,
   // The lazy wrapper, not the editor itself: this map is evaluated eagerly, and
   // registering the real component would put CodeMirror in the entry chunk.
   CodeEditor: LazyCodeEditor,

--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -685,7 +685,11 @@ describe('explicit-mode documents (real compiled markers)', () => {
   // because in `auto` there is no way to keep loose prose out of a deck.
   it('keeps the book’s closing navigation sentence out of intro-estructuras’ deck', async () => {
     renderAt('/d/intro-estructuras/present');
-    expect(await findCounter()).toHaveTextContent('1 / 4');
+    // The count is the vehicle, not the subject: what this pins is that `End`
+    // lands on the last MARKED slide and the trailing sentence is not one. It
+    // moves whenever the document gains a slide — 4 → 5 in #119, which added the
+    // mosaic of four structures.
+    expect(await findCounter()).toHaveTextContent('1 / 5');
 
     fireEvent.keyDown(window, { key: 'End' });
     expect(
@@ -697,7 +701,10 @@ describe('explicit-mode documents (real compiled markers)', () => {
   it('decks only the marked slides, leaving loose prose book-only', async () => {
     await renderAt(`/d/${explicitId}/present`);
     const counter = await findCounter();
-    expect(counter).toHaveTextContent('1 / 3');
+    // Same as above: the number tracks the fixture's marked slides — 3 → 4 in
+    // #119, which added the cost-curve slide — while the case is about the loose
+    // prose staying out.
+    expect(counter).toHaveTextContent('1 / 4');
 
     fireEvent.keyDown(window, { key: 'ArrowRight' });
     expect(await screen.findByRole('heading', { name: 'La idea' })).toBeInTheDocument();

--- a/apps/web/src/catalog/families.ts
+++ b/apps/web/src/catalog/families.ts
@@ -32,8 +32,9 @@ const definitions: Record<CatalogFamily, Omit<FamilyDef, 'id' | 'name'>> = {
       'Visualizers, code editors, quizzes, steppers — anything with client-side behavior (ADR-0001).',
   },
   media: {
-    definition: 'Components that embed external or heavy media.',
-    whatBelongs: 'Images with behavior, video, audio, embeds — media beyond plain Markdown.',
+    definition: 'Components that present an image or embed heavier media.',
+    whatBelongs:
+      'Figures and images, video, audio, embeds — visual media, from a captioned content image (Figure, #119) up.',
   },
 };
 
@@ -49,9 +50,9 @@ export function familyName(id: CatalogFamily): string {
 }
 
 /**
- * Why a family can be empty. Two of the four are, and that is policy, not a
- * gap: components are built when a class asks for one (ADR-0010, §Inventory is
- * emergent). Said on both surfaces that can show an empty family, so neither
+ * Why a family can be empty. One of the four is (`semantic`, since #119
+ * populated `media`), and that is policy, not a gap: components are built when a
+ * class asks for one (ADR-0010, §Inventory is emergent). Said on both surfaces that can show an empty family, so neither
  * reads as broken — and because this is the page an agent consults before
  * inventing a component, where silence next to "no components" reads as an
  * invitation.

--- a/apps/web/src/components/described.ts
+++ b/apps/web/src/components/described.ts
@@ -1,0 +1,23 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * Whether a container already carries the description for everything inside it.
+ *
+ * `<Mosaic>` names the whole group once — "empresas que usan estructuras de
+ * datos a diario" — and its cells go silent, because a screen reader announcing
+ * nine brand names in a row tells the listener less than one sentence does.
+ *
+ * A context rather than a prop for the same reason as `embedded.ts`: a cell is
+ * authored as its own element and the container cannot pass it anything. It is
+ * also what keeps `<Figure>`'s rule absolute — an empty `alt` is an authoring
+ * error everywhere, and the single exception lives in the container that has
+ * already spoken.
+ */
+const DescribedContext = createContext(false);
+
+export const DescribedProvider = DescribedContext.Provider;
+
+/** True when the surrounding container already describes this content. */
+export function useDescribed(): boolean {
+  return useContext(DescribedContext);
+}

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -4,9 +4,12 @@ import type { CatalogEntry } from '../lib/catalogEntry';
 import { codeEditorCatalogEntry } from './interactive/CodeEditor.catalog';
 import { exerciseCatalogEntry } from './interactive/Exercise.catalog';
 import { memoryDiagramCatalogEntry } from './interactive/MemoryDiagram.catalog';
+import { figureCatalogEntry } from './media/Figure.catalog';
+import { mosaicCatalogEntry } from './structure/Mosaic.catalog';
 import { sectionBreakCatalogEntry } from './structure/SectionBreak.catalog';
 import { sideBySideCatalogEntry } from './structure/SideBySide.catalog';
 import { slideCatalogEntry } from './structure/Slide.catalog';
+import { splitCatalogEntry } from './structure/Split.catalog';
 
 // Documents and the catalog both get the lazy wrapper — nothing outside
 // `interactive/lazyCodeEditor.tsx` may name the editor module, or CodeMirror
@@ -19,15 +22,21 @@ export { LazyMemoryDiagram } from './interactive/lazyMemoryDiagram';
 // Not a document-facing component and deliberately not in the catalog: authors
 // never write it, they write a fence. The shell maps it onto `pre`.
 export { MdxPre } from './MdxPre';
+export { Figure } from './media/Figure';
+export { Mosaic } from './structure/Mosaic';
 export { SectionBreak } from './structure/SectionBreak';
 export { SideBySide } from './structure/SideBySide';
 export { Slide } from './structure/Slide';
+export { Split } from './structure/Split';
 
 /** Every catalog entry this feature ships (colocated *.catalog.tsx files). */
 export const catalogEntries: CatalogEntry[] = [
   slideCatalogEntry,
   sectionBreakCatalogEntry,
   sideBySideCatalogEntry,
+  splitCatalogEntry,
+  mosaicCatalogEntry,
+  figureCatalogEntry,
   codeEditorCatalogEntry,
   exerciseCatalogEntry,
   memoryDiagramCatalogEntry,

--- a/apps/web/src/components/media/Figure.catalog.tsx
+++ b/apps/web/src/components/media/Figure.catalog.tsx
@@ -1,0 +1,65 @@
+import type { CatalogEntry } from '../../lib/catalogEntry';
+
+import { Figure } from './Figure';
+
+// What an author writes is a path relative to their document; what runs here is
+// the `asset:` key `remarkContentImages` rewrites it into. Same split as the
+// SideBySide entry, whose snippets show fences and whose render shows what the
+// fences became.
+const COST_CURVE = 'asset:courses/sample-course/costo-busqueda.svg';
+const ALT =
+  'Dos curvas de costo sobre los mismos ejes: la búsqueda lineal sube en línea recta con el tamaño del arreglo, mientras la binaria se aplana casi de inmediato.';
+
+/** Catalog entry (ADR-0010) — colocated with the component, exported via the seam. */
+export const figureCatalogEntry: CatalogEntry = {
+  name: 'Figure',
+  family: 'media',
+  description:
+    'One image with its alternative text and, optionally, its caption. The atom of the media family: it renders a picture and nothing else.',
+  whenToUse:
+    'Whenever a document shows a picture. Put it beside a block of text with <Split>, or in a grid with <Mosaic> — layout lives in those containers, so a figure never grows a prop about its neighbours. ' +
+    'The `alt` is a runtime contract rather than a type, because MDX is not typechecked and the reader who needs the alt is the one who cannot see that it is missing: a figure without it renders an authoring error instead of an image. An empty alt is an error too, except inside a <Mosaic>, which carries the description for the whole group. ' +
+    'An image that resolves nowhere renders visibly broken and warns, exactly as an unresolved wiki-link does (ADR-0002): writing the slide before drawing the picture is a legitimate order of work.',
+  props: [
+    {
+      name: 'src',
+      type: 'string',
+      description:
+        'The image, written relative to the document (`./curva.svg`). The MDX pipeline rewrites it into an `asset:` key and the build emits the file, which is what makes the url correct under the deployed base path.',
+    },
+    {
+      name: 'alt',
+      type: 'string',
+      description:
+        'What the picture says, in Spanish (the page is served `lang="es"`). Required. Empty only inside a <Mosaic>.',
+    },
+    {
+      name: 'caption',
+      type: 'MDX',
+      description: 'Optional visible caption, rendered under the image as a <figcaption>.',
+    },
+  ],
+  examples: [
+    {
+      title: 'A figure with a caption',
+      code: `<Figure
+  src="./costo-busqueda.svg"
+  alt="Dos curvas de costo sobre los mismos ejes: la búsqueda lineal sube en línea recta con el tamaño del arreglo, mientras la binaria se aplana casi de inmediato."
+  caption="El costo de buscar, comparado"
+/>`,
+      render: () => <Figure src={COST_CURVE} alt={ALT} caption="El costo de buscar, comparado" />,
+    },
+    {
+      title: 'Given no alt',
+      code: `<Figure src="./costo-busqueda.svg" />`,
+      render: () => <Figure src={COST_CURVE} />,
+    },
+    {
+      title: 'Given an image that is not there',
+      code: `<Figure src="./todavia-no-existe.svg" alt="Un heap dibujado como árbol" />`,
+      render: () => (
+        <Figure src="asset:courses/sample-course/todavia-no-existe.svg" alt="Un heap" />
+      ),
+    },
+  ],
+};

--- a/apps/web/src/components/media/Figure.test.tsx
+++ b/apps/web/src/components/media/Figure.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Figure } from './Figure';
+
+// The named fixture (ADR-0025): the cost curve `busqueda-binaria` carries.
+const REAL_ASSET = 'asset:courses/sample-course/costo-busqueda.svg';
+
+describe('Figure', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('resolves an asset key to the url the build emitted', () => {
+    render(<Figure src={REAL_ASSET} alt="Dos curvas de costo" />);
+
+    const image = screen.getByRole('img', { name: 'Dos curvas de costo' });
+    // Not the key it was handed: what a document writes never reaches the DOM,
+    // which is the whole point of the asset pipeline (S1).
+    expect(image.getAttribute('src')).not.toBe(REAL_ASSET);
+    // Not anchored at the end: what Vite hands back carries its query in dev
+    // (`…costo-busqueda.svg?no-inline`) and a content hash in the build.
+    expect(image.getAttribute('src')).toMatch(/costo-busqueda[^/]*\.svg/);
+  });
+
+  it('shows a caption under the image when given one', () => {
+    render(<Figure src={REAL_ASSET} alt="Dos curvas" caption="Costo comparado" />);
+
+    const caption = screen.getByText('Costo comparado');
+    expect(caption.tagName).toBe('FIGCAPTION');
+  });
+
+  it('renders no caption element when there is no caption', () => {
+    const { container } = render(<Figure src={REAL_ASSET} alt="Dos curvas" />);
+
+    expect(container.querySelector('figcaption')).toBeNull();
+  });
+
+  it('tells the author when the alt is missing', () => {
+    // MDX is not typechecked, so the contract has to hold at render time. An
+    // image with no alt is invisible to a screen reader and the reader cannot
+    // fix it — the author can.
+    const { container } = render(<Figure src={REAL_ASSET} />);
+
+    expect(container.textContent).toContain('<Figure>');
+    expect(container.textContent).toMatch(/alt/);
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  it('tells the author when the alt is empty', () => {
+    // Deliberately not the same as "decorative": a lone figure with an empty
+    // alt is an image the document never describes.
+    const { container } = render(<Figure src={REAL_ASSET} alt="" />);
+
+    expect(container.textContent).toContain('<Figure>');
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  it('tells the author when there is no src', () => {
+    const { container } = render(<Figure alt="Dos curvas" />);
+
+    expect(container.textContent).toContain('<Figure>');
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  it('renders visibly broken when nothing under content/ matches', () => {
+    // Same treatment as an unresolved wiki-link (ADR-0002): writing the slide
+    // before drawing the picture is a legitimate order of work.
+    const { container } = render(<Figure src="asset:courses/eda/no-existe.svg" alt="Un heap" />);
+
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.textContent).toContain('courses/eda/no-existe.svg');
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it('marks itself out of the reading measure', () => {
+    // ADR-0022: a figure is a block, not running text. Without this the measure
+    // narrows it to 39rem while the code beside it keeps the full column.
+    const { container } = render(<Figure src={REAL_ASSET} alt="Dos curvas" />);
+
+    expect(container.querySelector('figure')?.className).toContain('not-prose');
+  });
+});

--- a/apps/web/src/components/media/Figure.tsx
+++ b/apps/web/src/components/media/Figure.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 
 import { AuthoringError } from '../AuthoringError';
+import { useDescribed } from '../described';
 import { ASSET_PREFIX } from '../../lib/assetPrefix';
 import { resolveAsset } from '../../lib/contentAssets';
 import { warnOnce } from '../../lib/warnOnce';
@@ -35,12 +36,18 @@ const BROKEN_STYLE = 'rounded border border-dashed border-flag px-3 py-2 text-sm
  * addresses the author (`AuthoringError`) rather than blaming the reader.
  */
 export function Figure({ src, alt, caption }: FigureProps) {
+  // A cell of a `<Mosaic>` is silent by design: the container already carries
+  // the description for the whole group.
+  const described = useDescribed();
+
   if (src === undefined || src === '') {
     return (
       <AuthoringError component="Figure">necesita un src con la ruta de la imagen.</AuthoringError>
     );
   }
-  if (alt === undefined || alt === '') {
+  // `alt=""` stays an error outside a describing container, and `alt` missing is
+  // an error even inside one: silence has to be something the author wrote.
+  if (alt === undefined || (alt === '' && !described)) {
     return (
       <AuthoringError component="Figure">
         necesita un alt que describa la imagen, en español.

--- a/apps/web/src/components/media/Figure.tsx
+++ b/apps/web/src/components/media/Figure.tsx
@@ -1,0 +1,73 @@
+import type { ReactNode } from 'react';
+
+import { AuthoringError } from '../AuthoringError';
+import { ASSET_PREFIX } from '../../lib/assetPrefix';
+import { resolveAsset } from '../../lib/contentAssets';
+import { warnOnce } from '../../lib/warnOnce';
+
+export interface FigureProps {
+  /**
+   * The image, written relative to the document (`./curva.svg`).
+   * `remarkContentImages` rewrites it into an `asset:` key on the way in.
+   */
+  src?: string;
+  /** What the picture says, in Spanish. Required: the page is served `lang="es"`. */
+  alt?: string;
+  /** Visible caption under the image. */
+  caption?: ReactNode;
+}
+
+// Same treatment an unresolved wiki-link gets, in the same tokens: `flag` for
+// the colour, a dashed border so the signal is not colour alone (ADR-0026).
+const BROKEN_STYLE = 'rounded border border-dashed border-flag px-3 py-2 text-sm text-flag';
+
+/**
+ * One image with its alternative text and, optionally, its caption.
+ *
+ * The atom of the media family: it renders a picture and nothing else. Putting
+ * one beside a block of text is `<Split>`, and a grid of them is `<Mosaic>` —
+ * layout lives in containers that do not know what they hold, so a figure never
+ * grows a prop about its neighbours.
+ *
+ * **`alt` is a runtime contract, not a type.** MDX is not typechecked: a
+ * document that omits it compiles happily, and the reader who needs it is the
+ * one who cannot see that it is missing. So the check has to hold here, and it
+ * addresses the author (`AuthoringError`) rather than blaming the reader.
+ */
+export function Figure({ src, alt, caption }: FigureProps) {
+  if (src === undefined || src === '') {
+    return (
+      <AuthoringError component="Figure">necesita un src con la ruta de la imagen.</AuthoringError>
+    );
+  }
+  if (alt === undefined || alt === '') {
+    return (
+      <AuthoringError component="Figure">
+        necesita un alt que describa la imagen, en español.
+      </AuthoringError>
+    );
+  }
+
+  const url = src.startsWith(ASSET_PREFIX) ? resolveAsset(src) : src;
+  if (url === null) {
+    const key = src.slice(ASSET_PREFIX.length);
+    warnOnce(src, `Imagen no encontrada en content/: "${key}"`);
+    return (
+      <figure className="not-prose my-6">
+        <p className={BROKEN_STYLE}>Falta la imagen: {key}</p>
+      </figure>
+    );
+  }
+
+  return (
+    // `not-prose` because a figure is a block, not running text: without it the
+    // reading measure narrows it to 39rem while the code beside it keeps the
+    // full column (ADR-0022).
+    <figure className="not-prose my-6 flex flex-col items-center gap-2">
+      <img src={url} alt={alt} className="max-w-full" />
+      {caption === undefined ? null : (
+        <figcaption className="text-center text-sm text-ink-faint">{caption}</figcaption>
+      )}
+    </figure>
+  );
+}

--- a/apps/web/src/components/structure/Mosaic.catalog.tsx
+++ b/apps/web/src/components/structure/Mosaic.catalog.tsx
@@ -2,6 +2,7 @@ import type { CatalogEntry } from '../../lib/catalogEntry';
 
 import { Figure } from '../media/Figure';
 import { Mosaic } from './Mosaic';
+import { ModeProvider } from '../../presentation';
 
 const COST_CURVE = 'asset:courses/sample-course/costo-busqueda.svg';
 const GROUP = 'Cuatro veces la misma curva de costo, a modo de ejemplo';
@@ -53,6 +54,23 @@ export const mosaicCatalogEntry: CatalogEntry = {
         <Mosaic columns={2} description={GROUP}>
           {cells(4)}
         </Mosaic>
+      ),
+    },
+    {
+      title: 'Nine cells on a slide',
+      code: `<Mosaic columns={3} description="Nueve lenguajes de programación">
+  ... nine figures
+</Mosaic>`,
+      render: () => (
+        // Staged in presentation mode, because the height budget only applies
+        // there: three rows of full-width cells overflow a projector, and the
+        // deck answers an oversized slide by scaling the whole thing — text
+        // included. The cap is per row, so this is the case that sets it.
+        <ModeProvider mode="presentation">
+          <Mosaic columns={3} description="Nueve veces la misma curva, a modo de ejemplo">
+            {cells(9)}
+          </Mosaic>
+        </ModeProvider>
       ),
     },
     {

--- a/apps/web/src/components/structure/Mosaic.catalog.tsx
+++ b/apps/web/src/components/structure/Mosaic.catalog.tsx
@@ -1,0 +1,66 @@
+import type { CatalogEntry } from '../../lib/catalogEntry';
+
+import { Figure } from '../media/Figure';
+import { Mosaic } from './Mosaic';
+
+const COST_CURVE = 'asset:courses/sample-course/costo-busqueda.svg';
+const GROUP = 'Cuatro veces la misma curva de costo, a modo de ejemplo';
+
+function cells(count: number) {
+  return Array.from({ length: count }, (_, i) => <Figure key={i} src={COST_CURVE} alt="" />);
+}
+
+/** Catalog entry (ADR-0010) — colocated with the component, exported via the seam. */
+export const mosaicCatalogEntry: CatalogEntry = {
+  name: 'Mosaic',
+  family: 'structure',
+  description:
+    'Several blocks in a grid — 2, 3 or 4 per row — carrying a single accessible description for the whole group, with silent cells.',
+  whenToUse:
+    'When the picture is the SET and not any of its members: a wall of company logos, of languages, of competition badges. ' +
+    'That shape is why this is a component and not a CSS class. The container speaks once — a screen reader announces "empresas que usan estructuras de datos a diario" instead of nine brand names in a row — and <Figure> accepts an empty alt only inside one of these, so the rule stays absolute and its single exception lives where the description already is. A missing alt is still an error even here: silence must be something the author wrote. ' +
+    'The column count is never inferred from the child count, because six figures are 3x2 or 2x3 depending on what the author meant.',
+  props: [
+    {
+      name: 'columns',
+      type: '2 | 3 | 4',
+      description:
+        'Cells per row. Required. On a slide the grid holds at that count (ADR-0013 scales a slide whole); in the book it drops to two columns below the md breakpoint, where nine logos across a phone would each be a smudge.',
+    },
+    {
+      name: 'description',
+      type: 'string',
+      description:
+        'What the whole group says, in Spanish. Required — it is the only voice in the mosaic, since every cell is silent.',
+    },
+    {
+      name: 'children',
+      type: 'MDX',
+      description:
+        'The cells. Figures, usually, but the grid does not care what they are: it holds anything, which is what keeps <Figure> free of props about its neighbours.',
+    },
+  ],
+  examples: [
+    {
+      title: 'A 2x2 group described once',
+      code: `<Mosaic columns={2} description="Empresas que usan estructuras de datos a diario">
+  <Figure src="./logos/una.svg" alt="" />
+  <Figure src="./logos/otra.svg" alt="" />
+  <Figure src="./logos/tercera.svg" alt="" />
+  <Figure src="./logos/cuarta.svg" alt="" />
+</Mosaic>`,
+      render: () => (
+        <Mosaic columns={2} description={GROUP}>
+          {cells(4)}
+        </Mosaic>
+      ),
+    },
+    {
+      title: 'Given no description',
+      code: `<Mosaic columns={3}>
+  <Figure src="./logos/una.svg" alt="" />
+</Mosaic>`,
+      render: () => <Mosaic columns={3}>{cells(3)}</Mosaic>,
+    },
+  ],
+};

--- a/apps/web/src/components/structure/Mosaic.test.tsx
+++ b/apps/web/src/components/structure/Mosaic.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Figure } from '../media/Figure';
+import { Mosaic } from './Mosaic';
+import { ModeProvider } from '../../presentation';
+
+const LOGOS = 'Empresas que usan estructuras de datos a diario';
+// The named fixture (ADR-0025): the cost curve `busqueda-binaria` carries.
+const REAL_ASSET = 'asset:courses/sample-course/costo-busqueda.svg';
+
+function cells(count: number) {
+  return Array.from({ length: count }, (_, i) => <Figure key={i} src={REAL_ASSET} alt="" />);
+}
+
+describe('Mosaic', () => {
+  it('speaks once for the whole group', () => {
+    render(
+      <Mosaic columns={3} description={LOGOS}>
+        {cells(9)}
+      </Mosaic>,
+    );
+
+    // The decision this component exists to hold: a screen reader announces one
+    // sentence, not nine brand names in a row. Nine silent cells and one name.
+    expect(screen.getByRole('figure', { name: LOGOS })).toBeInTheDocument();
+    expect(screen.queryAllByRole('img')).toHaveLength(0);
+  });
+
+  it('lets a cell be silent, which nothing else may be', () => {
+    // `alt=""` is legal HERE and an authoring error anywhere else (Figure.test):
+    // the exception lives in the container that carries the description, so
+    // Figure's own rule stays absolute.
+    const { container } = render(
+      <Mosaic columns={2} description={LOGOS}>
+        {cells(4)}
+      </Mosaic>,
+    );
+
+    expect(container.querySelectorAll('img')).toHaveLength(4);
+    expect(container.textContent).not.toContain('<Figure>');
+  });
+
+  it('lays the cells out in the number of columns it was given', () => {
+    // A class assertion: jsdom lays nothing out. The real grid is a browser
+    // check (S6).
+    const { container } = render(
+      <Mosaic columns={3} description={LOGOS}>
+        {cells(9)}
+      </Mosaic>,
+    );
+
+    expect(container.querySelector('figure')?.className).toContain('md:grid-cols-3');
+  });
+
+  it('keeps its grid on a slide and relaxes it in the book', () => {
+    const gridFor = (mode: 'book' | 'presentation'): string => {
+      const { container } = render(
+        <ModeProvider mode={mode}>
+          <Mosaic columns={3} description={LOGOS}>
+            {cells(9)}
+          </Mosaic>
+        </ModeProvider>,
+      );
+      return container.querySelector('figure')?.className ?? '';
+    };
+
+    // ADR-0013 scales a slide WHOLE, so a 3x3 stays a 3x3 and shrinks with
+    // everything else on it. The book has no such scaling: nine logos across a
+    // phone would each be a smudge, so it drops to two columns until there is
+    // room.
+    expect(gridFor('presentation')).toContain('grid-cols-3');
+    expect(gridFor('presentation')).not.toContain('grid-cols-2');
+    expect(gridFor('book')).toContain('grid-cols-2');
+    expect(gridFor('book')).toContain('md:grid-cols-3');
+  });
+
+  it('tells the author when there is no description', () => {
+    // Without it the mosaic is nine unnamed pictures — the exact outcome the
+    // silent cells were chosen to avoid.
+    const { container } = render(<Mosaic columns={3}>{cells(9)}</Mosaic>);
+
+    expect(container.textContent).toContain('<Mosaic>');
+    expect(container.querySelectorAll('img')).toHaveLength(0);
+  });
+
+  it('tells the author when the column count is missing', () => {
+    // Never inferred from the child count: six figures are 3x2 or 2x3 depending
+    // on what the author meant, and guessing picks one silently.
+    const { container } = render(<Mosaic description={LOGOS}>{cells(6)}</Mosaic>);
+
+    expect(container.textContent).toContain('<Mosaic>');
+    expect(container.querySelectorAll('img')).toHaveLength(0);
+  });
+});

--- a/apps/web/src/components/structure/Mosaic.test.tsx
+++ b/apps/web/src/components/structure/Mosaic.test.tsx
@@ -150,4 +150,20 @@ describe('Mosaic', () => {
     expect(container.textContent).toContain('<Mosaic>');
     expect(container.querySelectorAll('img')).toHaveLength(0);
   });
+
+  it.each([1, 5, 6])('tells the author when columns is out of range (%s)', (columns) => {
+    // MDX is not typechecked, so `columns={5}` compiles and reaches the runtime
+    // (the cast here stands in for that untyped author input). Before the guard
+    // this threw `Cannot read properties of undefined` on GRID[5] and, with no
+    // error boundary, took the whole document down — this asserts it degrades to
+    // an AuthoringError instead, the way the missing-count case above does.
+    const { container } = render(
+      <Mosaic columns={columns as 2 | 3 | 4} description={LOGOS}>
+        {cells(4)}
+      </Mosaic>,
+    );
+
+    expect(container.textContent).toContain('<Mosaic>');
+    expect(container.querySelectorAll('img')).toHaveLength(0);
+  });
 });

--- a/apps/web/src/components/structure/Mosaic.test.tsx
+++ b/apps/web/src/components/structure/Mosaic.test.tsx
@@ -75,6 +75,64 @@ describe('Mosaic', () => {
     expect(gridFor('book')).toContain('md:grid-cols-3');
   });
 
+  it('fills the cell on a slide and keeps the drawn size in the book', () => {
+    const classesFor = (mode: 'book' | 'presentation'): string => {
+      const { container } = render(
+        <ModeProvider mode={mode}>
+          <Mosaic columns={2} description={LOGOS}>
+            {cells(4)}
+          </Mosaic>
+        </ModeProvider>,
+      );
+      return container.querySelector('figure')?.className ?? '';
+    };
+
+    // Both halves measured. Projected at 1024x768, four 160px SVGs sat at their
+    // intrinsic size: four smudges in a sea of background. In the book at 1440,
+    // the same fill blew each one up to 384px and its lettering came out bigger
+    // than the document's own headings.
+    expect(classesFor('presentation')).toContain('[&_img]:w-full');
+    expect(classesFor('book')).not.toContain('[&_img]:w-full');
+    expect(classesFor('book')).toContain('[&_img]:max-w-full');
+    // And it takes the cell's own vertical rhythm away: a Figure carries `my-6`
+    // for standing alone in prose, which inside a cell is dead space fighting
+    // the grid's gap. Measured at 1024x768: 144px of it across three rows, a
+    // 3x3 going from 54vh to 73vh.
+    expect(classesFor('presentation')).toContain('[&_figure]:my-0');
+  });
+
+  it('splits the slide height budget across the rows it actually has', () => {
+    const budget = (count: number, columns: 2 | 3): string | undefined => {
+      const { container } = render(
+        <ModeProvider mode="presentation">
+          <Mosaic columns={columns} description={LOGOS}>
+            {cells(count)}
+          </Mosaic>
+        </ModeProvider>,
+      );
+      return container.querySelector('figure')?.getAttribute('style') ?? undefined;
+    };
+
+    // The reason a cap exists at all: nine full-width cells overflow a
+    // projector, and the deck answers an oversized slide by scaling ALL of it
+    // down (ADR-0013), text included. Three rows get a third of the budget
+    // each; two rows get half. A fixed cap would starve the small case and
+    // still overflow the big one.
+    expect(budget(9, 3)).toContain('21vh');
+    expect(budget(4, 2)).toContain('32vh');
+  });
+
+  it('caps nothing in the book, where the page simply scrolls', () => {
+    const { container } = render(
+      <Mosaic columns={3} description={LOGOS}>
+        {cells(9)}
+      </Mosaic>,
+    );
+
+    expect(container.querySelector('figure')?.getAttribute('style')).toBeNull();
+    expect(container.querySelector('figure')?.className).not.toContain('max-h');
+  });
+
   it('tells the author when there is no description', () => {
     // Without it the mosaic is nine unnamed pictures — the exact outcome the
     // silent cells were chosen to avoid.

--- a/apps/web/src/components/structure/Mosaic.tsx
+++ b/apps/web/src/components/structure/Mosaic.tsx
@@ -1,0 +1,64 @@
+import type { ReactNode } from 'react';
+
+import { AuthoringError } from '../AuthoringError';
+import { DescribedProvider } from '../described';
+import { useMode } from '../../presentation';
+
+export interface MosaicProps {
+  /** How many cells per row. Required: never inferred from the child count. */
+  columns?: 2 | 3 | 4;
+  /** What the whole group says, in Spanish. Required — it is the only voice here. */
+  description?: string;
+  /** The cells: figures, usually, but the grid does not care what they are. */
+  children?: ReactNode;
+}
+
+// Written out rather than composed, because Tailwind reads these classes as
+// literals: a template string builds a name no stylesheet ever contains.
+const GRID = {
+  2: { book: 'grid-cols-2', slide: 'grid-cols-2' },
+  3: { book: 'grid-cols-2 md:grid-cols-3', slide: 'grid-cols-3' },
+  4: { book: 'grid-cols-2 md:grid-cols-4', slide: 'grid-cols-4' },
+} as const;
+
+/**
+ * Several blocks in a grid, described once as a group.
+ *
+ * Built for the logo mosaics of the opening class — nine companies, nine
+ * languages — where the picture is the set and not any of its members. So the
+ * container carries the accessible name and the cells go silent: `<Figure>`
+ * accepts an empty `alt` only inside one of these, and refuses it everywhere
+ * else.
+ *
+ * It holds anything, not only images: the grid does not know what a cell is,
+ * which is what keeps `<Figure>` free of props about its neighbours.
+ */
+export function Mosaic({ columns, description, children }: MosaicProps) {
+  const mode = useMode();
+
+  if (columns === undefined) {
+    return (
+      <AuthoringError component="Mosaic">
+        necesita columns con el número de columnas (2, 3 o 4).
+      </AuthoringError>
+    );
+  }
+  if (description === undefined || description === '') {
+    return (
+      <AuthoringError component="Mosaic">
+        necesita description: es lo único que describe el conjunto, porque sus celdas van mudas.
+      </AuthoringError>
+    );
+  }
+
+  return (
+    // A figure with a label, not a bare div: the group needs one accessible name
+    // and this is the element that has one without inventing a role.
+    <figure
+      aria-label={description}
+      className={`measure-full my-6 grid items-center gap-4 ${GRID[columns][mode === 'presentation' ? 'slide' : 'book']}`}
+    >
+      <DescribedProvider value={true}>{children}</DescribedProvider>
+    </figure>
+  );
+}

--- a/apps/web/src/components/structure/Mosaic.tsx
+++ b/apps/web/src/components/structure/Mosaic.tsx
@@ -56,6 +56,19 @@ export function Mosaic({ columns, description, children }: MosaicProps) {
       </AuthoringError>
     );
   }
+  // MDX is not typechecked, so the `2 | 3 | 4` prop type is authoring-time
+  // fiction: an author can write `columns={5}`. Without this guard `GRID[5]` is
+  // undefined and the `[mode]` index below throws, and with no error boundary in
+  // the app (there is none) the throw blanks the WHOLE document, not just this
+  // block — worse than the handled `undefined` case. Same runtime-contract
+  // reasoning as Figure's required `alt`: a bad value degrades to an
+  // AuthoringError. GRID is the single source of truth for which counts are laid
+  // out, so the check reads from it rather than repeating 2/3/4.
+  if (!Object.hasOwn(GRID, columns)) {
+    return (
+      <AuthoringError component="Mosaic">necesita columns con el valor 2, 3 o 4.</AuthoringError>
+    );
+  }
   if (description === undefined || description === '') {
     return (
       <AuthoringError component="Mosaic">

--- a/apps/web/src/components/structure/Mosaic.tsx
+++ b/apps/web/src/components/structure/Mosaic.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { Children, type CSSProperties, type ReactNode } from 'react';
 
 import { AuthoringError } from '../AuthoringError';
 import { DescribedProvider } from '../described';
@@ -20,6 +20,19 @@ const GRID = {
   3: { book: 'grid-cols-2 md:grid-cols-3', slide: 'grid-cols-3' },
   4: { book: 'grid-cols-2 md:grid-cols-4', slide: 'grid-cols-4' },
 } as const;
+
+/**
+ * How much of the slide's height the whole grid may take, in vh, before the
+ * title and the deck's own chrome start losing room. Split across the rows.
+ */
+const SLIDE_BUDGET_VH = 64;
+
+/** Cells, ignoring the whitespace MDX contributes between blocks. */
+function cellCount(children: ReactNode): number {
+  return Children.toArray(children).filter(
+    (child) => typeof child !== 'string' || child.trim() !== '',
+  ).length;
+}
 
 /**
  * Several blocks in a grid, described once as a group.
@@ -51,12 +64,37 @@ export function Mosaic({ columns, description, children }: MosaicProps) {
     );
   }
 
+  // The cap is per ROW, so the grid as a whole cannot outgrow the stage: nine
+  // cells at full width overflow a 1024x768 projector, and the deck answers an
+  // oversized slide by scaling ALL of it down (ADR-0013) — the text with it.
+  // Measured: below roughly half scale the body stops being readable.
+  const rows = Math.max(1, Math.ceil(cellCount(children) / columns));
+  const cellHeight = {
+    '--mosaic-cell': `${Math.floor(SLIDE_BUDGET_VH / rows)}vh`,
+  } as CSSProperties;
+
   return (
     // A figure with a label, not a bare div: the group needs one accessible name
     // and this is the element that has one without inventing a role.
     <figure
       aria-label={description}
-      className={`measure-full my-6 grid items-center gap-4 ${GRID[columns][mode === 'presentation' ? 'slide' : 'book']}`}
+      style={mode === 'presentation' ? cellHeight : undefined}
+      // Filling the cell is a SLIDE rule, and both halves of that were measured:
+      // projected at 1024x768 a 160px SVG sits as a smudge in a sea of
+      // background, while in the book at 1440 the same `w-full` blew it up to
+      // 384px and its lettering came out bigger than the document's own
+      // headings. Read off a wall, fill the cell; read from 50cm, keep the size
+      // the file was drawn at.
+      //
+      // `[&_figure]:my-0`: a Figure carries its own vertical rhythm for when it
+      // stands alone in prose, and inside a cell that margin is dead space
+      // fighting the grid's gap. Measured on a 1024x768 stage: 144px of it
+      // across three rows, which took a 3x3 from 54vh to 73vh.
+      className={`measure-full my-6 grid items-center gap-4 [&_figure]:my-0 [&_img]:object-contain ${
+        mode === 'presentation'
+          ? '[&_img]:w-full [&_img]:max-h-[var(--mosaic-cell)]'
+          : '[&_img]:max-w-full'
+      } ${GRID[columns][mode === 'presentation' ? 'slide' : 'book']}`}
     >
       <DescribedProvider value={true}>{children}</DescribedProvider>
     </figure>

--- a/apps/web/src/components/structure/Split.catalog.tsx
+++ b/apps/web/src/components/structure/Split.catalog.tsx
@@ -1,0 +1,68 @@
+import type { CatalogEntry } from '../../lib/catalogEntry';
+
+import { Figure } from '../media/Figure';
+import { Split } from './Split';
+
+const COST_CURVE = 'asset:courses/sample-course/costo-busqueda.svg';
+
+/** Catalog entry (ADR-0010) — colocated with the component, exported via the seam. */
+export const splitCatalogEntry: CatalogEntry = {
+  name: 'Split',
+  family: 'structure',
+  description:
+    'Two blocks side by side, stacked on a narrow screen, with an optional uneven ratio. Draws nothing of its own: no border, no label, no type scaling.',
+  whenToUse:
+    'When a figure belongs BESIDE the text it illustrates rather than under it — the commonest slide in a class that explains a picture. It holds any two blocks: prose, a figure, a fence, a component. ' +
+    'Not to be confused with <SideBySide>, which is the code comparator: its border, its language chip and its 0.72em are measured for a <pre> (ADR-0022, #76), and a picture dropped into one renders inside something that looks like a listing. The difference is behaviour, not decoration — SideBySide declares itself a frame, so an editor inside it drops its own chrome; a Split declares nothing, so everything inside renders exactly as it would alone. ' +
+    'The two are duplicated layout on purpose for now; the ADR records when to revisit merging them.',
+  props: [
+    {
+      name: 'ratio',
+      type: "'50/50' | '60/40' | '40/60'",
+      default: "'50/50'",
+      description:
+        'How the width divides from the md breakpoint up. The uneven options exist so a figure need not take half the slide from the text it illustrates.',
+    },
+    {
+      name: 'children',
+      type: 'MDX',
+      description:
+        'Exactly two blocks; authored order is kept, so the first is the left column. Any other number renders an authoring error, because with three the pairing is ambiguous and guessing would silently drop one.',
+    },
+  ],
+  examples: [
+    {
+      title: 'A figure beside the text it explains',
+      code: `<Split ratio="60/40">
+
+- La búsqueda lineal compara hasta n veces.
+- La binaria descarta la mitad en cada paso.
+
+<Figure src="./costo-busqueda.svg" alt="Dos curvas de costo comparadas" />
+
+</Split>`,
+      render: () => (
+        <Split ratio="60/40">
+          <ul>
+            <li>La búsqueda lineal compara hasta n veces.</li>
+            <li>La binaria descarta la mitad en cada paso.</li>
+          </ul>
+          <Figure src={COST_CURVE} alt="Dos curvas de costo comparadas" />
+        </Split>
+      ),
+    },
+    {
+      title: 'Given any number of blocks that is not two',
+      code: `<Split>
+
+Un solo bloque.
+
+</Split>`,
+      render: () => (
+        <Split>
+          <p>Un solo bloque.</p>
+        </Split>
+      ),
+    },
+  ],
+};

--- a/apps/web/src/components/structure/Split.test.tsx
+++ b/apps/web/src/components/structure/Split.test.tsx
@@ -33,7 +33,11 @@ describe('Split', () => {
     );
 
     const grid = container.firstElementChild?.className ?? '';
-    expect(grid).toContain('grid');
+    // Exact token, not a substring: `md:grid-cols-2` also *contains* "grid", so
+    // `toContain('grid')` would survive removing the display:grid class — the
+    // substring hazard testing-strategy.md records (text-accent vs
+    // hover:text-accent). Split on whitespace so only the standalone token counts.
+    expect(grid.split(/\s+/)).toContain('grid');
     expect(grid).toMatch(/md:grid-cols/);
   });
 

--- a/apps/web/src/components/structure/Split.test.tsx
+++ b/apps/web/src/components/structure/Split.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Split } from './Split';
+import { useEmbedded } from '../embedded';
+
+function EmbeddedProbe() {
+  return <span data-testid="probe">{String(useEmbedded())}</span>;
+}
+
+describe('Split', () => {
+  it('renders both blocks in the order they were authored', () => {
+    const { container } = render(
+      <Split>
+        <p>izquierda</p>
+        <p>derecha</p>
+      </Split>,
+    );
+
+    const paragraphs = [...container.querySelectorAll('p')].map((p) => p.textContent);
+    expect(paragraphs).toEqual(['izquierda', 'derecha']);
+  });
+
+  it('asks for two columns from the md breakpoint up, and none below it', () => {
+    // A class assertion, deliberately: jsdom lays nothing out, so the only
+    // honest thing to pin here is the instruction. That the columns are really
+    // side by side is a browser check (S6).
+    const { container } = render(
+      <Split>
+        <p>a</p>
+        <p>b</p>
+      </Split>,
+    );
+
+    const grid = container.firstElementChild?.className ?? '';
+    expect(grid).toContain('grid');
+    expect(grid).toMatch(/md:grid-cols/);
+  });
+
+  it('gives the first block more room when asked for an uneven ratio', () => {
+    const template = (ratio: '50/50' | '60/40' | '40/60'): string => {
+      const { container } = render(
+        <Split ratio={ratio}>
+          <p>a</p>
+          <p>b</p>
+        </Split>,
+      );
+      return container.firstElementChild?.className ?? '';
+    };
+
+    // The whole reason the prop exists: a curve beside three bullets should not
+    // take half the slide from the text it illustrates.
+    expect(template('60/40')).toContain('md:grid-cols-[3fr_2fr]');
+    expect(template('40/60')).toContain('md:grid-cols-[2fr_3fr]');
+    expect(template('50/50')).toContain('md:grid-cols-2');
+  });
+
+  it.each([
+    ['one block', 1],
+    ['three blocks', 3],
+  ])('tells the author when it gets %s instead of two', (_label, count) => {
+    const { container } = render(
+      <Split>
+        {Array.from({ length: count }, (_, i) => (
+          <p key={i}>bloque</p>
+        ))}
+      </Split>,
+    );
+
+    // Same reasoning as SideBySide: with three blocks the pairing is ambiguous,
+    // and guessing would silently drop one.
+    expect(container.textContent).toContain('<Split>');
+    expect(container.querySelector('.grid')).toBeNull();
+  });
+
+  it('does not tell its children they are inside a frame', () => {
+    // This is the line between Split and SideBySide, and it is behaviour rather
+    // than looks: SideBySide draws a border and a language chip, so it declares
+    // itself embedded and the editor inside drops its own chrome (#85). A Split
+    // draws nothing, so a fence inside it must keep its frame, its filename and
+    // its gutter.
+    render(
+      <Split>
+        <EmbeddedProbe />
+        <p>derecha</p>
+      </Split>,
+    );
+
+    expect(screen.getByTestId('probe')).toHaveTextContent('false');
+  });
+
+  it('keeps the full column without cancelling prose styling', () => {
+    // `measure-full`, not `not-prose` (ADR-0022): a Split's columns usually hold
+    // running text — bullets beside a figure — and `not-prose` would strip the
+    // typography from exactly the half that needs it.
+    const { container } = render(
+      <Split>
+        <p>a</p>
+        <p>b</p>
+      </Split>,
+    );
+
+    const grid = container.firstElementChild?.className ?? '';
+    expect(grid).toContain('measure-full');
+    expect(grid).not.toContain('not-prose');
+  });
+});

--- a/apps/web/src/components/structure/Split.tsx
+++ b/apps/web/src/components/structure/Split.tsx
@@ -1,0 +1,58 @@
+import { Children, type ReactNode } from 'react';
+
+import { AuthoringError } from '../AuthoringError';
+
+export interface SplitProps {
+  /**
+   * How the width is divided from the `md` breakpoint up. Even by default; the
+   * uneven options exist so a figure need not take half the slide from the text
+   * it illustrates.
+   */
+  ratio?: '50/50' | '60/40' | '40/60';
+  /** Exactly two blocks — any two: prose, a figure, a fence, a component. */
+  children?: ReactNode;
+}
+
+const TEMPLATE = {
+  '50/50': 'md:grid-cols-2',
+  '60/40': 'md:grid-cols-[3fr_2fr]',
+  '40/60': 'md:grid-cols-[2fr_3fr]',
+} as const;
+
+/**
+ * Two blocks side by side, stacked on a narrow screen.
+ *
+ * The neutral one: no border, no label, no type scaling, and it does not declare
+ * itself a frame — so whatever it holds renders exactly as it would on its own.
+ * That is the whole difference from `<SideBySide>`, whose box and chip and
+ * `0.72em` are measured for code (ADR-0022, #76) and turn a picture into
+ * something that looks like a listing.
+ *
+ * The two are duplicated layout on purpose and for now: consolidating them would
+ * change a component already used in published content, and nothing has yet seen
+ * a `Split` in real use. The revisit trigger is recorded in the ADR.
+ */
+export function Split({ ratio = '50/50', children }: SplitProps) {
+  // MDX contributes whitespace between blocks; it is not a column.
+  const columns = Children.toArray(children).filter(
+    (child) => typeof child !== 'string' || child.trim() !== '',
+  );
+
+  if (columns.length !== 2) {
+    return (
+      <AuthoringError component="Split">
+        espera exactamente dos bloques; recibió {columns.length}.
+      </AuthoringError>
+    );
+  }
+
+  return (
+    // `measure-full` and not `not-prose` (ADR-0022): the reading measure would
+    // narrow the whole layout to 39rem, but a column usually holds running text
+    // that must keep its typography.
+    <div className={`measure-full my-6 grid items-center gap-6 ${TEMPLATE[ratio]}`}>
+      <div className="min-w-0">{columns[0]}</div>
+      <div className="min-w-0">{columns[1]}</div>
+    </div>
+  );
+}

--- a/apps/web/src/components/structure/Split.tsx
+++ b/apps/web/src/components/structure/Split.tsx
@@ -50,7 +50,10 @@ export function Split({ ratio = '50/50', children }: SplitProps) {
     // `measure-full` and not `not-prose` (ADR-0022): the reading measure would
     // narrow the whole layout to 39rem, but a column usually holds running text
     // that must keep its typography.
-    <div className={`measure-full my-6 grid items-center gap-6 ${TEMPLATE[ratio]}`}>
+    // `[&_figure]:my-0` for the same reason a Mosaic does it: a Figure's own
+    // vertical rhythm is for standing alone in prose, and inside a column it is
+    // dead space fighting the layout's gap.
+    <div className={`measure-full my-6 grid items-center gap-6 [&_figure]:my-0 ${TEMPLATE[ratio]}`}>
       <div className="min-w-0">{columns[0]}</div>
       <div className="min-w-0">{columns[1]}</div>
     </div>

--- a/apps/web/src/content/MdxImage.tsx
+++ b/apps/web/src/content/MdxImage.tsx
@@ -1,0 +1,37 @@
+import type { ImgHTMLAttributes } from 'react';
+
+import { ASSET_PREFIX } from '../lib/assetPrefix';
+import { resolveAsset } from '../lib/contentAssets';
+import { warnOnce } from '../lib/warnOnce';
+
+// `flag` and not a raw colour: a raw one is right in at most one theme and no
+// jsdom test can see which (ADR-0026, design-system.md). The dashed border is
+// the second signal colour is not allowed to carry alone.
+const BROKEN_STYLE =
+  'inline-block rounded border border-dashed border-flag px-2 py-1 text-sm text-flag';
+
+type Props = ImgHTMLAttributes<HTMLImageElement>;
+
+/**
+ * Image renderer for MDX documents: resolves the `asset:` urls emitted by
+ * `remarkContentImages` against the built asset map; an asset that is not in
+ * `content/` renders visibly broken instead of a broken-image icon.
+ *
+ * Broken rather than fatal, deliberately and by precedent: an unresolved
+ * wiki-link renders wavy and warns (ADR-0002), because writing a document
+ * before its target exists is a legitimate order of work — and a picture that
+ * has not been drawn yet is the same situation.
+ */
+export function MdxImage({ src = '', alt, ...rest }: Props) {
+  if (typeof src === 'string' && src.startsWith(ASSET_PREFIX)) {
+    const url = resolveAsset(src);
+    if (url === null) {
+      const key = src.slice(ASSET_PREFIX.length);
+      warnOnce(src, `Imagen no encontrada en content/: "${key}"`);
+      return <span className={BROKEN_STYLE}>Falta la imagen: {key}</span>;
+    }
+    return <img {...rest} src={url} alt={alt} />;
+  }
+
+  return <img {...rest} src={src} alt={alt} />;
+}

--- a/apps/web/src/content/MdxLink.tsx
+++ b/apps/web/src/content/MdxLink.tsx
@@ -1,6 +1,7 @@
 import type { AnchorHTMLAttributes } from 'react';
 import { Link } from 'react-router-dom';
 
+import { warnOnce } from '../lib/warnOnce';
 import { registry } from './liveContent';
 
 const WIKI_PREFIX = 'wiki:';
@@ -10,14 +11,6 @@ const SAFE_HREF = /^(?:https?:|mailto:|[/.#])/i;
 const EXTERNAL_HREF = /^(?:https?:|mailto:|\/\/)/i;
 
 const BROKEN_STYLE = 'cursor-not-allowed text-flag underline decoration-flag decoration-wavy';
-
-// Render-path warnings repeat every re-render (twice under StrictMode) — warn once per target.
-const warned = new Set<string>();
-function warnOnce(key: string, message: string): void {
-  if (warned.has(key)) return;
-  warned.add(key);
-  console.warn(message);
-}
 
 type Props = AnchorHTMLAttributes<HTMLAnchorElement>;
 

--- a/apps/web/src/content/architecture.test.ts
+++ b/apps/web/src/content/architecture.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -78,5 +78,59 @@ describe('architecture: content invariants', () => {
         `${key} does not declare "presentation". It still ships a deck (the default is 'auto') — one nobody chose. Declare auto, explicit or none.`,
       ).toBe(true);
     });
+  });
+
+  // Issue #119. Where the gate on a missing image goes, and why here.
+  //
+  // Rendering one is deliberately forgiving: an unresolved asset shows a broken
+  // box and warns, exactly as an unresolved wiki-link does (ADR-0002), because
+  // writing twenty-two slides before drawing nine diagrams is a real order of
+  // work. Failing the BUILD would also take the dev server down — the integrity
+  // plugin runs at `buildStart` — so an author could not preview the very
+  // document they are drafting.
+  //
+  // But merging to main publishes the site, and a hole where a diagram belongs
+  // gets projected in front of a class. So the gate sits in the suite: it does
+  // not block writing, and it does block publishing (pre-PR protocol + CI).
+  //
+  // Deliberately a second opinion rather than a re-run of `remarkContentImages`:
+  // this reads the source and touches the filesystem, so a bug in the plugin's
+  // path arithmetic cannot make both agree that a missing file is fine.
+  describe('every image a document references is a file that exists', () => {
+    const MARKDOWN_IMAGE = /!\[[^\]]*\]\(([^)\s]+)\)/g;
+    const JSX_SRC = /\bsrc=(?:"([^"]+)"|'([^']+)')/g;
+    // Anything with a scheme, protocol-relative, or already rooted is not ours.
+    const NOT_RELATIVE = /^(?:[a-z][a-z0-9+.-]*:|\/\/|\/)/i;
+
+    function referencesIn(key: string): string[] {
+      const source = readFileSync(join(APP_ROOT, key), 'utf8');
+      const found = [
+        ...[...source.matchAll(MARKDOWN_IMAGE)].map((m) => m[1]),
+        ...[...source.matchAll(JSX_SRC)].map((m) => m[1] ?? m[2]),
+      ];
+      return found.filter((url) => url !== undefined && !NOT_RELATIVE.test(url));
+    }
+
+    const withImages = documents.flatMap((key) =>
+      referencesIn(key).map((url) => ({ key, url }) as const),
+    );
+
+    it('finds image references to check', () => {
+      expect(
+        withImages.length,
+        'no document references a relative image any more — either the convention changed or this regex stopped matching it; fix this before trusting the cases below',
+      ).toBeGreaterThan(0);
+    });
+
+    it.each(withImages.map(({ key, url }) => [`${key} -> ${url}`, key, url] as const))(
+      '%s',
+      (_label, key, url) => {
+        const file = join(dirname(join(APP_ROOT, key)), url);
+        expect(
+          existsSync(file),
+          `${key} references "${url}", which is not a file. Draw it, or fix the path — it renders as a broken box and would ship that way.`,
+        ).toBe(true);
+      },
+    );
   });
 });

--- a/apps/web/src/content/architecture.test.ts
+++ b/apps/web/src/content/architecture.test.ts
@@ -133,4 +133,43 @@ describe('architecture: content invariants', () => {
       },
     );
   });
+
+  // Issue #119 (review CT-3). Alt is required and in Spanish (root CLAUDE.md: the
+  // page is lang="es", so an accessible name is announced with Spanish phonemes).
+  // `<Figure>` enforces this at runtime, but a markdown image `![](./x.svg)`
+  // routes through `MdxImage`, which passes alt straight through — so an empty-alt
+  // markdown image would ship an unnamed picture past every gate. The one
+  // documented exception (`alt=""`) lives inside a `<Mosaic>` cell, a JSX-only
+  // affordance; markdown has no Mosaic, so every relative markdown image must
+  // name itself. Reads the source and ships at publish-time weight, like the
+  // file-existence gate above.
+  describe('every relative markdown image names itself', () => {
+    const MARKDOWN_IMAGE = /!\[([^\]]*)\]\(([^)\s]+)\)/g;
+    // Anything with a scheme, protocol-relative, or already rooted is not ours.
+    const NOT_RELATIVE = /^(?:[a-z][a-z0-9+.-]*:|\/\/|\/)/i;
+
+    const markdownImages = documents.flatMap((key) => {
+      const source = readFileSync(join(APP_ROOT, key), 'utf8');
+      return [...source.matchAll(MARKDOWN_IMAGE)]
+        .filter((m) => !NOT_RELATIVE.test(m[2]!))
+        .map((m) => ({ key, alt: m[1]!, url: m[2]! }));
+    });
+
+    it('finds markdown images to check', () => {
+      expect(
+        markdownImages.length,
+        'no document uses relative markdown image syntax any more — if the convention moved to <Figure> only, drop this block; otherwise the regex stopped matching it',
+      ).toBeGreaterThan(0);
+    });
+
+    it.each(markdownImages.map(({ key, alt, url }) => [`${key} -> ${url}`, alt] as const))(
+      '%s',
+      (_label, alt) => {
+        expect(
+          alt.trim(),
+          'a markdown image with empty alt ships an unnamed picture — write its alt in Spanish, or use <Figure> if it belongs on a slide',
+        ).not.toBe('');
+      },
+    );
+  });
 });

--- a/apps/web/src/content/contentImages.test.ts
+++ b/apps/web/src/content/contentImages.test.ts
@@ -1,0 +1,93 @@
+import type { Image, Paragraph, Root, RootContent } from 'mdast';
+import { describe, expect, it } from 'vitest';
+
+import { remarkContentImages } from './contentImages';
+
+/** The JSX node shape, spelled out here so the test names no extra package. */
+interface JsxElement {
+  type: 'mdxJsxFlowElement';
+  name: string;
+  attributes: { type: string; name: string; value: unknown }[];
+  children: [];
+}
+
+// Hermetic stand-ins for the real tree: the plugin's whole job is turning a path
+// relative to THIS document into one relative to the content root.
+const CONTENT_ROOT = new URL('file:///repo/content/');
+const DOCUMENT = { path: '/repo/content/courses/eda/01-bienvenida.mdx' };
+
+function withImage(url: string): Root {
+  return {
+    type: 'root',
+    children: [
+      { type: 'paragraph', children: [{ type: 'image', url, alt: 'un diagrama' }] } as Paragraph,
+    ],
+  };
+}
+
+function withJsx(attributeValue: string): Root {
+  const element: JsxElement = {
+    type: 'mdxJsxFlowElement',
+    name: 'Figure',
+    attributes: [{ type: 'mdxJsxAttribute', name: 'src', value: attributeValue }],
+    children: [],
+  };
+  return { type: 'root', children: [element as unknown as RootContent] };
+}
+
+function transform(tree: Root, file: { path?: string } = DOCUMENT): Root {
+  remarkContentImages({ contentRoot: CONTENT_ROOT })(tree, file);
+  return tree;
+}
+
+function imageUrl(tree: Root): string {
+  return ((tree.children[0] as Paragraph).children[0] as Image).url;
+}
+
+function jsxSrc(tree: Root): unknown {
+  const element = tree.children[0] as unknown as JsxElement;
+  return element.attributes[0].value;
+}
+
+describe('remarkContentImages', () => {
+  it('rewrites a relative markdown image into a content-root asset key', () => {
+    // The failure this exists for: MDX leaves the authored path as a literal
+    // string, Vite never sees it, and under /nalanda/ the browser resolves it
+    // against the document route and 404s. Measured on main: the build emitted
+    // no asset and `./spike.svg` survived verbatim into the document chunk.
+    const tree = transform(withImage('./curva.svg'));
+
+    expect(imageUrl(tree)).toBe('asset:courses/eda/curva.svg');
+  });
+
+  it('resolves a path that climbs out of the document folder', () => {
+    const tree = transform(withImage('../compartidas/heap.svg'));
+
+    expect(imageUrl(tree)).toBe('asset:courses/compartidas/heap.svg');
+  });
+
+  it('rewrites the src of a JSX element, not only markdown syntax', () => {
+    // <Figure src="./x.svg" /> is the form every slide uses; it is the same
+    // literal-string hazard one syntax over.
+    const tree = transform(withJsx('./logos/google.svg'));
+
+    expect(jsxSrc(tree)).toBe('asset:courses/eda/logos/google.svg');
+  });
+
+  it.each([
+    ['https://example.com/x.svg'],
+    ['//example.com/x.svg'],
+    ['/nalanda/favicon.svg'],
+    ['data:image/svg+xml,%3csvg%3e%3c/svg%3e'],
+  ])('leaves %s alone', (url) => {
+    expect(imageUrl(transform(withImage(url)))).toBe(url);
+  });
+
+  it('leaves an image alone when the document has no path', () => {
+    // `evaluate()` in a test compiles a bare string: there is no document to be
+    // relative to, and guessing one would invent a key that resolves nowhere.
+    const tree = transform(withImage('./curva.svg'), {});
+
+    expect(imageUrl(tree)).toBe('./curva.svg');
+  });
+});

--- a/apps/web/src/content/contentImages.ts
+++ b/apps/web/src/content/contentImages.ts
@@ -1,0 +1,95 @@
+import type { Image, Root } from 'mdast';
+import { visit } from 'unist-util-visit';
+
+// The constant only — this module is evaluated by Node when vite.config.ts
+// loads the plugin list, and `lib/contentAssets` builds its map with
+// `import.meta.glob`, which does not exist there.
+// Extension-qualified: this file is also compiled under tsconfig.node
+// (nodenext), because vite.config.ts imports the plugin list.
+import { ASSET_PREFIX } from '../lib/assetPrefix.ts';
+
+// Anything with a scheme (https:, data:), protocol-relative, or already rooted
+// is the author addressing something that is not a file of theirs — left alone.
+const NOT_RELATIVE = /^(?:[a-z][a-z0-9+.-]*:|\/\/|\/)/i;
+
+/** The MDX JSX nodes this walks; typed structurally so no extra dependency is named. */
+interface JsxAttribute {
+  type: string;
+  name?: string;
+  value?: unknown;
+}
+interface JsxElement {
+  type: 'mdxJsxFlowElement' | 'mdxJsxTextElement';
+  attributes: JsxAttribute[];
+}
+
+/**
+ * The document's own folder as a URL, so a relative asset path can be resolved
+ * the way a browser would — including `../`, which string surgery gets wrong.
+ */
+function folderOf(documentPath: string): URL {
+  return new URL(`file://${documentPath}`);
+}
+
+function assetKey(url: string, documentPath: string, contentRoot: URL): string | null {
+  if (url === '' || NOT_RELATIVE.test(url)) return null;
+
+  const resolved = new URL(url, folderOf(documentPath));
+  // An asset outside content/ is not course material; leave it as authored and
+  // let it fail visibly rather than inventing a key for it.
+  if (!resolved.pathname.startsWith(contentRoot.pathname)) return null;
+
+  return decodeURIComponent(resolved.pathname.slice(contentRoot.pathname.length));
+}
+
+/**
+ * `content/` as a URL — this file sits four folders below it (apps/web/src/content).
+ *
+ * The module url goes through a variable deliberately: written literally,
+ * `new URL('…', import.meta.url)` is a pattern Vite rewrites at transform time
+ * into an *asset* url, and under Vitest this file's root came out as
+ * `http://localhost:3000/@fs/…` — against which no document path ever matched,
+ * so every image silently kept the path its author wrote.
+ */
+const moduleUrl = import.meta.url;
+const CONTENT_ROOT = new URL('../../../../content/', moduleUrl);
+
+/**
+ * Remark plugin: rewrites relative image references — markdown `![](./x.svg)`
+ * and the `src` of any JSX element — into `asset:` urls keyed on the path from
+ * `content/`. Purely syntactic, like `remarkWikiLinks`: resolution against the
+ * built asset map happens at render time (`lib/contentAssets`), so the plugin
+ * needs no bundler and a test can drive it with a made-up tree.
+ *
+ * It exists because MDX compiles `![](./x.svg)` to a literal string attribute.
+ * Vite transforms imports, not strings, so the authored path survives verbatim
+ * into the document chunk, no asset is emitted, and the build stays green:
+ * under `/nalanda/` the browser then resolves it against the document's route
+ * and 404s. Measured on main before this plugin existed.
+ */
+export function remarkContentImages(options?: { contentRoot?: URL }) {
+  const contentRoot = options?.contentRoot ?? CONTENT_ROOT;
+
+  return (tree: Root, file: { path?: string }): void => {
+    const documentPath = file.path;
+    // Compiling a bare string (a test, a REPL) has no document to be relative
+    // to; inventing one would produce a key that resolves nowhere.
+    if (documentPath === undefined) return;
+
+    visit(tree, (node) => {
+      if (node.type === 'image') {
+        const key = assetKey((node as Image).url, documentPath, contentRoot);
+        if (key !== null) (node as Image).url = ASSET_PREFIX + key;
+        return;
+      }
+      if (node.type !== 'mdxJsxFlowElement' && node.type !== 'mdxJsxTextElement') return;
+
+      for (const attribute of (node as unknown as JsxElement).attributes) {
+        if (attribute.type !== 'mdxJsxAttribute' || attribute.name !== 'src') continue;
+        if (typeof attribute.value !== 'string') continue;
+        const key = assetKey(attribute.value, documentPath, contentRoot);
+        if (key !== null) attribute.value = ASSET_PREFIX + key;
+      }
+    });
+  };
+}

--- a/apps/web/src/content/mdxComponents.ts
+++ b/apps/web/src/content/mdxComponents.ts
@@ -1,3 +1,4 @@
+import { MdxImage } from './MdxImage';
 import { MdxLink } from './MdxLink';
 import { MdxTable } from './MdxTable';
 import { headingFor } from './mdxHeading';
@@ -5,6 +6,7 @@ import { headingFor } from './mdxHeading';
 /** Content-owned MDX element mappings; the shell composes them with catalog components. */
 export const contentMdxComponents = {
   a: MdxLink,
+  img: MdxImage,
   table: MdxTable,
   h2: headingFor(2),
   h3: headingFor(3),

--- a/apps/web/src/content/mdxPipeline.test.tsx
+++ b/apps/web/src/content/mdxPipeline.test.tsx
@@ -17,8 +17,13 @@ import { rehypePlugins } from './rehypePlugins';
  * says nothing about what a document turns into. This is the only place that
  * answers "what does an author actually get".
  */
-async function renderMdx(source: string): Promise<HTMLElement> {
-  const { default: Content } = await evaluate(source, { ...runtime, remarkPlugins, rehypePlugins });
+async function renderMdx(source: string, path?: string): Promise<HTMLElement> {
+  // With a path, the compiler is told which file this is — which is the only way
+  // `remarkContentImages` can resolve `./x.svg` against the document's folder.
+  const { default: Content } = await evaluate(
+    path === undefined ? source : { path, value: source },
+    { ...runtime, remarkPlugins, rehypePlugins },
+  );
   // Through the real component map, and inside a router: wiki links render
   // react-router `Link`s, and a document is never rendered outside one.
   return render(
@@ -87,6 +92,30 @@ describe('the MDX pipeline', () => {
 
     // GFM arriving must not disturb what Exercise reads its fences by (ADR-0019).
     expect(container.querySelector('code')?.getAttribute('data-meta')).toBe('starter');
+  });
+
+  it('resolves a document image to a built asset url, not the path the author wrote', async () => {
+    // The named fixture (ADR-0025): `busqueda-binaria` carries the cost curve.
+    const file = join(process.cwd(), '../../content/courses/sample-course/03-busqueda-binaria.mdx');
+    const image = readFileSync(file, 'utf8')
+      .split('\n')
+      .find((line) => line.startsWith('!['));
+    expect(
+      image,
+      'busqueda-binaria no longer carries a markdown image — repoint this fixture at a document that does',
+    ).toBeDefined();
+
+    const container = await renderMdx(image ?? '', file);
+
+    // What main shipped: the authored path survives verbatim, no asset is
+    // emitted, the build stays green, and under /nalanda/ the browser resolves
+    // it against the document's route and 404s.
+    const src = container.querySelector('img')?.getAttribute('src');
+    expect(src).not.toBe('./costo-busqueda.svg');
+    expect(src, 'the image did not resolve to anything a browser can fetch').toMatch(
+      /^(?:data:image\/svg\+xml|\/|https?:)/,
+    );
+    expect(container.querySelector('img')?.getAttribute('alt')).toContain('curvas de costo');
   });
 
   it('still renders a wiki link', async () => {

--- a/apps/web/src/content/mdxPlugins.ts
+++ b/apps/web/src/content/mdxPlugins.ts
@@ -5,6 +5,7 @@ import remarkMdxFrontmatter from 'remark-mdx-frontmatter';
 import type { PluggableList } from 'unified';
 
 import { remarkCodeMeta } from './codeMeta.ts';
+import { remarkContentImages } from './contentImages.ts';
 import { remarkWikiLinks } from './wikiLinks.ts';
 
 /**
@@ -39,5 +40,9 @@ export const remarkPlugins: PluggableList = [
   // `\$` escape, and what a single-dollar formula does instead: ADR-0027 §2.
   [remarkMath, { singleDollarTextMath: false }],
   remarkWikiLinks,
+  // Reads the document's path off the vfile, so it must run over a tree that
+  // still knows which file it came from — every remark plugin does, but it is
+  // the only one here that depends on it.
+  remarkContentImages,
   remarkCodeMeta,
 ];

--- a/apps/web/src/lib/assetPrefix.ts
+++ b/apps/web/src/lib/assetPrefix.ts
@@ -1,0 +1,17 @@
+/**
+ * The url scheme `remarkContentImages` emits for an image that lives under
+ * `content/`, keyed on its path from the content root
+ * (`asset:courses/sample-course/curva.svg`). Same shape as `wiki:` links, for
+ * the same reason: the remark plugin stays syntactic and resolution happens at
+ * render time.
+ *
+ * **Alone in its own module on purpose.** The plugin needs the constant and the
+ * renderer needs the asset map, but the map is built with `import.meta.glob`,
+ * which only exists inside Vite's transform — and `vite.config.ts` imports the
+ * plugin, so Node evaluates that graph. Sharing one module makes
+ * `vite --config` die with `(intermediate value).glob is not a function`, before
+ * a single test runs. Same class as the entry-chunk rule in
+ * `add-a-content-component.md`: importing a module for one constant drags
+ * everything else it touches into a place that cannot run it.
+ */
+export const ASSET_PREFIX = 'asset:';

--- a/apps/web/src/lib/contentAssets.test.ts
+++ b/apps/web/src/lib/contentAssets.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveAsset } from './contentAssets';
+
+// A real committed content asset (the named fixture the búsqueda-binaria document
+// draws): the eager import.meta.glob in contentAssets picks it up here exactly as
+// it does in a build, so this exercises the real byKey wiring, not a stub.
+const REAL_KEY = 'asset:courses/sample-course/costo-busqueda.svg';
+
+describe('resolveAsset', () => {
+  it('resolves an asset: key that names a committed file to its built url', () => {
+    // Pins the byKey wiring end to end: the glob strips the leading `content/`
+    // from every path and the lookup finds the file. A rename of the key, or a
+    // broken prefix regex in the map, turns this null — mutation-detectable.
+    const url = resolveAsset(REAL_KEY);
+    expect(url).not.toBeNull();
+    // The url carries a build-dependent prefix and query (`/@fs/…?no-inline` in
+    // vitest, a hashed `/nalanda/assets/…` name in a real build), so match the
+    // committed filename inside it rather than pinning the wrapper.
+    expect(url).toContain('costo-busqueda.svg');
+  });
+
+  it('returns null for an asset: key with no file under content/', () => {
+    // The caller (MdxImage/Figure) renders that visibly broken, the way an
+    // unresolved wiki-link does — resolveAsset never fabricates a url.
+    expect(resolveAsset('asset:courses/sample-course/does-not-exist.svg')).toBeNull();
+  });
+
+  it('leaves anything that is not an asset: reference alone', () => {
+    // A literal path, an absolute url and an already-based url are all not ours;
+    // resolveAsset only owns the `asset:` scheme remarkContentImages emits.
+    expect(resolveAsset('./curva.svg')).toBeNull();
+    expect(resolveAsset('https://example.com/x.svg')).toBeNull();
+    expect(resolveAsset('/nalanda/favicon.svg')).toBeNull();
+  });
+});
+
+// The `/nalanda/` base prefix on a resolved url is NOT assertable here, by
+// construction: Vite bakes it into the `?url` import at BUILD time, and under
+// vitest import.meta.env.BASE_URL is always '/' (testing-strategy.md, build-shape
+// invariants — "a green jsdom suite says nothing about the deployed build"). It
+// is pinned where it is decided: app/deployedApp.test.tsx asserts the resolved
+// config base is '/nalanda/' for both build and preview, and content images ride
+// the very same `?url` rewriting. This file pins the resolution wiring; that file
+// pins the base; together they cover a base-url regression without a manual pass.

--- a/apps/web/src/lib/contentAssets.ts
+++ b/apps/web/src/lib/contentAssets.ts
@@ -1,0 +1,38 @@
+import { ASSET_PREFIX } from './assetPrefix';
+
+/**
+ * Every image under `content/`, keyed by its path from the content root.
+ *
+ * Eager on purpose: what a `?url` import yields is a short string, so the map
+ * costs the reader a handful of bytes per asset and nothing is fetched until an
+ * `<img>` asks for it. It is also what makes the base path correct — Vite
+ * rewrites these urls for `/nalanda/`, which a literal path in a document never
+ * gets. `lib/` and not `content/` because `components/` resolves the same keys
+ * and may not import a sibling feature.
+ */
+const assetUrls = import.meta.glob('@content/**/*.{svg,png,jpg,jpeg,webp,avif,gif}', {
+  query: '?url&no-inline',
+  import: 'default',
+  eager: true,
+}) as Record<string, string>;
+
+// Glob keys arrive relative to this module (`../../content/courses/…`); the
+// content root is the anchor every document's key is written against.
+const byKey = new Map(
+  Object.entries(assetUrls).map(([path, url]) => [path.replace(/^(?:\.\.\/)*content\//, ''), url]),
+);
+
+/**
+ * The built url for an `asset:` reference, or `null` when nothing under
+ * `content/` matches — the caller renders that visibly broken, the way an
+ * unresolved wiki-link does.
+ */
+export function resolveAsset(src: string): string | null {
+  if (!src.startsWith(ASSET_PREFIX)) return null;
+  return byKey.get(src.slice(ASSET_PREFIX.length)) ?? null;
+}
+
+/** The keys the map holds — for the authoring error that has to say what exists. */
+export function knownAssetKeys(): string[] {
+  return [...byKey.keys()];
+}

--- a/apps/web/src/lib/contentAssets.ts
+++ b/apps/web/src/lib/contentAssets.ts
@@ -31,8 +31,3 @@ export function resolveAsset(src: string): string | null {
   if (!src.startsWith(ASSET_PREFIX)) return null;
   return byKey.get(src.slice(ASSET_PREFIX.length)) ?? null;
 }
-
-/** The keys the map holds — for the authoring error that has to say what exists. */
-export function knownAssetKeys(): string[] {
-  return [...byKey.keys()];
-}

--- a/apps/web/src/lib/warnOnce.ts
+++ b/apps/web/src/lib/warnOnce.ts
@@ -1,0 +1,10 @@
+// Render-path warnings repeat every re-render (twice under StrictMode) — one
+// per key is what makes them readable instead of a wall.
+const warned = new Set<string>();
+
+/** Warns the author once per key, from a render path that runs many times. */
+export function warnOnce(key: string, message: string): void {
+  if (warned.has(key)) return;
+  warned.add(key);
+  console.warn(message);
+}

--- a/content/courses/sample-course/02-intro-estructuras.mdx
+++ b/content/courses/sample-course/02-intro-estructuras.mdx
@@ -18,6 +18,18 @@ llegar es la primera en ser atendida. Una pila de platos es exactamente eso,
 una _pila_: el último plato en llegar es el primero en salir.
 </Slide>
 
+<Slide title="Cuatro formas de guardar lo mismo">
+<Mosaic
+  columns={2}
+  description="Cuatro estructuras dibujadas: un arreglo indexado, una lista enlazada, una cola que entra por un extremo y sale por el otro, y una pila que entra y sale por arriba."
+>
+  <Figure src="./estructuras/arreglo.svg" alt="" />
+  <Figure src="./estructuras/lista.svg" alt="" />
+  <Figure src="./estructuras/cola.svg" alt="" />
+  <Figure src="./estructuras/pila.svg" alt="" />
+</Mosaic>
+</Slide>
+
 <Slide title="Operaciones y costos">
 Cada estructura ofrece un contrato: qué operaciones existen y cuánto cuestan.
 Por ejemplo, buscar en una lista desordenada cuesta tiempo lineal, mientras que

--- a/content/courses/sample-course/03-busqueda-binaria.mdx
+++ b/content/courses/sample-course/03-busqueda-binaria.mdx
@@ -41,3 +41,5 @@ $$
 
 iteraciones. Esta sección es prosa de libro: al no estar marcada, no aparece en
 el deck. Contrasta con [[intro-estructuras|la introducción]].
+
+![Dos curvas de costo sobre los mismos ejes: la búsqueda lineal sube en línea recta con el tamaño del arreglo, mientras la binaria se aplana casi de inmediato.](./costo-busqueda.svg)

--- a/content/courses/sample-course/03-busqueda-binaria.mdx
+++ b/content/courses/sample-course/03-busqueda-binaria.mdx
@@ -16,6 +16,21 @@ solo el contenido marcado forma parte del deck.
   quedarnos sin elementos.
 </Slide>
 
+<Slide title="Cuánto cuesta buscar">
+<Split ratio="60/40">
+
+- La búsqueda lineal compara hasta $$n$$ veces: recorre el arreglo entero.
+- La binaria descarta la mitad en cada paso, así que crece como $$\log_2 n$$.
+- Con un millón de elementos son veinte comparaciones, no un millón.
+
+<Figure
+  src="./costo-busqueda.svg"
+  alt="Dos curvas de costo sobre los mismos ejes: la búsqueda lineal sube en línea recta con el tamaño del arreglo, mientras la binaria se aplana casi de inmediato."
+/>
+
+</Split>
+</Slide>
+
 <Slide title="Implementación">
 ```java
 int busquedaBinaria(int[] a, int objetivo) {

--- a/content/courses/sample-course/costo-busqueda.svg
+++ b/content/courses/sample-course/costo-busqueda.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 240" width="400" height="240">
+  <!-- Colours are fixed rather than inherited: an <img> cannot see the page's
+       currentColor. Chosen to clear 3:1 against both the light and the dark
+       background, and the two curves also differ in dash pattern so the reading
+       never depends on colour alone. -->
+  <path d="M70 24 L70 200 L380 200" stroke="#6b7280" stroke-width="1.5" fill="none" />
+  <g fill="#6b7280" font-family="system-ui, sans-serif" font-size="12">
+    <text x="64" y="16">comparaciones</text>
+    <text x="70" y="216" text-anchor="middle">0</text>
+    <text x="225" y="232" text-anchor="middle">tamaño del arreglo (n)</text>
+  </g>
+  <path d="M70 200 L380 24" stroke="#ef4444" stroke-width="2.5" fill="none" />
+  <path
+    d="M70 200 L86 148 L101 124 L132 96 L163 78 L210 60 L256 47 L318 34 L380 24"
+    stroke="#3b82f6"
+    stroke-width="2.5"
+    stroke-dasharray="7 4"
+    fill="none"
+  />
+  <g font-family="system-ui, sans-serif" font-size="13">
+    <text x="150" y="45" fill="#3b82f6">binaria: log₂ n</text>
+    <text x="255" y="114" fill="#ef4444">lineal: n</text>
+  </g>
+</svg>

--- a/content/courses/sample-course/estructuras/arreglo.svg
+++ b/content/courses/sample-course/estructuras/arreglo.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 120" width="160" height="120">
+  <!-- Fixed colours: an <img> cannot see the page's currentColor. Both clear
+       3:1 on the light and the dark ground. -->
+  <g fill="none" stroke="#6b7280" stroke-width="1.5">
+    <rect x="16" y="44" width="26" height="26" />
+    <rect x="42" y="44" width="26" height="26" />
+    <rect x="68" y="44" width="26" height="26" />
+    <rect x="94" y="44" width="26" height="26" />
+    <rect x="120" y="44" width="26" height="26" />
+  </g>
+  <g fill="#6b7280" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle">
+    <text x="29" y="84">0</text>
+    <text x="55" y="84">1</text>
+    <text x="81" y="84">2</text>
+    <text x="107" y="84">3</text>
+    <text x="133" y="84">4</text>
+  </g>
+  <text
+    x="80"
+    y="24"
+    fill="#3b82f6"
+    font-family="system-ui, sans-serif"
+    font-size="13"
+    text-anchor="middle"
+  >
+    arreglo
+  </text>
+</svg>

--- a/content/courses/sample-course/estructuras/cola.svg
+++ b/content/courses/sample-course/estructuras/cola.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 120" width="160" height="120">
+  <!-- Fixed colours: an <img> cannot see the page's currentColor. Both clear
+       3:1 on the light and the dark ground. -->
+  <g fill="none" stroke="#6b7280" stroke-width="1.5">
+    <rect x="42" y="44" width="26" height="26" />
+    <rect x="68" y="44" width="26" height="26" />
+    <rect x="94" y="44" width="26" height="26" />
+  </g>
+  <g fill="none" stroke="#3b82f6" stroke-width="1.5">
+    <path d="M150 57 L124 57" />
+    <path d="M130 53 L124 57 L130 61" />
+    <path d="M38 57 L12 57" />
+    <path d="M18 53 L12 57 L18 61" />
+  </g>
+  <g fill="#6b7280" font-family="system-ui, sans-serif" font-size="10" text-anchor="middle">
+    <text x="137" y="84">entra</text>
+    <text x="25" y="84">sale</text>
+  </g>
+  <text
+    x="80"
+    y="24"
+    fill="#3b82f6"
+    font-family="system-ui, sans-serif"
+    font-size="13"
+    text-anchor="middle"
+  >
+    cola
+  </text>
+</svg>

--- a/content/courses/sample-course/estructuras/lista.svg
+++ b/content/courses/sample-course/estructuras/lista.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 120" width="160" height="120">
+  <!-- Fixed colours: an <img> cannot see the page's currentColor. Both clear
+       3:1 on the light and the dark ground. -->
+  <g fill="none" stroke="#6b7280" stroke-width="1.5">
+    <rect x="12" y="44" width="30" height="26" />
+    <rect x="62" y="44" width="30" height="26" />
+    <rect x="112" y="44" width="30" height="26" />
+    <path d="M42 57 L60 57" />
+    <path d="M92 57 L110 57" />
+    <path d="M54 53 L60 57 L54 61" />
+    <path d="M104 53 L110 57 L104 61" />
+    <path d="M132 48 L138 66" />
+  </g>
+  <text
+    x="80"
+    y="24"
+    fill="#3b82f6"
+    font-family="system-ui, sans-serif"
+    font-size="13"
+    text-anchor="middle"
+  >
+    lista enlazada
+  </text>
+  <text
+    x="80"
+    y="88"
+    fill="#6b7280"
+    font-family="system-ui, sans-serif"
+    font-size="10"
+    text-anchor="middle"
+  >
+    cada nodo apunta al siguiente
+  </text>
+</svg>

--- a/content/courses/sample-course/estructuras/pila.svg
+++ b/content/courses/sample-course/estructuras/pila.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 120" width="160" height="120">
+  <!-- Fixed colours: an <img> cannot see the page's currentColor. Both clear
+       3:1 on the light and the dark ground. -->
+  <text
+    x="80"
+    y="24"
+    fill="#3b82f6"
+    font-family="system-ui, sans-serif"
+    font-size="13"
+    text-anchor="middle"
+  >
+    pila
+  </text>
+  <g fill="none" stroke="#6b7280" stroke-width="1.5">
+    <rect x="50" y="76" width="52" height="18" />
+    <rect x="50" y="58" width="52" height="18" />
+    <rect x="50" y="40" width="52" height="18" />
+  </g>
+  <g fill="none" stroke="#3b82f6" stroke-width="1.5">
+    <path d="M118 40 L118 52" />
+    <path d="M114 46 L118 52 L122 46" />
+    <path d="M134 52 L134 40" />
+    <path d="M130 46 L134 40 L138 46" />
+  </g>
+  <text
+    x="80"
+    y="110"
+    fill="#6b7280"
+    font-family="system-ui, sans-serif"
+    font-size="10"
+    text-anchor="middle"
+  >
+    entra y sale por arriba
+  </text>
+</svg>

--- a/docs/decisions/0029-an-image-atom-and-neutral-layout-containers.md
+++ b/docs/decisions/0029-an-image-atom-and-neutral-layout-containers.md
@@ -1,0 +1,157 @@
+# ADR-0029: An image atom, and layout in containers that do not know what they hold
+
+**Status:** Accepted
+**Date:** 2026-08-14
+**Decision-makers:** Miguel Rodriguez
+**Source:** Issue #119. Extends ADR-0003 (MDX format) and ADR-0010 (component
+contract); applies ADR-0002 (content model), ADR-0013 (presentation), ADR-0022
+(the reading measure) and ADR-0026 (colour).
+
+## Context
+
+Before this WP a Nalanda document could not show a picture, and the way it failed
+was silent. MDX compiles `![alt](./x.svg)` into a literal string attribute, and
+Vite transforms imports, not strings. Measured on `main`: the build stayed green,
+emitted no asset, and `./spike.svg` survived verbatim into the document chunk —
+so under `/nalanda/` the browser resolved it against the document's route and
+404'd. The dev server, which serves at `/`, hides that entirely.
+
+The gap was not only "no image". Of the ~22 slides of the course opening class
+(#120), **nine carry a diagram or a logo mosaic**, and three of those are square
+logo mosaics that no single-image component can build. Several others want the
+figure *beside* the text rather than under it.
+
+The one two-column component in the tree does not serve that. `SideBySide` is
+code-shaped by construction: each column draws a border and an uppercase language
+chip, and type shrinks to `0.72em` in presentation because a `<pre>` is what it
+expects to hold — measured in ADR-0022 and #76. A picture inside one renders in
+something that looks like a listing.
+
+## Decision
+
+### 1. An atom plus neutral containers
+
+`<Figure>` is one image with its alternative text and, optionally, its caption.
+Layout lives in containers that do not know what they hold: `<Split>` places two
+blocks side by side, `<Mosaic>` places N in a grid. A figure never grows a prop
+about its neighbours.
+
+### 2. Two families, because the taxonomy already said so
+
+`Figure` → `media`, its first habitant. `Split` and `Mosaic` → `structure`, whose
+definition in `catalog/families.ts` already promised "future layout blocks".
+
+### 3. `Split` is new; `SideBySide` is untouched
+
+Two two-column components ship deliberately. The difference is behaviour, not
+decoration: `SideBySide` declares itself a frame, so an editor inside it drops its
+own chrome (#85, ADR-0024); a `Split` declares nothing, so whatever it holds
+renders exactly as it would alone.
+
+**Deferred consolidation, with a trigger.** They are duplicated layout, and one
+day they should be one primitive — `SideBySide` becoming a variant, or its chrome
+moving into the column's content where it belongs. Not now, for three reasons: it
+would change a component already used in published content
+(`06-java-desde-cpp.mdx`), the contracts differ in more than looks (child count,
+embedding, type scale), and nothing had yet seen a `Split` in real use. Revisit
+**when a third two-column need appears, or when a `Split` in real content wants
+any part of `SideBySide`'s chrome.**
+
+### 4. A mosaic speaks once
+
+`<Mosaic>` carries a required `description` — the accessible name of the whole
+group — and its cells go silent (`alt=""`). A screen reader announces one
+sentence instead of nine brand names in a row. This is the **only** exception to
+"alt is always required", and it lives in the container
+(`components/described.ts`, same shape as `embedded.ts`), so `<Figure>`'s own rule
+stays absolute: an empty alt outside a describing container is an authoring error,
+and a *missing* alt is an error even inside one — silence has to be something the
+author wrote.
+
+`columns` is required and never inferred from the child count: six figures are
+3×2 or 2×3 depending on intent, and inference picks one silently.
+
+### 5. Assets live beside the document, addressed relatively
+
+`remarkContentImages` rewrites a relative reference — markdown `![]()` and the
+`src` of any JSX element — into `asset:<path from content/>`. Purely syntactic,
+exactly like `remarkWikiLinks`; `lib/contentAssets` resolves those keys at render
+time against an eager `import.meta.glob`, which is what makes the deployed base
+path correct.
+
+The glob asks for `?url&no-inline`. Measured: inlining put a 1.2KB SVG into the
+entry chunk (502.60 → 505.02 kB) and would have grown with every logo; as separate
+files the same asset costs 0.78 kB of map, and the map grows with the **number**
+of assets rather than their bytes (four more images: +0.4 kB).
+
+### 6. Size is a per-view rule, and both halves were measured
+
+In the book an image keeps the dimensions of its file, bounded by the column. On a
+slide a mosaic cell fills its column, and the cell height is capped **per row** so
+the grid cannot outgrow the stage.
+
+Measured at 1024×768 and 1440: four 160px SVGs projected sat as smudges in a sea
+of background, while forcing the same fill in the book blew one up to 384px with
+lettering bigger than the document's own headings. The per-row cap exists because
+the deck answers an oversized slide by scaling **all** of it down (ADR-0013) —
+text included, and below roughly half scale the body stops being readable. A 3×3
+staged in presentation mode measures 54vh against a 64vh budget.
+
+A container also zeroes the vertical margin a `Figure` carries for standing alone
+in prose: inside a cell it is dead space fighting the layout's gap — 144px of it
+across three rows, which took a 3×3 from 54vh to 73vh.
+
+### 7. A missing image blocks publishing, not writing
+
+It renders a visible broken box and warns, exactly as an unresolved wiki-link does
+(ADR-0002), because writing twenty-two slides before drawing nine diagrams is a
+real order of work — and failing the build would take the dev server with it, so
+an author could not preview the document they are drafting.
+
+The gate therefore sits in the suite (`content/architecture.test.ts`), one case
+per image reference: it does not block writing and it does block publishing
+(pre-PR protocol + CI). It reads the source and touches the filesystem — a second
+opinion rather than a re-run of the plugin, so a bug in the plugin's path
+arithmetic cannot make both agree that a missing file is fine.
+
+## Alternatives considered
+
+**Layout props on `Figure`** (`side="right"`, `columns={3}`). Rejected: it makes a
+figure responsible for its neighbours, and a mosaic needs sibling figures to know
+about each other.
+
+**A data-driven `<Gallery images={[...]}>`.** More compact for nine logos, but a
+cell could then never hold a caption, a link, or anything that is not an image.
+
+**Generalising `SideBySide` with a `variant`.** Fewer components, but it changes a
+component already used in published content and merges two contracts that differ
+in child count, embedding and type scale. Deferred with a trigger instead (§3).
+
+**Compiling images into real ESM imports** (`remark-mdx-images`-style). Vite would
+fingerprint them with no runtime map, and per-document chunking would beat an
+eager one. Rejected on testability: `evaluate()` in the suite compiles MDX with no
+bundler, so an import resolves nowhere and the pipeline test that catches the
+original defect could not exist. The `asset:` scheme keeps the plugin syntactic
+and the resolution testable, and it matches the precedent one file over.
+
+**Failing the build on a missing image.** Strictest, and it blocks the dev server
+at `buildStart` — the one moment an author needs the page most. Replaced by the
+suite gate (§7).
+
+## Consequences
+
+- Two components in `structure/` do two-column layout. The duplication is
+  recorded, with the trigger in §3; a reviewer finding it should read this section
+  before proposing the merge.
+- `media` is no longer empty, which moved the hardcoded empty-family case in
+  `app/catalogRoute.test.tsx` onto `semantic` — the family now waiting for its
+  first component.
+- Every content image lands in an eager map. It holds short URLs, so it grows with
+  the number of assets (~100 bytes each) and not their size; if a course ever
+  carries hundreds of images, revisit with a non-eager glob.
+- A drawn asset must fix its own colours, because an `<img>` never sees the page's
+  `currentColor`. That is a rule for the author, documented in the guide, and the
+  only place it can be checked is a screenshot in both themes (ADR-0026).
+- Two slide counters in `presentationRoute.test.tsx` moved, because the documents
+  they name gained a slide. Their subject is the loose prose staying out of the
+  deck; the number is the vehicle, and it now says so in place.

--- a/docs/decisions/0029-an-image-atom-and-neutral-layout-containers.md
+++ b/docs/decisions/0029-an-image-atom-and-neutral-layout-containers.md
@@ -84,6 +84,11 @@ entry chunk (502.60 → 505.02 kB) and would have grown with every logo; as sepa
 files the same asset costs 0.78 kB of map, and the map grows with the **number**
 of assets rather than their bytes (four more images: +0.4 kB).
 
+`no-inline` is also load-bearing for security, not only for bytes: it keeps a
+content SVG rendering through `<img src>` (script-inert) rather than as inline
+markup. See `security-notes.md` §"Content images render through `<img src>`" —
+the two records govern one lever, and neither may be reversed alone.
+
 ### 6. Size is a per-view rule, and both halves were measured
 
 In the book an image keeps the dimensions of its file, bounded by the column. On a

--- a/docs/security-notes.md
+++ b/docs/security-notes.md
@@ -208,11 +208,21 @@ script — a `<script>`, an `onload`, a `foreignObject`, an external `<use>`/`<i
 — so how content SVG reaches the page is a security decision, not a rendering
 detail.
 
-- **The rule**: content images are rendered exclusively via `<img src={url}>`. A
+- **The rule**: author-supplied content images are rendered exclusively via
+  `<img src={url}>` (`content/MdxImage.tsx`, `components/media/Figure.tsx`). A
   browser disables scripting for an SVG loaded through `<img>`, so a script or
   event handler inside a content SVG cannot execute. Inline SVG and
-  `dangerouslySetInnerHTML` on content are forbidden (grepped in the #119 review:
-  zero hits anywhere in `apps/web/src`).
+  `dangerouslySetInnerHTML` on **author** content are forbidden: verified in the
+  #119 review that the content-image path uses neither. (Inline `<svg>` does exist
+  elsewhere — `components/interactive/MemoryState.tsx` draws a diagram from a
+  program's execution trace, ADR-0028 — but that is platform-generated geometry,
+  not author markup, and reaches the page as compiled component code, not as a
+  content asset; `dangerouslySetInnerHTML` appears only in a test fixture. Neither
+  is an author-injection surface.)
+- **This is also why the glob asks for `no-inline`**: ADR-0029 §5 justifies
+  `?url&no-inline` on bundle bytes, but the same lever is load-bearing here — an
+  inlined SVG would render as markup, not through `<img>`, and lose the inertness
+  above. The two records govern one lever; neither may be reversed alone.
 - **Why it is safe today**: the committed SVGs are plain geometry (no `<script>`,
   no handlers, no external refs), and the `<img>` path keeps them inert even if
   one were not. Content ships via git + PR review (see "All bundled MDX is
@@ -220,5 +230,6 @@ detail.
 - **Review trigger**: the first time a content SVG must be inlined — the usual
   reason is `currentColor` theming, which `<img>` cannot reach. At that point the
   SVG must be sanitised (strip scripts, handlers and external refs) before it is
-  trusted, and this invariant re-decided. Equally, the first non-repo-authored
-  content path, which changes who can author an SVG at all.
+  trusted, this invariant re-decided, and ADR-0029 §5 revisited with it. Equally,
+  the first non-repo-authored content path, which changes who can author an SVG at
+  all.

--- a/docs/security-notes.md
+++ b/docs/security-notes.md
@@ -198,3 +198,27 @@ Decisions: ADR-0019 §3b/§7, ADR-0020 §6, ADR-0028 §6/§7.
   v0.2 authoring-agent output that bypasses PR review, a future in-platform
   editor (vision phase C), or user-submitted material. At that point the MDX
   pipeline and this adapter must be re-reviewed as an injection surface.
+
+### Content images render through `<img src>`, never inlined (accepted 2026-08-14, #119)
+
+Issue #119 gives documents images: SVGs under `content/courses/`, resolved through
+Vite's asset pipeline and rendered by `content/MdxImage.tsx` and
+`components/media/Figure.tsx`. SVG is the one common image format that can carry
+script — a `<script>`, an `onload`, a `foreignObject`, an external `<use>`/`<image>`
+— so how content SVG reaches the page is a security decision, not a rendering
+detail.
+
+- **The rule**: content images are rendered exclusively via `<img src={url}>`. A
+  browser disables scripting for an SVG loaded through `<img>`, so a script or
+  event handler inside a content SVG cannot execute. Inline SVG and
+  `dangerouslySetInnerHTML` on content are forbidden (grepped in the #119 review:
+  zero hits anywhere in `apps/web/src`).
+- **Why it is safe today**: the committed SVGs are plain geometry (no `<script>`,
+  no handlers, no external refs), and the `<img>` path keeps them inert even if
+  one were not. Content ships via git + PR review (see "All bundled MDX is
+  repo-controlled content").
+- **Review trigger**: the first time a content SVG must be inlined — the usual
+  reason is `currentColor` theming, which `<img>` cannot reach. At that point the
+  SVG must be sanitised (strip scripts, handlers and external refs) before it is
+  trusted, and this invariant re-decided. Equally, the first non-repo-authored
+  content path, which changes who can author an SVG at all.

--- a/docs/standards/frontend-code-style.md
+++ b/docs/standards/frontend-code-style.md
@@ -23,9 +23,10 @@ src/
 │                   # and the shell's own build plugin (spaFallback.ts)
 ├── components/     # catalog content components, by family:
 │   ├── structure/  ├── semantic/  ├── interactive/  └── media/
-│                   # the family id IS the folder name (#87). semantic/ and media/
-│                   # do not exist yet: an empty family has no folder, and the
-│                   # first component added to one creates it.
+│                   # the family id IS the folder name (#87). semantic/ does not
+│                   # exist yet: an empty family has no folder, and the first
+│                   # component added to one creates it (media/ was created by
+│                   # #119 for Figure).
 │                   # plus shared, non-document-facing components at the root
 ├── catalog/        # /catalog feature: registry, catalog pages
 ├── content/        # content pipeline AND the book-reading surface: registry, loader,

--- a/docs/standards/guides/add-a-content-component.md
+++ b/docs/standards/guides/add-a-content-component.md
@@ -172,9 +172,10 @@ own wrapper in `ALLOWED`, or nothing checks you. The
       the component marks a section, and the measure one if it renders wide.
 - [ ] **If the family was empty before this PR**: you created its folder, and you
       moved the one hardcoded empty-family case in `app/catalogRoute.test.tsx`
-      (it names `/catalog/media` today and fails with instructions when media
-      stops being empty) to a family that is still empty — the other empty-family
-      tests find the empty family themselves and need nothing. Keep the
+      (it names `/catalog/semantic` today — `media` having been populated in #119 —
+      and fails with instructions when semantic stops being empty) to a family
+      that is still empty — the other empty-family tests find the empty family
+      themselves and need nothing. Keep the
       rendered-English `it.each` list covering one populated and one still-empty
       family page.
 - [ ] Registered in `app/mdxComponents.ts` (mandatory for every catalogued component).

--- a/docs/standards/guides/add-a-content-component.md
+++ b/docs/standards/guides/add-a-content-component.md
@@ -37,16 +37,18 @@ apps/web/src/components/structure/
    mapping to look up. The taxonomy itself lives in
    `apps/web/src/catalog/families.ts` and is rendered on `/catalog/governance`
    and on each family page — read it there rather than from this guide.
-   Two of the four families are empty, and deliberately so: a component is built
-   when a class needs one. Picking an empty family is normal; creating its folder
-   is part of adding the first component to it.
+   One of the four families is still empty (`semantic`, since #119 populated
+   `media`), and deliberately so: a component is built when a class needs one.
+   Picking an empty family is normal; creating its folder is part of adding the
+   first component to it — as is moving the one hardcoded empty-family case in
+   `app/catalogRoute.test.tsx`, whose failure message says where.
 2. **Implement** in `apps/web/src/components/<family id>/<Name>.tsx`, satisfying
    the contract points (`/catalog/governance` → Component contract). If
    the component reacts to the render mode, read it with `useMode()`
    (presentation seam); if a parser must recognize it, declare metadata with
    `withMeta` (`lib/componentMeta.ts`) — never expect identity imports.
 
-   Five seams worth knowing before writing your own:
+   Six seams worth knowing before writing your own:
 
    - **Labelled code fences.** A component whose children carry code the author
      marks — ```` ```java starter ```` — reads them with `fencesByMeta` /
@@ -64,8 +66,11 @@ apps/web/src/components/structure/
      768px column (`.measured-prose`, `styles/index.css`, ADR-0022). Every
      direct child of the article is narrowed unless it is a bare `pre`, marks
      itself **`.not-prose`** (a block, not text — `CodeEditor`, `Exercise`,
-     `SideBySide`, `AuthoringError` all do) or **`.measure-full`** (neither
-     block nor text: the table scroll box, the prev/next row, `<SectionBreak/>`).
+     `SideBySide`, `AuthoringError`, `Figure` all do) or **`.measure-full`**
+     (neither block nor text: the table scroll box, the prev/next row,
+     `<SectionBreak/>`, and the two layout containers `Split` and `Mosaic`, whose
+     columns hold running text that must keep its typography — `not-prose` would
+     strip it from exactly the half that needs it).
      **Anything the reader drags sideways must be a REAL scroller.** In
      presentation the deck owns the horizontal swipe and yields only to a
      descendant whose computed `overflow-x` is `auto` or `scroll` AND that
@@ -91,6 +96,15 @@ apps/web/src/components/structure/
      which is exactly why they stopped working the day a fence became one.
      Worked case: `<SideBySide>` × `CodeEditor` (#85, ADR-0024) — the column supplies the
      language label, so the editor suppresses its filename and its chip.
+   - **Being inside something that has already spoken for you.** A container that
+     carries one accessible name for a whole group wraps its children in
+     `<DescribedProvider value={true}>` (`components/described.ts`), and a
+     component that would otherwise demand its own description reads
+     `useDescribed()` and accepts silence instead. Same shape as `embedded.ts`,
+     one level up: that one is about chrome, this one about voice. Worked case:
+     `<Mosaic>` × `<Figure>` (#119, ADR-0029) — nine logos read as one sentence
+     rather than nine brand names, and `Figure`'s "alt is required" rule keeps its
+     single exception where the description already is.
    - **Inside `interactive/`**, reuse `Panel` (a labelled output strip),
      `useRunShortcut` (Ctrl/Cmd + Enter), `useLoadedRuntime` (loads a runtime
      module and hands back a bound `run`, `warm`, `queued`, `ready` and the

--- a/docs/standards/guides/add-a-course-document.md
+++ b/docs/standards/guides/add-a-course-document.md
@@ -17,8 +17,11 @@ The seed course `content/courses/sample-course/` exercises everything:
 ```
 content/courses/sample-course/
 ├── 01-bienvenida.mdx          # presentation: auto     — h2 slicing; the suite's `auto` fixture
-├── 02-intro-estructuras.mdx   # presentation: explicit — uses <Slide>
-├── 03-busqueda-binaria.mdx    # presentation: explicit — uses <Slide>, plus a markdown ## (both h2 sources)
+├── 02-intro-estructuras.mdx   # presentation: explicit — uses <Slide> + <Mosaic>
+├── 03-busqueda-binaria.mdx    # presentation: explicit — uses <Slide> + <Split>, plus a markdown ## (both h2 sources)
+├── costo-busqueda.svg         # an asset sits beside the document that uses it
+├── estructuras/               # …in a subfolder once there are several
+│   └── arreglo.svg, lista.svg, cola.svg, pila.svg
 ├── 04-apuntes.mdx             # presentation: none     — book-only
 ├── 05-codigo-ejecutable.mdx   # presentation: explicit — uses <CodeEditor>
 ├── 06-java-desde-cpp.mdx      # presentation: explicit — uses <Exercise> + <SideBySide>
@@ -375,12 +378,93 @@ GFM, so a bare URL becomes a link on its own — and a bare `www.host` resolves
 to **`http://`**, a cleartext link the reader can be downgraded on. Tables,
 strikethrough (`~~`), task lists and footnotes also work now.
 
-6. **Cross-reference with wiki-links**: `[[otro-id]]` renders that document's
+6. **Show a picture (optional)**: the asset lives **beside the `.mdx` that uses
+   it**, addressed relatively, and a subfolder is fine when there are several
+   (`./estructuras/cola.svg`, `./logos/`). Both syntaxes work and get the same
+   pipeline: markdown `![alt](./curva.svg)` for a picture that just needs to be
+   there, and `<Figure>` when it needs a caption or sits inside a layout.
+
+   ```mdx
+   <Figure src="./costo-busqueda.svg" alt="Dos curvas de costo..." caption="El costo de buscar" />
+   ```
+
+   **Never write a path into `src` that is not relative to your document.** The
+   pipeline rewrites a relative reference into an asset the build emits and
+   fingerprints, which is what makes it resolve under `/nalanda/`. A rooted path
+   like `/assets/curva.svg` is left exactly as written and 404s in production
+   while working in `npm run dev` — the failure the base-path rule exists for.
+
+6a. **`alt` is required, in Spanish, and the component enforces it.** A `<Figure>`
+   without one renders an authoring error instead of an image; so does an empty
+   one. The single exception is a `<Mosaic>` cell — see below.
+
+6b. **Beside, not under**: `<Split>` puts two blocks side by side and stacks them
+   on a narrow screen, with `ratio="60/40"` when the picture should not take half
+   the room from the text it illustrates.
+
+   ```mdx
+   <Split ratio="60/40">
+
+   - La búsqueda lineal compara hasta $$n$$ veces.
+   - La binaria descarta la mitad en cada paso.
+
+   <Figure src="./costo-busqueda.svg" alt="Dos curvas de costo..." />
+
+   </Split>
+   ```
+
+   **`<Split>` is not `<SideBySide>`.** SideBySide is the *code comparator*: it
+   draws a border and a language chip and shrinks type, all measured for a `<pre>`
+   (ADR-0022). A picture inside one renders in something that looks like a
+   listing. Two code fences → `SideBySide`. Anything else → `Split`.
+
+6c. **A wall of pictures**: `<Mosaic columns={2|3|4} description="...">` lays its
+   cells out in a grid. It carries **one** accessible description for the whole
+   group and its cells go silent (`alt=""`), because a screen reader announcing
+   nine brand names in a row tells the listener less than one sentence does. The
+   column count is required — six figures are 3×2 or 2×3 depending on what you
+   meant.
+
+   ```mdx
+   <Mosaic columns={3} description="Empresas que usan estructuras de datos a diario">
+     <Figure src="./logos/una.svg" alt="" />
+     ... eight more
+   </Mosaic>
+   ```
+
+6d. **Draw it at the size you want it read in the book.** In the book an image
+   keeps the dimensions of the file, bounded by the column; on a slide a mosaic
+   cell fills its column instead, because a 160px diagram projected on a wall is
+   a smudge. Measured both ways at 1024×768 and at 1440 (#119): forcing the fill
+   in the book blew a 160px diagram up to 384 and its lettering came out bigger
+   than the document's own headings.
+
+6e. **Weight and format.** Prefer **SVG** for anything drawn — diagrams, curves,
+   logos — and a raster format only for photographs, at no more than ~1600px on
+   the long edge. Every image under `content/` is emitted as its own file rather
+   than inlined, so the page costs one small request per picture instead of
+   carrying it in JavaScript: measured, inlining one 1.2KB SVG added 2.4KB to the
+   entry chunk that *every* page loads, and nine logos would have added twenty.
+
+   Two more things a drawn asset must do, because an `<img>` cannot inherit them:
+   **fix its own colours** (it never sees the page's `currentColor`, so pick
+   values that clear 3:1 on both the light and the dark ground) and **never let
+   colour be the only signal** — the cost curves are one solid line and one
+   dashed for exactly that reason (ADR-0026).
+
+6f. **A missing image does not fail the build**, on purpose: writing the slides
+   before drawing the diagrams is a real order of work, and gating the build
+   would take the dev server with it. It renders a visible broken box naming what
+   is missing, and `npm run test` fails until the file exists — so it cannot be
+   published, only drafted. Same shape as a wiki-link (ADR-0002); decided in
+   ADR-0029.
+
+7. **Cross-reference with wiki-links**: `[[otro-id]]` renders that document's
    link, `[[otro-id|texto visible]]` overrides the label. A target that doesn't
    exist does NOT fail the build: it renders visibly broken (red wavy underline)
    and logs a console warning — forward links to drafts are allowed on purpose.
 
-7. **Register it in the teaching path** (`index.yaml`) if it belongs to the
+8. **Register it in the teaching path** (`index.yaml`) if it belongs to the
    recorrido. Schema (strictly validated; unknown keys fail the build):
 
    ```yaml
@@ -412,7 +496,7 @@ strikethrough (`~~`), task lists and footnotes also work now.
    at the unit; give it an empty or non-string value and the build fails like any
    other field.
 
-8. **Verify**: `npm run build` from `apps/web/`. The contentIntegrity gate fails
+9. **Verify**: `npm run build` from `apps/web/`. The contentIntegrity gate fails
    the build (and CI — `content/**` triggers it) with a file-and-field message
    on: missing/non-kebab/duplicate `id`, missing `title`, invalid `presentation`
    value (must be auto, explicit, or none), malformed `index.yaml` (unknown key,
@@ -444,7 +528,7 @@ strikethrough (`~~`), task lists and footnotes also work now.
    The same applies to width: an over-wide `<SideBySide>` column now shrinks
    the ENTIRE slide rather than overflowing on its own.
 
-9. **Publish**: merging to `main` republishes
+10. **Publish**: merging to `main` republishes
    <https://so77id.github.io/nalanda/> automatically — `content/**` is a deploy
    trigger (ADR-0015). **Everything under `content/courses/` becomes public**,
    listed or not: material that must not be seen (exam keys, solutions,
@@ -474,6 +558,15 @@ strikethrough (`~~`), task lists and footnotes also work now.
       banner, cases pass against a correct solution and fail against the starter.
       Nothing in the build or the suite can check this for you.
 - [ ] Anything on a slide looked at in presentation mode, not only in the book.
+- [ ] Every picture looked at in **both** views and **both** themes. A drawn asset
+      fixes its own colours — an `<img>` cannot inherit the page's — so a diagram
+      that reads on the dark ground can be invisible on the light one, past a
+      green build and a green suite (#109, #119). Sizes differ by view on purpose:
+      the book keeps the drawn dimensions, a mosaic cell fills its column on a
+      slide.
+- [ ] Every image has Spanish `alt` text, and every `<Mosaic>` a `description`.
+      The components refuse to render without them, so this is really a check that
+      you did not paper over the error by emptying the string.
 - [ ] Every formula looked at on the rendered page. A malformed one publishes in
       KaTeX's error colour and an unclosed `$$` swallows the rest of the
       document, both past a green build. Check the page still ends where you


### PR DESCRIPTION
**Closes #119**

## Summary

- Gives course documents images and visual composition: `<Figure>` (an image atom with a required Spanish `alt`, caption and height cap), plus two neutral layout containers — `<Split>` (two blocks side by side, optional `ratio`, no code chrome) and `<Mosaic columns={n}>` (a grid described once, silent cells).
- Adds a content-image asset pipeline: authors write `![](./x.svg)` or `<Figure src="./x.svg" …>`, resolved through Vite (`asset:` scheme + remark plugin + eager `import.meta.glob('?url&no-inline')`) so the deployed `/nalanda/` base is always correct; a missing image renders visibly broken and is gated at publish/suite time (not at build time, so drafting is never blocked).
- `Figure` → the `media` family's first habitant; `Split` and `Mosaic` → `structure`. `SideBySide` is untouched; the deferred `Split`/`SideBySide` consolidation is recorded in ADR-0029 with its revisit trigger.

## Slices completed

- [x] S1: asset location + reference form, resolved in dev and under `/nalanda/`
- [x] S2: `<Figure>` (required alt, caption) + test
- [x] S3: `<Split>` (ratio, stacking, no code chrome) + test
- [x] S4: `<Mosaic>` (explicit columns, required description, silent cells) + test
- [x] S5: catalog entries — Media's first, two new Structure blocks
- [x] S6: slide sizing for all three, browser-verified
- [x] S7: missing-image behaviour in the publish-time gate
- [x] S8: guide section + ADR (incl. the deferred consolidation + trigger)

## Acceptance criteria

- [x] AC1 — image renders in book **and** on a slide — browser: `busqueda-binaria` (book + slide 3), `intro-estructuras` (book + slide 4)
- [x] AC2 — alt required by `Figure`, in Spanish — `Figure.tsx` runtime guard (alt undefined/empty → `AuthoringError`); content alts are Spanish
- [x] AC3 — `Split` beside, no code chrome, honours ratio, stacks; `SideBySide` unchanged — `Split.tsx` + `Split.test.tsx`; `SideBySide.tsx` not in the diff; browser slide 3 shows the 60/40 split beside the text
- [x] AC4 — `Mosaic columns={n}` grid; 4@`columns={2}` and 9@`columns={3}` — `Mosaic.test.tsx` (`cells(4)` cols 2, `cells(9)` cols 3)
- [x] AC5 — one accessible description, silent cells, asserted in a test — `Mosaic.test.tsx` "speaks once" (`getByRole('figure',{name})` + `queryAllByRole('img')` length 0)
- [x] AC6 — a slide holding a figure/Split/Mosaic verified at 1024×768 and phone landscape — browser: figure+Split slide and the 2×2 Mosaic slide, both legible at 1024×768 and at 844×390 (iPhone 13 landscape). The 3×3 case is component-tested (`cells(9)`) and lands with its content in #120.
- [x] AC7 — verified under `npm run preview` (base `/nalanda/`) — every asset served `GET /nalanda/assets/<hash>.svg [200]` (all five SVGs)
- [x] AC8 — `/catalog`: `Figure` under Media, `Split`/`Mosaic` under Structure — three `*.catalog.tsx` registered in `components/index.ts`; `catalog/architecture.test.tsx` backs the shape
- [x] AC9 — `add-a-course-document.md` documents asset convention, weight rule, Split-vs-SideBySide — guide §6 / §6e / §6b
- [x] AC10 — missing-image behaviour decided/implemented/documented — publish-time gate in `content/architecture.test.ts`, broken render in `MdxImage.tsx`, ADR-0029 §7 + guide §6f
- [x] AC11 — ADR covering decisions 1–6 + the deferred consolidation with its trigger — `docs/decisions/0029-*.md`
- [x] AC12 — per-commit green before every commit; pre-PR green before the PR — pre-PR protocol: format ✓ · lint ✓ · test 818/818 ✓ · build ✓

## Tests

- Added/changed (per `testing-strategy.md` levels): `Figure`/`Split`/`Mosaic` component tests (L3), `contentAssets.test.ts` resolveAsset wiring (L2), `contentImages`/`mdxPipeline` (L2/L3), a markdown-image non-empty-alt invariant in `content/architecture.test.ts` (L4), and the missing-image publish gate (L4).
- Protocols run: per-commit ✓ · pre-PR ✓ (format:check, lint, `vitest run` 818/818, build — all exit 0).

## Reviews run

Pre-PR review pipeline (integrated mode), diff range `origin/main...HEAD`.

- **Round A (code panel)** — `lens-correctness-tests`, `lens-arch-simplicity`, `lens-security` (perf lens deliberately not spawned: static SVGs + neutral layout containers, no render/compute hot path). 1 important + 6 suggestions. Verifier: **CT-1 CONFIRMED** (Mosaic out-of-range `columns` crashed the render → guard added). Acted: CT-1, CT-2, AS-1, CT-3, CT-4, SEC-1. Deferred: AS-2. Fixes in `fix(issue-119): review fixes` + `docs(issue-119): record the content-image SVG invariant`. Per-fix rechecks: all resolved (CT-1 mutation-checked).
- **Round B (docs panel)** — `lens-docs-completeness` (no findings), `lens-docs-accuracy`, `lens-adr-hunter`, `lens-agent-readability`. 4 important + 2 suggestions. Acted: all six (AR-1, AR-2, AR-3, AH-1, DA-1, DA-2) in `docs(issue-119): review fixes (docs round)`. Per-fix recheck: all resolved (incl. DA-1, which corrected an over-broad grep claim in the security note this PR added).
- Patterns recorded: none new.

## Manual verification

- [ ] Open `/d/busqueda-binaria`: the "Cuánto cuesta buscar" section shows bullets with the cost curve **beside** them (Split), image loads.
- [ ] Open `/d/intro-estructuras`: "Cuatro formas de guardar lo mismo" shows a 2×2 Mosaic of the four structure diagrams, all four SVGs load.
- [ ] Present each (`/d/<id>/present`): the figure/Split/Mosaic slides are legible at projector size and in phone landscape; no slide is driven below the legibility floor.
- [ ] `/catalog`: `Figure` appears under Media, `Split` and `Mosaic` under Structure, each rendering live.
- [ ] Confirm assets are served under `/nalanda/assets/…` (run `npm run build && npm run preview`, not just `dev`).

## Notes

- Branch is one commit behind `origin/main` (#130, an issue-118/math change with no overlap with this WP); squash-merge will merge cleanly. Rebase not required.
- AS-2 (extract a shared resolve-and-warn helper for `Figure`/`MdxImage`) was deferred by choice — small refactor, no behaviour change, safe to do later.
