### PR TITLE
feat(issue-146): embed a shared spreadsheet, in book and slide

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,18 @@ prefix may not survive the move, so decide before handing URLs to students
   the control question bank, including which alternatives are correct. Public on
   purpose, so never author a question whose answer must stay private (see
   `docs/security-notes.md`).
+- **Not everything a reader sees is published by us.** Since #146,
+  `/nalanda/d/planificacion` frames a Google spreadsheet: the calendar is not in
+  this repository, it changes with **no commit and no deploy**, and nothing in
+  the build or the suite can see what it says (ADR-0035). Add it to the
+  after-deploy check and look at the rectangle — a sheet that stops being shared
+  shows Google's own request-access page there, and nothing anywhere will tell
+  you.
 - **Rollback**: revert the offending commit on `main`. The revert is itself a
   push to `main`, so it redeploys the previous version — there is no separate
-  deploy button to press.
+  deploy button to press. **It does not restore the calendar**: reverting can
+  remove the frame, never change what the sheet says. That is Google Drive's
+  version history, not git's.
 - **When something is broken**, work back from the symptom:
 
   | Symptom | Cause | Guarded by |
@@ -115,6 +124,8 @@ prefix may not survive the move, so decide before handing URLs to students
   | Deploy job fails on permissions | repo Settings ▸ Pages source must be "GitHub Actions", and the `github-pages` environment must allow `main` | — |
   | Deploy job fails before Vite starts | `prebuild` could not reach Maven Central, or the ECJ checksum did not match | the script's own error; nothing is written on mismatch (ADR-0017) |
   | Site fine, but Ejecutar never finishes or never warms | a runtime CDN is down or blocked (`cjrtnc.leaningtech.com`, `cdn.jsdelivr.net`) | nothing — accepted risk, `docs/security-notes.md` |
+  | `/d/planificacion` shows "Cargando la planilla…" and never the grid, or shows Google's request-access page | the sheet stopped being shared, or Drive is unreachable | nothing — cross-origin, undetectable; fix the share setting in Drive, `docs/security-notes.md` |
+  | The calendar is wrong and reverting the commit does not fix it | the sheet is not in this repo (ADR-0035) — edit the spreadsheet | nothing, by design: that decoupling is the feature |
   | `/d/<id>/present` blank on an old iPhone | `MediaQueryList.addEventListener` needs Safari/iOS 14 | nothing — accepted baseline, ADR-0023 |
   | `/d/<id>/present` shows "Gira el teléfono" and no slide | working as designed on a touch device held upright; rotate, or use the book view | `presentationRoute.test.tsx`, ADR-0023 |
   | Slide text renders small, or slide sizes vary across a deck | working as designed — each slide is scaled to fit its stage (ADR-0013 §5.1). If it is unreadable the slide is too dense: split it | `presentation/fit.test.ts` |

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -32,9 +32,10 @@ SPA fallback and the `vite preview` gotcha). One home per fact, per
 - `npm run dev` and `npm run build` run `scripts/fetch-java-compiler.mjs` first
   (`predev`/`prebuild`): it downloads ~2.9MB from Maven Central on a clean
   checkout, so **an offline first build fails before Vite starts**.
-- **The suite cannot execute code, lay out a page, or move focus like a
-  browser.** Two classes, both needing a real browser, both spelled out in
-  `docs/standards/testing-strategy.md` §Conventions with their worked cases:
+- **The suite cannot execute code, lay out a page, move focus, or load another
+  origin like a browser.** Three classes, all needing a real browser, all spelled
+  out in `docs/standards/testing-strategy.md` §Conventions with their worked
+  cases:
   1. _Execution_: every runtime is faked in jsdom, so anything that **DRIVES a
      runtime** needs a browser too — any change under `src/runtime/**`, anything
      that calls `run()` through `useRuntime`/`useLoadedRuntime`, anything that
@@ -76,11 +77,29 @@ SPA fallback and the `vite preview` gotcha). One home per fact, per
      A device rule also needs an emulated device, not
      merely a small window: the recipe is in `testing-strategy.md` §Conventions.
 
+  3. _A document from somewhere else_: jsdom has no network and never loads a
+     frame, so a component that **EMBEDS ANOTHER ORIGIN** is unverifiable here in
+     the only way that counts. The suite can pin the attribute string and
+     nothing about its effect — whether the document renders at all, what a
+     `sandbox` token actually permits, what the frame weighs, whether the
+     reader's gesture even reaches our handlers. All three of those were
+     answered only in Chromium in #146: `sandbox="allow-popups"` without
+     `allow-popups-to-escape-sandbox` opened a link and then broke the page it
+     opened; `loading="lazy"` on an iframe defers nothing until roughly 4000px
+     below the fold, so it bought nothing on either shipping page; and one frame
+     costs ~570kB of third-party payload, three times the whole app. Anything
+     rendering an `<iframe>` is checked in a real browser against the built site:
+     the frame paints, each permission re-measured whenever the string changes,
+     weight from a cold profile, and a sideways drag on a touch context. Worked
+     case: `<SheetEmbed>` (ADR-0035).
+
   Written as classes rather than lists of names because the list was already
   stale once: `Exercise` arrived with the same shape and the same hazard, and
   the rule still said `CodeEditor`. The class was _also_ stale as a set — it
   named execution alone until #84 shipped two layout/focus bugs past a green
-  suite.
+  suite, and named only those two until #146 embedded a third party. State a new
+  class by what the code DOES — loads another origin — never by the tag it
+  happens to use.
 
 - Java deliberately does NOT run in a Web Worker (ADR-0017), and a Java infinite
   loop freezes the tab with no recovery — relevant whenever you author or verify

