### PR TITLE
feat: write the question bank for java-tipos-y-flujo

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -108,7 +108,7 @@ ADR-0023.
 - Gotcha: `vite preview` has its own SPA fallback, so it cannot prove the
   `404.html` exists — `src/app/spaFallback.test.ts` and the build-shape cases in
   `src/app/deployedApp.test.tsx` are what actually guard both mechanisms.
-- `dist/` also ships **`questions.json`** (11.4 kB today), emitted by the
+- `dist/` also ships **`questions.json`**, emitted by the
   `nalanda:question-bank` plugin at `generateBundle`: every document
   `index.yaml` lists, in reading order, with its section slugs in document
   order, and every control question with its statement, its listing and the

--- a/apps/web/src/components/interactive/QuestionListing.tsx
+++ b/apps/web/src/components/interactive/QuestionListing.tsx
@@ -12,8 +12,21 @@ export interface QuestionListingProps {
  * A fence in a document body is an editor with a Run button (the shell maps
  * `pre` to one). Inside a question that button would answer "¿qué imprime este
  * programa?" before the student did, so this renders the reading variant
- * instead — which also loads no compiler, so a code question costs a reader
- * nothing extra on a document that had no code.
+ * instead — which loads no compiler.
+ *
+ * It is NOT free, and the first version of this comment said it was ("costs a
+ * reader nothing extra on a document that had no code"). Measured in #144 by
+ * appending one `java` question to the code-free `04-planificacion.mdx` and
+ * building: that document went from 4 local chunks to 11 — `CodeEditor`,
+ * `runtime`, `java`, `useRunShortcut` and three CodeMirror bundles, 486,382
+ * bytes raw and ~157 kB gzip. The cause is `CodeEditor.tsx`, which calls
+ * `loadRuntime(languageId)` in an effect for EVERY variant, `read` included;
+ * only the compiler behind `createWorker` stays untouched.
+ *
+ * So the honest rule is: on a document that already carries runnable code the
+ * listing is free (measured on `07-java-tipos-y-flujo`: same 14 responses, same
+ * asset set, +0.37% of the page's JS). On one that carries none, a single code
+ * question buys the whole editor stack. Weigh it before adding the first one.
  *
  * Its own file so `Question.tsx` exports a component and nothing else, which is
  * what the fast-refresh lint rule asks for.

--- a/apps/web/src/content/architecture.test.ts
+++ b/apps/web/src/content/architecture.test.ts
@@ -152,13 +152,12 @@ describe('architecture: content invariants', () => {
         'comprueba a mano que import es una abreviatura, que es justo lo que mide la pregunta de "import y paquetes"',
       'lo-que-sigue': 'cierre del documento: anuncia el siguiente, no enseña nada propio',
     },
-    // Only three, against java-desde-cpp's six, and the difference is not
-    // laxity. Its "Ejecútalo" slides carry the editor and nothing else, so a
-    // question about one would be filler. The lab slides here sit inside
-    // sections whose prose and callouts teach something measurable — the
-    // newline nextInt() leaves behind, the decimal point this page's JVM
-    // insists on — and a section boundary runs to the next h2, not to the end
-    // of the slide.
+    // A section boundary runs to the next h2, NOT to the end of the slide. So a
+    // slide that is mostly an editor can still owe a question: what follows it,
+    // up to the next heading, belongs to the same section. That is why the lab
+    // slides here are covered rather than exempt — the newline `nextInt()`
+    // leaves behind, the decimal point this page's JVM insists on — while the
+    // three below teach nothing of their own.
     'java-tipos-y-flujo': {
       'ejercicio-en-vivo-es-par':
         'actividad: el alumno escribe el método y lo comprueba, no hay nada que preguntar',

--- a/apps/web/src/content/architecture.test.ts
+++ b/apps/web/src/content/architecture.test.ts
@@ -152,6 +152,19 @@ describe('architecture: content invariants', () => {
         'comprueba a mano que import es una abreviatura, que es justo lo que mide la pregunta de "import y paquetes"',
       'lo-que-sigue': 'cierre del documento: anuncia el siguiente, no enseña nada propio',
     },
+    // Only three, against java-desde-cpp's six, and the difference is not
+    // laxity. Its "Ejecútalo" slides carry the editor and nothing else, so a
+    // question about one would be filler. The lab slides here sit inside
+    // sections whose prose and callouts teach something measurable — the
+    // newline nextInt() leaves behind, the decimal point this page's JVM
+    // insists on — and a section boundary runs to the next h2, not to the end
+    // of the slide.
+    'java-tipos-y-flujo': {
+      'ejercicio-en-vivo-es-par':
+        'actividad: el alumno escribe el método y lo comprueba, no hay nada que preguntar',
+      ejercicios: 'actividad: cinco problemas para escribir, no materia que medir en cinco minutos',
+      'lo-que-sigue': 'cierre del documento: anuncia lo que viene, no enseña nada propio',
+    },
   };
 
   function sourceOf(key: string): string {

--- a/apps/web/src/content/architecture.test.ts
+++ b/apps/web/src/content/architecture.test.ts
@@ -152,12 +152,9 @@ describe('architecture: content invariants', () => {
         'comprueba a mano que import es una abreviatura, que es justo lo que mide la pregunta de "import y paquetes"',
       'lo-que-sigue': 'cierre del documento: anuncia el siguiente, no enseña nada propio',
     },
-    // A section boundary runs to the next h2, NOT to the end of the slide. So a
-    // slide that is mostly an editor can still owe a question: what follows it,
-    // up to the next heading, belongs to the same section. That is why the lab
-    // slides here are covered rather than exempt — the newline `nextInt()`
-    // leaves behind, the decimal point this page's JVM insists on — while the
-    // three below teach nothing of their own.
+    // Why these three and not the lab slides too: `write-control-questions.md`
+    // §"When a section owes nothing, and when one owes two" holds the rule and
+    // both worked cases. Reasons here, rule there — one home per fact.
     'java-tipos-y-flujo': {
       'ejercicio-en-vivo-es-par':
         'actividad: el alumno escribe el método y lo comprueba, no hay nada que preguntar',

--- a/content/courses/sample-course/06-java-desde-cpp.mdx
+++ b/content/courses/sample-course/06-java-desde-cpp.mdx
@@ -15,6 +15,12 @@ questions: per-section
 {/* last <Slide> (that is the behaviour #108 bought, and the case exists to */}
 {/* prove the deck leaves it out), and slide index 10 — "Compilar y ejecutar", */}
 {/* the deck's only <pre> — is driven directly as `?slide=10`. */}
+{/* This document declares `questions: per-section` (#139). Adding or */}
+{/* retitling a section therefore means writing a question for it, or */}
+{/* declaring it WITH ITS REASON in NO_QUESTION in */}
+{/* apps/web/src/content/architecture.test.ts — the suite is red until you do. */}
+{/* app/documentFences.test.tsx also pins the untagged fences of the two Java */}
+{/* documents at 2, so any new listing here carries a language tag. */}
 
 # Java desde C++
 

--- a/content/courses/sample-course/07-java-tipos-y-flujo.mdx
+++ b/content/courses/sample-course/07-java-tipos-y-flujo.mdx
@@ -15,6 +15,12 @@ questions: per-section
 {/* of documentSections.test.tsx, chosen because it carries both heading */}
 {/* sources — <Slide title> h2s AND markdown `##` — so it must keep at least */}
 {/* one `##` (today `## Ejercicios` and `## Lo que sigue`). */}
+{/* This document declares `questions: per-section` (#144). Adding or */}
+{/* retitling a section therefore means writing a question for it, or */}
+{/* declaring it WITH ITS REASON in NO_QUESTION in */}
+{/* apps/web/src/content/architecture.test.ts — the suite is red until you do. */}
+{/* app/documentFences.test.tsx also pins the untagged fences of the two Java */}
+{/* documents at 2, so any new listing here carries a language tag. */}
 
 # Tipos, operadores y entrada/salida
 

--- a/content/courses/sample-course/07-java-tipos-y-flujo.mdx
+++ b/content/courses/sample-course/07-java-tipos-y-flujo.mdx
@@ -527,6 +527,104 @@ check(Solution.sumaLarga(-2000000000, -2000000000), -4000000000L);
 
 </Exercise>
 
+<Questions>
+
+<Question id="bits-de-un-char" anchor="tipos-primitivos">
+
+¿Cuántos bits ocupa un `char` en Java?
+
+- [x] 16
+- [ ] 8
+- [ ] 32
+- [ ] Depende de la máquina
+
+</Question>
+
+<Question id="tipos-de-java-ciertas" anchor="cuatro-diferencias-con-c">
+
+¿Cuáles de estas afirmaciones sobre los tipos de Java son ciertas?
+
+- [x] El tamaño de un `int` es el mismo en toda máquina donde corra Java
+- [x] `char` es el único entero sin signo
+- [ ] `if (1)` compila y se comporta como `if (true)`
+- [ ] Existe `unsigned int`, igual que en C++
+
+</Question>
+
+<Question id="desborde-de-un-int" anchor="el-desborde-en-vivo">
+
+¿Qué imprime este programa?
+
+```java
+class Desborde {
+    public static void main(String[] args) {
+        int maximo = Integer.MAX_VALUE;
+        System.out.println(maximo + 1);
+    }
+}
+```
+
+- [x] -2147483648
+- [ ] 2147483648
+- [ ] 0
+- [ ] No compila
+
+</Question>
+
+<Question id="desborde-especificado" anchor="definido-en-java-indefinido-en-c">
+
+¿Qué dice la especificación de Java sobre el desbordamiento de un `int`?
+
+- [x] Que siempre da la vuelta, en cualquier máquina
+- [ ] Que es comportamiento indefinido, como en C++
+- [ ] Que lanza una excepción en tiempo de ejecución
+- [ ] Que el compilador debe rechazar el programa
+
+</Question>
+
+<Question id="division-entre-enteros" anchor="operadores">
+
+En Java, ¿cuánto vale `7 / 2`?
+
+- [x] `3`
+- [ ] `3.5`
+- [ ] `4`
+- [ ] `3.0`
+
+</Question>
+
+<Question id="tres-diferencias-de-operadores" anchor="tres-diferencias-reales">
+
+¿Cuáles de estas afirmaciones sobre los operadores de Java son ciertas?
+
+- [x] No se puede definir qué significa `+` para una clase propia
+- [x] `+` concatena texto, y eso es un privilegio del lenguaje
+- [ ] `>>` rellena con ceros al correr a la derecha
+- [ ] Se puede sobrecargar `==` para comparar objetos
+
+</Question>
+
+<Question id="concatenar-antes-de-sumar" anchor="que-imprime-esto">
+
+¿Qué imprime este programa?
+
+```java
+class Concatenacion {
+    public static void main(String[] args) {
+        System.out.println("total: " + 1 + 2);
+    }
+}
+```
+
+- [x] `total: 12`
+- [ ] `total: 3`
+- [ ] `total: 1 + 2`
+- [ ] No compila
+
+</Question>
+
+</Questions>
+
 ## Lo que sigue
 
 Con esto puedes leer y escribir programas Java que calculan cosas. Lo que todavía

--- a/content/courses/sample-course/07-java-tipos-y-flujo.mdx
+++ b/content/courses/sample-course/07-java-tipos-y-flujo.mdx
@@ -546,7 +546,7 @@ check(Solution.sumaLarga(-2000000000, -2000000000), -4000000000L);
 
 - [x] El tamaño de un `int` es el mismo en toda máquina donde corra Java
 - [x] `char` es el único entero sin signo
-- [ ] `if (1)` compila y se comporta como `if (true)`
+- [ ] Un emoji fuera del plano básico ocupa un solo `char`
 - [ ] Existe `unsigned int`, igual que en C++
 
 </Question>
@@ -573,12 +573,12 @@ class Desborde {
 
 <Question id="desborde-especificado" anchor="definido-en-java-indefinido-en-c">
 
-¿Qué dice la especificación de Java sobre el desbordamiento de un `int`?
+¿En qué se diferencian Java y C++ ante el desborde de un entero con signo?
 
-- [x] Que siempre da la vuelta, en cualquier máquina
-- [ ] Que es comportamiento indefinido, como en C++
-- [ ] Que lanza una excepción en tiempo de ejecución
-- [ ] Que el compilador debe rechazar el programa
+- [x] En Java está especificado; en C++ es comportamiento indefinido
+- [ ] En Java lanza una excepción; en C++ da la vuelta
+- [ ] En los dos está especificado que da la vuelta
+- [ ] En Java lo rechaza el compilador; en C++ compila
 
 </Question>
 
@@ -586,10 +586,10 @@ class Desborde {
 
 En Java, ¿cuánto vale `7 / 2`?
 
-- [x] `3`
-- [ ] `3.5`
-- [ ] `4`
-- [ ] `3.0`
+- [x] 3
+- [ ] 3.5
+- [ ] 4
+- [ ] 3.0
 
 </Question>
 
@@ -599,7 +599,7 @@ En Java, ¿cuánto vale `7 / 2`?
 
 - [x] No se puede definir qué significa `+` para una clase propia
 - [x] `+` concatena texto, y eso es un privilegio del lenguaje
-- [ ] `>>` rellena con ceros al correr a la derecha
+- [ ] `>>` rellena siempre con ceros al correr a la derecha
 - [ ] Se puede sobrecargar `==` para comparar objetos
 
 </Question>
@@ -616,9 +616,9 @@ class Concatenacion {
 }
 ```
 
-- [x] `total: 12`
-- [ ] `total: 3`
-- [ ] `total: 1 + 2`
+- [x] total: 12
+- [ ] total: 3
+- [ ] total: 1 + 2
 - [ ] No compila
 
 </Question>
@@ -636,7 +636,8 @@ class Concatenacion {
 
 <Question id="decimales-con-punto" anchor="lee-dos-numeros">
 
-En esta página, ¿qué acepta `nextDouble()` como decimal?
+En el Java que corre en el navegador de este curso, ¿qué acepta `nextDouble()` como
+decimal?
 
 - [x] `3.14`, con punto
 - [ ] `3,14`, con coma
@@ -667,14 +668,14 @@ Después de `nextInt()`, ¿qué devuelve el `nextLine()` que sigue?
 
 </Question>
 
-<Question id="que-hace-el-for-each" anchor="control-de-flujo">
+<Question id="switch-sin-break" anchor="control-de-flujo">
 
-¿Qué recorre `for (int x : nums)`?
+En un `switch`, ¿qué pasa si a un `case` le falta el `break`?
 
-- [x] Cada elemento de `nums`, sin índice a la vista
-- [ ] Los índices de `nums`, de 0 al largo
-- [ ] `nums` al revés, del último al primero
-- [ ] Solo los elementos distintos de cero
+- [x] Sigue ejecutando los casos siguientes
+- [ ] Salta al `default` y termina ahí
+- [ ] El compilador rechaza el programa
+- [ ] Sale del `switch`, igual que con `break`
 
 </Question>
 

--- a/content/courses/sample-course/07-java-tipos-y-flujo.mdx
+++ b/content/courses/sample-course/07-java-tipos-y-flujo.mdx
@@ -2,7 +2,7 @@
 id: java-tipos-y-flujo
 title: Tipos, operadores y entrada/salida
 presentation: explicit
-questions: none
+questions: per-section
 ---
 
 {/* This deck is pinned by app/presentationRoute.test.tsx (ADR-0025: the */}

--- a/content/courses/sample-course/07-java-tipos-y-flujo.mdx
+++ b/content/courses/sample-course/07-java-tipos-y-flujo.mdx
@@ -575,7 +575,7 @@ class Desborde {
 
 ¿En qué se diferencian Java y C++ ante el desborde de un entero con signo?
 
-- [x] En Java está especificado; en C++ es comportamiento indefinido
+- [x] En Java está especificado; en C++ es indefinido
 - [ ] En Java lanza una excepción; en C++ da la vuelta
 - [ ] En los dos está especificado que da la vuelta
 - [ ] En Java lo rechaza el compilador; en C++ compila

--- a/content/courses/sample-course/07-java-tipos-y-flujo.mdx
+++ b/content/courses/sample-course/07-java-tipos-y-flujo.mdx
@@ -623,6 +623,61 @@ class Concatenacion {
 
 </Question>
 
+<Question id="metodo-que-lee-la-linea" anchor="entrada-y-salida">
+
+¿Qué método de `Scanner` lee el resto de la línea?
+
+- [x] `nextLine()`
+- [ ] `next()`
+- [ ] `nextString()`
+- [ ] `hasNext()`
+
+</Question>
+
+<Question id="decimales-con-punto" anchor="lee-dos-numeros">
+
+En esta página, ¿qué acepta `nextDouble()` como decimal?
+
+- [x] `3.14`, con punto
+- [ ] `3,14`, con coma
+- [ ] Las dos formas, según el idioma del navegador
+- [ ] Solo enteros; los decimales se leen con `next()`
+
+</Question>
+
+<Question id="trampa-de-nextline" anchor="la-trampa-de-nextline">
+
+Después de `nextInt()`, ¿qué devuelve el `nextLine()` que sigue?
+
+- [x] El resto vacío de la línea del número
+- [ ] La línea siguiente completa
+- [ ] La misma línea del número, entera
+- [ ] Lanza una excepción por falta de datos
+
+</Question>
+
+<Question id="if-con-asignacion" anchor="control-de-flujo">
+
+¿Por qué `if (x = 5)` no compila en Java?
+
+- [x] Porque `x = 5` vale `5`, y `5` no es un `boolean`
+- [ ] Porque no se puede asignar dentro de un paréntesis
+- [ ] Porque el compilador supone que querías `==`
+- [ ] Porque `if` solo acepta comparaciones, no variables
+
+</Question>
+
+<Question id="que-hace-el-for-each" anchor="control-de-flujo">
+
+¿Qué recorre `for (int x : nums)`?
+
+- [x] Cada elemento de `nums`, sin índice a la vista
+- [ ] Los índices de `nums`, de 0 al largo
+- [ ] `nums` al revés, del último al primero
+- [ ] Solo los elementos distintos de cero
+
+</Question>
+
 </Questions>
 
 ## Lo que sigue

--- a/docs/design/2026-08-controles.md
+++ b/docs/design/2026-08-controles.md
@@ -7,10 +7,13 @@
 >
 > **Status:** design closed. **WP-A shipped** (#138) — the engine is confirmed
 > by ADR-0030 with one paper check outstanding, and the reading report it
-> returns is owned by ADR-0031. **WP-B is in flight** (#139: the question bank,
-> its gates and the published artifact; #144 alongside it, #148 landed the bank
-> itself under ADR-0032, and #147 landed multiple-answer questions under
-> ADR-0033). **WP-C1 shipped** (#149) — `apps/server`
+> returns is owned by ADR-0031. **WP-B shipped for the current teaching path** —
+> #148 landed the bank itself under ADR-0032, #147 landed multiple-answer
+> questions under ADR-0033, and #144 landed the second `per-section` bank
+> (`java-tipos-y-flujo`: twelve questions, three declared exemptions). That
+> leaves `bienvenida` the only `pool` document and no document on the path
+> without questions; B reopens whenever the path grows. **WP-C1 shipped**
+> (#149) — `apps/server`
 > exists, with the layered shape of C11 enforced by a test and every
 > add-a-new-app obligation discharged; ADR-0034 records C10 and C11. WP-C2
 > (#150) and WP-C3 (#151) are filed and not started; WPs D–G not started.
@@ -123,7 +126,7 @@ touched.
 | WP | Issue | Scope | Depends on |
 |----|-------|-------|-----------|
 | A ✅ | [#138](https://github.com/so77id/nalanda/issues/138) | **AMC worker** — the spike, its acceptance list, the container and its HTTP contract, and the ADR recording engine choice | — |
-| B | [#139](https://github.com/so77id/nalanda/issues/139) | **Question bank in content** — authoring format, anchor resolution and its gate, the rendering component, catalog entry, published JSON | — |
+| B ✅ | [#139](https://github.com/so77id/nalanda/issues/139), [#144](https://github.com/so77id/nalanda/issues/144) | **Question bank in content** — authoring format, anchor resolution and its gate, the rendering component, catalog entry, published JSON; and a bank for every document on the teaching path | — |
 | C1 ✅ | [#149](https://github.com/so77id/nalanda/issues/149) | **`apps/server` is born** — Go + SQLite + goose, the layered skeleton with its dependency rule enforced by a test, `/health`, the image and compose, and every process obligation below | — |
 | C2 | [#150](https://github.com/so77id/nalanda/issues/150) | **Auth domain** — ported from DocumentBuddy per ADR-0009, Google OAuth, sessions, seed | C1 |
 | C3 | [#151](https://github.com/so77id/nalanda/issues/151) | **Backoffice** — server-rendered layout and the professor CRUD | C2 |
@@ -152,9 +155,12 @@ ADR-0030 §Not yet proven). Nothing earlier depends on it, so it is not a gate o
 #138 — but E and F would otherwise be specified against an engine nobody has
 shown can read a pencil, which is the failure the spike existed to prevent.
 
-**B is scheduled early despite not being the first dependency.** Its real work
-is the professor writing questions, which is the long pole and cannot be
-parallelised by anyone else. Everything else can be built while the bank fills.
+**B was scheduled early despite not being the first dependency**, because its
+real work is the professor writing questions — the one thing nobody else can
+parallelise. That reasoning held: the bank for the current teaching path is full
+(#139, #144), so questions are no longer the long pole. What now stands between
+here and WP-E is the paper check (ADR-0030 §Not yet proven) and C2/C3. B reopens
+only when the path grows a document.
 
 ### What WP-A must prove
 

--- a/docs/standards/documentation.md
+++ b/docs/standards/documentation.md
@@ -47,6 +47,15 @@ case: the deployed shape (#66).
 1. **Docs ship in the same PR** as the change that makes them necessary. The
    Tier-4 review step asks "which docs does this diff obligate?" — the table
    above is the answer key.
+   **A commit message is never a fact's only home.** Knowledge discovered while
+   doing the work — a trap seen to fail, a boundary a review fix relied on — is
+   transcribed into its home in the table in the same PR; the commit may then
+   explain WHY the edit was made. The two surfaces read very differently: a
+   commit message is excellent for whoever reviews the change and invisible to
+   whoever writes the next one. Worked case #144, where three measured traps (a
+   question's fence needs a language tag, an id is mutable until it merges,
+   which sections legitimately owe no question) reached only commit messages and
+   the issue body, and a review had to move them.
 2. **ADR when a decision is architectural**: library/tool selection, cross-module
    structure, reversing a prior ADR, accepted operational constraints. Not for
    local changes, bug fixes, or refactors without boundary changes.

--- a/docs/standards/guides/add-a-course-document.md
+++ b/docs/standards/guides/add-a-course-document.md
@@ -60,16 +60,33 @@ the frontmatter `id`, never the path. v0.1 supports exactly ONE course directory
    and like `presentation` it is optional in the schema and required in
    practice. `per-section` means every section carries at least one question,
    with deliberate gaps declared in `NO_QUESTION`
-   (`apps/web/src/content/architecture.test.ts` — one of the two places where
-   writing content means editing a file under `src/`)
+   (`apps/web/src/content/architecture.test.ts` — one of the three exceptions
+   listed in `repository-structure.md` §`content/`, where writing content means
+   editing a file under `src/`)
    **with their reason**; `pool` means a set of questions and no per-section
    expectation, and it must not be empty — an empty pool says exactly what
    `none` says; `none` means deliberately none, and it is the honest value for a
    document whose questions are not written yet.
 
    The point is to force a decision, not to force writing. A rule demanding one
-   question per section produces filler for hands-on slides and side-by-side
-   listings, and filler measures noise and then lands in a real control.
+   question per section produces filler for a section that teaches nothing of
+   its own, and filler measures noise and then lands in a real control. Which
+   sections those are is a judgement with its own rules — see
+   [`write-control-questions.md`](write-control-questions.md) §When a section
+   owes nothing, and when one owes two. It is **not** "the slide has an editor":
+   a section runs to the next `h2`, so a hands-on slide usually teaches
+   something in the prose that follows it.
+
+   > **Flip `questions:` in the SAME commit that supplies the questions and the
+   > `NO_QUESTION` entries.** The declaration is a promise the suite checks the
+   > moment it is written, so a commit that declares `per-section` over a
+   > document that is not yet covered is red by construction — and nothing is
+   > committed in red (root `CLAUDE.md`). Questions authored while the document
+   > still says `none` are already checked for shape, so the order that stays
+   > green is: write the questions, then flip the declaration and declare the
+   > exemptions together. Same family as the slice rule in
+   > [`../../conventions.md`](../../conventions.md) §Commit format. Learned in
+   > #144, whose original slice plan could not produce a green commit.
 
    `presentation` controls the document's slide form (ADR-0013): `auto`
    (default when absent) slices the deck on `h2` headings; `explicit` decks
@@ -674,9 +691,12 @@ is not scaled at all.
    and logs a console warning — forward links to drafts are allowed on purpose.
 
 7b. **Write the control questions** — the pool an entrance control draws from.
-   One `<Questions>` block, **after the last section and before the document's
-   closing invitation** where it has one: questions after a goodbye read as an
-   appendix nobody scrolls to.
+   One `<Questions>` block, **after the last section that TEACHES something and
+   before the document's closing section** — `## Lo que sigue` in both Java
+   documents: questions after a goodbye read as an appendix nobody scrolls to.
+   The closing section is then one of the gaps you declare in `NO_QUESTION`.
+   ("After the last section" alone is wrong whenever the goodbye is itself a
+   section, which is every document on the path today.)
 
    ````mdx
    <Questions>
@@ -697,18 +717,33 @@ is not scaled at all.
 
    Four things to get right, all enforced:
 
-   - **`id` is written by hand and never changes**, kebab-case, and **unique
-     across the whole `content/` tree**. It is the join key all the way to a
-     grade (ADR-0031), so a duplicate merges two students' answers into one
-     column — and that one fails `npm run build`, which the suite does not see.
-     Deriving it fails both ways: anchor-plus-ordinal renumbers when questions
-     are reordered, and a hash of the statement changes when a typo is fixed.
+   - **`id` is written by hand**, kebab-case, and **unique across the whole
+     `content/` tree**. It is the join key all the way to a grade (ADR-0031), so
+     a duplicate merges two students' answers into one column — and that one
+     fails `npm run build`, the gate that must stop it publishing (the suite
+     catches it too, in `content/questionBank.test.ts`, which drives the plugin
+     over the real `content/`; the build is the one that matters and ADR-0032
+     §Consequences says not to harmonise it down). Deriving it fails both ways:
+     anchor-plus-ordinal renumbers when questions are reordered, and a hash of
+     the statement changes when a typo is fixed.
+
+     An id may still change while the question is **unmerged** — review can
+     replace a question outright, as #144 did. Once the PR lands the bank is
+     published and the id is frozen: from that point it is the join key from a
+     printed sheet into a grade, and moving it orphans an answer column.
    - **`anchor` is the slug of an `h2`** — and a `<Slide title>` renders an `h2`,
      so slide titles are anchorable and are where most anchors point. Omit it
      when the question belongs to the whole chapter. An anchor naming no section
      paints an authoring error on the page and reddens the suite; the build
      stays green, because drafting before the section exists is a real order of
      work.
+
+     The slug is the title lowercased, accents stripped, every run of
+     non-alphanumerics turned into `-`, and leading/trailing dashes removed
+     (`apps/web/src/lib/slug.ts`). So `Cuatro diferencias con C++` anchors as
+     `cuatro-diferencias-con-c` — the `++` disappears entirely — and
+     `¿Qué imprime esto?` as `que-imprime-esto`. **Do not guess it**: read it off
+     the rendered heading's link, or off `headingSlugs()`.
    - **The answer is marked in place** with `- [x]`, never named from outside.
      Naming one by position means reordering the alternatives silently changes
      the answer.
@@ -719,6 +754,16 @@ is not scaled at all.
    fence is a runnable editor, and a Run button would answer *"¿qué imprime este
    programa?"* before the student did. **One listing per question** — only the
    first becomes the `code` field.
+
+   **Tag the fence with its language** (` ```java `). Without a tag it is not a
+   listing at all: both readers require a non-empty language
+   (`questionSource.ts`, `lib/questions.ts`), so the question ships with **no
+   listing** — missing from the page and missing from `questions.json` — past a
+   green build, and the printed sheet asks *"¿qué imprime este programa?"* with
+   no program. In the two Java documents an untagged fence also reddens
+   `app/documentFences.test.tsx`, which pins THEIR untagged count at 2 (the two
+   ASCII diagrams) and whose failure message mentions neither questions nor your
+   listing. Everywhere else there is no guard: it ships silently. (#144)
 
    **Type the opening tag on ONE line, with double-quoted attributes**, and put
    the question's prose immediately after it. The gates read the `.mdx` source,

--- a/docs/standards/guides/write-control-questions.md
+++ b/docs/standards/guides/write-control-questions.md
@@ -39,7 +39,7 @@ because they are checkable — not because they matter more than the ones below.
 | No *todas las anteriores* | If every alternative is correct, mark them — that is what a multiple is. Pinning does not save this one. |
 | No negated stem (`NO`, *excepto*, *salvo*) | Under a clock with shuffled alternatives, a negation measures hurried reading. Lowercase *no* is fine — *"¿Por qué no compila?"* is a real question, not a negated stem. The uppercase form is caught after a space or after `¿`. |
 | The correct alternative is not far longer than the rest | The most exploitable tell there is: pick the longest, be right, never study. Compared against the SECOND longest, and switched off below 15 characters — between `123` and `No compila` the ratio means nothing, and `{3, 6, 123, No compila}` is correct authoring. |
-| `id` present, kebab-case, unique across the whole `content/` tree | It is the join key from the printed sheet, through the scanner, into a grade (ADR-0031). A duplicate merges two students' answers into one column — and that one fails `npm run build`, not the suite. |
+| `id` present, kebab-case, unique across the whole `content/` tree | It is the join key from the printed sheet, through the scanner, into a grade (ADR-0031). A duplicate merges two students' answers into one column — and that one fails `npm run build`, which is the gate that must block publishing; the suite catches it too, in `content/questionBank.test.ts`. |
 | A statement, and no empty alternative | A blank stem or a blank option reaches a printed, graded sheet as a question with nothing on it. |
 | `anchor` names a real section of the document | Otherwise the question belongs to nothing and enters no control. |
 
@@ -50,6 +50,11 @@ These decide whether the control measures anything. No test will catch you.
 **Answerable from its own section alone.** This is what makes "from section X to
 section Y" mean anything at all. If answering needs something from three sections
 back, the control silently tests material it did not announce.
+
+A section runs from its `h2` to the **next `h2`** (ADR-0021), never to the end of
+the `<Slide>` that opened it. So the prose, the callout or the editor that
+follows a slide is still inside that section — and an `###` subsection belongs to
+the `h2` above it, whole.
 
 **Asks what the section says, not what can be inferred from it.** An entrance
 control measures whether the student read the class. Reasoning problems belong in
@@ -188,6 +193,34 @@ skips it when it emits the bank. Its questions would be unreachable by
 definition. Write questions for a document only once it is on the path, and
 declare `questions: none` on one that is deliberately off it.
 
+## When a section owes nothing, and when one owes two
+
+`per-section` promises a question for every section, and the gap you leave is
+**declared with its reason** in `NO_QUESTION`
+(`apps/web/src/content/architecture.test.ts`; the mechanics are in
+`add-a-course-document.md` step 2). The set is closed in both directions: forget
+a section and the gate reddens, cover one that is listed and it reddens too, so
+a stale exemption cannot outlive the gap it described.
+
+**A section owes nothing only when it teaches nothing of its own** — an activity
+the student performs, a side-by-side listing whose lesson is measured elsewhere,
+a closing that announces the next document.
+
+**"It is a hands-on slide" is not the test.** Because a section runs to the next
+`h2`, what follows the editor is still inside it, and that is usually where the
+teaching lives. The two Java documents differ for exactly this reason and both
+are right: `java-desde-cpp` exempts its *Ejecútalo* slides, which are followed by
+nothing but the next heading, while `java-tipos-y-flujo` covers its lab slides,
+because the newline `nextInt()` leaves behind and the decimal point the browser's
+JVM insists on are taught in the prose *after* the editor (#144).
+
+**One section may owe two.** Coverage is counted per `h2`, so the gate is
+satisfied by one — but a section that swallows an `###` subsection can hold more
+material than one question can measure. `control-de-flujo` carries two for that
+reason: the `###` beneath it teaches `switch`, `do-while`, `final` and the
+`for-each`, and one question would have left all of that unmeasured while the
+gate stayed green.
+
 ## How many, and how balanced
 
 No maximum. A control draws four from whatever the range offers, so a bigger
@@ -206,8 +239,10 @@ teaching judgement before it is a fact. Nothing here changes that.
 
 ## Checklist
 
-- [ ] `questions:` declared in the frontmatter (`per-section`, `pool` or `none`).
-- [ ] Every question has a hand-written `id`, kebab-case, stable across edits, and not used by any other question in `content/`.
+- [ ] `questions:` declared in the frontmatter (`per-section`, `pool` or `none`), and flipped in the SAME commit that supplies the questions and the exemptions (`add-a-course-document.md` step 2).
+- [ ] Every question has a hand-written `id`, kebab-case, and not used by any other question in `content/`. Free to change until the PR merges; frozen after, because from then on it is the join key into a grade.
+- [ ] Every section either carries a question or appears in `NO_QUESTION` with its reason — the exemptions are part of the work, not a gate change (`repository-structure.md` §`content/`).
+- [ ] Every listing inside a question is tagged with its language (`add-a-course-document.md` §7b) — an untagged fence ships no listing at all.
 - [ ] Anchored to the section it is answerable from, or unanchored on purpose.
 - [ ] Read each question against its own section, alone, and answered it.
 - [ ] Each distractor is something a real student might believe.

--- a/docs/standards/testing-strategy.md
+++ b/docs/standards/testing-strategy.md
@@ -60,8 +60,11 @@ npm run lint           # oxlint
 npm run build          # tsc -b + vite build (type gate + content/ integrity gate:
                        # document frontmatter (id, title, presentation, questions)
                        # and index.yaml validated by contentIntegrity; ALSO fails on
-                       # a duplicate question id, which the suite does not see —
-                       # it is the join key into a grade, so it fails the build)
+                       # a duplicate question id — it is the join key into a grade,
+                       # so publishing is what must be blocked. The suite catches it
+                       # too (content/questionBank.test.ts drives the plugin over
+                       # real content/), but do not harmonise the build gate away:
+                       # ADR-0032 §Consequences)
 npm run test           # vitest run — at minimum the touched scope, in green
 ```
 


### PR DESCRIPTION
**Closes #144**

## Summary

`java-tipos-y-flujo` — the last document on the teaching path without questions —
now declares `questions: per-section` and carries twelve, with its three
deliberately uncovered sections declared in `NO_QUESTION` with their reason. With
this, every document on the path has a bank, which is what WP-E needs to generate
a control over any range.

The twelve were drafted and approved **question by question before any code was
written**, during a re-refinement of #144. That re-refinement also caught that the
issue's original slice plan could not produce a green commit: declaring
`per-section` over a half-covered document is red by construction, and nothing is
committed in red. The questions therefore land under `questions: none` and the
declaration flips last, in the commit that also supplies the exemptions.

The review pipeline then found a second, larger body of work: three documents
asserted something false about the build gate, the README's artifact size was
falsified by this diff, and five facts this WP measured had no home outside a
commit message. That is the `docs(issue-144)` commit.

## Slices completed

- [x] S1 (`490b2fa`) — questions for sections 1–7, under `questions: none`
- [x] S2 (`81841dc`) — questions for sections 8–11
- [x] S3 (`360ebe5`) — flip to `per-section`, declare the three exemptions
- [x] S4 — verify in a browser, both themes. **No commit**: it turned up nothing
      to fix in the product. The only defects were in my own check script.

Plus `13cfed8` and `009cace` (review fixes), `74629f7` (documentation), and
`14e7f35` — the one accepted Round-A pattern: `QuestionListing`'s doc comment
claimed a code question costs a code-free document nothing, and the performance
lens measured ~157 kB gzip. Comment only, no behaviour change.

## Acceptance criteria

| AC | Evidence |
|---|---|
| 1. Declares `questions: per-section` | `07-java-tipos-y-flujo.mdx:5`, commit `360ebe5` |
| 2. Every section covered or exempt with a reason; gate green | Ran `headingSlugs`/`readQuestions` directly: 14 sections, gaps = `ejercicio-en-vivo-es-par, ejercicios, lo-que-sigue`, exactly the three declared in `architecture.test.ts`. Seen to fail first: flipping the declaration with an empty `NO_QUESTION` reddens the gate naming those three. |
| 3. Every question obeys the mechanical rules | 0 problems from `questionProblems` over all twelve. The correctness lens mutation-tested the gate six ways (missing anchor, 5 alternatives, 4/4 marked, bogus anchor, uppercase-NO stem, padded correct alternative) — all six went red, so the pass is not vacuous. |
| 4. At least two questions carry a read-only listing | `desborde-de-un-int` and `concatenar-antes-de-sumar`, both ```` ```java ````, both `code.language == "java"` in `dist/questions.json`. Browser: no *Ejecutar* button, `contenteditable=false`. |
| 5. At least one multiple, badged | Two: `tipos-de-java-ciertas`, `tres-diferencias-de-operadores`. Both `"type": "multiple"` in the artifact and both badged **varias respuestas** in the browser; a simple question carries no badge. |
| 6. In the published JSON with stable ids and the right derived type | `dist/questions.json`: 12 questions under `java-tipos-y-flujo`, `coverage: per-section`, 2 `multiple` / 10 `simple`, no id clash against the other 18 in `content/`. |
| 7. Full pre-PR protocol green | `format:check`, `lint`, `test` (84 files / **984 tests**), `build` — **exit 0** checked, not the summary line. |
| 8. Opened in a browser, both themes | 21/21 checks green via Playwright against `npm run preview` (which serves under `/nalanda/`, like production), **re-run on the final state** after the review fixes changed seven questions. Screenshots read at 1920 and 1440, light and dark. |

## Tests

No new test file. `content/` is the suite's fixture set (ADR-0025), so the twelve
questions are themselves exercised by the existing gates — and the suite grew by
one case, 983 → 984: `a per-section document carries a question for every section
it did not exempt` is an `it.each` over the documents that declare it, so this
document's coverage case did not exist until `360ebe5` created it.

## Reviews run

Full mode, both rounds, every lens in its own worktree.

- **Round A** — 4 lenses (correctness, architecture, security, performance) +
  adversarial verifier. **10 findings**: 0 critical, 1 important, 6 suggestions,
  3 patterns. Verifier CONFIRMED the important one and DEFLATED one I had raised
  myself. 7 accepted → `13cfed8`; per-fix recheck by the two originating lenses
  confirmed all 7 resolved and raised 5 more, of which 1 accepted → `009cace`.
- **Round B** — 4 documentation lenses. **20 findings**, with three lenses
  independently reaching the same two gaps. 13 accepted → `74629f7`.
- **Security**: no findings. Verified the artifact's shape against ADR-0032, that
  `security-notes.md` still describes reality, and that the two Java listings
  carry no TeX special outside the `code` field.
- **Performance**: no regression. CLS identical to five decimals (0.46539 both
  sides), no new chunk, +1,292 bytes gzip (+0.37% of the page's JS).

Two things a lens measured that I had asserted and had wrong: the page already
mounts 16 CodeMirror instances, not 7 (so this is +12.5%, not +30%), and a
duplicate question id fails the suite as well as the build.

## Manual verification

1. Open `/nalanda/d/java-tipos-y-flujo` and scroll to **Preguntas** at the end.
2. Answer **¿Cuántos bits ocupa un `char`?** with `16` — it should say *Correcto.*
   and reveal in green.
3. Answer any question wrongly — the right one is marked, and the verdict is
   spelled out, not only coloured.
4. On **¿Cuáles de estas afirmaciones sobre los tipos de Java son ciertas?**:
   check that it is badged **varias respuestas**, that *Comprobar* is disabled
   until you tick something, and that ticking only ONE of the two correct ones is
   graded incorrect — a multiple commits as a set.
5. On **¿Qué imprime este programa?**: the listing must be coloured and
   **read-only** — no *Ejecutar* button, and you cannot type in it.
6. Switch to the other theme and repeat 2 and 4.
7. In the right rail, confirm **Preguntas** is NOT listed as a section (needs a
   window wider than ~1536px; the rail is hidden below that).
8. Read the twelve questions as the professor: **the drafts are mine, the
   pedagogical judgement is yours.** Three I would look at hardest — the stem of
   `decimales-con-punto` is now the longest in the bank (92 chars) because it had
   to name the runtime for the printed sheet; `switch-sin-break`'s distractor
   *"Salta al `default` y termina ahí"* is arguably reachable by mentally running
   that section's listing, where `default` happens to be last; and
   `tres-diferencias-de-operadores` leans on `siempre` to make its `>>` distractor
   unambiguously false.

## Notes

- **A defect in already-published content, filed rather than fixed here:** #160.
  `que-imprime-arreglo` in `java-desde-cpp` is anchored to the section about the
  five words of `main`, which never mentions arrays or `for-each` — the exact
  shape the guide calls "the failure mode to watch". It came from #139 and is
  live. This WP's review replaced its own `for-each` question because it
  overlapped that one, which leaves `java-tipos-y-flujo` with no question on the
  `for-each` its own text calls "la única novedad de la lista". #160 fixes both
  halves.
- One question id changed during review (`que-hace-el-for-each` →
  `switch-sin-break`), which is safe only because nothing is published yet. Both
  guides said an id "never changes"; they now carry the real boundary — free
  until the PR merges, frozen after, because from then on it is the join key from
  a printed sheet into a grade.
- `apps/web/README.md` no longer states `questions.json`'s size in bytes. It said
  "11.4 kB today" and was right until this diff (measured: 11,510 bytes on `main`,
  17,722 here). Nothing pinned it, and every future question falsifies it again,
  so the figure is dropped rather than updated.
- `docs/standards/documentation.md` Rule 1 gains a clause: a commit message is
  never a fact's only home. Three traps measured in this WP reached only commit
  messages and the issue body, and a review had to move them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ek1qP2L9zhKs9TFHCgAGmo

