### PR TITLE
fix: the last review pass, which missed the #141 merge

### DIFF
--- a/apps/web/src/components/structure/Mosaic.catalog.tsx
+++ b/apps/web/src/components/structure/Mosaic.catalog.tsx
@@ -38,7 +38,7 @@ export const mosaicCatalogEntry: CatalogEntry = {
       name: 'plate',
       type: 'boolean',
       description:
-        'Put each cell on a white plate. For brand marks, which are drawn to sit on white and are often monochrome: served through <img> they never see the page currentColor, so unplated they paint black and vanish on the dark theme. Opt-in because the other kind of mosaic is the opposite — diagrams drawn for the page, transparent and coloured to clear both grounds, which a plate would box in for nothing.',
+        'Puts each cell IMAGE on a white plate — rounded, with 12% padding — so it is the img that is plated, not the cell: a Figure caption stays off it, and a cell holding no image gets nothing. For brand marks, which are drawn to sit on white and are often monochrome: served through <img> they never see the page currentColor, so unplated they paint black and vanish on the dark theme. Opt-in because the other kind of mosaic is the opposite — diagrams drawn for the page, transparent and coloured to clear both grounds, which a plate would box in for nothing.',
     },
     {
       name: 'children',

--- a/content/courses/sample-course/01-bienvenida.mdx
+++ b/content/courses/sample-course/01-bienvenida.mdx
@@ -150,7 +150,7 @@ A veces no existe.
 
 <Figure
   src="./viajante.svg"
-  alt="Doce ciudades unidas por un recorrido cerrado, y dos más en el interior a las que solo llega un tramo alternativo, dibujado en línea punteada: un recorrido posible entre muchos."
+  alt="Catorce ciudades unidas por un recorrido cerrado que las visita todas, y un tramo alternativo en línea punteada sobre las mismas ciudades: un recorrido posible entre muchos."
 />
 
 </Split>
@@ -286,7 +286,7 @@ todos permiten implementarlo.
 <Mosaic
   plate
   columns={3}
-  description="Nueve lenguajes en los que estas mismas estructuras se implementan: Java, C++, C#, Python, Go, Rust, JavaScript, Kotlin y Swift."
+  description="Nueve lenguajes en los que estas mismas estructuras se implementan: Java (marca OpenJDK), C++, C# (marca .NET), Python, Go, Rust, JavaScript, Kotlin y Swift."
 >
   <Figure src="./logos/java.svg" alt="" />
   <Figure src="./logos/cpp.svg" alt="" />

--- a/content/courses/sample-course/logos/README.md
+++ b/content/courses/sample-course/logos/README.md
@@ -16,13 +16,19 @@ the review of #120 found the provenance existed only in a PR body.
 `python` · `rust` · `spotify` · `swift` · `uber`
 
 - **Source**: [Simple Icons](https://simpleicons.org), fetched 2026-08-14 from
-  `cdn.jsdelivr.net/npm/simple-icons@latest/icons/<slug>.svg` (v16.28.0).
+  `cdn.jsdelivr.net/npm/simple-icons@latest/icons/<slug>.svg`. Eighteen came from
+  **v16.28.0**, the version `@latest` resolved to.
+- **Two came from older releases, because Simple Icons has removed them**:
+  `amazon` last shipped in **v14.13.0** and `microsoft` in **v12.4.0** — the CDN
+  quietly served those majors when `@latest` had no such file, which is worth
+  knowing precisely because these are the two marks whose owners are most
+  likely to care. Both were CC0 at the release they came from.
 - **File licence**: **CC0-1.0** — the SVG files are public domain. The marks
   themselves remain their owners' property.
-- **Modified**: each glyph carries an explicit `fill` at the brand's own colour
-  (Simple Icons ships them unfilled, and an `<img>` never inherits the page's
-  `currentColor`, so unfilled they paint black and vanish on the dark theme).
-  Geometry is untouched.
+- **Modified**: each glyph carries an explicit `fill` at the brand's own colour.
+  Simple Icons ships them unfilled, and an `<img>` inherits nothing, so an
+  unfilled mark would default to black rather than to anything chosen. Geometry
+  is untouched.
 - Four slugs differ from the file name: `java` is `openjdk`, `cpp` is
   `cplusplus`, `csharp` is `dotnet`, `js` is `javascript`.
 
@@ -44,6 +50,12 @@ the review of #120 found the provenance existed only in a PR body.
 ## Replacing one
 
 The white plate they are read on belongs to `<Mosaic plate>`, not to these
-files — so a new logo needs no background of its own. A monochrome mark needs an
-explicit `fill` that clears 3:1 against white; a mark that is black by design is
-fine as it is, because the plate is what it sits on.
+files — so a new logo needs no background of its own, and its `fill` is simply
+the brand's own colour reproduced faithfully.
+
+Note what is NOT required: a logotype is exempt from the contrast minimum
+(WCAG 1.4.11), and several of these do not clear 3:1 against the plate —
+JavaScript's yellow is 1.35. That is the mark as its owner draws it, and the
+group's meaning is carried by the mosaic's `description`, not by any one cell.
+What a mark does need is an explicit `fill`, so it never inherits black by
+accident.

--- a/docs/security-notes.md
+++ b/docs/security-notes.md
@@ -181,14 +181,14 @@ Decisions: ADR-0019 §3b/§7, ADR-0020 §6, ADR-0028 §6/§7.
   "unpublished" and is wrong.
 - **Why it is safe today**: the repo is public anyway. **No longer only sample
   documents** — since #120 the tree holds the real opening class, with the
-  professor'"'"'s institutional address and the term'"'"'s grading rules, and since #136
+  professor's institutional address and the term's grading rules, and since #136
   and #137 four documents are deliberately off the teaching path while still
   served. Nothing there needs hiding, so the invariant holds; what changed is
   that it is now load-bearing rather than hypothetical.
 - **The address is published on purpose**: `miguel.rodriguez@mail.udp.cl`
-  appears on the opening class as an autolinked `mailto:`, the professor'"'"'s own
+  appears on the opening class as an autolinked `mailto:`, the professor's own
   decision. Harm is harvesting at a university mailbox. Review trigger for this
-  one: any address that is not the author'"'"'s own, and any student address ever
+  one: any address that is not the author's own, and any student address ever
   appearing under `content/`.
 - **Review trigger**: the first time material that must not be seen (exam keys,
   solutions, unreleased classes) needs a home. Park it OUTSIDE


### PR DESCRIPTION
## Summary

**#141 merged while its branch had two more commits coming.** One landed before
the merge; this is the other, rebuilt on current `main` because that branch has
since fallen behind several unrelated WPs.

Five things the accuracy lens found by *executing* rather than reading. All are
still live on the site.

## The one that matters most

**The salesman alt describes the defect the drawing no longer has.**

#141 redrew `viajante.svg` so the closed tour visits all fourteen cities — that
*was* the fix — and left the alt reading *"Doce ciudades unidas por un recorrido
cerrado, y dos más en el interior"*. The description is the only channel a
screen-reader user has, so the defect was removed for everyone **except** the
reader who cannot check.

Worth naming plainly: this is the same mistake as the heap alt, made again in the
commit that fixed the heap alt. A drawing and its description are two artefacts,
and changing one is not changing the other.

## The other four

| | |
|---|---|
| **`security-notes.md`** | four shell-escape artifacts — `professor'"'"'s` where `professor's` belongs, from writing the file through a quoted shell command |
| **Logo provenance** | `amazon` and `microsoft` **404** on simple-icons 16.28.0; jsDelivr silently served them from **14.13.0** and **12.4.0**, because Simple Icons removed both. A CC0 claim is worth exactly its accuracy — and these are the two marks whose owners are most likely to care |
| **The language mosaic's description** | said "Java" and "C#" while the marks drawn are **OpenJDK** and **.NET**. That description is the group's only accessible voice |
| **`logos/README.md`** | required 3:1 against the plate, which six of the twenty do not meet (JavaScript's yellow is 1.35). A logotype is exempt from the contrast minimum (WCAG 1.4.11); the real rule is an explicit fill so a mark never inherits black by accident |

Plus: the catalog said `plate` plates each *cell*; it plates the cell's **image**,
so a caption stays off it and a cell holding no image gets nothing.

## Tests

```
format:check   OK
lint           OK
test           857 passed
build          OK
```

## Manual verification

- [ ] Slide "¿Y si le pedimos directamente la mejor solución?" — the alt now matches the drawing (inspect the `<img>`, or read it with VoiceOver)
- [ ] `docs/security-notes.md` reads as prose, with no `'"'"'` anywhere

## Notes

Merging republishes the site (`content/**` is a deploy trigger).

Nothing else from either pipeline round is outstanding — this closes #120's
review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