--- a/apps/web/src/app/mdxComponents.ts
+++ b/apps/web/src/app/mdxComponents.ts
@@ -33,10 +33,11 @@ export const mdxComponents = {
   Split,
   Mosaic,
   Figure,
-  // Not lazy: it is one iframe. Measured, registering it eagerly costs the
-  // entry chunk 1.15kB of component code (+4.4kB raw with its catalog prose,
-  // which travels eagerly for every component, lazy or not — ADR-0018 §7), and
-  // it pulls in no package the first paint did not already need.
+  // Not lazy: it is one iframe. Measured on the shipped build, registering it
+  // eagerly costs the entry chunk 1,463 bytes of component code (+5.6kB raw
+  // with its catalog prose, which travels eagerly for every component, lazy or
+  // not — ADR-0018 §7), and it pulls in no package the first paint did not
+  // already need.
   //
   // Do NOT read that as "the sheet is free until someone scrolls to it": the
   // frame carries `loading="lazy"`, and lazy on an iframe was measured to defer

--- a/apps/web/src/app/mdxComponents.ts
+++ b/apps/web/src/app/mdxComponents.ts
@@ -8,6 +8,7 @@ import {
   Question,
   Questions,
   SectionBreak,
+  SheetEmbed,
   SideBySide,
   Slide,
   Split,
@@ -32,6 +33,9 @@ export const mdxComponents = {
   Split,
   Mosaic,
   Figure,
+  // Not lazy: it is an iframe and a div. The weight is Google's, fetched by the
+  // browser when the frame scrolls into view, and never in our entry chunk.
+  SheetEmbed,
   // The lazy wrapper, not the editor itself: this map is evaluated eagerly, and
   // registering the real component would put CodeMirror in the entry chunk.
   CodeEditor: LazyCodeEditor,

--- a/apps/web/src/app/mdxComponents.ts
+++ b/apps/web/src/app/mdxComponents.ts
@@ -33,8 +33,17 @@ export const mdxComponents = {
   Split,
   Mosaic,
   Figure,
-  // Not lazy: it is an iframe and a div. The weight is Google's, fetched by the
-  // browser when the frame scrolls into view, and never in our entry chunk.
+  // Not lazy: it is one iframe. Measured, registering it eagerly costs the
+  // entry chunk 1.15kB of component code (+4.4kB raw with its catalog prose,
+  // which travels eagerly for every component, lazy or not — ADR-0018 §7), and
+  // it pulls in no package the first paint did not already need.
+  //
+  // Do NOT read that as "the sheet is free until someone scrolls to it": the
+  // frame carries `loading="lazy"`, and lazy on an iframe was measured to defer
+  // nothing until roughly 4000px below the fold in Chromium. On both pages that
+  // ship one today the frame is above that, so Google's ~570kB first-visit
+  // weight lands with the page. The attribute stays because it costs nothing
+  // and pays off the day a frame sits at the foot of a long document.
   SheetEmbed,
   // The lazy wrapper, not the editor itself: this map is evaluated eagerly, and
   // registering the real component would put CodeMirror in the entry chunk.

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -7,6 +7,7 @@ import { memoryDiagramCatalogEntry } from './interactive/MemoryDiagram.catalog';
 import { questionCatalogEntry } from './interactive/Question.catalog';
 import { questionsCatalogEntry } from './interactive/Questions.catalog';
 import { figureCatalogEntry } from './media/Figure.catalog';
+import { sheetEmbedCatalogEntry } from './media/SheetEmbed.catalog';
 import { mosaicCatalogEntry } from './structure/Mosaic.catalog';
 import { sectionBreakCatalogEntry } from './structure/SectionBreak.catalog';
 import { sideBySideCatalogEntry } from './structure/SideBySide.catalog';
@@ -25,6 +26,7 @@ export { LazyMemoryDiagram } from './interactive/lazyMemoryDiagram';
 // never write it, they write a fence. The shell maps it onto `pre`.
 export { MdxPre } from './MdxPre';
 export { Figure } from './media/Figure';
+export { SheetEmbed } from './media/SheetEmbed';
 export { Question } from './interactive/Question';
 export { Questions } from './interactive/Questions';
 export { Mosaic } from './structure/Mosaic';
@@ -41,6 +43,7 @@ export const catalogEntries: CatalogEntry[] = [
   splitCatalogEntry,
   mosaicCatalogEntry,
   figureCatalogEntry,
+  sheetEmbedCatalogEntry,
   codeEditorCatalogEntry,
   exerciseCatalogEntry,
   memoryDiagramCatalogEntry,

--- a/apps/web/src/components/media/SheetEmbed.catalog.tsx
+++ b/apps/web/src/components/media/SheetEmbed.catalog.tsx
@@ -1,0 +1,71 @@
+import type { CatalogEntry } from '../../lib/catalogEntry';
+
+import { SheetEmbed } from './SheetEmbed';
+
+// The course's own plan, shared as "anyone with the link can view". Written
+// here as the share link rather than the preview one precisely because that is
+// what an author pastes — the examples show the component doing the rewrite.
+const PLAN =
+  'https://docs.google.com/spreadsheets/d/1_cxMUbcF9Tscd3_4Nu71HiXy-MZuaz28IapmvhS7FkM/edit?usp=sharing';
+
+/** Catalog entry (ADR-0010) — colocated with the component, exported via the seam. */
+export const sheetEmbedCatalogEntry: CatalogEntry = {
+  name: 'SheetEmbed',
+  family: 'media',
+  description:
+    'A shared Google Sheet, framed read-only inside the page. The author edits the spreadsheet and the page follows, with no commit and no deploy.',
+  whenToUse:
+    'When what the course needs to publish already lives in a spreadsheet and changes on its own schedule — the week-by-week plan, the grades. A table typed into MDX is wrong the first time a class moves; this one is never re-typed. ' +
+    'It shows the sheet as Google renders it and does nothing else: it does not read the data, does not know the columns, and transforms nothing. Tidying happens in the spreadsheet. ' +
+    'The `title` is a runtime contract rather than a type, for the same reason as <Figure>: an iframe carries no accessible name of its own, so a frame without one is announced as an unnamed region the reader cannot identify or skip. ' +
+    'Two things about the frame are worth knowing before you use it. It paints its own white ground, so in the dark theme it is a white rectangle. And a sheet that is not shared renders Google request-access page inside the rectangle — that is cross-origin and nothing here can detect it, so check the share setting yourself.',
+  props: [
+    {
+      name: 'src',
+      type: 'string',
+      description:
+        'The share link, exactly as the Compartir button gives it. Required. It is rewritten into the embeddable /preview form, keeping the gid when the link points at one tab of several — the /edit url Google hands you is refused by its own frame-ancestors and would frame a blank rectangle. Anything that is not a docs.google.com spreadsheet url is an authoring error.',
+    },
+    {
+      name: 'title',
+      type: 'string',
+      description:
+        'What this sheet is, in Spanish (the page is served lang="es"). Required: it is the frame accessible name and there is no other source for one.',
+    },
+    {
+      name: 'height',
+      type: 'number',
+      description:
+        'How tall the frame is, in px. Defaults to 480, which is about nine rows of the course plan. An iframe has no content-driven height, so this is a decision rather than a fallback. On a slide the frame is capped at 64vh whatever this says, because a slide is fit and uniformly scaled (ADR-0013 §5.1) — an oversized frame is not clipped, it shrinks the whole slide, text included.',
+    },
+  ],
+  examples: [
+    {
+      title: 'The course plan',
+      code: `<SheetEmbed
+  src="https://docs.google.com/spreadsheets/d/1_cxMUbcF9Tscd3_4Nu71HiXy-MZuaz28IapmvhS7FkM/edit?usp=sharing"
+  title="Planificación del semestre"
+/>`,
+      render: () => <SheetEmbed src={PLAN} title="Planificación del semestre" />,
+    },
+    {
+      title: 'Shorter, for a sheet with few rows',
+      code: `<SheetEmbed
+  src="https://docs.google.com/spreadsheets/d/1_cxMUbcF9Tscd3_4Nu71HiXy-MZuaz28IapmvhS7FkM/edit?usp=sharing"
+  title="Fechas de laboratorio"
+  height={260}
+/>`,
+      render: () => <SheetEmbed src={PLAN} title="Fechas de laboratorio" height={260} />,
+    },
+    {
+      title: 'Given no title',
+      code: `<SheetEmbed src="https://docs.google.com/spreadsheets/d/1_cxMUb.../edit?usp=sharing" />`,
+      render: () => <SheetEmbed src={PLAN} />,
+    },
+    {
+      title: 'Given something that is not a sheet',
+      code: `<SheetEmbed src="https://example.com/plan.xlsx" title="Planificación" />`,
+      render: () => <SheetEmbed src="https://example.com/plan.xlsx" title="Planificación" />,
+    },
+  ],
+};

--- a/apps/web/src/components/media/SheetEmbed.catalog.tsx
+++ b/apps/web/src/components/media/SheetEmbed.catalog.tsx
@@ -15,16 +15,17 @@ export const sheetEmbedCatalogEntry: CatalogEntry = {
   description:
     'A shared Google Sheet, framed read-only inside the page. The author edits the spreadsheet and the page follows, with no commit and no deploy.',
   whenToUse:
-    'When what the course needs to publish already lives in a spreadsheet and changes on its own schedule — the week-by-week plan, the grades. A table typed into MDX is wrong the first time a class moves; this one is never re-typed. ' +
+    'When what the course needs to publish already lives in a spreadsheet and changes on its own schedule — today that is the week-by-week plan. NOT grades, and nothing else carrying student identifiers: a link-shared sheet is public, there is no student login to put in front of it, and the disposition until one exists is not to ship that data this way (docs/security-notes.md, ADR-0035). A table typed into MDX is wrong the first time a class moves; this one is never re-typed. ' +
     'It shows the sheet as Google renders it and does nothing else: it does not read the data, does not know the columns, and transforms nothing. Tidying happens in the spreadsheet. ' +
     'The `title` is a runtime contract rather than a type, for the same reason as <Figure>: an iframe carries no accessible name of its own, so a frame without one is announced as an unnamed region the reader cannot identify or skip. ' +
-    'Two things about the frame are worth knowing before you use it. It paints its own white ground, so in the dark theme it is a white rectangle. And a sheet that is not shared renders Google request-access page inside the rectangle — that is cross-origin and nothing here can detect it, so check the share setting yourself.',
+    'Prefer a table typed into MDX for anything genuinely static: this is the most expensive thing the site serves — one frame costs about 10 requests and 570 kB on a first visit, roughly 2.9 times the whole application entry chunk (ADR-0035). It earns that only when the data changes on its own and a typed copy would go stale. ' +
+    'Two more things about the frame are worth knowing before you use it. It paints its own white ground, so in the dark theme it is a white rectangle. And a sheet that is not shared renders Google request-access page inside the rectangle — that is cross-origin and nothing here can detect it, so check the share setting yourself.',
   props: [
     {
       name: 'src',
       type: 'string',
       description:
-        'The share link, exactly as the Compartir button gives it. Required. It is rewritten into the embeddable /preview form, keeping the gid when the link points at one tab of several — the /edit url Google hands you is refused by its own frame-ancestors and would frame a blank rectangle. Anything that is not a docs.google.com spreadsheet url is an authoring error.',
+        'The share link, exactly as the Compartir button gives it — or the /spreadsheets/u/0/d/... url out of the address bar. Required. It is rewritten into the embeddable /preview form, because the /edit url Google hands you frames the EDITOR — not blocked, but its own requests fail inside the sandbox and it paints the grid behind an error dialog. The gid is carried across when the link points at one tab of several, but THAT part is unverified (see sheetUrl.ts): check the published page if you use a multi-tab sheet. The Publicar-en-la-web url is a different identifier entirely and is refused. So is anything that is not a docs.google.com spreadsheet url.',
     },
     {
       name: 'title',

--- a/apps/web/src/components/media/SheetEmbed.test.tsx
+++ b/apps/web/src/components/media/SheetEmbed.test.tsx
@@ -42,6 +42,7 @@ describe('SheetEmbed', () => {
     const { container } = render(<SheetEmbed src={SHARE} title="" />);
 
     expect(container.textContent).toContain('<SheetEmbed>');
+    expect(container.textContent).toMatch(/title/);
     expect(frameOf(container)).toBeNull();
   });
 
@@ -49,6 +50,7 @@ describe('SheetEmbed', () => {
     const { container } = render(<SheetEmbed title={TITLE} />);
 
     expect(container.textContent).toContain('<SheetEmbed>');
+    expect(container.textContent).toMatch(/src/);
     expect(frameOf(container)).toBeNull();
   });
 
@@ -59,6 +61,13 @@ describe('SheetEmbed', () => {
     const { container } = render(<SheetEmbed src="https://example.com/plan.xlsx" title={TITLE} />);
 
     expect(container.textContent).toContain('<SheetEmbed>');
+    // The message is the whole product of an AuthoringError, so it is pinned
+    // rather than merely present: the shape it must name, the trap it must warn
+    // about, and the echo of the value that makes the error actionable. All
+    // three were droppable while green.
+    expect(container.textContent).toMatch(/Compartir/);
+    expect(container.textContent).toMatch(/Publicar en la web/);
+    expect(container.textContent).toContain('https://example.com/plan.xlsx');
     expect(frameOf(container)).toBeNull();
   });
 
@@ -68,6 +77,10 @@ describe('SheetEmbed', () => {
     // docs/security-notes.md.
     it('runs the frame in an opaque origin', () => {
       const { container } = render(<SheetEmbed src={SHARE} title={TITLE} />);
+      // Asserted before the negatives below, and not defaulted to '': a frame
+      // with NO sandbox attribute grants everything they claim to deny, and
+      // `?? ''` let all three of them pass in exactly that case.
+      expect(frameOf(container)?.hasAttribute('sandbox')).toBe(true);
       const sandbox = frameOf(container)?.getAttribute('sandbox') ?? '';
 
       // `allow-same-origin` would hand the frame its Google origin back, and
@@ -119,22 +132,56 @@ describe('SheetEmbed', () => {
       // An iframe has no content-driven height: unset, it is 150px of nothing.
       const { container } = render(<SheetEmbed src={SHARE} title={TITLE} />);
 
-      expect(heightOf(container)).toMatch(/^\d+px$/);
+      expect(heightOf(container)).toBe('480px');
     });
 
+    // These assert the WHOLE string rather than parts of it. jsdom cannot
+    // evaluate `min()`, but it stores the declaration verbatim, and that is
+    // enough to pin both halves of the cap. Asserting `toContain('vh')` and
+    // `toContain('900px')` was not: `min` -> `max` (which turns the cap into a
+    // floor, guaranteeing the oversized slide it exists to prevent) and
+    // `64` -> `640` both left the file green. Same shape as Mosaic.test.tsx,
+    // which pins its per-row budget as `21vh` / `32vh` for the same reason.
     it('caps itself against the stage on a slide', () => {
       // A slide is fit and uniformly scaled (ADR-0013 §5.1), so a frame that
       // asks for 900px does not get clipped — it shrinks the whole slide, text
-      // included. The cap is the same shape <Mosaic> uses for the same reason.
+      // included.
       const { container } = render(
         <ModeProvider mode="presentation">
           <SheetEmbed src={SHARE} title={TITLE} height={900} />
         </ModeProvider>,
       );
 
-      expect(heightOf(container)).toContain('vh');
-      expect(heightOf(container)).toContain('900px');
+      expect(heightOf(container)).toBe('min(900px, 64vh)');
     });
+
+    it('keeps the author number on a slide when it already fits', () => {
+      const { container } = render(
+        <ModeProvider mode="presentation">
+          <SheetEmbed src={SHARE} title={TITLE} />
+        </ModeProvider>,
+      );
+
+      expect(heightOf(container)).toBe('min(480px, 64vh)');
+    });
+  });
+
+  it('says something is coming while the frame is still transparent', () => {
+    // Measured at ~1.6 Mbps: about six seconds of empty bordered box, which
+    // reads exactly like the two failures this component cannot detect (an
+    // unshared sheet, Drive down). The placeholder sits UNDER the frame and is
+    // covered when Google paints its own ground.
+    const { container } = render(<SheetEmbed src={SHARE} title={TITLE} />);
+
+    const hint = screen.getByText(/Cargando la planilla/);
+    expect(hint).toBeInTheDocument();
+    // Not content: the frame already carries the accessible name, so a screen
+    // reader must not hear a loading line that never goes away.
+    expect(hint.getAttribute('aria-hidden')).toBe('true');
+    // Under, not over — otherwise it hides the sheet it was announcing.
+    expect(hint.compareDocumentPosition(frameOf(container) as Node)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
   });
 
   it('marks itself out of the reading measure', () => {

--- a/apps/web/src/components/media/SheetEmbed.test.tsx
+++ b/apps/web/src/components/media/SheetEmbed.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ModeProvider } from '../../presentation';
+import { SheetEmbed } from './SheetEmbed';
+
+const ID = '1_cxMUbcF9Tscd3_4Nu71HiXy-MZuaz28IapmvhS7FkM';
+const SHARE = `https://docs.google.com/spreadsheets/d/${ID}/edit?usp=sharing`;
+const TITLE = 'Planificacion del curso';
+
+const frameOf = (container: HTMLElement) => container.querySelector('iframe');
+
+describe('SheetEmbed', () => {
+  it('frames the sheet at the url Google will actually serve', () => {
+    const { container } = render(<SheetEmbed src={SHARE} title={TITLE} />);
+
+    expect(frameOf(container)?.getAttribute('src')).toBe(
+      `https://docs.google.com/spreadsheets/d/${ID}/preview`,
+    );
+  });
+
+  it('names the frame so a screen reader can identify it', () => {
+    render(<SheetEmbed src={SHARE} title={TITLE} />);
+
+    // An iframe's accessible name comes from `title` and nowhere else: with no
+    // title it is announced as an unnamed frame the reader cannot skip past.
+    expect(screen.getByTitle(TITLE).tagName).toBe('IFRAME');
+  });
+
+  it('tells the author when the title is missing', () => {
+    // Same runtime contract as <Figure>'s alt (ADR-0029): MDX is not
+    // typechecked, and the reader who needs the name is the one who cannot see
+    // that it is missing.
+    const { container } = render(<SheetEmbed src={SHARE} />);
+
+    expect(container.textContent).toContain('<SheetEmbed>');
+    expect(container.textContent).toMatch(/title/);
+    expect(frameOf(container)).toBeNull();
+  });
+
+  it('tells the author when the title is empty', () => {
+    const { container } = render(<SheetEmbed src={SHARE} title="" />);
+
+    expect(container.textContent).toContain('<SheetEmbed>');
+    expect(frameOf(container)).toBeNull();
+  });
+
+  it('tells the author when there is no src', () => {
+    const { container } = render(<SheetEmbed title={TITLE} />);
+
+    expect(container.textContent).toContain('<SheetEmbed>');
+    expect(frameOf(container)).toBeNull();
+  });
+
+  it('tells the author when the src is not a Google Sheets link', () => {
+    // The failure this replaces is silent: a wrong host frames something, and
+    // a refused one frames nothing, both with the suite green and the page
+    // looking merely empty.
+    const { container } = render(<SheetEmbed src="https://example.com/plan.xlsx" title={TITLE} />);
+
+    expect(container.textContent).toContain('<SheetEmbed>');
+    expect(frameOf(container)).toBeNull();
+  });
+
+  describe('the frame permissions (AC5)', () => {
+    // Every value here was measured in a real browser against the course's own
+    // sheet on 2026-08-16, not inherited by omission. The probe is recorded in
+    // docs/security-notes.md.
+    it('runs the frame in an opaque origin', () => {
+      const { container } = render(<SheetEmbed src={SHARE} title={TITLE} />);
+      const sandbox = frameOf(container)?.getAttribute('sandbox') ?? '';
+
+      // `allow-same-origin` would hand the frame its Google origin back, and
+      // the sheet renders and scrolls without it — so it is not granted.
+      expect(sandbox).not.toContain('allow-same-origin');
+      // Nothing in a read-only embed needs to navigate the page around it.
+      expect(sandbox).not.toContain('allow-top-navigation');
+      expect(sandbox).not.toContain('allow-forms');
+    });
+
+    it('lets the sheet run its own scripts, which is what renders the grid', () => {
+      const { container } = render(<SheetEmbed src={SHARE} title={TITLE} />);
+
+      expect(frameOf(container)?.getAttribute('sandbox')).toContain('allow-scripts');
+    });
+
+    it('lets a link in a cell open, and open unsandboxed', () => {
+      // The course plan carries 14 `target="_blank"` links to the class decks.
+      // Measured: without `allow-popups` the click is swallowed with only a
+      // console error the reader never sees; with it but WITHOUT
+      // `allow-popups-to-escape-sandbox` the deck opens and Google Slides then
+      // fails with "Se produjo un error", because the new tab inherits this
+      // sandbox. The pair is load-bearing — neither half works alone.
+      const { container } = render(<SheetEmbed src={SHARE} title={TITLE} />);
+      const sandbox = frameOf(container)?.getAttribute('sandbox') ?? '';
+
+      expect(sandbox).toContain('allow-popups');
+      expect(sandbox).toContain('allow-popups-to-escape-sandbox');
+    });
+
+    it('does not tell Google which page the reader came from', () => {
+      const { container } = render(<SheetEmbed src={SHARE} title={TITLE} />);
+
+      expect(frameOf(container)?.getAttribute('referrerpolicy')).toBe('no-referrer');
+    });
+  });
+
+  describe('how tall it is', () => {
+    const heightOf = (container: HTMLElement) =>
+      (container.firstElementChild as HTMLElement | null)?.style.height;
+
+    it('takes the height the author asked for, in the book', () => {
+      const { container } = render(<SheetEmbed src={SHARE} title={TITLE} height={900} />);
+
+      expect(heightOf(container)).toBe('900px');
+    });
+
+    it('has a height of its own when the author gives none', () => {
+      // An iframe has no content-driven height: unset, it is 150px of nothing.
+      const { container } = render(<SheetEmbed src={SHARE} title={TITLE} />);
+
+      expect(heightOf(container)).toMatch(/^\d+px$/);
+    });
+
+    it('caps itself against the stage on a slide', () => {
+      // A slide is fit and uniformly scaled (ADR-0013 §5.1), so a frame that
+      // asks for 900px does not get clipped — it shrinks the whole slide, text
+      // included. The cap is the same shape <Mosaic> uses for the same reason.
+      const { container } = render(
+        <ModeProvider mode="presentation">
+          <SheetEmbed src={SHARE} title={TITLE} height={900} />
+        </ModeProvider>,
+      );
+
+      expect(heightOf(container)).toContain('vh');
+      expect(heightOf(container)).toContain('900px');
+    });
+  });
+
+  it('marks itself out of the reading measure', () => {
+    // ADR-0022: the frame is a block, not running text. Without this it is
+    // centred at 39rem in the book while the prose beside it keeps the column.
+    const { container } = render(<SheetEmbed src={SHARE} title={TITLE} />);
+
+    expect(container.firstElementChild?.className).toContain('not-prose');
+  });
+});

--- a/apps/web/src/components/media/SheetEmbed.tsx
+++ b/apps/web/src/components/media/SheetEmbed.tsx
@@ -1,0 +1,115 @@
+import { AuthoringError } from '../AuthoringError';
+import { useMode } from '../../presentation';
+import { sheetPreviewUrl } from './sheetUrl';
+
+export interface SheetEmbedProps {
+  /**
+   * The sheet's share link, exactly as the Compartir button gives it. Must be
+   * shared as "cualquiera con el enlace puede ver"; the component rewrites it
+   * into the embeddable `/preview` form.
+   */
+  src?: string;
+  /**
+   * What this sheet is, in Spanish. Required: an iframe's accessible name comes
+   * from `title` and nowhere else.
+   */
+  title?: string;
+  /** How tall the frame is, in px. Capped against the stage on a slide. */
+  height?: number;
+}
+
+/**
+ * An iframe has no content-driven height — unset it is 150px of nothing — so
+ * this is a decision, not a fallback. 480px shows roughly nine rows of the
+ * course plan, which is a screenful without swallowing the page around it.
+ */
+const DEFAULT_HEIGHT = 480;
+
+/**
+ * How much of the slide's height the frame may take before the title and the
+ * deck's own chrome start losing room. Same budget and the same reasoning as
+ * `<Mosaic>`: a slide is fit and uniformly scaled (ADR-0013 §5.1), so an
+ * oversized frame is not clipped — it shrinks the whole slide, text included.
+ */
+const SLIDE_BUDGET_VH = 64;
+
+/**
+ * What the frame is allowed to do. Every token was measured in a real browser
+ * against the course's own sheet on 2026-08-16 rather than inherited by
+ * omission — the record is in `docs/security-notes.md`.
+ *
+ * - `allow-scripts` renders the grid; without it there is nothing to see.
+ * - `allow-popups` + `allow-popups-to-escape-sandbox` are ONE decision, not
+ *   two. The course plan carries 14 `target="_blank"` links to the class decks:
+ *   without the first the click is swallowed behind a console error, and with
+ *   the first but not the second the deck opens and Google Slides fails with
+ *   "Se produjo un error" — the new tab inherits this sandbox.
+ *
+ * `allow-same-origin` is deliberately absent: the sheet renders and scrolls
+ * both ways without it, so the frame stays in an opaque origin.
+ */
+const SANDBOX = 'allow-scripts allow-popups allow-popups-to-escape-sandbox';
+
+/**
+ * A shared Google Sheet, rendered read-only inside the page.
+ *
+ * The professor edits the spreadsheet and the page follows — no commit, no
+ * deploy. Deliberately the whole of it: this component does not read the sheet,
+ * does not know its columns and transforms nothing. Google renders it; we frame
+ * it and say how tall.
+ *
+ * It paints its own white ground, so in the dark theme it is a white rectangle.
+ * That is accepted (#146) — the sheet's own cell colours are the information.
+ */
+export function SheetEmbed({ src, title, height = DEFAULT_HEIGHT }: SheetEmbedProps) {
+  const mode = useMode();
+
+  if (src === undefined || src === '') {
+    return (
+      <AuthoringError component="SheetEmbed">
+        necesita un src con el enlace de la planilla.
+      </AuthoringError>
+    );
+  }
+  if (title === undefined || title === '') {
+    return (
+      <AuthoringError component="SheetEmbed">
+        necesita un title que diga qué planilla es, en español: es lo único que un lector de
+        pantalla anuncia de un marco.
+      </AuthoringError>
+    );
+  }
+
+  const url = sheetPreviewUrl(src);
+  if (url === null) {
+    return (
+      <AuthoringError component="SheetEmbed">
+        necesita un enlace de Google Sheets (docs.google.com/spreadsheets/d/…), y este no lo es:{' '}
+        {src}
+      </AuthoringError>
+    );
+  }
+
+  return (
+    // `not-prose` because a framed sheet is a block, not running text: without
+    // it the reading measure narrows it to 39rem inside the column (ADR-0022).
+    // The height rides on the wrapper rather than the frame so the cap is one
+    // value in one place, and `min()` lets the slide keep the author's number
+    // whenever it already fits.
+    <div
+      className="not-prose my-6"
+      style={{
+        height: mode === 'presentation' ? `min(${height}px, ${SLIDE_BUDGET_VH}vh)` : `${height}px`,
+      }}
+    >
+      <iframe
+        src={url}
+        title={title}
+        sandbox={SANDBOX}
+        referrerPolicy="no-referrer"
+        loading="lazy"
+        className="h-full w-full rounded border border-rule"
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/media/SheetEmbed.tsx
+++ b/apps/web/src/components/media/SheetEmbed.tsx
@@ -1,4 +1,5 @@
 import { AuthoringError } from '../AuthoringError';
+import { SLIDE_BUDGET_VH } from '../slideBudget';
 import { useMode } from '../../presentation';
 import { sheetPreviewUrl } from './sheetUrl';
 
@@ -24,14 +25,6 @@ export interface SheetEmbedProps {
  * course plan, which is a screenful without swallowing the page around it.
  */
 const DEFAULT_HEIGHT = 480;
-
-/**
- * How much of the slide's height the frame may take before the title and the
- * deck's own chrome start losing room. Same budget and the same reasoning as
- * `<Mosaic>`: a slide is fit and uniformly scaled (ADR-0013 §5.1), so an
- * oversized frame is not clipped — it shrinks the whole slide, text included.
- */
-const SLIDE_BUDGET_VH = 64;
 
 /**
  * What the frame is allowed to do. Every token was measured in a real browser
@@ -84,46 +77,48 @@ export function SheetEmbed({ src, title, height = DEFAULT_HEIGHT }: SheetEmbedPr
   if (url === null) {
     return (
       <AuthoringError component="SheetEmbed">
-        necesita un enlace de Google Sheets (docs.google.com/spreadsheets/d/…), y este no lo es:{' '}
-        {src}
+        necesita el enlace de <strong>Compartir</strong> de una planilla de Google
+        (docs.google.com/spreadsheets/d/…), no el de Publicar en la web. Este no sirve: {src}
       </AuthoringError>
     );
   }
 
   return (
-    // `not-prose` because a framed sheet is a block, not running text: without
-    // it the reading measure narrows it to 39rem inside the column (ADR-0022).
-    // Measured in the book at 1440: 768px of column, against 624px for the
-    // prose above it.
+    // The wrapper exists for the placeholder, not for layout: an unloaded
+    // iframe is transparent, so a sibling underneath it shows through and is
+    // covered the moment Google paints its own white ground. Measured on a
+    // ~1.6 Mbps connection, that window is about six seconds, during which the
+    // reader would otherwise be looking at an empty bordered box —
+    // indistinguishable from the two failures this component accepts as
+    // undetectable (an unshared sheet, Drive down). `aria-hidden` because the
+    // frame already has an accessible name and the placeholder is not content.
     //
-    // It carries no `overflow-x-auto`, and that is not the oversight it looks
-    // like. ADR-0013 §5.2 makes a component that pans sideways declare itself a
-    // real scroller or have the drag taken as a slide change — but the sheet's
-    // scroller lives inside ANOTHER DOCUMENT, so the deck never sees the touch
-    // at all. Measured on an iPhone 13 in landscape, same slide, same gesture:
-    // dragging inside the frame left `?slide` untouched, dragging on the ground
-    // beside it moved 2 -> 1. Adding the class here would only advertise a
-    // scroller this element does not have.
+    // `not-prose` because a framed sheet is a block, not running text: the
+    // measure would otherwise narrow it to 39rem inside the column (ADR-0022).
     //
-    // The height rides on the wrapper rather than the frame so the cap is one
-    // value in one place, and `min()` lets the slide keep the author's number
-    // whenever it already fits. Measured: at 1024x768 the frame draws at its
-    // full 480px (64vh = 491px, so the author's number wins and the slide is
-    // not scaled at all); on a 750x342 phone the cap bites at 219px and the
-    // deck fits the slide at 0.85, well above the half-scale legibility floor.
+    // No `overflow-x-auto`, and that is not the oversight it looks like:
+    // ADR-0013 §5.2 governs a scroller in THIS document, and the sheet's is in
+    // another one, so the deck's swipe can never see it. Measured; the numbers
+    // are in ADR-0035 §Consequences.
     <div
-      className="not-prose my-6"
+      className="not-prose relative my-6 rounded bg-sunk"
       style={{
         height: mode === 'presentation' ? `min(${height}px, ${SLIDE_BUDGET_VH}vh)` : `${height}px`,
       }}
     >
+      <p
+        aria-hidden="true"
+        className="absolute inset-0 flex items-center justify-center text-sm text-ink-faint"
+      >
+        Cargando la planilla…
+      </p>
       <iframe
         src={url}
         title={title}
         sandbox={SANDBOX}
         referrerPolicy="no-referrer"
         loading="lazy"
-        className="h-full w-full rounded border border-rule"
+        className="relative h-full w-full rounded border border-rule"
       />
     </div>
   );

--- a/apps/web/src/components/media/SheetEmbed.tsx
+++ b/apps/web/src/components/media/SheetEmbed.tsx
@@ -93,9 +93,24 @@ export function SheetEmbed({ src, title, height = DEFAULT_HEIGHT }: SheetEmbedPr
   return (
     // `not-prose` because a framed sheet is a block, not running text: without
     // it the reading measure narrows it to 39rem inside the column (ADR-0022).
+    // Measured in the book at 1440: 768px of column, against 624px for the
+    // prose above it.
+    //
+    // It carries no `overflow-x-auto`, and that is not the oversight it looks
+    // like. ADR-0013 §5.2 makes a component that pans sideways declare itself a
+    // real scroller or have the drag taken as a slide change — but the sheet's
+    // scroller lives inside ANOTHER DOCUMENT, so the deck never sees the touch
+    // at all. Measured on an iPhone 13 in landscape, same slide, same gesture:
+    // dragging inside the frame left `?slide` untouched, dragging on the ground
+    // beside it moved 2 -> 1. Adding the class here would only advertise a
+    // scroller this element does not have.
+    //
     // The height rides on the wrapper rather than the frame so the cap is one
     // value in one place, and `min()` lets the slide keep the author's number
-    // whenever it already fits.
+    // whenever it already fits. Measured: at 1024x768 the frame draws at its
+    // full 480px (64vh = 491px, so the author's number wins and the slide is
+    // not scaled at all); on a 750x342 phone the cap bites at 219px and the
+    // deck fits the slide at 0.85, well above the half-scale legibility floor.
     <div
       className="not-prose my-6"
       style={{

--- a/apps/web/src/components/media/sheetUrl.test.ts
+++ b/apps/web/src/components/media/sheetUrl.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { sheetPreviewUrl } from './sheetUrl';
+
+// The course's own plan, whose share link is what a professor actually pastes.
+const ID = '1_cxMUbcF9Tscd3_4Nu71HiXy-MZuaz28IapmvhS7FkM';
+const PREVIEW = `https://docs.google.com/spreadsheets/d/${ID}/preview`;
+
+describe('sheetPreviewUrl', () => {
+  it('turns the share link Google hands out into the embeddable one', () => {
+    // This is the whole reason the function exists. `/edit` is refused by
+    // Google's own `frame-ancestors` (verified in a real iframe, 2026-08-16):
+    // an author who pastes what the Compartir button gave them would otherwise
+    // publish a blank rectangle and never see the console violation.
+    expect(sheetPreviewUrl(`https://docs.google.com/spreadsheets/d/${ID}/edit?usp=sharing`)).toBe(
+      PREVIEW,
+    );
+  });
+
+  it('leaves a preview url alone', () => {
+    expect(sheetPreviewUrl(PREVIEW)).toBe(PREVIEW);
+  });
+
+  it('keeps the tab the author picked', () => {
+    // A `gid` selects one sheet of several. Dropping it would silently publish
+    // the first tab instead of the one in the link the author copied.
+    expect(sheetPreviewUrl(`https://docs.google.com/spreadsheets/d/${ID}/edit#gid=1234567`)).toBe(
+      `${PREVIEW}?gid=1234567`,
+    );
+  });
+
+  it('ignores the whitespace a pasted link drags in', () => {
+    expect(sheetPreviewUrl(`  ${PREVIEW}\n`)).toBe(PREVIEW);
+  });
+
+  it('refuses a Google Doc, which is not a spreadsheet', () => {
+    expect(sheetPreviewUrl(`https://docs.google.com/document/d/${ID}/edit`)).toBeNull();
+  });
+
+  it('refuses a url on another host', () => {
+    // Impersonating the path is not enough: the host is what the sandbox and
+    // this site's future CSP are written against.
+    expect(sheetPreviewUrl(`https://evil.example/spreadsheets/d/${ID}/preview`)).toBeNull();
+  });
+
+  it('refuses plain http', () => {
+    expect(sheetPreviewUrl(`http://docs.google.com/spreadsheets/d/${ID}/preview`)).toBeNull();
+  });
+
+  it('refuses a string that is not a url at all', () => {
+    expect(sheetPreviewUrl('Plan de trabajo EDA')).toBeNull();
+  });
+
+  it('refuses an empty string', () => {
+    expect(sheetPreviewUrl('')).toBeNull();
+  });
+});

--- a/apps/web/src/components/media/sheetUrl.test.ts
+++ b/apps/web/src/components/media/sheetUrl.test.ts
@@ -33,6 +33,28 @@ describe('sheetPreviewUrl', () => {
     expect(sheetPreviewUrl(`  ${PREVIEW}\n`)).toBe(PREVIEW);
   });
 
+  it('accepts the url Google puts in the address bar for a second account', () => {
+    // `/u/0/` is what a professor signed into more than one Google account
+    // copies from the address bar — likelier than opening the Compartir dialog.
+    expect(sheetPreviewUrl(`https://docs.google.com/spreadsheets/u/0/d/${ID}/edit`)).toBe(PREVIEW);
+  });
+
+  it('refuses the Publicar-en-la-web link rather than framing a 404', () => {
+    // The published form is `/d/e/<token>/pubhtml`. It IS a docs.google.com
+    // spreadsheet url, so the naive pattern accepted it, captured the literal
+    // "e" as the id and built `/spreadsheets/d/e/preview` — a 404 that frames
+    // Google's own "el archivo que solicitaste no existe", with no authoring
+    // error and the whole suite green. Exactly the silent failure this module
+    // exists to prevent (#146 review).
+    expect(
+      sheetPreviewUrl('https://docs.google.com/spreadsheets/d/e/2PACX-1vQx9Zk3example/pubhtml'),
+    ).toBeNull();
+  });
+
+  it('refuses an id too short to be one', () => {
+    expect(sheetPreviewUrl('https://docs.google.com/spreadsheets/d/abc/edit')).toBeNull();
+  });
+
   it('refuses a Google Doc, which is not a spreadsheet', () => {
     expect(sheetPreviewUrl(`https://docs.google.com/document/d/${ID}/edit`)).toBeNull();
   });

--- a/apps/web/src/components/media/sheetUrl.test.ts
+++ b/apps/web/src/components/media/sheetUrl.test.ts
@@ -8,10 +8,11 @@ const PREVIEW = `https://docs.google.com/spreadsheets/d/${ID}/preview`;
 
 describe('sheetPreviewUrl', () => {
   it('turns the share link Google hands out into the embeddable one', () => {
-    // This is the whole reason the function exists. `/edit` is refused by
-    // Google's own `frame-ancestors` (verified in a real iframe, 2026-08-16):
-    // an author who pastes what the Compartir button gave them would otherwise
-    // publish a blank rectangle and never see the console violation.
+    // This is the whole reason the function exists. `/edit` is not blocked —
+    // Google sends no `frame-ancestors` — it is the EDITOR, and framed without
+    // `allow-same-origin` its own requests fail: an author who pastes what the
+    // Compartir button gave them would publish the grid behind a "Se ha
+    // producido un error" dialog (verified 2026-08-16).
     expect(sheetPreviewUrl(`https://docs.google.com/spreadsheets/d/${ID}/edit?usp=sharing`)).toBe(
       PREVIEW,
     );

--- a/apps/web/src/components/media/sheetUrl.ts
+++ b/apps/web/src/components/media/sheetUrl.ts
@@ -1,12 +1,31 @@
 /**
- * A Google Sheets url, captured as (spreadsheet id). Anchored at the scheme and
- * the host on purpose: this is the value that ends up in an `<iframe src>`, so
- * the host is the whole of what is being trusted, and matching the PATH alone
- * would accept `https://evil.example/spreadsheets/d/…`.
+ * A Google Sheets url, captured as (spreadsheet id). Three parts earn their
+ * keep:
+ *
+ * - **Anchored at the scheme and the host**, because this value ends up in an
+ *   `<iframe src>`: the host is the whole of what is being trusted, and a
+ *   pattern on the path alone accepts `https://evil.example/spreadsheets/d/…`.
+ * - **`(?:u\/\d+\/)?`** accepts the account-scoped form Google puts in the
+ *   address bar when the professor is signed into more than one account
+ *   (`/spreadsheets/u/0/d/…`) — the url you get by copying from the address bar
+ *   instead of the Compartir dialog, which is the likelier of the two.
+ * - **`(?!e\/)` and the 20-character floor** refuse the *published* form,
+ *   `/spreadsheets/d/e/<token>/pubhtml`. Without them it matches, captures the
+ *   literal `"e"` as the id, and builds `/spreadsheets/d/e/preview` — a 404
+ *   that frames Google's own "el archivo que solicitaste no existe" with the
+ *   whole suite green (#146 review). Real ids are 40+ characters.
  */
-const SHEET_URL = /^https:\/\/docs\.google\.com\/spreadsheets\/d\/([\w-]+)/;
+const SHEET_URL = /^https:\/\/docs\.google\.com\/spreadsheets\/(?:u\/\d+\/)?d\/(?!e\/)([\w-]{20,})/;
 
-/** The tab of a multi-sheet document, wherever Google put it in the link. */
+/**
+ * The tab of a multi-sheet document, wherever Google put it in the link.
+ *
+ * **The rewrite from `#gid=` to `?gid=` is unverified**, unlike everything else
+ * in this module: the course's own sheet has one tab, so the probe that
+ * measured the url forms could not tell a working query from an ignored one.
+ * Measure it against a two-tab sheet before relying on it — if `/preview`
+ * honours the fragment instead, this must emit `#gid=`.
+ */
 const GID = /[?#&]gid=(\d+)/;
 
 /**

--- a/apps/web/src/components/media/sheetUrl.ts
+++ b/apps/web/src/components/media/sheetUrl.ts
@@ -1,0 +1,32 @@
+/**
+ * A Google Sheets url, captured as (spreadsheet id). Anchored at the scheme and
+ * the host on purpose: this is the value that ends up in an `<iframe src>`, so
+ * the host is the whole of what is being trusted, and matching the PATH alone
+ * would accept `https://evil.example/spreadsheets/d/…`.
+ */
+const SHEET_URL = /^https:\/\/docs\.google\.com\/spreadsheets\/d\/([\w-]+)/;
+
+/** The tab of a multi-sheet document, wherever Google put it in the link. */
+const GID = /[?#&]gid=(\d+)/;
+
+/**
+ * The embeddable url for a shared Google Sheet, or `null` if this is not one.
+ *
+ * Authors paste what the Compartir button gives them, which is an `/edit` url —
+ * and `/edit` is refused by Google's own `frame-ancestors` (measured in a real
+ * iframe on 2026-08-16, alongside `/pubhtml` and `/htmlembed`, which work but
+ * first require publishing the sheet to the web). `/preview` needs nothing but
+ * "anyone with the link can view", so it is the one form this normalises to.
+ *
+ * Pure and separate from the component because the alternative is a silent
+ * failure with the suite green: a refused url frames a blank rectangle, and the
+ * only evidence is a console violation neither the author nor the reader sees.
+ */
+export function sheetPreviewUrl(src: string): string | null {
+  const match = SHEET_URL.exec(src.trim());
+  if (match === null) return null;
+
+  const gid = GID.exec(src);
+  const tab = gid === null ? '' : `?gid=${gid[1]}`;
+  return `https://docs.google.com/spreadsheets/d/${match[1]}/preview${tab}`;
+}

--- a/apps/web/src/components/media/sheetUrl.ts
+++ b/apps/web/src/components/media/sheetUrl.ts
@@ -31,11 +31,18 @@ const GID = /[?#&]gid=(\d+)/;
 /**
  * The embeddable url for a shared Google Sheet, or `null` if this is not one.
  *
- * Authors paste what the Compartir button gives them, which is an `/edit` url —
- * and `/edit` is refused by Google's own `frame-ancestors` (measured in a real
- * iframe on 2026-08-16, alongside `/pubhtml` and `/htmlembed`, which work but
- * first require publishing the sheet to the web). `/preview` needs nothing but
- * "anyone with the link can view", so it is the one form this normalises to.
+ * Authors paste what the Compartir button gives them, which is an `/edit` url.
+ * That url is **not** frame-blocked — Google sends no `frame-ancestors` and no
+ * `X-Frame-Options` on it (checked with `curl -sI`, 2026-08-16) — it is simply
+ * the wrong thing to publish: framed under this component's sandbox, without
+ * `allow-same-origin`, the editor's own requests fail and it paints the grid
+ * behind a "Se ha producido un error" dialog, editing chrome and all.
+ *
+ * The other two forms measured the same day: `/pubhtml` needs the sheet
+ * published to the web (401 without it), and `/htmlembed` works on a merely
+ * link-shared sheet but shows no tab bar. `/preview` needs nothing but "anyone
+ * with the link can view" and renders the sheet as Google draws it, so it is
+ * the one form this normalises to.
  *
  * Pure and separate from the component because the alternative is a silent
  * failure with the suite green: a refused url frames a blank rectangle, and the

--- a/apps/web/src/components/slideBudget.ts
+++ b/apps/web/src/components/slideBudget.ts
@@ -8,6 +8,22 @@
  * being readable. Every component that draws something tall on a slide caps
  * itself against this number.
  *
+ * **Where 64 comes from**: measured on a 1024x768 stage, the size the guide
+ * names for a projector. That leaves ~36vh — about 276px — for the slide title
+ * and the deck's own chrome, which is what a two-line title at the deck's
+ * heading size needs plus the footer. The case that breaks if it grows: a 3x3
+ * `<Mosaic>` went from 54vh to 73vh when per-cell margins were not zeroed, and
+ * at 73vh the deck scaled the whole slide down far enough that the body text
+ * stopped being readable — below roughly half scale, per ADR-0013 §5.1.
+ *
+ * **The cheaper alternative, rejected**: let the fit scaler handle it. It
+ * already scales an oversized slide to fit, so nothing is ever clipped — but it
+ * scales the TEXT with the block, which turns one component's greed into an
+ * unreadable slide. Capping the block instead keeps the type at its design
+ * size and costs only the bottom of the block, which scrolls or crops
+ * gracefully. Clipping the block outright was the third option and is worse
+ * than both: it hides content with no indication that anything is missing.
+ *
  * Shared rather than duplicated because the two current users each declared it
  * privately and each said in a comment that theirs was "the same budget" as the
  * other's — a claim nothing checked, and the kind that stays true only until

--- a/apps/web/src/components/slideBudget.ts
+++ b/apps/web/src/components/slideBudget.ts
@@ -1,0 +1,17 @@
+/**
+ * How much of a slide's height one block may take, in vh, before the title and
+ * the deck's own chrome start losing room.
+ *
+ * A slide is fit and uniformly scaled rather than clipped (ADR-0013 §5.1), so a
+ * block that asks for more than the stage has does not get cut off — it shrinks
+ * the WHOLE slide, the text with it, and below roughly half scale the body stops
+ * being readable. Every component that draws something tall on a slide caps
+ * itself against this number.
+ *
+ * Shared rather than duplicated because the two current users each declared it
+ * privately and each said in a comment that theirs was "the same budget" as the
+ * other's — a claim nothing checked, and the kind that stays true only until
+ * someone tunes one of them (#146 review). Worked cases: `<Mosaic>`, which
+ * splits it across rows, and `<SheetEmbed>`, which clamps its frame to it.
+ */
+export const SLIDE_BUDGET_VH = 64;

--- a/apps/web/src/components/structure/Mosaic.tsx
+++ b/apps/web/src/components/structure/Mosaic.tsx
@@ -2,6 +2,8 @@ import { Children, type CSSProperties, type ReactNode } from 'react';
 
 import { AuthoringError } from '../AuthoringError';
 import { DescribedProvider } from '../described';
+// The grid splits this across its rows; `<SheetEmbed>` clamps a frame to it.
+import { SLIDE_BUDGET_VH } from '../slideBudget';
 import { useMode } from '../../presentation';
 
 export interface MosaicProps {
@@ -32,12 +34,6 @@ const GRID = {
   3: { book: 'grid-cols-2 md:grid-cols-3', slide: 'grid-cols-3' },
   4: { book: 'grid-cols-2 md:grid-cols-4', slide: 'grid-cols-4' },
 } as const;
-
-/**
- * How much of the slide's height the whole grid may take, in vh, before the
- * title and the deck's own chrome start losing room. Split across the rows.
- */
-const SLIDE_BUDGET_VH = 64;
 
 /** Cells, ignoring the whitespace MDX contributes between blocks. */
 function cellCount(children: ReactNode): number {

--- a/content/courses/sample-course/04-planificacion.mdx
+++ b/content/courses/sample-course/04-planificacion.mdx
@@ -25,15 +25,34 @@ questions: none
 {/*      to that file (copy it from app/documentSections.test.tsx) or repoint */}
 {/*      DEEP_LINK_FIXTURE at another non-landing document — otherwise the */}
 {/*      flake class those issues closed comes back. */}
-{/* Concretely, for #146: the class-by-class calendar CANNOT be written as */}
-{/* `## Septiembre` without moving that case first. Use `###`, or a table, or */}
-{/* make the fixture synthetic — SectionNav.test.tsx already covers the unit */}
-{/* case with `sections={[]}`. */}
+
+{/* #146 filled this document and kept all three. The calendar arrives as a */}
+{/* framed spreadsheet rather than a table, so it adds one element and no */}
+{/* headings, and the component reaches the page through the shell's MDX map */}
+{/* — this document's own chunk stays as small as it was. */}
+
+{/* The `src` is the ordinary share link; <SheetEmbed> rewrites it into the */}
+{/* embeddable form. To point at a different sheet, replace it and change */}
+{/* nothing else. The sheet must be shared as "cualquiera con el enlace puede */}
+{/* ver" — an unshared one renders Google's request-access page inside the */}
+{/* frame and NOTHING here can detect it. See guides/add-a-course-document.md */}
+{/* §6g. */}
 
 # Planificación
 
-Aquí se publica el calendario clase a clase de este semestre: qué materia toca
-cada semana y qué hay que leer. Se publica durante las primeras semanas, en cuanto
-estén cerradas las fechas de laboratorio.
+El calendario del curso se publica aquí tal como está en la planilla de trabajo:
+qué materia toca cada semana, qué clase cae en qué fecha y qué hay que leer. No
+es una copia. Es la planilla misma, así que cuando una clase se mueve, se mueve
+también en esta página.
+
+<SheetEmbed
+  src="https://docs.google.com/spreadsheets/d/1_cxMUbcF9Tscd3_4Nu71HiXy-MZuaz28IapmvhS7FkM/edit?usp=sharing"
+  title="Planificación clase a clase del curso"
+  height={560}
+/>
+
+La planilla tiene más columnas de las que caben en pantalla: arrástrala hacia el
+lado para ver la bibliografía y el material de cada clase. Los títulos en azul
+son enlaces y se abren en una pestaña nueva.
 
 Las fechas de las dos solemnes están en la [[bienvenida|clase inaugural]].

--- a/content/courses/sample-course/04-planificacion.mdx
+++ b/content/courses/sample-course/04-planificacion.mdx
@@ -10,9 +10,9 @@ questions: none
 {/* control could ask about. It carried `questions: none` as the demo page it */}
 {/* replaced, and it keeps it. */}
 
-{/* Three test files bind to this document (ADR-0025: the conflict is */}
-{/* recorded at the document). Two invariants, and BOTH are easy to break by */}
-{/* writing ordinary content here: */}
+{/* Four test files bind to this document (ADR-0025: the conflict is */}
+{/* recorded at the document). THREE invariants, and all three are easy to */}
+{/* break by writing ordinary content here: */}
 {/*   1. `presentation: none` — presentationRoute.test.tsx drives it as the */}
 {/*      no-deck document (/present redirects to the book, the control hides), */}
 {/*      and deployedApp.test.tsx uses it as the deep-link fixture. */}
@@ -25,11 +25,23 @@ questions: none
 {/*      to that file (copy it from app/documentSections.test.tsx) or repoint */}
 {/*      DEEP_LINK_FIXTURE at another non-landing document — otherwise the */}
 {/*      flake class those issues closed comes back. */}
+{/*   4. Since #146, the <SheetEmbed> src must stay a valid Google Sheets */}
+{/*      share link: app/contentRenders.test.tsx renders every published */}
+{/*      document and fails on the authoring error a bad one produces. */}
 
-{/* #146 filled this document and kept all three. The calendar arrives as a */}
-{/* framed spreadsheet rather than a table, so it adds one element and no */}
-{/* headings, and the component reaches the page through the shell's MDX map */}
-{/* — this document's own chunk stays as small as it was. */}
+{/* #146 filled this document and kept all three, but NOT by writing around */}
+{/* them. The calendar is a framed spreadsheet because a typed table is wrong */}
+{/* the first time a class moves (ADR-0035 §Context) — the editorial reason, */}
+{/* decided before the fixture bindings were looked at. That it also adds one */}
+{/* element and no headings, and leaves the chunk small because the component */}
+{/* arrives through the shell's MDX map, is a consequence and not the motive. */}
+{/* The distinction is the limit ADR-0025 puts on itself: the suite may */}
+{/* constrain HOW content is written, never WHAT it says. */}
+
+{/* Book-only, and that IS the fixture's doing: presentation stays `none` */}
+{/* because this document is presentationRoute.test.tsx's no-deck fixture. So */}
+{/* the calendar cannot be projected. If it ever should be, move that fixture */}
+{/* first — do not flip the field here. */}
 
 {/* The `src` is the ordinary share link; <SheetEmbed> rewrites it into the */}
 {/* embeddable form. To point at a different sheet, replace it and change */}

--- a/content/courses/sample-course/04-planificacion.mdx
+++ b/content/courses/sample-course/04-planificacion.mdx
@@ -33,8 +33,11 @@ questions: none
 {/* them. The calendar is a framed spreadsheet because a typed table is wrong */}
 {/* the first time a class moves (ADR-0035 §Context) — the editorial reason, */}
 {/* decided before the fixture bindings were looked at. That it also adds one */}
-{/* element and no headings, and leaves the chunk small because the component */}
-{/* arrives through the shell's MDX map, is a consequence and not the motive. */}
+{/* element and no headings, and that the component itself never lands in this */}
+{/* document's chunk because it arrives through the shell's MDX map, is a */}
+{/* consequence and not the motive. The chunk did grow — 971 to 1713 bytes, */}
+{/* all of it the prose above — which is still far inside what invariant 3 */}
+{/* needs. */}
 {/* The distinction is the limit ADR-0025 puts on itself: the suite may */}
 {/* constrain HOW content is written, never WHAT it says. */}
 

--- a/docs/decisions/0035-a-third-party-frame-is-a-content-source.md
+++ b/docs/decisions/0035-a-third-party-frame-is-a-content-source.md
@@ -120,17 +120,23 @@ whole slide with its title.
   the same page built from `main`: 5 requests / 190 kB becomes 15 requests /
   762 kB. The third-party half is 570 kB across 10 requests, and **490 kB of it
   is one already-gzipped Google stylesheet** — 2.9× the application's entire
-  entry chunk (171 kB gzip). Google serves its static assets with
-  `max-age=31536000`, so a second visit costs 34 kB / 10 requests; at ~1.6 Mbps
-  the last byte lands at 5.9 s against 3.5 s. The method is ADR-0018 §7's, and
-  the number is recorded for the same reason: an author choosing between a frame
-  and a typed table cannot otherwise know the frame is three times the app.
-- **Registering it eagerly is the cheap half**, measured on the same build:
-  the entry chunk goes 535,310 → 539,718 raw bytes (+0.8%), of which only
-  1,151 bytes are component code — the rest is catalog prose, which travels
-  eagerly for every component, lazy or not. No new eagerly-shipped package;
-  `architecture: what the shell reaches eagerly` is untouched. A lazy wrapper
-  would defer 1.15 kB while the 570 kB above stayed exactly where it is.
+  entry chunk (171.5 kB gzip). Google serves its static assets with
+  `max-age=31536000`, so a second visit costs 34 kB / 10 requests. The method is
+  ADR-0018 §7's, and the number is recorded for the same reason: an author
+  choosing between a frame and a typed table cannot otherwise know the frame is
+  three times the app. Measured on the merge commit's build, from a cold
+  profile, counting `request.sizes()` transfer bytes; a throttled figure was
+  taken too and is deliberately **not** recorded, because the throttling profile
+  was not written down with it and a number nobody can re-derive is worse than
+  none.
+- **Registering it eagerly is the cheap half**, measured on the same build
+  (main 535,310 → branch 540,879 raw, +1.0%). Only **1,463 bytes** of that is
+  component code and registration: dropping just `sheetEmbedCatalogEntry` from
+  the seam and rebuilding gives 536,773, so the other 4,106 bytes are catalog
+  prose, which travels eagerly for every component, lazy or not. No new
+  eagerly-shipped package; `architecture: what the shell reaches eagerly` is
+  untouched. A lazy wrapper would defer 1.4 kB while the 570 kB above stayed
+  exactly where it is.
 - **`loading="lazy"` is close to inert here.** Measured in Chromium: a lazy
   iframe defers nothing until roughly **4000px** below the fold, and the frame
   on `/d/planificacion` sits at 325px, the two on `/catalog/c/SheetEmbed` at

--- a/docs/decisions/0035-a-third-party-frame-is-a-content-source.md
+++ b/docs/decisions/0035-a-third-party-frame-is-a-content-source.md
@@ -95,6 +95,29 @@ whole slide with its title.
   `security-notes.md` §"Executing student code". Unlike those, it is not
   integrity-checkable: it is a document, not a versioned bundle. A future CSP
   must allow `docs.google.com` in `frame-src`.
+- **It is the heaviest thing this site serves, and the weight is not ours to
+  reduce.** Measured on `/d/planificacion` at 1440×900, cold profile, against
+  the same page built from `main`: 5 requests / 190 kB becomes 15 requests /
+  762 kB. The third-party half is 570 kB across 10 requests, and **490 kB of it
+  is one already-gzipped Google stylesheet** — 2.9× the application's entire
+  entry chunk (171 kB gzip). Google serves its static assets with
+  `max-age=31536000`, so a second visit costs 34 kB / 10 requests; at ~1.6 Mbps
+  the last byte lands at 5.9 s against 3.5 s. The method is ADR-0018 §7's, and
+  the number is recorded for the same reason: an author choosing between a frame
+  and a typed table cannot otherwise know the frame is three times the app.
+- **Registering it eagerly is the cheap half**, measured on the same build:
+  the entry chunk goes 535,310 → 539,718 raw bytes (+0.8%), of which only
+  1,151 bytes are component code — the rest is catalog prose, which travels
+  eagerly for every component, lazy or not. No new eagerly-shipped package;
+  `architecture: what the shell reaches eagerly` is untouched. A lazy wrapper
+  would defer 1.15 kB while the 570 kB above stayed exactly where it is.
+- **`loading="lazy"` is close to inert here.** Measured in Chromium: a lazy
+  iframe defers nothing until roughly **4000px** below the fold, and the frame
+  on `/d/planificacion` sits at 325px, the two on `/catalog/c/SheetEmbed` at
+  1149px and 1883px — all three load with the page, and scrolling produces no
+  further request. The attribute is kept because it costs nothing and pays off
+  the day a frame lands at the foot of a long document, but no page should be
+  designed as though the sheet were deferred.
 - **Availability is Google's.** If Drive is down or the sheet is unshared, the
   rectangle shows Google's own page and nothing here can tell — cross-origin. The
   authoring guide's instruction is to look at the published page.

--- a/docs/decisions/0035-a-third-party-frame-is-a-content-source.md
+++ b/docs/decisions/0035-a-third-party-frame-is-a-content-source.md
@@ -1,0 +1,111 @@
+# ADR-0035: A third-party frame is a content source
+
+**Status:** Accepted
+**Date:** 2026-08-16
+
+## Context
+
+Two things the course must publish live in spreadsheets and change on their own
+schedule: the week-by-week plan (27 dated classes) and the grades. Both are the
+professor's working files, edited in Google Drive between classes.
+
+Until now every byte a reader sees came from this repository. A document is
+`.mdx` under `content/`, reviewed in a PR, compiled into the bundle
+(ADR-0003/0012); an image is an asset beside it (ADR-0029); even a runnable
+listing is authored here and merely _executed_ elsewhere. `security-notes.md`
+§"All bundled MDX is repo-controlled content" is written on that premise.
+
+A calendar typed by hand into MDX is wrong the first time a class moves, and a
+document that must be re-typed each term stops being true while still looking
+authoritative. The alternative the professor asked for, verbatim: _"solo sea un
+rectangulo donde se renderiza la planilla"_.
+
+This is also the repository's **first `<iframe>`**, and no CSP is declared, so
+the decision is not only "can we show a sheet" but "what is this site willing to
+embed at all".
+
+## Decision
+
+**1. A shared Google Sheet is a legitimate content source, framed read-only.**
+`<SheetEmbed src title height>` (family _media_) renders one. The professor edits
+the spreadsheet; the page follows with no commit and no deploy. That decoupling
+is the entire point, and it is a deliberate exception to "everything a reader
+sees is reviewed in a PR" — bounded to a rectangle whose contents this site never
+interprets.
+
+**2. The component does not read the data.** No CSV, no parser, no columns, no
+transformation, no search. Google renders the sheet; we frame it and say how
+tall. Tidying happens in the spreadsheet. This keeps the exception narrow: the
+site has no opinion about the data, so it cannot be wrong about it.
+
+**3. `/preview` is the embed url, and the component normalises to it.** Four
+forms were loaded in a real iframe against the course's own sheet on 2026-08-16:
+`/preview` works with nothing but "anyone with the link can view"; `/pubhtml` and
+`/htmlembed` work but first require publishing the sheet to the web; `/edit` is
+refused by Google's own `frame-ancestors`. Since `/edit` is exactly what the
+Compartir button hands an author, a pure module (`sheetUrl.ts`) rewrites the
+share link and keeps the `gid`, and refuses any other host with an authoring
+error. The failure it replaces is silent — a refused url frames a blank
+rectangle whose only trace is a console violation nobody sees.
+
+**4. The frame's permissions are measured, not inherited.**
+
+```
+sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
+referrerpolicy="no-referrer"
+```
+
+`allow-same-origin` is not granted: the sheet renders and scrolls both ways
+without it, so the frame stays in an opaque origin. The two popup tokens are one
+decision — the plan carries 14 `target="_blank"` links to the class decks, and
+neither half works alone. The evidence and the review triggers are in
+`docs/security-notes.md`.
+
+**5. `title` is a runtime contract**, enforced like `<Figure>`'s `alt`
+(ADR-0029). An iframe has no accessible name of its own, MDX is not typechecked,
+and the reader who needs the name is the one who cannot see that it is missing.
+
+**6. Height is a decision, capped on a slide.** An iframe has no content-driven
+height. The default is 480px; on a slide the frame is `min(height, 64vh)`, the
+same budget and the same reasoning as `<Mosaic>` — a slide is fit and uniformly
+scaled (ADR-0013 §5.1), so an oversized frame is not clipped, it shrinks the
+whole slide with its title.
+
+## Alternatives considered
+
+- **Fetch the sheet as CSV and render our own table.** Rejected by the professor
+  before it was built, and rightly: it would put this site in the business of
+  parsing someone else's file, break on every column the professor adds, and lose
+  the cell colouring that carries meaning in the real plan (holidays, recesses,
+  the two solemnes). It would also be the only design here that could show
+  something the sheet does not say.
+- **A build-time snapshot** (fetch at build, commit the result). Keeps everything
+  repo-controlled and keeps the CSP closed, but reintroduces exactly the failure
+  this WP exists to remove: the page is only as fresh as the last deploy, and a
+  class that moves on Tuesday is wrong until someone remembers.
+- **Publish the sheet to the web and use `/pubhtml`.** Works, and needs a second
+  setting the professor must not forget; `/preview` needs only the share setting
+  that must be right anyway.
+- **Type the calendar into MDX.** The status quo. It is the thing that is wrong
+  the first time a class moves.
+
+## Consequences
+
+- **A third origin the site depends on at render time**, joining the two in
+  `security-notes.md` §"Executing student code". Unlike those, it is not
+  integrity-checkable: it is a document, not a versioned bundle. A future CSP
+  must allow `docs.google.com` in `frame-src`.
+- **Availability is Google's.** If Drive is down or the sheet is unshared, the
+  rectangle shows Google's own page and nothing here can tell — cross-origin. The
+  authoring guide's instruction is to look at the published page.
+- **The exception is narrow but real**: `security-notes.md` §"All bundled MDX is
+  repo-controlled content" still holds for MDX, and now has a neighbour that does
+  not. What a `<SheetEmbed>` shows is outside PR review by construction.
+- **The next use is the grades**, and it is not free. Framing a grades sheet puts
+  student names and marks on a public page behind an unguessable URL. That fires
+  the review trigger already written for student data; the component does not
+  decide it, the share setting does.
+- **No `overflow-x-auto` on the wrapper**, which reads as an ADR-0013 §5.2
+  oversight and is not: the sheet's scroller is inside another document, so the
+  deck never sees the touch. Measured on a phone in landscape — dragging inside
+  the frame left `?slide` untouched, dragging beside it moved a slide.

--- a/docs/decisions/0035-a-third-party-frame-is-a-content-source.md
+++ b/docs/decisions/0035-a-third-party-frame-is-a-content-source.md
@@ -2,6 +2,16 @@
 
 **Status:** Accepted
 **Date:** 2026-08-16
+**Decision-makers:** Miguel Rodriguez
+**Source:** Issue #146. Extends ADR-0010 (component contract) and ADR-0029 (the
+media family); applies ADR-0013 §5.1 (a slide is fit, not reflowed) and ADR-0022
+(the reading measure); measured with ADR-0018 §7's method, whose lazy-wrapper
+rule it does not fire. **Qualifies** the premise in `docs/security-notes.md`
+§"All bundled MDX is repo-controlled content": what a `<SheetEmbed>` shows is
+the first thing a reader sees that this repository never reviewed.
+Numbered 0035 rather than 0033 to clear the unmerged `0033-*` held by the
+branches of #147 and #149, which this branch cannot see — renumber at merge if
+either lands elsewhere.
 
 ## Context
 
@@ -40,12 +50,22 @@ site has no opinion about the data, so it cannot be wrong about it.
 
 **3. `/preview` is the embed url, and the component normalises to it.** Four
 forms were loaded in a real iframe against the course's own sheet on 2026-08-16:
-`/preview` works with nothing but "anyone with the link can view"; `/pubhtml` and
-`/htmlembed` work but first require publishing the sheet to the web; `/edit` is
-refused by Google's own `frame-ancestors`. Since `/edit` is exactly what the
+`/preview` works with nothing but "anyone with the link can view"; `/pubhtml`
+requires publishing the sheet to the web (401 without it); `/htmlembed` works on
+a merely link-shared sheet but shows no tab bar and no chrome; and `/edit` is
+the one to avoid — **not because Google blocks it**, which was the first
+explanation here and is wrong (it sends neither `frame-ancestors` nor
+`X-Frame-Options`, checked with `curl -sI`), but because framed under this
+component's sandbox, without `allow-same-origin`, the editor's own requests fail
+and it paints the grid behind a "Se ha producido un error" dialog with the
+editing chrome visible. Since `/edit` is exactly what the
 Compartir button hands an author, a pure module (`sheetUrl.ts`) rewrites the
-share link and keeps the `gid`, and refuses any other host with an authoring
-error. The failure it replaces is silent — a refused url frames a blank
+share link and keeps the `gid` — that last part **unverified**, since the
+course's own sheet has one tab and nothing has distinguished a working tab
+selector from an ignored one — and refuses any other host with an authoring
+error. It also refuses the *published* form, `/spreadsheets/d/e/<token>/pubhtml`,
+which is a different identifier that the first pattern accepted and turned into
+a framed 404 (#146 review). The failure it replaces is silent — a refused url frames a blank
 rectangle whose only trace is a console violation nobody sees.
 
 **4. The frame's permissions are measured, not inherited.**
@@ -124,11 +144,22 @@ whole slide with its title.
 - **The exception is narrow but real**: `security-notes.md` §"All bundled MDX is
   repo-controlled content" still holds for MDX, and now has a neighbour that does
   not. What a `<SheetEmbed>` shows is outside PR review by construction.
-- **The next use is the grades**, and it is not free. Framing a grades sheet puts
-  student names and marks on a public page behind an unguessable URL. That fires
-  the review trigger already written for student data; the component does not
-  decide it, the share setting does.
+- **The obvious next use is the grades, and it is blocked.** Framing a grades
+  sheet puts student names and marks — personal data under Ley 21.719 — on a
+  public page behind an unguessable URL, and there is no student login to put in
+  front of it: ADR-0009 is professor-only and no student accounts are planned.
+  The disposition until a student-identity decision exists is not to ship that
+  data through this component at all. The component does not enforce it; the
+  guide, the catalog entry and `security-notes.md` all say it.
 - **No `overflow-x-auto` on the wrapper**, which reads as an ADR-0013 §5.2
   oversight and is not: the sheet's scroller is inside another document, so the
   deck never sees the touch. Measured on a phone in landscape — dragging inside
   the frame left `?slide` untouched, dragging beside it moved a slide.
+- **§6's slide cap ships with no real-content user.** The one document that
+  carries a `<SheetEmbed>` is `04-planificacion.mdx`, which is `presentation:
+  none` — it is `presentationRoute.test.tsx`'s no-deck fixture (ADR-0025), so
+  the course calendar cannot be projected at all. The cap was measured on a
+  throwaway document and is exercised today only by unit tests and
+  `/catalog/c/SheetEmbed`. Worth knowing before trusting it in a class: the
+  first deck that wants a sheet moves that fixture first, and should re-measure
+  on the real projector rather than inherit these numbers.

--- a/docs/security-notes.md
+++ b/docs/security-notes.md
@@ -93,7 +93,9 @@ referrerpolicy="no-referrer"
   reader never sees. With the first but not the second, the deck opens and Google
   Slides then fails with "Se produjo un error" — the new tab inherits this
   sandbox and loses its own origin. Both halves were reproduced; neither works
-  alone, which is why removing either one later is a regression no test can see.
+  alone. `SheetEmbed.test.tsx` pins both tokens, so removing one goes red — what
+  no test can see is the CONSEQUENCE, which is why any change to this string is
+  re-measured in a real browser against a sheet carrying `target="_blank"` links.
 
   **State the capability, not only the symptom**: what the pair buys the frame is
   an unsandboxed new tab **at a URL the SHEET chooses** — outside `MdxLink`'s
@@ -371,6 +373,15 @@ Decisions: ADR-0019 §3b/§7, ADR-0020 §6, ADR-0028 §6/§7.
   `pull_request` with `contents: read` and no secrets in the web job.
 - **Why currently safe**: content ships exclusively via git + PR review; there is
   no runtime ingestion, no user-contributed documents, no CMS.
+- **Since #146, this is a claim about MDX only, and it needs saying.** A
+  `<SheetEmbed>` renders a document this repository never sees — the trigger
+  below was considered and deliberately not fired, because a cross-origin frame
+  is not what that trigger is about: it compiles nothing, reaches no build seam,
+  and cannot inject into the MDX or KaTeX pipelines above. What it does instead
+  is put content on the page that no PR reviewed, which is its own decision with
+  its own record and its own triggers — §"The site frames a third party, and the
+  sheet decides what it exposes", and ADR-0035, which qualifies this section by
+  name. The two must stay reachable from each other.
 - **Review trigger**: the moment ANY non-repo-authored content path appears —
   v0.2 authoring-agent output that bypasses PR review, a future in-platform
   editor (vision phase C), or user-submitted material. At that point the MDX

--- a/docs/security-notes.md
+++ b/docs/security-notes.md
@@ -94,10 +94,34 @@ referrerpolicy="no-referrer"
   Slides then fails with "Se produjo un error" — the new tab inherits this
   sandbox and loses its own origin. Both halves were reproduced; neither works
   alone, which is why removing either one later is a regression no test can see.
+
+  **State the capability, not only the symptom**: what the pair buys the frame is
+  an unsandboxed new tab **at a URL the SHEET chooses** — outside `MdxLink`'s
+  scheme allowlist, which every other link in this repo goes through, and outside
+  PR review. It buys nothing against this origin (no `allow-same-origin`, no
+  `allow-top-navigation`, no `allow` attribute, so Permissions-Policy's `self`
+  default denies the frame every powerful feature): it is a link-to-anywhere
+  primitive, not an origin compromise. The narrower option exists and was not
+  taken, and it is editorial rather than attribute-level — **the 14 deck links
+  could live in the MDX**, governed and reviewed, leaving the sheet to carry only
+  the calendar, and then neither popup token is needed. That is a content
+  decision this record owns, not a browser constraint.
 - **`allow-same-origin` is deliberately NOT granted.** The sheet renders and
-  scrolls both ways without it, so the frame runs in an opaque origin and cannot
-  reach the Google session of the person reading. Verified rather than assumed:
-  all four sandbox combinations rendered the sheet identically.
+  scrolls both ways without it, so the frame's document runs in an opaque origin
+  and cannot **script** Google's. Verified rather than assumed: all four sandbox
+  combinations rendered the sheet identically.
+
+  **This is not the same as "no Google session is involved".** The sandbox flag
+  governs the origin of the resulting document, never the cookie jar of the
+  request that fetched it: the frame carries no `credentialless` attribute, so
+  loading `/preview` is an ordinary credentialed cross-site request and a
+  signed-in reader is identified to Google as a viewer of this sheet — which
+  names the course, whatever `referrerpolicy` withholds about the page.
+  Accepted, in the same spirit as the CheerpJ and jsDelivr origins below and for
+  the same reason: the alternative is not publishing the plan. `credentialless`
+  would load the frame in an anonymous store and is worth measuring **before**
+  adopting — a link-shared sheet may or may not still render — but it is not free
+  and was not measured here.
 - **`allow-top-navigation` and `allow-forms` are not granted**, and nothing
   read-only needs them. The frame cannot navigate the page around it.
 - **`referrerpolicy="no-referrer"`** costs nothing measurable and stops Google
@@ -126,16 +150,32 @@ it:
   the rectangle.** That is cross-origin: nothing here can detect it, no test
   fails, and the document looks merely odd. The authoring guide says to look at
   the page.
+- **The opposite mistake has no page to look at.** Everything above, and every
+  instruction in the guide, is phrased in the read direction — "share it as
+  _cualquiera con el enlace puede ver_". One position further down that same
+  dropdown is _puede editar_, which is a plausible slip on a sheet a colleague
+  is meant to fill in, and it publishes an **anonymously writable surface as
+  part of a course page**. It is not passive: `/preview` is a read-only render
+  surface and shows no editing chrome, so a reader has to take the frame's `src`
+  and swap `/preview` for `/edit` — a deliberate act, and a trivial one for a
+  CS student. Nothing here detects it, in either direction.
 - **The grades sheet is the case this record exists ahead of.** Publishing one
-  through this component would put student names and marks on a public page
-  behind nothing but an unguessable URL — exactly the material §"Everything under
+  through this component would put student names and marks — **personal data
+  under Ley 21.719**, the same classification §"The control worker is
+  unauthenticated" gives RUTs and grades — on a public page behind nothing but
+  an unguessable URL. That is exactly the material §"Everything under
   content/courses/ is published" reserves its review trigger for. Nothing about
-  `<SheetEmbed>` decides that; the share setting on the sheet does, and that is
-  outside this repo's review.
+  `<SheetEmbed>` decides it; the share setting on the sheet does, and that is
+  outside this repo's review. A link-shared sheet also has no expiry and no
+  deletion path once the link has travelled.
 
-**Review trigger**: the first sheet carrying student identifiers or marks — at
-which point the question is not this component but whether the data belongs
-behind the v0.3 auth (ADR-0009) instead of behind a link. Also: the first
+**Review trigger**: the first sheet carrying student identifiers or marks. **The
+remedy does not exist yet, and that is the point of the trigger** — do not read
+it as "put it behind the v0.3 auth". ADR-0009 is *professor-only*: "Only
+professor logins exist… students remain anonymous spectators… no accounts", and
+`docs/design/2026-08-controles.md` repeats that none are planned. So there is no
+gate a student could pass, and the disposition until a student-identity decision
+exists is **not to ship grades through this component at all**. Also: the first
 `<SheetEmbed>` pointed at a host other than `docs.google.com`, which the
 component refuses today and which would reopen every line above.
 

--- a/docs/security-notes.md
+++ b/docs/security-notes.md
@@ -72,6 +72,73 @@ Either one means the bank stops being study material, and neither C1 nor this
 record survives it — park that material outside `content/`, since omitting it
 from the index is not a control.
 
+### The site frames a third party, and the sheet decides what it exposes (accepted 2026-08-16, #146)
+
+`<SheetEmbed>` is **the repo's first `<iframe>`**. It puts a document served by
+`docs.google.com` inside a Nalanda page, so what that frame is allowed to do is
+a decision rather than a default inherited by omission.
+
+**What it is allowed**, each token loaded in a real browser against the course's
+own plan before it was granted:
+
+```
+sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
+referrerpolicy="no-referrer"
+```
+
+- **`allow-scripts`** renders the grid; without it the rectangle is empty.
+- **`allow-popups` and `allow-popups-to-escape-sandbox` are one decision, not
+  two.** The plan carries 14 `target="_blank"` links to the class decks. Without
+  the first, the click is swallowed and the only trace is a console error the
+  reader never sees. With the first but not the second, the deck opens and Google
+  Slides then fails with "Se produjo un error" — the new tab inherits this
+  sandbox and loses its own origin. Both halves were reproduced; neither works
+  alone, which is why removing either one later is a regression no test can see.
+- **`allow-same-origin` is deliberately NOT granted.** The sheet renders and
+  scrolls both ways without it, so the frame runs in an opaque origin and cannot
+  reach the Google session of the person reading. Verified rather than assumed:
+  all four sandbox combinations rendered the sheet identically.
+- **`allow-top-navigation` and `allow-forms` are not granted**, and nothing
+  read-only needs them. The frame cannot navigate the page around it.
+- **`referrerpolicy="no-referrer"`** costs nothing measurable and stops Google
+  being told which class page a reader was on.
+
+**Why the frame is not, in itself, a new exposure.** A sheet shared as "anyone
+with the link can view" is readable by anyone holding the link whether or not
+this site frames it; framing changes who is likely to find it, not who is able
+to. The frame is cross-origin, so it cannot read this site's DOM or its
+`localStorage` (where drafts live — see below), and with `allow-same-origin`
+absent it cannot read its own either.
+
+**What is genuinely new**: a third origin the site depends on at render time,
+alongside the two recorded under "Executing student code". Unlike those, this one
+is not integrity-checkable at all — it is a document, not a versioned bundle, and
+its content is whatever the spreadsheet says today. A future CSP must allow
+`docs.google.com` in **`frame-src`**; not in `script-src`, because nothing from
+Google runs in our origin.
+
+**The sheet decides what it exposes, and that decision is not in this
+repository.** Which columns a sheet carries is the professor's call, made in
+Google Drive. Two consequences, stated before the second use rather than after
+it:
+
+- **A sheet that is not shared renders Google's own request-access page inside
+  the rectangle.** That is cross-origin: nothing here can detect it, no test
+  fails, and the document looks merely odd. The authoring guide says to look at
+  the page.
+- **The grades sheet is the case this record exists ahead of.** Publishing one
+  through this component would put student names and marks on a public page
+  behind nothing but an unguessable URL — exactly the material §"Everything under
+  content/courses/ is published" reserves its review trigger for. Nothing about
+  `<SheetEmbed>` decides that; the share setting on the sheet does, and that is
+  outside this repo's review.
+
+**Review trigger**: the first sheet carrying student identifiers or marks — at
+which point the question is not this component but whether the data belongs
+behind the v0.3 auth (ADR-0009) instead of behind a link. Also: the first
+`<SheetEmbed>` pointed at a host other than `docs.google.com`, which the
+component refuses today and which would reopen every line above.
+
 ### Drafts live on an origin shared with every other repo of the account (accepted 2026-08-13, #85)
 
 `localStorage` keys under `nalanda:draft:*` hold what a student had in an editor

--- a/docs/standards/design-system.md
+++ b/docs/standards/design-system.md
@@ -104,6 +104,29 @@ theme and is never a reading surface. `architecture.test.ts` cannot see it —
 it greps our class names, not vendor CSS or inline styles — so this note is
 the only guard.
 
+**A whole document we do not paint is the third exemption** (#146, ADR-0035).
+`<SheetEmbed>` frames a Google spreadsheet, and Google paints it white in every
+theme — there is no token to give it, no `currentColor` to inherit, and no way
+to ask: it is another origin's document, not an asset of ours. So on the dark
+theme a course page carries a white block, and that is accepted rather than
+worked around: the sheet's own cell colours (holidays, recess, the two solemnes)
+are the information, and they are designed for white.
+
+What IS ours around it, and what it pairs with:
+
+- `bg-sunk` on the wrapper — the placeholder's ground, the worst-case surface
+  the tokens are measured against, so `text-ink-faint` on it is already held to
+  4.5:1 by §The one rule. It is visible only until the frame paints.
+- `border-rule` on the frame — decorative, separating a white block from the
+  page rather than carrying information, so it has no contrast floor.
+- Nothing of ours is ever painted **on** the white: the frame's inside belongs
+  entirely to Google.
+
+Unlike `plate`, this one is not guarded by anything at all. `palette.test.ts`
+pins token values and `architecture.test.ts` greps our class names; neither can
+see a cross-origin document, and no test can. This note is the guard, and the
+check is to look at `/d/planificacion` in the dark theme.
+
 ## Verifying a colour change
 
 `getComputedStyle` returning the right value **is not evidence**. It reports what

--- a/docs/standards/frontend-code-style.md
+++ b/docs/standards/frontend-code-style.md
@@ -208,6 +208,19 @@ src/
   descriptive errors over `!` non-null assertions at DOM/external boundaries
   (see `app/main.tsx` root check); user-facing failures render friendly UI,
   never a blank screen.
+- **A url reaching a trusted sink is REBUILT, never passed through.** When an
+  author-written string ends up in an `<iframe src>` (or a future `<script
+  src>`), validate it, take only the captures you need, and construct the url
+  from a **literal** scheme and host. Matching and then forwarding the original
+  is the shape that fails: the host is the whole of what is being trusted, so a
+  pattern anchored on the path alone accepts
+  `https://evil.example/spreadsheets/d/…`. Rebuilding also makes the pattern's
+  tail harmless, which is why it may be loose. Worked case:
+  `components/media/sheetUrl.ts` (#146, ADR-0035) — 26 hostile inputs
+  (userinfo `@`, backslashes, `\t\n\r`, NUL, zero-width and ideographic spaces,
+  U+2024 in the host, trailing dot, explicit `:443`) all produced either `null`
+  or a url on `docs.google.com`, because none of the input survives into the
+  output except a `[\w-]+` id and a `\d+` tab.
 
 ## Styling
 

--- a/docs/standards/guides/add-a-content-component.md
+++ b/docs/standards/guides/add-a-content-component.md
@@ -49,7 +49,7 @@ apps/web/src/components/structure/
    (presentation seam); if a parser must recognize it, declare metadata with
    `withMeta` (`lib/componentMeta.ts`) — never expect identity imports.
 
-   Seven seams worth knowing before writing your own:
+   Eight seams worth knowing before writing your own:
 
    - **Labelled code fences.** A component whose children carry code the author
      marks — ` ```java starter ` — reads them with `fencesByMeta` /
@@ -81,6 +81,16 @@ apps/web/src/components/structure/
      on a phone; conversely a full-bleed scrollable component leaves the reader
      no swipe target on that slide. Give it `overflow-x-auto`, and check it on
      a touch context.
+
+     **One exception, and it is about ownership rather than styling**: a
+     scroller that lives inside ANOTHER document — a cross-origin `<iframe>` —
+     is unreachable by `swipe.ts`, which walks from the event target up to the
+     stage **within this DOM**. The deck never receives the touch at all, so no
+     `overflow-x-auto` is wanted and adding one would build a scroller of our
+     own around the frame. Measured, not reasoned: on a phone in landscape,
+     same slide and same gesture, dragging inside the frame left `?slide`
+     untouched while dragging beside it moved a slide. Worked case:
+     `<SheetEmbed>` (#146, ADR-0035 §Consequences).
 
      **A component that renders anything wide MUST carry one of the two**, or it
      is silently centred at 624px in documents. The rule is unlayered, so a
@@ -114,6 +124,15 @@ apps/web/src/components/structure/
      `<Mosaic>` × `<Figure>` (#119, ADR-0029) — nine logos read as one sentence
      rather than nine brand names, and `Figure`'s "alt is required" rule keeps its
      single exception where the description already is.
+   - **Drawing something tall on a slide.** A slide is fit and uniformly scaled,
+     never clipped (ADR-0013 §5.1), so a block that asks for more height than
+     the stage has does not get cut off — it shrinks the WHOLE slide, the title
+     with it. Cap against `SLIDE_BUDGET_VH` (`components/slideBudget.ts`), never
+     a private copy of the number: the two current users each declared it
+     privately and each claimed in a comment to be using "the same budget" as
+     the other, which nothing checked (#146 review). Worked cases: `<Mosaic>`
+     splits it across rows, `<SheetEmbed>` clamps its frame to
+     `min(height, SLIDE_BUDGET_VH vh)`.
    - **Inside `interactive/`**, reuse `Panel` (a labelled output strip),
      `useRunShortcut` (Ctrl/Cmd + Enter), `useLoadedRuntime` (loads a runtime
      module and hands back a bound `run`, `warm`, `queued`, `ready` and the
@@ -200,6 +219,12 @@ payload from 1 chunk to 9 with every name-based guard green).
 - [ ] Wide output carries `.not-prose` or `.measure-full`, checked in the book
       view of a real document (`npm run build && npm run preview`), not only in
       `/catalog` — which does not apply the reading measure.
+- [ ] If it draws something tall on a slide: capped against `SLIDE_BUDGET_VH`
+      (`components/slideBudget.ts`), not a number of its own.
+- [ ] If it embeds another origin: verified in a real browser per
+      `testing-strategy.md` §Conventions, third class — the frame paints, each
+      permission re-measured, network weight from a cold profile, and a sideways
+      drag on a touch context. No test at any level can see any of it.
 - [ ] If it carries a heavy dependency: lazy wrapper registered instead of the
       component, catalog entry importing the wrapper, its own L4 case copied in
       `src/architecture.test.ts`, entry chunk unchanged in `npm run build`.

--- a/docs/standards/guides/add-a-course-document.md
+++ b/docs/standards/guides/add-a-course-document.md
@@ -571,6 +571,17 @@ values that clear 3:1 on both the light and the dark ground — or, in a
 container supplies) and **never let colour be the only signal** — the cost curves are one solid line and one
 dashed for exactly that reason (ADR-0026).
 
+6f. **An authoring error does not fail the build**, on purpose: writing the
+slides before drawing the diagrams is a real order of work, and gating the
+build would take the dev server with it. A missing image, a `<Figure>` with no
+alt, a `<Split>` given other than two blocks, a `<Mosaic>` with no `columns`, a
+`<SheetEmbed>` with no `title` or pointed at something that is not a sheet —
+each renders a visible box naming what is wrong, and **`npm run test` fails
+until none of them survives** (`app/contentRenders.test.tsx` renders every
+document in the registry). So an authoring error cannot be published, only
+drafted. Same shape as a wiki-link (ADR-0002); decided in
+ADR-0029.
+
 6g. **Publish a spreadsheet instead of typing it out**: `<SheetEmbed>` frames a
 shared Google Sheet inside the page, read-only. You edit the spreadsheet and the
 page follows — **no commit and no deploy**. Use it for what changes on its own
@@ -585,17 +596,28 @@ schedule and already lives in a sheet: the week-by-week plan, the grades.
 
 **Paste the link the Compartir button gives you** — the component rewrites it
 into the embeddable form itself, keeping the `gid` when your link points at one
-tab of several. It refuses anything that is not a `docs.google.com` spreadsheet
-url with an authoring error, which is the failure worth catching: Google's own
-`frame-ancestors` blocks the `/edit` url, so a hand-written one would publish a
-blank rectangle and say nothing.
+tab of several. The url out of the address bar works too, including the
+`/spreadsheets/u/0/d/…` shape you get when you are signed into more than one
+Google account. Anything else is an authoring error, which is the failure worth
+catching: Google's own `frame-ancestors` blocks the `/edit` url, so a
+hand-written one would publish a blank rectangle and say nothing.
+
+**Not the "Publicar en la web" link.** That dialog hands out
+`/spreadsheets/d/e/<token>/pubhtml`, which looks close enough to be tempting and
+is a different document identifier entirely — it is refused, deliberately and
+loudly. Before it was, it produced a framed Google "el archivo que solicitaste
+no existe" with every test green (#146 review).
 
 **Share the sheet as "cualquiera con el enlace puede ver" before you publish the
-document.** A sheet that is not shared renders Google's own request-access page
-inside the rectangle, and that is cross-origin — nothing here can detect it and
-no test will fail. **Look at the page.** Equally: anyone who can read the page
-can read the sheet, so what a sheet carries is a decision you make in the
-spreadsheet, not here (`docs/security-notes.md`).
+document — _ver_, never _editar_.** A sheet that is not shared renders Google's
+own request-access page inside the rectangle, and that is cross-origin: nothing
+here can detect it and no test will fail, so **look at the page**. The mistake
+in the other direction has no page to look at — an editable share puts a
+surface anyone can write on inside a public course page, and nothing here
+detects that either. Anyone who can read the page can read the sheet, so what a
+sheet carries is a decision you make in the spreadsheet, not here
+(`docs/security-notes.md`). **Grades are not a case for this component today**:
+there is no student login to hide them behind, and the record says why.
 
 **`title` is required, in Spanish, and the component enforces it**, the same way
 `<Figure>` enforces `alt`. An iframe has no accessible name of its own, so a
@@ -617,6 +639,17 @@ are in the file.
   sheet and does **not** change the slide — measured — because that scroller
   lives inside Google's document, where the deck's swipe never reaches.
 
+**It is the most expensive thing on the page, by a wide margin.** Measured on
+`/d/planificacion` at 1440×900, cold: one frame adds **10 requests and ~570 kB**
+to a page that weighed 190 kB without it — and ~490 kB of that is a single
+Google stylesheet, **2.9× the whole application's entry chunk**. Google caches
+its static assets for a year, so a return visit costs ~34 kB; the price is the
+first visit, and on a slow connection (~1.6 Mbps) the last byte lands at ~6 s
+instead of ~3.5 s. Nothing here is fixable from this repo — it is Google's app.
+Worth knowing when you are choosing between a frame and a table: a calendar
+that is genuinely static is cheaper typed out. This one is not, which is the
+whole reason the component exists.
+
 **`height` is a decision, not a fallback** (default 480px, about nine rows of
 the course plan): an iframe has no content-driven height. Give it more for a
 long sheet in the book. On a slide it is capped at 64vh whatever you write,
@@ -624,17 +657,6 @@ because a slide is _fit and scaled_ rather than clipped (ADR-0013 §5.1) — an
 oversized frame does not get cut off, it shrinks the whole slide, your title
 with it. Measured at 1024×768: the default draws at its full 480px and the slide
 is not scaled at all.
-
-6f. **An authoring error does not fail the build**, on purpose: writing the
-slides before drawing the diagrams is a real order of work, and gating the
-build would take the dev server with it. A missing image, a `<Figure>` with no
-alt, a `<Split>` given other than two blocks, a `<Mosaic>` with no `columns`, a
-`<SheetEmbed>` with no `title` or pointed at something that is not a sheet —
-each renders a visible box naming what is wrong, and **`npm run test` fails
-until none of them survives** (`app/contentRenders.test.tsx` renders every
-document in the registry). So an authoring error cannot be published, only
-drafted. Same shape as a wiki-link (ADR-0002); decided in
-ADR-0029.
 
 7. **Cross-reference with wiki-links**: `[[otro-id]]` renders that document's
    link, `[[otro-id|texto visible]]` overrides the label. A target that doesn't

--- a/docs/standards/guides/add-a-course-document.md
+++ b/docs/standards/guides/add-a-course-document.md
@@ -478,7 +478,8 @@ build on the `@` (`Unexpected character '@' (U+0040) in member name`). GFM
 autolinks the bare address anyway, so the angle brackets buy nothing and cost
 a red build — hit while writing `01-bienvenida.mdx` (#120).
 
-6. **Show a picture (optional)**: the asset lives **beside the `.mdx` that uses
+6. **Show a picture, or embed a live document (optional)** — pictures in 6a–6f,
+   a spreadsheet in **6g**: the asset lives **beside the `.mdx` that uses
    it**, addressed relatively, and a subfolder is fine when there are several
    (`./logos/java.svg`). Both syntaxes work and get the same
    pipeline: markdown `![alt](./curva.svg)` for a picture that just needs to be
@@ -585,7 +586,10 @@ ADR-0029.
 6g. **Publish a spreadsheet instead of typing it out**: `<SheetEmbed>` frames a
 shared Google Sheet inside the page, read-only. You edit the spreadsheet and the
 page follows — **no commit and no deploy**. Use it for what changes on its own
-schedule and already lives in a sheet: the week-by-week plan, the grades.
+schedule and already lives in a sheet — today that is the week-by-week plan.
+**Not the grades**, and not anything else carrying student identifiers: a
+link-shared sheet is public and there is no student login to put in front of it.
+The reasoning is in `docs/security-notes.md` §"The site frames a third party".
 
 ```mdx
 <SheetEmbed
@@ -596,11 +600,17 @@ schedule and already lives in a sheet: the week-by-week plan, the grades.
 
 **Paste the link the Compartir button gives you** — the component rewrites it
 into the embeddable form itself, keeping the `gid` when your link points at one
-tab of several. The url out of the address bar works too, including the
+tab of several — **that last part is unverified** (`sheetUrl.ts`: the course's
+sheet has one tab, so nothing has yet distinguished a working tab selector from
+an ignored one). If you link one tab of several, open the published page and
+check the right tab is showing. The url out of the address bar works too,
+including the
 `/spreadsheets/u/0/d/…` shape you get when you are signed into more than one
 Google account. Anything else is an authoring error, which is the failure worth
-catching: Google's own `frame-ancestors` blocks the `/edit` url, so a
-hand-written one would publish a blank rectangle and say nothing.
+catching: a hand-written `/edit` url is not blocked by Google — it frames
+happily — it just publishes Google's **editor**, whose own requests fail inside
+the frame, so the reader gets the grid behind a "Se ha producido un error"
+dialog. The rewrite is what avoids that.
 
 **Not the "Publicar en la web" link.** That dialog hands out
 `/spreadsheets/d/e/<token>/pubhtml`, which looks close enough to be tempting and
@@ -842,6 +852,14 @@ is not scaled at all.
 - [ ] Every exercise opened in `npm run preview` and actually run: no authoring
       banner, cases pass against a correct solution and fail against the starter.
       Nothing in the build or the suite can check this for you.
+- [ ] Every `<SheetEmbed>` opened at `/nalanda/d/<id>` under
+      `npm run build && npm run preview`, and **looked at**: the grid is on
+      screen — not Google's request-access page, not a rectangle stuck on
+      "Cargando la planilla…", not the wrong tab. Then check in Drive that the
+      sheet is shared as _cualquiera con el enlace puede **ver**_ and not
+      _editar_. All of it is cross-origin: no level of the suite and no part of
+      the build can see any of it, and a wrong share setting in either direction
+      publishes silently.
 - [ ] Anything on a slide looked at in presentation mode, not only in the book.
 - [ ] `npm run test` green — `app/contentRenders.test.tsx` renders every document
       and fails on any authoring error the build cannot see (a missing alt, a

--- a/docs/standards/guides/add-a-course-document.md
+++ b/docs/standards/guides/add-a-course-document.md
@@ -29,7 +29,7 @@ content/courses/sample-course/
 ├── viajante.svg
 ├── logos/                     # …in a subfolder once there are several
 │   └── google.svg, java.svg, … (22, with a README recording provenance)
-├── 04-planificacion.mdx       # presentation: none     — book-only
+├── 04-planificacion.mdx       # presentation: none     — book-only; <SheetEmbed> around the live plan
 ├── 06-java-desde-cpp.mdx      # presentation: explicit — uses <SideBySide>, plus a markdown ##
 ├── 07-java-tipos-y-flujo.mdx  # presentation: explicit — uses <Exercise> + <CodeEditor>, plus two markdown ##
 └── index.yaml                 # the ordered teaching path
@@ -571,10 +571,65 @@ values that clear 3:1 on both the light and the dark ground — or, in a
 container supplies) and **never let colour be the only signal** — the cost curves are one solid line and one
 dashed for exactly that reason (ADR-0026).
 
+6g. **Publish a spreadsheet instead of typing it out**: `<SheetEmbed>` frames a
+shared Google Sheet inside the page, read-only. You edit the spreadsheet and the
+page follows — **no commit and no deploy**. Use it for what changes on its own
+schedule and already lives in a sheet: the week-by-week plan, the grades.
+
+```mdx
+<SheetEmbed
+  src="https://docs.google.com/spreadsheets/d/1_cxMU.../edit?usp=sharing"
+  title="Planificación del semestre"
+/>
+```
+
+**Paste the link the Compartir button gives you** — the component rewrites it
+into the embeddable form itself, keeping the `gid` when your link points at one
+tab of several. It refuses anything that is not a `docs.google.com` spreadsheet
+url with an authoring error, which is the failure worth catching: Google's own
+`frame-ancestors` blocks the `/edit` url, so a hand-written one would publish a
+blank rectangle and say nothing.
+
+**Share the sheet as "cualquiera con el enlace puede ver" before you publish the
+document.** A sheet that is not shared renders Google's own request-access page
+inside the rectangle, and that is cross-origin — nothing here can detect it and
+no test will fail. **Look at the page.** Equally: anyone who can read the page
+can read the sheet, so what a sheet carries is a decision you make in the
+spreadsheet, not here (`docs/security-notes.md`).
+
+**`title` is required, in Spanish, and the component enforces it**, the same way
+`<Figure>` enforces `alt`. An iframe has no accessible name of its own, so a
+frame without one is announced as an unnamed region a screen-reader user cannot
+identify or skip past.
+
+**It shows the sheet exactly as Google renders it** — cell colours, merged
+cells, the tab bar. It reads nothing and transforms nothing, so **tidying
+happens in the spreadsheet**, before the document ships: interleaved empty
+columns and a stray block off to the right will be on the page exactly as they
+are in the file.
+
+**Two things about the rectangle**, both accepted rather than worked around:
+
+- **It paints its own white ground**, so in the dark theme it is a white block
+  on the page. The sheet's own cell colours are the information, and they are
+  designed for white.
+- **On a phone it shows a few columns and scrolls.** Dragging inside it pans the
+  sheet and does **not** change the slide — measured — because that scroller
+  lives inside Google's document, where the deck's swipe never reaches.
+
+**`height` is a decision, not a fallback** (default 480px, about nine rows of
+the course plan): an iframe has no content-driven height. Give it more for a
+long sheet in the book. On a slide it is capped at 64vh whatever you write,
+because a slide is _fit and scaled_ rather than clipped (ADR-0013 §5.1) — an
+oversized frame does not get cut off, it shrinks the whole slide, your title
+with it. Measured at 1024×768: the default draws at its full 480px and the slide
+is not scaled at all.
+
 6f. **An authoring error does not fail the build**, on purpose: writing the
 slides before drawing the diagrams is a real order of work, and gating the
 build would take the dev server with it. A missing image, a `<Figure>` with no
-alt, a `<Split>` given other than two blocks, a `<Mosaic>` with no `columns` —
+alt, a `<Split>` given other than two blocks, a `<Mosaic>` with no `columns`, a
+`<SheetEmbed>` with no `title` or pointed at something that is not a sheet —
 each renders a visible box naming what is wrong, and **`npm run test` fails
 until none of them survives** (`app/contentRenders.test.tsx` renders every
 document in the registry). So an authoring error cannot be published, only

--- a/docs/standards/testing-strategy.md
+++ b/docs/standards/testing-strategy.md
@@ -290,6 +290,29 @@ npm run preview` — run, stdin, and a deliberate compile error — per
   the toggle behind the drawer; and the first fix for it, a visibility filter on
   `offsetParent`, which under jsdom matched _nothing_, emptied the trap's list
   and made its own tests pass while proving nothing.
+- **A document from a third origin is invisible to everything**, and this is a
+  third class, added in #146 when the repo grew its first `<iframe>`. jsdom has
+  no network and never loads a frame, so the suite can pin the attribute
+  **string** and nothing about its effect; and unlike the two classes above, a
+  browser does not close the gap either, because Playwright cannot query across
+  the origin — it can see that a frame is there, not what it says. So a sheet
+  that stopped being shared, a url the vendor refuses, an outage, and the
+  content itself all pass a fully green suite AND a DOM-level browser check.
+  **The evidence is the pixels and the network log**, which is why the browser
+  pass for this class is a screenshot somebody looks at plus a request/byte
+  count from a cold profile.
+
+  What must be re-measured whenever such a component changes, all four earned in
+  #146 (ADR-0035) and none of them visible to any test: that the frame paints at
+  all; what each `sandbox` token actually permits — `allow-popups` without
+  `allow-popups-to-escape-sandbox` opened a link and broke the page it opened,
+  and both spellings pass every assertion; the network weight, since one frame
+  cost ~570kB against a 190kB page; and whether `loading="lazy"` defers
+  anything, since on an iframe it defers nothing until roughly 4000px below the
+  fold. A fifth, if the component can appear on a slide: a real touch drag
+  inside the frame, because the deck's swipe rule (ADR-0013 §5.2) is written
+  about scrollers in **this** document and a cross-origin one is invisible to it.
+
 - **A media query is the sharpest case of it**: the suite can pin **which
   question is asked** and fake the answer, never evaluate it, so what is
   asserted is the query string plus the behaviour that follows from a faked


### PR DESCRIPTION
**Closes #146**

## Summary

The course had two things to publish that live in spreadsheets and change on
their own schedule: the week-by-week plan, and later the grades. A table typed
into MDX is wrong the first time a class moves.

`<SheetEmbed src title height>` frames a shared Google Sheet read-only. The
professor edits the spreadsheet; the page follows, **with no commit and no
deploy**. It reads nothing, parses nothing and transforms nothing — Google
renders the sheet, we frame it and say how tall. `/d/planificacion`, which #135
shipped declared and empty, now carries one.

This is the repository's **first `<iframe>`**, so what the frame is allowed to
do is a decision (ADR-0035) rather than a default inherited by omission.

## Slices completed

| | commit | |
|---|---|---|
| S1 | `f561f06` | the component, the pure `sheetUrl.ts`, the measured permissions |
| S2 | `51dd8fb` | registration + catalog entry; book and slide measured in a browser |
| S3 | `c5a88d7` | authoring guide §6g, `security-notes.md`, ADR-0035 |
| S4 | `b0dc1bd` | `/d/planificacion` written around the real sheet |

Then `df16c81`, `f967459`, `8771f65`, `b0fa817` — review-pipeline fixes.

**S2/S3 were adjusted while building** (recorded on the issue): the catalog
entry moved from S3 into S2, because `app/mdxComponents.test.ts` asserts the MDX
map and the catalog are the same set in both directions — registering the
component and writing its entry is one commit or neither is green.

## Acceptance criteria

**AC1 — renders a shared sheet in the book, read-only.** Verified against
`build && preview` at 1440×900: one iframe, 768×560, `src` = `…/preview`, no
authoring error. The `/edit` share link written in the MDX reaches the DOM as
`/preview` — the component doing the rewrite.

**AC2 — editing the sheet changes the page with no commit and no deploy.**
Structural proof, since the sheet is your working file and this session did not
write to it: `grep -rl "Introduccion al Curso\|Bubble-sort\|Objetivo Semanal" dist/`
returns **nothing**. The build carries no cell of the sheet, only the
spreadsheet id. Everything the reader sees is fetched from Google at load, so an
edit cannot require a rebuild. The literal cell-edit is in the manual checklist,
for the person who owns the sheet.

**AC3 — renders on a slide and scales with it, above the legibility floor at
1024×768.** Measured on a throwaway `presentation: explicit` document (removed
before the S2 commit): at 1024×768 the frame draws 896×480 and the deck applies
**no scale at all** (the cap is `min(480px, 64vh)`, and 64vh is 491px there). On
an iPhone 13 in landscape the cap bites at 219px and the deck fits at **0.85** —
well above the half-scale floor of ADR-0013 §5.1.

**AC4 — a missing `title` is an authoring error.** Guarded before any frame
renders; three tests assert `<SheetEmbed>` in the text and **no iframe** in the
DOM. `app/contentRenders.test.tsx` makes it unpublishable.

**AC5 — the frame's permissions are explicit, with the reasoning recorded.**
`sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"`,
`referrerpolicy="no-referrer"`, `loading="lazy"`, and `allow-same-origin`
deliberately absent. Each token loaded in a real browser against your own sheet:

| variant | sheet renders | link opens | the opened deck works |
|---|---|---|---|
| no sandbox (control) | ✅ | ✅ | ✅ |
| `allow-scripts` | ✅ | ❌ swallowed, console only | — |
| `+ allow-popups` | ✅ | ✅ | ❌ "Se produjo un error" |
| `+ allow-popups-to-escape-sandbox` | ✅ | ✅ | ✅ |

All four sandbox variants rendered the sheet identically, which is what earned
dropping `allow-same-origin`. Recorded in `security-notes.md` and ADR-0035 §4,
pinned by four tests.

**AC6 — catalog entry with ≥2 live examples; documented in the authoring
guide.** Four examples, full props table; gated by the catalog and MDX-map
invariants. Both live frames confirmed to load. Guide: §6g, plus §6f's
authoring-error list, the tree diagram and a checklist line.

**AC7 — `security-notes.md` records what embedding a third-party frame means.**
New section: every sandbox token with its measurement, why the frame is not in
itself a new exposure, what IS new (a third origin, not integrity-checkable; a
future CSP needs `docs.google.com` in `frame-src`, not `script-src`), the
over-shared and under-shared sheet, and the grades case with its trigger.

**AC8 — per-commit protocol green before every commit.** Eight commits, eight
runs, **exit status** checked rather than the summary line.

**AC9 — verified under `build && preview`, not only `dev`.** Every measurement
here. Pages judged as rendered images: `/d/planificacion` at 1440 light and
dark and at 390 portrait, the slide at 1024×768 and on a phone in landscape,
`/catalog/c/SheetEmbed`, and the loading placeholder with the frame held back.

## Tests

`sheetUrl.test.ts` (12) and `SheetEmbed.test.tsx` (17). Full suite **982
passed**, exit 0.

Two of them exist because the review proved the originals could not fail:
mutating `min()` to `max()` — turning the slide cap into a floor — and
`SLIDE_BUDGET_VH` from 64 to 640 both left all 977 tests green. Both now go red.

> **Running the suite here**: this machine was under a Spotlight indexing storm
> (load average 90, 18 `mdworker`) for part of the session, which starves vitest
> and produces mass 5-second timeouts that are **not** real failures. Every gate
> above was run with `--maxWorkers=2`, which is the same suite with less
> contention; on an idle machine plain `npm run test` is green in ~15s.

## Reviews run

`review-pipeline` in integrated mode, full (code + docs), both rounds, every
lens in its own worktree.

**Round A** — correctness, architecture, security, and performance (spawned
conditionally: the diff adds a third-party frame to a course page). 21 findings.
The four `important` ones went to the adversarial verifier: **COR-1 CONFIRMED,
COR-2 CONFIRMED, SEC-2 CONFIRMED, SEC-1 deflated to a suggestion** and acted at
the smaller scope it recommended. Acted: 15. Not acted: a pre-existing `nanoid`
advisory (no manifest touched by this diff) and a CLS finding that is #96's,
recorded there.

**Round B** — completeness, accuracy, ADR hunter, agent readability. 31
findings, 28 acted.

**The three things the review caught that I had got wrong:**

1. **A bug.** `/spreadsheets/d/e/<token>/pubhtml` — the "Publicar en la web"
   link — matched the pattern, captured the literal `e` as the spreadsheet id
   and produced `/spreadsheets/d/e/preview`, a 404 that Google serves with no
   frame-blocking header, so it rendered "El archivo que solicitaste no existe"
   **inside the rectangle** with no authoring error and the suite green. Found
   alongside it: `/spreadsheets/u/0/d/<id>/edit`, the address-bar url when
   you are signed into more than one account, returns 200 and was being refused.
2. **A test that could not fail** (COR-2, above).
3. **A false claim I repeated in five places.** Every surface said `/edit` "is
   refused by Google's own `frame-ancestors`". It is not — `curl -sI` returns
   200 with no `frame-ancestors` and no `X-Frame-Options`. `/edit` frames fine;
   it is simply the *editor*, whose own requests fail without
   `allow-same-origin`, so it paints the grid behind an error dialog. I carried
   that explanation over from the issue, where it was made about a different
   url, without re-checking it.

Also from Round B: three homes shipped in this PR contradicted each other about
grades, and four homes that own facts this WP created had never been opened —
the deployment README (**rollback no longer restores what a reader sees**),
`design-system.md` (a vendor colour is exempt only when recorded there),
`testing-strategy.md` + `apps/web/CLAUDE.md` (a third class of thing the suite
cannot see — and unlike the other two, a browser does not close it either,
because Playwright cannot query across the origin), and the component guide.

## Manual verification

- [ ] Open `/nalanda/d/planificacion` and look at it. The grid is there, colours
      intact, not Google's request-access page.
- [ ] **Edit a cell in the sheet, reload the page.** This is AC2's literal
      check and it needs the sheet's owner — I proved the structure, not the act.
- [ ] Drag the sheet sideways on a phone; confirm you reach the bibliography
      columns.
- [ ] Click one of the deck links in the sheet — it should open the
      presentation, working, in a new tab.
- [ ] Look at the page in the **dark** theme: the sheet is a white rectangle.
      That is accepted, and now recorded in `design-system.md`; confirm you are
      still happy with it.
- [ ] `/catalog/c/SheetEmbed` — four examples, two live frames, two authoring
      errors.
- [ ] Check in Drive that the sheet is shared *cualquiera con el enlace puede
      **ver*** and not *editar*.

## Notes

**⚠️ Decide before merging: the embedded sheet is `Plan de trabajo EDA-2023-2`,
and its dates are 2023.** Merging publishes `8/8/2023`, `15/8/2023 Feriado` and
the rest at a public URL under the heading "Planificación", where a student will
read it as this term's calendar. You said you would redo the sheet and swap the
link in a following task, so the component was built for exactly that: **the
swap is one attribute in `04-planificacion.mdx`**, nothing else. Either merge
now and swap when the new sheet is ready, or swap the link in this branch first.
The prose deliberately claims no term.

**The sheet is untidy in a way that shows on a phone**: the first visible column
(`Bloques`) is wide and nearly empty, so a phone spends most of its width before
reaching `Semana`. The component shows the sheet as Google draws it by design —
the fix is in the spreadsheet.

**ADR number.** This took **0035**, not 0033: the branches of #147 and #149 each
hold an unmerged `0033-*` that git cannot see from here. Whoever merges last
still has to check.

**One frame costs ~570 kB and 10 requests on a first visit** — about 490 kB of
it a single Google stylesheet, 2.9× the whole application's entry chunk. ~34 kB
on return visits. Nothing here can reduce it; it is recorded so an author
choosing between a frame and a typed table can see the price.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MegeuyC5ea9FDyNvTvh2pg
