### PR TITLE
chore: trim the teaching path to the two units that are live

### DIFF
--- a/apps/web/src/app/documentBreadcrumb.test.tsx
+++ b/apps/web/src/app/documentBreadcrumb.test.tsx
@@ -59,7 +59,12 @@ describe('the breadcrumb row of a document', () => {
   // because it is also the invariant below: the set of unlisted documents is
   // closed, and a document that joins it by accident is a mistake nothing else
   // catches.
-  const RETIRED = ['intro-estructuras', 'busqueda-binaria', 'codigo-ejecutable'];
+  const RETIRED = [
+    'intro-estructuras',
+    'busqueda-binaria',
+    'codigo-ejecutable',
+    'apuntes-del-curso',
+  ];
 
   // The registry→index direction, which nothing else in the suite covers:
   // `contentIntegrity.ts` and `content/architecture.test.ts` both walk the index

--- a/content/courses/sample-course/index.yaml
+++ b/content/courses/sample-course/index.yaml
@@ -2,9 +2,8 @@ title: Estructuras de Datos y Algoritmos
 entries:
   - docId: bienvenida
     label: Clase inaugural
-  - label: Java para quien viene de C++
+  - label: Java
     levelName: Unidad
     children:
       - docId: java-desde-cpp
       - docId: java-tipos-y-flujo
-  - docId: apuntes-del-curso

--- a/docs/standards/guides/add-a-course-document.md
+++ b/docs/standards/guides/add-a-course-document.md
@@ -84,8 +84,11 @@ the frontmatter `id`, never the path. v0.1 supports exactly ONE course directory
    > - `apuntes-del-curso` is named three times over (#136): as the book-only
    >   fixture of `presentationRoute.test.tsx` and `documentSections.test.tsx`
    >   (it must keep `presentation: none` and no `h2` at all), and as
-   >   `deployedApp.test.tsx`'s deep-link fixture (it must stay in `content/` and
-   >   must not become the landing page).
+   >   `deployedApp.test.tsx`'s deep-link fixture. It must stay in `content/` and
+   >   must not become the landing page — but it is **off the teaching path**
+   >   since the course was trimmed to its two live units, which is exactly the
+   >   split those three cases now rely on: they resolve it from the registry,
+   >   never from the index.
    > - `documentBreadcrumb.test.tsx` pins the unlisted SET rather than a single
    >   document — see step 8.
    >


### PR DESCRIPTION
## Summary

Two edits to the teaching path, asked for directly:

- **`apuntes-del-curso` comes off it.** Navigation only, as with #136 — the file
  stays in `content/`, compiled and served at `/d/apuntes-del-curso`.
- **The Java unit is renamed** from "Java para quien viene de C++" to **"Java"**.
  The long label was written when that unit was a single document explaining the
  switch; it is two documents about the language now, and the C++ framing belongs
  to the material rather than to the level above it.

The course reads: **Clase inaugural → Java** (dos documentos).

## The alarm from #136 earned itself here

`apuntes-del-curso` is a named fixture three times over — the book-only fixture
of `presentationRoute.test.tsx` and `documentSections.test.tsx`, and the
deep-link fixture of `deployedApp.test.tsx`. Before #136 that combination was
exactly what broke unrelated tests when the index changed.

What actually happened:

| | |
|---|---|
| The three fixture cases | **stayed green** — #136 moved them onto the registry, so the index no longer decides whether a document exists |
| `documentBreadcrumb.test.tsx` | **reddened on purpose**, with the message naming the fix: *"A document missing from index.yaml: add it to the teaching path, or to RETIRED above if it is off the path on purpose."* |

So the only edit the suite demanded was declaring the id in `RETIRED` — which is
the decision being made, not a repair. First use of that shape by something
other than the commit that introduced it.

## Files

- `content/courses/sample-course/index.yaml` — the two edits
- `apps/web/src/app/documentBreadcrumb.test.tsx` — `apuntes-del-curso` declared in `RETIRED`
- `docs/standards/guides/add-a-course-document.md` — the fixture note now says this document is both a named fixture and off the path, and why those do not conflict

## Tests

```
format:check   OK
lint           OK
test           848 passed
build          OK
```

## Manual verification

- [ ] Sidebar reads **Clase inaugural → Java**, and the unit expands to the two Java documents
- [ ] `/d/apuntes-del-curso` still loads, with only the course in the breadcrumb
- [ ] From the opening class, prev/next still goes to Java desde C++

## Notes

Merging republishes the site (`content/**` is a deploy trigger).

Not folded into #135: that issue removes the three Fundamentos documents, and
nobody asked for `04-apuntes.mdx` to be deleted — only taken off the path. If it
should go too, say so and I will add it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
