### PR TITLE
chore: point planificacion at the 2026-2 course spreadsheet

### DIFF
--- a/content/courses/sample-course/04-planificacion.mdx
+++ b/content/courses/sample-course/04-planificacion.mdx
@@ -61,7 +61,7 @@ es una copia. Es la planilla misma, así que cuando una clase se mueve, se mueve
 también en esta página.
 
 <SheetEmbed
-  src="https://docs.google.com/spreadsheets/d/1_cxMUbcF9Tscd3_4Nu71HiXy-MZuaz28IapmvhS7FkM/edit?usp=sharing"
+  src="https://docs.google.com/spreadsheets/d/1BcAPEXgVO9Jscr7VhpuKhB2jP08Y4QcGj5m9tVrv358/edit?usp=sharing"
   title="Planificación clase a clase del curso"
   height={560}
 />


### PR DESCRIPTION
## Summary
- Point `content/courses/sample-course/04-planificacion.mdx` at the 2026-2 course spreadsheet.
- No issue: the sheet the reader was seeing was still the 2023-2 fixture #146 seeded the page with; Miguel published the new one and asked to swap it.
- Only the `src` string on `<SheetEmbed>` changes; the component and its validation gate (ADR-0035) are untouched.

## Tests
- Protocols run: per-commit ✓ · pre-PR ✓
  - `npm run format:check` — clean
  - `npm run lint` — clean
  - `npm run test` — 85 files / 1033 tests, all green (`contentRenders.test.tsx` in the set, so the new share link is validated by SheetEmbed's authoring gate)
  - `npm run build` — clean

## Manual verification
- `npm run build && npm run preview` under `/nalanda/`, `/d/planificacion` at 1440×900, both themes.
- Iframe `src` transforms to `https://docs.google.com/spreadsheets/d/1BcAPEXgVO9Jscr7VhpuKhB2jP08Y4QcGj5m9tVrv358/preview` (as SheetEmbed rewrites it).
- Sheet paints inside the frame — the calendar shown is the 2026-2 one (semana 1 comienza 14/8/2026), not the 2023-2 fixture.
- Sandbox attribute unchanged (`allow-scripts allow-popups allow-popups-to-escape-sandbox`), frame box unchanged (768×560 at this viewport).
- Only console noise inside the frame is Google Docs' own (`DOCS_timing`, blocked persistent-fonts) — inherent to the sandbox policy, present before this PR.

## Notes
- Repo-wide sweep for the old ID landed three other hits, all fixtures of the component itself (`SheetEmbed.test.tsx`, `sheetUrl.test.ts`, `SheetEmbed.catalog.tsx`); they exercise URL validation with an arbitrary sample ID, they don't claim "this is the course sheet". Left alone.
- Not a WP; no slice checkboxes / AC / review pipeline for a one-line content swap (`docs/conventions.md` "yolo mode" bar is met; a branch + PR is used anyway because merging to `main` publishes the site).
