### PR TITLE
docs: gate WP-E on the paper check

### DIFF
--- a/docs/decisions/0030-auto-multiple-choice-as-the-control-engine.md
+++ b/docs/decisions/0030-auto-multiple-choice-as-the-control-engine.md
@@ -234,6 +234,22 @@ sheets badly on purpose, scan, `make read-paper`, compare. Fifteen minutes. Its
 §5 asks five questions; record their verdict here, and the darkness number from
 question 4, which is what calibrates the thresholds ADR-0031 owns.
 
+**When it must happen: before WP-E starts** (decided 2026-08-15). Nothing
+before that depends on it — WP-B is content and frontend and never touches AMC,
+WP-C is Go, auth and SQLite — so the check is not a merge gate for #138. WP-E is
+where it becomes one, and for the reason the spike existed at all: WP-E and WP-F
+would otherwise be specified against an engine that cannot read paper, and
+discovering that afterwards throws both away. The calibration matters as much as
+the verdict — WP-F's review queue is built on the thresholds ADR-0031 owns, and
+their current values (0.30 / 0.10) were set against synthetic fills measuring
+0.63 and 0.159. Nobody yet knows where a student's pencil lands.
+
+**A reduced version buys most of it.** `make paper PAPER_COPIES=2`, one sheet
+marked cleanly and one with a faint pencil, answers the two questions that
+decide the engine — does the printed geometry survive, and does a real pencil
+clear the threshold. The other four sheets exercise the review queue, which can
+wait for WP-F.
+
 **Review trigger.** If the real cycle fails — corner marks not found, codes
 misread, thresholds unusable — reopen this decision and record which criterion
 broke. The fallback is unchanged (our own PDF generation plus OMRChecker) and

--- a/docs/design/2026-08-controles.md
+++ b/docs/design/2026-08-controles.md
@@ -115,7 +115,7 @@ touched.
 | B | [#139](https://github.com/so77id/nalanda/issues/139) | **Question bank in content** — authoring format, anchor resolution and its gate, the rendering component, catalog entry, published JSON | — |
 | C | not refined | **`apps/server` is born** — Go + SQLite + goose, auth domain ported, Google OAuth, seed, professor CRUD, plus the process obligations below. Likely two WPs | — |
 | D | not refined | **Course and roster** — tables and CSV import. Canvas import noted, not assumed | C |
-| E | not refined | **Create a control, generate the PDF** | A, B, C |
+| E | not refined | **Create a control, generate the PDF** | A, B, C, **+ the paper check** |
 | F | not refined | **Read scans, manual review queue** | E |
 | G | not refined | **Publish grades** — spreadsheet, email, Canvas | F |
 
@@ -127,6 +127,11 @@ conversation (see *What WP-C brings with it*).
 The first real control needs **A, B and E**, grading by hand that first time —
 which is worth doing anyway, to see the printed sheet before automating its
 reading.
+
+**WP-E does not start before the paper check runs** (decided 2026-08-15,
+ADR-0030 §Not yet proven). Nothing earlier depends on it, so it is not a gate on
+#138 — but E and F would otherwise be specified against an engine nobody has
+shown can read a pencil, which is the failure the spike existed to prevent.
 
 **B is scheduled early despite not being the first dependency.** Its real work
 is the professor writing questions, which is the long pole and cannot be


### PR DESCRIPTION
## Summary

ADR-0030 recorded that the real print → mark → scan cycle was outstanding but never said **when** it stops being optional. "Outstanding" with no deadline is how a verification quietly never happens.

- **ADR-0030 §Not yet proven** gains when it must run (before WP-E starts), why it was correctly not a gate on #138, and the reduced two-sheet version.
- **The design doc's roadmap** gains the paper check to WP-E's dependencies.

## Why WP-E and not earlier

Nothing before it depends on the check: WP-B is content and frontend and never touches AMC, WP-C is Go, auth and SQLite. WP-E is where it becomes a gate, for the reason the spike existed — E and F would otherwise be specified against an engine nobody has shown can read a pencil, and discovering that afterwards throws both away.

The calibration matters as much as the verdict: WP-F's review queue is built on the thresholds ADR-0031 owns, and their current values (0.30 / 0.10) were set against synthetic fills measuring 0.63 and 0.159. Where a student's pencil actually lands is unmeasured.

## Manual verification

- [ ] Agree that WP-E is the right gate, and not earlier or later.

Docs only — no code, no protocol affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017rGN1YEDGuq1gEZJtuqN1U