### PR TITLE
feat: create a control and generate the PDF ready to print (WP-E, #166)

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -93,6 +93,17 @@ jobs:
       # (apps/server/GOOGLE-CHECK.md).
       - name: Run the image and probe it
         run: |
+          # WP-E adds three required variables and a shared-volume mount.
+          # The bank comes from the checked-in example (zero questions,
+          # enough to make the boot fetch succeed). The worker URL is a
+          # placeholder — the probe never asks the server to generate a
+          # control, so nothing actually calls the worker; it just has to
+          # be a URL the config validator accepts.
+          #
+          # A host directory holds the bank; that directory is bind-mounted
+          # onto /work read-only. The probe does not write to /work.
+          mkdir -p "$GITHUB_WORKSPACE/ci-work"
+          cp "$GITHUB_WORKSPACE/infra/local/questions.example.json" "$GITHUB_WORKSPACE/ci-work/questions.json"
           docker run -d --name server-ci \
             -e NALANDA_ADDR=0.0.0.0:8081 \
             -e NALANDA_DATABASE_URL=/data/nalanda.db \
@@ -102,6 +113,10 @@ jobs:
             -e NALANDA_GOOGLE_CLIENT_SECRET=placeholder-secret \
             -e NALANDA_SESSION_TTL=720h \
             -e NALANDA_BOOTSTRAP_PROFESSOR_EMAIL= \
+            -e NALANDA_QUESTIONS_JSON_URL=file:///work/questions.json \
+            -e NALANDA_AMC_WORKER_URL=http://amc-worker-placeholder:8080 \
+            -e NALANDA_WORK_DIR=/work \
+            -v "$GITHUB_WORKSPACE/ci-work:/work:ro" \
             -p 127.0.0.1:8081:8081 \
             nalanda/server:ci
           for attempt in $(seq 1 20); do

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -61,3 +61,34 @@ NALANDA_SESSION_TTL=720h
 # already in the database it does nothing at all, so leaving it set is not a
 # standing door — but removing it once you are in is still the tidier habit.
 NALANDA_BOOTSTRAP_PROFESSOR_EMAIL=
+
+# --- Entrance controls, WP-E (issue #166) --------------------------------
+#
+# Without these the CONTROL SCREENS refuse to work. The login and health
+# paths still answer; the professor sees an empty backoffice.
+
+# Where the published question bank lives (ADR-0032). Required.
+# Fetched ONCE at boot and held in memory; a parse failure there is a
+# panic and the server does not start (the same rule the templates
+# follow). http:// and https:// are production; file:// is the local-file
+# override for development.
+#
+# For local development, point at the artifact apps/web builds and
+# preview serves:
+#   file:///path/to/nalanda/apps/web/dist/questions.json
+# Or, for a compose run, at the mounted example file:
+#   file:///work/questions.json
+NALANDA_QUESTIONS_JSON_URL=file:///work/questions.json
+
+# The AMC worker's HTTP origin (ADR-0030). Required.
+# No path, no trailing slash — the worker's own routes are appended. In
+# compose it is the service name: http://amc-worker:8080. Against
+# `make serve` from apps/amc-worker it is http://127.0.0.1:8080.
+NALANDA_AMC_WORKER_URL=http://amc-worker:8080
+
+# Where the server sees the shared volume (ADR-0034 §Consequences).
+# The .tex the generator emits always uses /work absolute paths — that
+# is the worker's mount, not this one — so this value only decides where
+# the server writes its files. In compose it is /work (the shared
+# amc-work volume, mounted into both services).
+NALANDA_WORK_DIR=/work

--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -24,12 +24,22 @@ RUN go mod download
 
 COPY . .
 
-# The directory the database lives in, created here because scratch has no
-# shell to mkdir with and no chown to fix ownership afterwards. Docker seeds a
+# The two writable mount points, created here because scratch has no shell
+# to mkdir with and no chown to fix ownership afterwards. Docker seeds a
 # named volume from whatever is at the mount point in the image, permissions
-# included, so this is what makes the volume writable by the unprivileged UID
-# below.
-RUN mkdir -p /data && chown 65532:65532 /data
+# included, so this is what makes both volumes writable by the unprivileged
+# UID below:
+#
+#   /data — the SQLite database (this app's own volume, seeded once).
+#   /work — the SHARED volume with amc-worker (issue #166 WP-E, ADR-0034
+#           §Consequences). Both containers mount it. The compose file
+#           depends_on: server so THIS container is the one that seeds
+#           the volume the first time it comes up; without that, the
+#           worker (which runs as root) seeds it root:root and the
+#           server's first os.MkdirAll under /work fails EACCES on the
+#           first /generate — a failure invisible to `compose up --wait`
+#           because that step only probes /health.
+RUN mkdir -p /data /work && chown 65532:65532 /data /work
 
 # CGO_ENABLED=0 is the load-bearing flag. With it on, the toolchain would link
 # against Alpine's musl and the binary would not run on `scratch` — and the
@@ -59,6 +69,7 @@ COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 ENV TZ=UTC
 
 COPY --from=build --chown=65532:65532 /data /data
+COPY --from=build --chown=65532:65532 /work /work
 COPY --from=build /server /server
 
 # An unprivileged, numeric UID. Numeric because scratch has no /etc/passwd for a

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -40,6 +40,9 @@ Environment variables, read once at boot. A required variable that is absent
 | `NALANDA_GOOGLE_CLIENT_SECRET` | yes | Its secret. Never printed: `config.Config` redacts it for both `fmt` and `slog` |
 | `NALANDA_SESSION_TTL` | no (`720h`) | Session lifetime, as a Go duration. Zero or negative is a startup error |
 | `NALANDA_BOOTSTRAP_PROFESSOR_EMAIL` | no | On a database with **no** professors, the first Google login by this address creates one. Inert as soon as any professor exists |
+| `NALANDA_QUESTIONS_JSON_URL` | yes | The published question bank (ADR-0032). `http://`, `https://` or `file://`. Fetched **once at boot** and held in memory; a parse failure is a panic there. WP-E |
+| `NALANDA_AMC_WORKER_URL` | yes | The AMC worker's HTTP origin, e.g. `http://amc-worker:8080` in compose. Absolute http/https URL, no path. WP-E |
+| `NALANDA_WORK_DIR` | yes | Where the server sees the shared volume. The `.tex` generator emits `/work` absolute paths regardless (that is the worker's mount); this only decides where the server writes its files. WP-E |
 
 ## Commands
 

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -175,11 +175,21 @@ menu on the right holding the POST logout. Both themes come from
 `color-scheme: light dark` and `currentColor`; no stylesheet is served
 (§C13 — the backoffice is an internal tool and does not follow ADR-0026).
 
+Since WP-E (#166) the shell also holds the entrance-controls screens: a
+professor picks a section range from the published question bank, gets a
+printable `sujet.pdf` back, and every control is persisted with its pool
+and its per-copy identity. `apps/amc-worker` is the compilation engine
+(ADR-0030) and `questions.json` (ADR-0032) is the input.
+
 Routes today:
 
 | Route | What |
 |---|---|
-| `GET /` | Redirects to `/professors` (an anonymous request lands in `/login` first, via the gate) |
+| `GET /` | Redirects to `/controls` (an anonymous request lands in `/login` first, via the gate). Superseded #151's redirect to `/professors` when WP-E landed |
+| `GET /controls` | The list, ordered by application_date desc with nulls last |
+| `GET /controls/new` · `POST /controls` | Pick a section range, generate the PDF |
+| `GET /controls/{id}` | Detail: metadata, PDF downloads, the WP-F placeholder Escaneos box |
+| `GET /controls/{id}/sujet.pdf` · `GET /controls/{id}/corrige.pdf` | Streamed from the shared volume |
 | `GET /professors` | The list: address, name, state, created, last sign-in |
 | `GET /professors/new` · `POST /professors` | Create by address and name — the `Authenticate` path (2) round trip |
 | `GET /professors/{id}/edit` · `POST /professors/{id}` | Rename. The address is not editable |
@@ -212,7 +222,7 @@ Deliberately, and each with an owner:
 |---|---|
 | Courses, students, enrolment — any domain table | WP-D |
 | JSON contracts, CORS, WebSocket on `/api` | with a consumer (ADR-0008) |
-| Talking to `apps/amc-worker` | WP-E |
+| Reading scans back, per-question grades, review queue | WP-F |
 | Deploy, hosting, secrets | deferred (`2026-08-controles.md` §C15) |
 | Deleting or re-addressing a professor who has never signed in | WP that reopens the mistyped-address debt (#151 §Notes) |
 | An audit trail of who did what | The WP that gains a second class of actor (#151 §Non-goals) |

--- a/apps/server/cmd/server/main.go
+++ b/apps/server/cmd/server/main.go
@@ -19,13 +19,17 @@ import (
 	"github.com/so77id/nalanda/apps/server/internal/app/web/middleware"
 	"github.com/so77id/nalanda/apps/server/internal/app/web/oauthstate"
 	"github.com/so77id/nalanda/apps/server/internal/domain/auth"
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+	"github.com/so77id/nalanda/apps/server/internal/domain/course/bank"
 	"github.com/so77id/nalanda/apps/server/internal/domain/health"
+	"github.com/so77id/nalanda/apps/server/internal/infra/amcworker"
 	"github.com/so77id/nalanda/apps/server/internal/infra/config"
 	"github.com/so77id/nalanda/apps/server/internal/infra/httpserver"
 	"github.com/so77id/nalanda/apps/server/internal/infra/oidc"
 	"github.com/so77id/nalanda/apps/server/internal/infra/selfcheck"
 	"github.com/so77id/nalanda/apps/server/internal/infra/storage"
 	"github.com/so77id/nalanda/apps/server/internal/infra/storage/authstore"
+	"github.com/so77id/nalanda/apps/server/internal/infra/storage/controlstore"
 	"github.com/so77id/nalanda/apps/server/migrations"
 )
 
@@ -138,6 +142,35 @@ func run(logger *slog.Logger) error {
 		return err
 	}
 
+	// The published question bank (ADR-0032). Loaded once at boot; a
+	// failure here IS a startup failure, not a first-request failure, so
+	// an operator sees it immediately.
+	loadedBank, err := bank.Load(ctx, cfg.QuestionsJSONURL)
+	if err != nil {
+		return err
+	}
+	logger.Info("question bank loaded",
+		"url", cfg.QuestionsJSONURL,
+		"documents", len(loadedBank.Documents),
+		"questions", len(loadedBank.Questions))
+
+	controlStore := controlstore.New(db)
+	amcClient := amcworker.New(amcworker.Config{BaseURL: cfg.AmcWorkerURL})
+	controlsService := controls.NewService(controls.Service{
+		Bank:      loadedBank,
+		Store:     controlStore,
+		Generator: amcClient,
+		WorkDir:   cfg.WorkDir,
+		Now:       time.Now,
+		// Constant seed for reproducibility (tex.Compile refuses zero).
+		// A per-control seed is a future decision: today every control
+		// runs the same shuffle, and re-generating one produces the same
+		// pool — which the four traps of ADR-0030 need to be testable
+		// against.
+		Seed: 4242,
+		Log:  logger,
+	})
+
 	backoffice := web.Deps{
 		Database: storage.NewProber(db),
 		Gate: middleware.NewAuth(middleware.Auth{
@@ -155,6 +188,13 @@ func run(logger *slog.Logger) error {
 				Sessions: store,
 				Now:      time.Now,
 			}),
+			PublicURL: cfg.PublicURL,
+			Log:       logger,
+		}),
+		Controls: handler.NewControls(handler.Controls{
+			Service:   controlsService,
+			Store:     controlStore,
+			Bank:      loadedBank,
 			PublicURL: cfg.PublicURL,
 			Log:       logger,
 		}),

--- a/apps/server/cmd/server/main.go
+++ b/apps/server/cmd/server/main.go
@@ -193,7 +193,6 @@ func run(logger *slog.Logger) error {
 		}),
 		Controls: handler.NewControls(handler.Controls{
 			Service:   controlsService,
-			Store:     controlStore,
 			Bank:      loadedBank,
 			PublicURL: cfg.PublicURL,
 			Log:       logger,

--- a/apps/server/cmd/server/main_test.go
+++ b/apps/server/cmd/server/main_test.go
@@ -23,12 +23,25 @@ import (
 	"github.com/so77id/nalanda/apps/server/internal/app/web/middleware"
 	"github.com/so77id/nalanda/apps/server/internal/app/web/oauthstate"
 	"github.com/so77id/nalanda/apps/server/internal/domain/auth"
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+	"github.com/so77id/nalanda/apps/server/internal/domain/course/bank"
 	"github.com/so77id/nalanda/apps/server/internal/domain/health"
+	"github.com/so77id/nalanda/apps/server/internal/infra/amcworker/amctest"
 	"github.com/so77id/nalanda/apps/server/internal/infra/oidc/oidctest"
 	"github.com/so77id/nalanda/apps/server/internal/infra/storage"
 	"github.com/so77id/nalanda/apps/server/internal/infra/storage/authstore"
+	"github.com/so77id/nalanda/apps/server/internal/infra/storage/controlstore"
 	"github.com/so77id/nalanda/apps/server/migrations"
 )
+
+func emptyBank(t *testing.T) *bank.Bank {
+	t.Helper()
+	b, err := bank.Parse(strings.NewReader(`{"version":1,"documents":[],"questions":[]}`))
+	if err != nil {
+		t.Fatalf("emptyBank: %v", err)
+	}
+	return b
+}
 
 // composed builds the root handler the way run() does, so these cases exercise
 // the composition rather than a rehearsal of it.
@@ -71,6 +84,21 @@ func composed(t *testing.T, prober health.Prober) (http.Handler, *authstore.Stor
 				Sessions: store,
 				Now:      time.Now,
 			}),
+			PublicURL: "https://nalanda.test",
+			Log:       logger,
+		}),
+		Controls: handler.NewControls(handler.Controls{
+			Service: controls.NewService(controls.Service{
+				Bank:      emptyBank(t),
+				Store:     controlstore.New(db),
+				Generator: &amctest.Fake{},
+				WorkDir:   t.TempDir(),
+				Now:       time.Now,
+				Seed:      1,
+				Log:       logger,
+			}),
+			Store:     controlstore.New(db),
+			Bank:      emptyBank(t),
 			PublicURL: "https://nalanda.test",
 			Log:       logger,
 		}),

--- a/apps/server/cmd/server/main_test.go
+++ b/apps/server/cmd/server/main_test.go
@@ -97,7 +97,6 @@ func composed(t *testing.T, prober health.Prober) (http.Handler, *authstore.Stor
 				Seed:      1,
 				Log:       logger,
 			}),
-			Store:     controlstore.New(db),
 			Bank:      emptyBank(t),
 			PublicURL: "https://nalanda.test",
 			Log:       logger,

--- a/apps/server/internal/app/web/handler/controls.go
+++ b/apps/server/internal/app/web/handler/controls.go
@@ -43,9 +43,12 @@ const (
 // reasoning: several handlers sharing dependencies, refused when the set
 // is incomplete so a wiring mistake is a panic at boot rather than a nil
 // dereference inside a request (backend-code-style.md §Errors).
+//
+// Only Service is here on the domain side — reads and writes both go
+// through it (WP-E review, ARQ-11: the earlier shape held both Service
+// and Store and reviewers could not tell which was canonical for reads).
 type Controls struct {
 	Service   *controls.Service
-	Store     controls.Store
 	Bank      *bank.Bank
 	PublicURL string
 	Log       *slog.Logger
@@ -58,8 +61,6 @@ func NewControls(deps Controls) *Controls {
 	switch {
 	case deps.Service == nil:
 		panic("handler.NewControls: no service")
-	case deps.Store == nil:
-		panic("handler.NewControls: no store")
 	case deps.Bank == nil:
 		panic("handler.NewControls: no bank")
 	case deps.PublicURL == "":
@@ -71,10 +72,10 @@ func NewControls(deps Controls) *Controls {
 	return &deps
 }
 
-// List renders every control the store returns, ordered as the store
+// List renders every control the service returns, ordered as the store
 // promises (application_date desc, nulls last).
 func (h *Controls) List(w http.ResponseWriter, r *http.Request) {
-	rows, err := h.Store.ListControls(r.Context())
+	rows, err := h.Service.List(r.Context())
 	if err != nil {
 		h.Log.Error("listing controls", "error", err)
 		middleware.WriteError(w, r, http.StatusInternalServerError,
@@ -95,7 +96,7 @@ func (h *Controls) List(w http.ResponseWriter, r *http.Request) {
 
 // New renders the empty create form.
 func (h *Controls) New(w http.ResponseWriter, r *http.Request) {
-	page := h.newFormPage(r, defaultFormValues(), nil, "", "")
+	page := h.newFormPage(r, defaultFormValues(), nil, "")
 	if err := view.RenderControlsForm(w, http.StatusOK, page); err != nil {
 		h.Log.Error("rendering the controls create form", "error", err)
 	}
@@ -106,20 +107,14 @@ func (h *Controls) New(w http.ResponseWriter, r *http.Request) {
 func (h *Controls) Create(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		h.rerenderNew(w, r, defaultFormValues(), nil,
-			"No se pudo leer el formulario. Inténtalo de nuevo.", "")
+			"No se pudo leer el formulario. Inténtalo de nuevo.")
 		return
 	}
 
 	values := valuesFromRequest(r)
-	errs, req, appDateErr := validateCreate(values, h.Bank)
-	if appDateErr != "" {
-		if errs == nil {
-			errs = map[string]string{}
-		}
-		errs["application_date"] = appDateErr
-	}
+	errs, req := validateCreate(values, h.Bank)
 	if len(errs) > 0 {
-		h.rerenderNew(w, r, values, errs, "", "")
+		h.rerenderNew(w, r, values, errs, "")
 		return
 	}
 
@@ -135,7 +130,7 @@ func (h *Controls) Create(w http.ResponseWriter, r *http.Request) {
 
 	control, err := h.Service.Create(r.Context(), req)
 	if err != nil {
-		fieldErr, message, ok := domainErrorToForm(err)
+		fieldErr, ok := domainErrorToForm(err)
 		if !ok {
 			// A failure the professor cannot repair — worker down, sujet
 			// missing, disk full. Log it, render a 500 through the shell
@@ -145,7 +140,7 @@ func (h *Controls) Create(w http.ResponseWriter, r *http.Request) {
 				"El servidor no pudo generar el control. Vuelve a intentarlo en unos minutos; si el problema persiste, avisa a alguien de infraestructura.")
 			return
 		}
-		h.rerenderNew(w, r, values, fieldErr, message, "")
+		h.rerenderNew(w, r, values, fieldErr, "")
 		return
 	}
 
@@ -160,7 +155,7 @@ func (h *Controls) Detail(w http.ResponseWriter, r *http.Request) {
 		middleware.WriteError(w, r, http.StatusNotFound, "Ese control no existe.")
 		return
 	}
-	c, err := h.Store.ControlByID(r.Context(), id)
+	c, err := h.Service.Get(r.Context(), id)
 	if err != nil {
 		if errors.Is(err, controls.ErrControlNotFound) {
 			middleware.WriteError(w, r, http.StatusNotFound, "Ese control no existe.")
@@ -205,7 +200,7 @@ func (h *Controls) servePDF(w http.ResponseWriter, r *http.Request, name string)
 	// A lookup rather than a bare filepath.Join(WorkDir, id): the row is
 	// the authority, so a control that has no row cannot have its files
 	// served either (auth's list-then-serve pattern applied here).
-	if _, err := h.Store.ControlByID(r.Context(), id); err != nil {
+	if _, err := h.Service.Get(r.Context(), id); err != nil {
 		if errors.Is(err, controls.ErrControlNotFound) {
 			middleware.WriteError(w, r, http.StatusNotFound, "Ese control no existe.")
 			return
@@ -249,14 +244,14 @@ func (h *Controls) servePDF(w http.ResponseWriter, r *http.Request, name string)
 }
 
 // rerenderNew re-renders the form after a validation refusal (422).
-func (h *Controls) rerenderNew(w http.ResponseWriter, r *http.Request, values view.ControlFormValues, errs map[string]string, notice, poolPreview string) {
-	page := h.newFormPage(r, values, errs, notice, poolPreview)
+func (h *Controls) rerenderNew(w http.ResponseWriter, r *http.Request, values view.ControlFormValues, errs map[string]string, notice string) {
+	page := h.newFormPage(r, values, errs, notice)
 	if err := view.RenderControlsForm(w, http.StatusUnprocessableEntity, page); err != nil {
 		h.Log.Error("rendering the controls form after validation", "error", err)
 	}
 }
 
-func (h *Controls) newFormPage(r *http.Request, values view.ControlFormValues, errs map[string]string, notice, poolPreview string) view.ControlsFormPage {
+func (h *Controls) newFormPage(r *http.Request, values view.ControlFormValues, errs map[string]string, notice string) view.ControlsFormPage {
 	return view.ControlsFormPage{
 		Page:           middleware.PageFor(r, "Nuevo control"),
 		Action:         ControlsPath,
@@ -265,8 +260,7 @@ func (h *Controls) newFormPage(r *http.Request, values view.ControlFormValues, e
 		Values:         values,
 		Errors:         errs,
 		Notice:         notice,
-		SectionOptions: sectionOptionsFromBank(h.Bank, values),
-		PoolPreview:    poolPreview,
+		SectionOptions: sectionOptionsFromBank(h.Bank),
 	}
 }
 
@@ -298,12 +292,9 @@ func valuesFromRequest(r *http.Request) view.ControlFormValues {
 }
 
 // validateCreate is the form's validation convention: field-keyed map,
-// empty means valid. Also returns the parsed CreateRequest (populated only
-// when the map is empty) and any application_date error to be re-inserted
-// after the map is built (a parse error is per-field but application_date
-// is optional; the empty case is valid and the presence of an error only
-// matters when a value was typed).
-func validateCreate(v view.ControlFormValues, b *bank.Bank) (map[string]string, controls.CreateRequest, string) {
+// empty means valid. Also returns the parsed CreateRequest (populated
+// only when the map is empty).
+func validateCreate(v view.ControlFormValues, b *bank.Bank) (map[string]string, controls.CreateRequest) {
 	errs := map[string]string{}
 
 	if v.Name == "" {
@@ -314,12 +305,14 @@ func validateCreate(v view.ControlFormValues, b *bank.Bank) (map[string]string, 
 		errs["name"] = "El nombre debe tener a lo más 100 caracteres."
 	}
 
+	// application_date is optional: an empty string is valid and skips
+	// the parse. A non-empty value that fails to parse is a per-field
+	// refusal.
 	var appDate *time.Time
-	var appDateErr string
 	if v.ApplicationDate != "" {
 		parsed, err := time.Parse("2006-01-02", v.ApplicationDate)
 		if err != nil {
-			appDateErr = "La fecha no tiene la forma esperada (AAAA-MM-DD)."
+			errs["application_date"] = "La fecha no tiene la forma esperada (AAAA-MM-DD)."
 		} else {
 			appDate = &parsed
 		}
@@ -355,7 +348,7 @@ func validateCreate(v view.ControlFormValues, b *bank.Bank) (map[string]string, 
 		QuestionsPerCopy: qpc,
 		Copies:           copies,
 	}
-	return errs, req, appDateErr
+	return errs, req
 }
 
 // parsePositive parses a positive integer in [min, max]. Empty is
@@ -375,16 +368,16 @@ func parsePositive(raw string, min, max int) (int, string) {
 }
 
 // domainErrorToForm maps a Service.Create failure onto (field errors,
-// notice, ok). ok is false for errors the professor cannot repair; those
-// bubble up as a 500 in Create.
-func domainErrorToForm(err error) (map[string]string, string, bool) {
+// ok). ok is false for errors the professor cannot repair; those bubble
+// up as a 500 in Create.
+func domainErrorToForm(err error) (map[string]string, bool) {
 	switch {
 	case errors.Is(err, bank.ErrRangeInverted):
-		return map[string]string{"to": "El fin va antes que el inicio en el orden de lectura."}, "", true
+		return map[string]string{"to": "El fin va antes que el inicio en el orden de lectura."}, true
 	case errors.Is(err, bank.ErrEmptyRange):
-		return map[string]string{"to": "El rango no tiene preguntas todavía."}, "", true
+		return map[string]string{"to": "El rango no tiene preguntas todavía."}, true
 	case errors.Is(err, bank.ErrUnknownDocument), errors.Is(err, bank.ErrUnknownSection):
-		return map[string]string{"from": "Ese rango no existe en el banco."}, "", true
+		return map[string]string{"from": "Ese rango no existe en el banco."}, true
 	case errors.Is(err, controls.ErrPoolTooSmall):
 		var pool controls.PoolTooSmallErr
 		if errors.As(err, &pool) {
@@ -392,17 +385,17 @@ func domainErrorToForm(err error) (map[string]string, string, bool) {
 				"questions_per_copy": fmt.Sprintf(
 					"Pediste %d preguntas por copia, pero el rango solo tiene %d disponibles.",
 					pool.QuestionsPerCopy, pool.Pool),
-			}, "", true
+			}, true
 		}
 	}
-	return nil, "", false
+	return nil, false
 }
 
 // sectionOptionsFromBank builds the range dropdowns from the bank, in
-// reading order. A pre-selected value (from a form re-render) sets
-// IsSelected — actually done inline in the template with a comparison
-// against the composite value, so no per-option flag is needed here.
-func sectionOptionsFromBank(b *bank.Bank, _ view.ControlFormValues) []view.DocumentSections {
+// reading order. The template decides which option is selected by
+// comparing option.Value against the composite form value; no per-option
+// flag is needed and no per-render state has to travel through here.
+func sectionOptionsFromBank(b *bank.Bank) []view.DocumentSections {
 	if b == nil {
 		return nil
 	}

--- a/apps/server/internal/app/web/handler/controls.go
+++ b/apps/server/internal/app/web/handler/controls.go
@@ -1,0 +1,524 @@
+package handler
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/so77id/nalanda/apps/server/internal/app/web/flash"
+	"github.com/so77id/nalanda/apps/server/internal/app/web/middleware"
+	"github.com/so77id/nalanda/apps/server/internal/app/web/view"
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+	"github.com/so77id/nalanda/apps/server/internal/domain/course/bank"
+	"github.com/so77id/nalanda/apps/server/internal/infra/config"
+)
+
+// The controls routes (issue #166 §The screens). URL paths in English like
+// every other route in this surface (issue #151 §Routes).
+const (
+	ControlsPath       = "/controls"
+	ControlsNewPath    = "/controls/new"
+	ControlDetailPath  = "/controls/{id}"
+	ControlSujetPath   = "/controls/{id}/sujet.pdf"
+	ControlCorrigePath = "/controls/{id}/corrige.pdf"
+)
+
+// Defaults for the form fields. §C17: a control is four questions under a
+// five-minute clock. 30 copies is a reasonable class size.
+const (
+	defaultQuestionsPerCopy = 4
+	defaultCopies           = 30
+	maxQuestionsPerCopy     = 20
+	maxCopies               = 300
+	maxNameLength           = 100
+	minNameLength           = 3
+)
+
+// Controls holds the CRUD's handlers. Same shape as Professors, same
+// reasoning: several handlers sharing dependencies, refused when the set
+// is incomplete so a wiring mistake is a panic at boot rather than a nil
+// dereference inside a request (backend-code-style.md §Errors).
+type Controls struct {
+	Service   *controls.Service
+	Store     controls.Store
+	Bank      *bank.Bank
+	PublicURL string
+	Log       *slog.Logger
+
+	secureCookie bool
+}
+
+// NewControls returns the handlers.
+func NewControls(deps Controls) *Controls {
+	switch {
+	case deps.Service == nil:
+		panic("handler.NewControls: no service")
+	case deps.Store == nil:
+		panic("handler.NewControls: no store")
+	case deps.Bank == nil:
+		panic("handler.NewControls: no bank")
+	case deps.PublicURL == "":
+		panic("handler.NewControls: no public URL — the flash cookie's Secure attribute is derived from it")
+	case deps.Log == nil:
+		panic("handler.NewControls: no logger")
+	}
+	deps.secureCookie = config.SecureFor(deps.PublicURL)
+	return &deps
+}
+
+// List renders every control the store returns, ordered as the store
+// promises (application_date desc, nulls last).
+func (h *Controls) List(w http.ResponseWriter, r *http.Request) {
+	rows, err := h.Store.ListControls(r.Context())
+	if err != nil {
+		h.Log.Error("listing controls", "error", err)
+		middleware.WriteError(w, r, http.StatusInternalServerError,
+			"Algo se rompió en el servidor. Vuelve a intentarlo en unos segundos.")
+		return
+	}
+
+	page := view.ControlsListPage{
+		Page:     middleware.PageFor(r, "Controles"),
+		Controls: h.toListedControls(rows),
+	}
+	page.Flash = flash.Consume(w, r, h.secureCookie)
+
+	if err := view.RenderControlsList(w, page); err != nil {
+		h.Log.Error("rendering the controls list", "error", err)
+	}
+}
+
+// New renders the empty create form.
+func (h *Controls) New(w http.ResponseWriter, r *http.Request) {
+	page := h.newFormPage(r, defaultFormValues(), nil, "", "")
+	if err := view.RenderControlsForm(w, http.StatusOK, page); err != nil {
+		h.Log.Error("rendering the controls create form", "error", err)
+	}
+}
+
+// Create validates the form, orchestrates via the Service, flashes and
+// redirects on success or re-renders with per-field errors on refusal.
+func (h *Controls) Create(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		h.rerenderNew(w, r, defaultFormValues(), nil,
+			"No se pudo leer el formulario. Inténtalo de nuevo.", "")
+		return
+	}
+
+	values := valuesFromRequest(r)
+	errs, req, appDateErr := validateCreate(values, h.Bank)
+	if appDateErr != "" {
+		if errs == nil {
+			errs = map[string]string{}
+		}
+		errs["application_date"] = appDateErr
+	}
+	if len(errs) > 0 {
+		h.rerenderNew(w, r, values, errs, "", "")
+		return
+	}
+
+	acting, ok := middleware.ProfessorFrom(r.Context())
+	if !ok {
+		// The gate would have redirected an anonymous request; keep the
+		// branch honest.
+		middleware.WriteError(w, r, http.StatusInternalServerError,
+			"Algo se rompió en el servidor. Vuelve a intentarlo en unos segundos.")
+		return
+	}
+	req.CreatedBy = acting.ID
+
+	control, err := h.Service.Create(r.Context(), req)
+	if err != nil {
+		fieldErr, message, ok := domainErrorToForm(err)
+		if !ok {
+			// A failure the professor cannot repair — worker down, sujet
+			// missing, disk full. Log it, render a 500 through the shell
+			// (§Failure modes: "Renders the shell's 500 page…").
+			h.Log.Error("creating a control", "error", err, "professor", acting.ID)
+			middleware.WriteError(w, r, http.StatusInternalServerError,
+				"El servidor no pudo generar el control. Vuelve a intentarlo en unos minutos; si el problema persiste, avisa a alguien de infraestructura.")
+			return
+		}
+		h.rerenderNew(w, r, values, fieldErr, message, "")
+		return
+	}
+
+	flash.Set(w, h.secureCookie, "Control «"+control.Name+"» generado.")
+	http.Redirect(w, r, controlDetailURL(control.ID), http.StatusSeeOther)
+}
+
+// Detail renders one control (S8).
+func (h *Controls) Detail(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if !isValidControlID(id) {
+		middleware.WriteError(w, r, http.StatusNotFound, "Ese control no existe.")
+		return
+	}
+	c, err := h.Store.ControlByID(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, controls.ErrControlNotFound) {
+			middleware.WriteError(w, r, http.StatusNotFound, "Ese control no existe.")
+			return
+		}
+		h.Log.Error("reading a control", "error", err, "id", id)
+		middleware.WriteError(w, r, http.StatusInternalServerError,
+			"Algo se rompió en el servidor. Vuelve a intentarlo en unos segundos.")
+		return
+	}
+
+	page := view.ControlDetailPage{
+		Page:       middleware.PageFor(r, c.Name),
+		Control:    toDetailedControl(c, h.Bank),
+		SujetURL:   controlSujetURL(c.ID),
+		CorrigeURL: controlCorrigeURL(c.ID),
+	}
+	page.Flash = flash.Consume(w, r, h.secureCookie)
+
+	if err := view.RenderControlDetail(w, page); err != nil {
+		h.Log.Error("rendering the control detail", "error", err)
+	}
+}
+
+// SujetPDF and CorrigePDF stream the PDF files from the shared volume.
+// Wrote-through helpers so a caller cannot accidentally hand back
+// something outside the control's own directory.
+func (h *Controls) SujetPDF(w http.ResponseWriter, r *http.Request) {
+	h.servePDF(w, r, "sujet.pdf")
+}
+
+func (h *Controls) CorrigePDF(w http.ResponseWriter, r *http.Request) {
+	h.servePDF(w, r, "corrige.pdf")
+}
+
+func (h *Controls) servePDF(w http.ResponseWriter, r *http.Request, name string) {
+	id := r.PathValue("id")
+	if !isValidControlID(id) {
+		middleware.WriteError(w, r, http.StatusNotFound, "Ese control no existe.")
+		return
+	}
+	// A lookup rather than a bare filepath.Join(WorkDir, id): the row is
+	// the authority, so a control that has no row cannot have its files
+	// served either (auth's list-then-serve pattern applied here).
+	if _, err := h.Store.ControlByID(r.Context(), id); err != nil {
+		if errors.Is(err, controls.ErrControlNotFound) {
+			middleware.WriteError(w, r, http.StatusNotFound, "Ese control no existe.")
+			return
+		}
+		h.Log.Error("reading a control for PDF", "error", err, "id", id)
+		middleware.WriteError(w, r, http.StatusInternalServerError,
+			"Algo se rompió en el servidor. Vuelve a intentarlo en unos segundos.")
+		return
+	}
+
+	var path string
+	switch name {
+	case "sujet.pdf":
+		path = h.Service.SujetPath(id)
+	case "corrige.pdf":
+		path = h.Service.CorrigePath(id)
+	default:
+		middleware.WriteError(w, r, http.StatusNotFound, "Descarga no disponible.")
+		return
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		h.Log.Warn("serving control PDF", "id", id, "name", name, "error", err)
+		middleware.WriteError(w, r, http.StatusNotFound,
+			"El PDF del control no está disponible. Puede que se haya limpiado del volumen compartido.")
+		return
+	}
+	defer func() { _ = f.Close() }()
+
+	info, err := f.Stat()
+	if err != nil {
+		h.Log.Error("stat control PDF", "id", id, "name", name, "error", err)
+		middleware.WriteError(w, r, http.StatusInternalServerError,
+			"Algo se rompió en el servidor. Vuelve a intentarlo en unos segundos.")
+		return
+	}
+	w.Header().Set("Content-Type", "application/pdf")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`inline; filename="control-%s-%s"`, id, name))
+	http.ServeContent(w, r, name, info.ModTime(), f)
+}
+
+// rerenderNew re-renders the form after a validation refusal (422).
+func (h *Controls) rerenderNew(w http.ResponseWriter, r *http.Request, values view.ControlFormValues, errs map[string]string, notice, poolPreview string) {
+	page := h.newFormPage(r, values, errs, notice, poolPreview)
+	if err := view.RenderControlsForm(w, http.StatusUnprocessableEntity, page); err != nil {
+		h.Log.Error("rendering the controls form after validation", "error", err)
+	}
+}
+
+func (h *Controls) newFormPage(r *http.Request, values view.ControlFormValues, errs map[string]string, notice, poolPreview string) view.ControlsFormPage {
+	return view.ControlsFormPage{
+		Page:           middleware.PageFor(r, "Nuevo control"),
+		Action:         ControlsPath,
+		Submit:         "Generar control",
+		Heading:        "Nuevo control",
+		Values:         values,
+		Errors:         errs,
+		Notice:         notice,
+		SectionOptions: sectionOptionsFromBank(h.Bank, values),
+		PoolPreview:    poolPreview,
+	}
+}
+
+// defaultFormValues returns the values the empty GET form starts from.
+func defaultFormValues() view.ControlFormValues {
+	return view.ControlFormValues{
+		QuestionsPerCopy: strconv.Itoa(defaultQuestionsPerCopy),
+		Copies:           strconv.Itoa(defaultCopies),
+	}
+}
+
+// valuesFromRequest reads the form values on POST. Whitespace-trimmed and
+// lowercased where a normalisation is safe.
+func valuesFromRequest(r *http.Request) view.ControlFormValues {
+	from := strings.TrimSpace(r.PostFormValue("from"))
+	to := strings.TrimSpace(r.PostFormValue("to"))
+	fromDoc, fromSec, _ := strings.Cut(from, ":")
+	toDoc, toSec, _ := strings.Cut(to, ":")
+	return view.ControlFormValues{
+		Name:             strings.TrimSpace(r.PostFormValue("name")),
+		ApplicationDate:  strings.TrimSpace(r.PostFormValue("application_date")),
+		FromDocument:     fromDoc,
+		FromSection:      fromSec,
+		ToDocument:       toDoc,
+		ToSection:        toSec,
+		QuestionsPerCopy: strings.TrimSpace(r.PostFormValue("questions_per_copy")),
+		Copies:           strings.TrimSpace(r.PostFormValue("copies")),
+	}
+}
+
+// validateCreate is the form's validation convention: field-keyed map,
+// empty means valid. Also returns the parsed CreateRequest (populated only
+// when the map is empty) and any application_date error to be re-inserted
+// after the map is built (a parse error is per-field but application_date
+// is optional; the empty case is valid and the presence of an error only
+// matters when a value was typed).
+func validateCreate(v view.ControlFormValues, b *bank.Bank) (map[string]string, controls.CreateRequest, string) {
+	errs := map[string]string{}
+
+	if v.Name == "" {
+		errs["name"] = "El nombre es obligatorio."
+	} else if len([]rune(v.Name)) < minNameLength {
+		errs["name"] = "El nombre debe tener al menos 3 caracteres."
+	} else if len([]rune(v.Name)) > maxNameLength {
+		errs["name"] = "El nombre debe tener a lo más 100 caracteres."
+	}
+
+	var appDate *time.Time
+	var appDateErr string
+	if v.ApplicationDate != "" {
+		parsed, err := time.Parse("2006-01-02", v.ApplicationDate)
+		if err != nil {
+			appDateErr = "La fecha no tiene la forma esperada (AAAA-MM-DD)."
+		} else {
+			appDate = &parsed
+		}
+	}
+
+	from := bank.SectionRef{Document: v.FromDocument, Section: v.FromSection}
+	to := bank.SectionRef{Document: v.ToDocument, Section: v.ToSection}
+	if v.FromDocument == "" || v.FromSection == "" {
+		errs["from"] = "Elige un inicio."
+	} else if !b.HasSection(from) {
+		errs["from"] = "Ese inicio no existe en el banco."
+	}
+	if v.ToDocument == "" || v.ToSection == "" {
+		errs["to"] = "Elige un fin."
+	} else if !b.HasSection(to) {
+		errs["to"] = "Ese fin no existe en el banco."
+	}
+
+	qpc, qpcErr := parsePositive(v.QuestionsPerCopy, 1, maxQuestionsPerCopy)
+	if qpcErr != "" {
+		errs["questions_per_copy"] = qpcErr
+	}
+	copies, copiesErr := parsePositive(v.Copies, 1, maxCopies)
+	if copiesErr != "" {
+		errs["copies"] = copiesErr
+	}
+
+	req := controls.CreateRequest{
+		Name:             v.Name,
+		ApplicationDate:  appDate,
+		RangeFrom:        from,
+		RangeTo:          to,
+		QuestionsPerCopy: qpc,
+		Copies:           copies,
+	}
+	return errs, req, appDateErr
+}
+
+// parsePositive parses a positive integer in [min, max]. Empty is
+// reported.
+func parsePositive(raw string, min, max int) (int, string) {
+	if raw == "" {
+		return 0, fmt.Sprintf("Escribe un número entre %d y %d.", min, max)
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, "Debe ser un número entero."
+	}
+	if n < min || n > max {
+		return 0, fmt.Sprintf("Debe estar entre %d y %d.", min, max)
+	}
+	return n, ""
+}
+
+// domainErrorToForm maps a Service.Create failure onto (field errors,
+// notice, ok). ok is false for errors the professor cannot repair; those
+// bubble up as a 500 in Create.
+func domainErrorToForm(err error) (map[string]string, string, bool) {
+	switch {
+	case errors.Is(err, bank.ErrRangeInverted):
+		return map[string]string{"to": "El fin va antes que el inicio en el orden de lectura."}, "", true
+	case errors.Is(err, bank.ErrEmptyRange):
+		return map[string]string{"to": "El rango no tiene preguntas todavía."}, "", true
+	case errors.Is(err, bank.ErrUnknownDocument), errors.Is(err, bank.ErrUnknownSection):
+		return map[string]string{"from": "Ese rango no existe en el banco."}, "", true
+	case errors.Is(err, controls.ErrPoolTooSmall):
+		var pool controls.PoolTooSmallErr
+		if errors.As(err, &pool) {
+			return map[string]string{
+				"questions_per_copy": fmt.Sprintf(
+					"Pediste %d preguntas por copia, pero el rango solo tiene %d disponibles.",
+					pool.QuestionsPerCopy, pool.Pool),
+			}, "", true
+		}
+	}
+	return nil, "", false
+}
+
+// sectionOptionsFromBank builds the range dropdowns from the bank, in
+// reading order. A pre-selected value (from a form re-render) sets
+// IsSelected — actually done inline in the template with a comparison
+// against the composite value, so no per-option flag is needed here.
+func sectionOptionsFromBank(b *bank.Bank, _ view.ControlFormValues) []view.DocumentSections {
+	if b == nil {
+		return nil
+	}
+	out := make([]view.DocumentSections, 0, len(b.Documents))
+	for _, d := range b.Documents {
+		sections := make([]view.SectionOption, 0, len(d.Sections))
+		for _, s := range d.Sections {
+			sections = append(sections, view.SectionOption{
+				Value:   d.ID + ":" + s,
+				Label:   s,
+				Section: s,
+			})
+		}
+		out = append(out, view.DocumentSections{
+			DocumentID:    d.ID,
+			DocumentTitle: d.Title,
+			Sections:      sections,
+		})
+	}
+	return out
+}
+
+// isValidControlID enforces the ID's shape at the URL boundary so a stray
+// path segment does not reach the store.
+func isValidControlID(id string) bool {
+	if len(id) != controls.IDLength {
+		return false
+	}
+	for _, r := range id {
+		if !(r >= 'A' && r <= 'Z') && !(r >= '2' && r <= '7') {
+			return false
+		}
+	}
+	return true
+}
+
+// controlDetailURL is the canonical URL of one control's detail page.
+func controlDetailURL(id string) string {
+	return ControlsPath + "/" + id
+}
+
+func controlSujetURL(id string) string {
+	return controlDetailURL(id) + "/sujet.pdf"
+}
+
+func controlCorrigeURL(id string) string {
+	return controlDetailURL(id) + "/corrige.pdf"
+}
+
+// toListedControls turns domain values into rows the template can render
+// without formatting. Same reasoning as toListedProfessors.
+func (h *Controls) toListedControls(rows []controls.Control) []view.ListedControl {
+	out := make([]view.ListedControl, 0, len(rows))
+	for _, c := range rows {
+		out = append(out, view.ListedControl{
+			ID:              c.ID,
+			Name:            c.Name,
+			ApplicationDate: formatOptionalDate(c.ApplicationDate),
+			Range:           formatRangeWithTitles(c.RangeFrom, c.RangeTo, h.Bank),
+			Shape:           fmt.Sprintf("%d preguntas × %d copias", c.QuestionsPerCopy, c.Copies),
+			State:           stateWordControl(c.State),
+			DetailURL:       controlDetailURL(c.ID),
+		})
+	}
+	return out
+}
+
+func toDetailedControl(c controls.Control, b *bank.Bank) view.DetailedControl {
+	return view.DetailedControl{
+		ID:              c.ID,
+		Name:            c.Name,
+		ApplicationDate: formatOptionalDate(c.ApplicationDate),
+		Range:           formatRangeWithTitles(c.RangeFrom, c.RangeTo, b),
+		Shape:           fmt.Sprintf("%d preguntas × %d copias", c.QuestionsPerCopy, c.Copies),
+		State:           stateWordControl(c.State),
+		CreatedAt:       spanishDate(c.CreatedAt),
+	}
+}
+
+func formatOptionalDate(t *time.Time) string {
+	if t == nil {
+		return "Sin fecha"
+	}
+	return spanishDate(*t)
+}
+
+func formatRangeWithTitles(from, to bank.SectionRef, b *bank.Bank) string {
+	fromDoc, fromOk := b.FindDocument(from.Document)
+	toDoc, toOk := b.FindDocument(to.Document)
+	fromTitle := from.Document
+	toTitle := to.Document
+	if fromOk {
+		fromTitle = fromDoc.Title
+	}
+	if toOk {
+		toTitle = toDoc.Title
+	}
+	return fmt.Sprintf("%s / %s → %s / %s", fromTitle, from.Section, toTitle, to.Section)
+}
+
+func stateWordControl(s controls.State) string {
+	switch s {
+	case controls.Generated:
+		return "Generado"
+	case controls.InReview:
+		return "En revisión"
+	case controls.Graded:
+		return "Corregido"
+	default:
+		return string(s)
+	}
+}
+
+// Root redirects `/` to `/controls`. Supersedes #151's redirect to
+// `/professors` (issue #166 §The screens: with WP-E landed, controls are
+// the professor's primary activity).
+func (h *Controls) Root(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, ControlsPath, http.StatusSeeOther)
+}

--- a/apps/server/internal/app/web/handler/controls_test.go
+++ b/apps/server/internal/app/web/handler/controls_test.go
@@ -1,0 +1,454 @@
+package handler_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/so77id/nalanda/apps/server/internal/app/web/handler"
+	"github.com/so77id/nalanda/apps/server/internal/app/web/middleware"
+	"github.com/so77id/nalanda/apps/server/internal/domain/auth"
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+	"github.com/so77id/nalanda/apps/server/internal/domain/course/bank"
+	"github.com/so77id/nalanda/apps/server/internal/infra/amcworker/amctest"
+	"github.com/so77id/nalanda/apps/server/internal/infra/storage"
+	"github.com/so77id/nalanda/apps/server/internal/infra/storage/authstore"
+	"github.com/so77id/nalanda/apps/server/internal/infra/storage/controlstore"
+	"github.com/so77id/nalanda/apps/server/migrations"
+)
+
+const controlsBankJSON = `{
+  "version": 1,
+  "documents": [
+    {"id": "welcome", "title": "Bienvenida", "coverage": "clase 0",
+     "sections": ["hola", "reglas"]},
+    {"id": "flujo",   "title": "Flujo",      "coverage": "clase 2",
+     "sections": ["if-else", "bucles"]}
+  ],
+  "questions": [
+    {"id": "q1", "document": "welcome", "anchor": "hola",   "type": "simple",
+     "statement": "?", "code": null, "alternatives": ["a","b"], "correct": [0]},
+    {"id": "q2", "document": "welcome", "anchor": "reglas", "type": "simple",
+     "statement": "?", "code": null, "alternatives": ["a","b"], "correct": [0]},
+    {"id": "q3", "document": "flujo",   "anchor": "if-else","type": "simple",
+     "statement": "?", "code": null, "alternatives": ["a","b"], "correct": [0]},
+    {"id": "q4", "document": "flujo",   "anchor": "bucles", "type": "multiple",
+     "statement": "?", "code": null, "alternatives": ["a","b"], "correct": [0]}
+  ]
+}`
+
+type controlsFixture struct {
+	handler *handler.Controls
+	fake    *amctest.Fake
+	store   controls.Store
+	workDir string
+	user    auth.User
+	session auth.Session
+	log     *slog.Logger
+}
+
+func newControlsFixture(t *testing.T) *controlsFixture {
+	t.Helper()
+	ctx := context.Background()
+
+	db, err := storage.Open(ctx, filepath.Join(t.TempDir(), "nalanda.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := storage.Migrate(ctx, db, migrations.FS); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	authStore := authstore.New(db)
+	prof, err := authStore.CreateUser(ctx, "profesora@example.com", "Profesora")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	session := auth.Session{
+		TokenHash: "hash-1",
+		UserID:    prof.ID,
+		CSRFToken: "csrf-1",
+		ExpiresAt: time.Now().Add(time.Hour),
+	}
+	if err := authStore.CreateSession(ctx, session); err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	b, err := bank.Parse(strings.NewReader(controlsBankJSON))
+	if err != nil {
+		t.Fatalf("bank.Parse: %v", err)
+	}
+	workDir := t.TempDir()
+	fake := &amctest.Fake{WorkDir: workDir, SujetSize: 42}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	cstore := controlstore.New(db)
+	svc := controls.NewService(controls.Service{
+		Bank: b, Store: cstore, Generator: fake, WorkDir: workDir,
+		Now: time.Now, Seed: 1, Log: log,
+	})
+	h := handler.NewControls(handler.Controls{
+		Service: svc, Store: cstore, Bank: b,
+		PublicURL: publicURL, Log: log,
+	})
+	return &controlsFixture{handler: h, fake: fake, store: cstore, workDir: workDir, user: prof, session: session, log: log}
+}
+
+func (f *controlsFixture) authedRequest(t *testing.T, method, path string, body url.Values) *http.Request {
+	t.Helper()
+	var req *http.Request
+	if body != nil {
+		req = httptest.NewRequest(method, path, strings.NewReader(body.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	} else {
+		req = httptest.NewRequest(method, path, nil)
+	}
+	ctx := middleware.WithProfessorForTest(req.Context(), f.user, f.session)
+	return req.WithContext(ctx)
+}
+
+func validForm() url.Values {
+	return url.Values{
+		"name":               {"Control 1"},
+		"application_date":   {"2026-08-25"},
+		"from":               {"welcome:hola"},
+		"to":                 {"flujo:bucles"},
+		"questions_per_copy": {"3"},
+		"copies":             {"2"},
+		"csrf_token":         {"csrf-1"},
+	}
+}
+
+func TestNewRendersTheFormWithBankSections(t *testing.T) {
+	f := newControlsFixture(t)
+	rec := httptest.NewRecorder()
+	f.handler.New(rec, f.authedRequest(t, http.MethodGet, handler.ControlsNewPath, nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	// The form's dropdowns must carry every (doc, section) as an option
+	// value "doc:section".
+	for _, opt := range []string{`value="welcome:hola"`, `value="flujo:bucles"`, `<optgroup label="Bienvenida">`} {
+		if !strings.Contains(body, opt) {
+			t.Errorf("form is missing %q", opt)
+		}
+	}
+	if !strings.Contains(body, `name="csrf_token" value="csrf-1"`) {
+		t.Error("form is missing the CSRF token")
+	}
+}
+
+func TestCreateWritesAControlAndRedirectsToItsDetail(t *testing.T) {
+	f := newControlsFixture(t)
+	rec := httptest.NewRecorder()
+	f.handler.Create(rec, f.authedRequest(t, http.MethodPost, handler.ControlsPath, validForm()))
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303; body:\n%s", rec.Code, rec.Body.String())
+	}
+	loc := rec.Header().Get("Location")
+	if !strings.HasPrefix(loc, handler.ControlsPath+"/") {
+		t.Errorf("Location = %q, want /controls/<id>", loc)
+	}
+
+	rows, err := f.store.ListControls(context.Background())
+	if err != nil {
+		t.Fatalf("ListControls: %v", err)
+	}
+	if len(rows) != 1 || rows[0].CreatedBy != f.user.ID {
+		t.Errorf("stored rows = %+v (created_by must be the acting professor)", rows)
+	}
+	if rows[0].State != controls.Generated {
+		t.Errorf("state = %v, want %v", rows[0].State, controls.Generated)
+	}
+
+	// The flash cookie was set — a caller landing on the detail page
+	// would see it once.
+	if cookie := rec.Header().Get("Set-Cookie"); !strings.Contains(cookie, "nalanda_flash") {
+		t.Errorf("no flash cookie set, want one (POST/redirect/GET convention)")
+	}
+
+	// sujet.pdf is on disk.
+	if _, err := os.Stat(filepath.Join(f.workDir, "controls", rows[0].ID, "out", "sujet.pdf")); err != nil {
+		t.Errorf("sujet.pdf missing on disk: %v", err)
+	}
+}
+
+func TestCreateRefusesMissingNameWith422(t *testing.T) {
+	f := newControlsFixture(t)
+	form := validForm()
+	form.Del("name")
+	rec := httptest.NewRecorder()
+	f.handler.Create(rec, f.authedRequest(t, http.MethodPost, handler.ControlsPath, form))
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "obligatorio") {
+		t.Error("body does not carry the 'obligatorio' error for the name field")
+	}
+	// A refusal does NOT redirect — asserting the status code covers this
+	// with the location check.
+	if rec.Header().Get("Location") != "" {
+		t.Error("a 422 refusal must not carry a Location header")
+	}
+	// The store is untouched.
+	rows, _ := f.store.ListControls(context.Background())
+	if len(rows) != 0 {
+		t.Errorf("stored %d rows after a refusal, want 0", len(rows))
+	}
+}
+
+func TestCreateRefusesAnUnknownRangeWith422(t *testing.T) {
+	f := newControlsFixture(t)
+	form := validForm()
+	form.Set("from", "no-such-doc:no-such-section")
+	rec := httptest.NewRecorder()
+	f.handler.Create(rec, f.authedRequest(t, http.MethodPost, handler.ControlsPath, form))
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "no existe") {
+		t.Error("body does not carry the 'no existe' error for the from field")
+	}
+}
+
+func TestCreateRefusesAPoolTooSmallForCopyWithSpanishNumbers(t *testing.T) {
+	f := newControlsFixture(t)
+	form := validForm()
+	form.Set("from", "welcome:hola")
+	form.Set("to", "welcome:hola")      // one question in the range
+	form.Set("questions_per_copy", "3") // ask for 3
+	rec := httptest.NewRecorder()
+	f.handler.Create(rec, f.authedRequest(t, http.MethodPost, handler.ControlsPath, form))
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422; body:\n%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	// The Spanish message names BOTH counts (issue #166 §The form:
+	// "Pediste 8 preguntas por copia, pero el rango solo tiene 5
+	// disponibles").
+	for _, want := range []string{"3 preguntas", "1 disponibles"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body does not carry %q; got:\n%s", want, body)
+		}
+	}
+}
+
+func TestCreateRefusesInvertedRangeWith422(t *testing.T) {
+	f := newControlsFixture(t)
+	form := validForm()
+	form.Set("from", "flujo:bucles")
+	form.Set("to", "welcome:hola")
+	rec := httptest.NewRecorder()
+	f.handler.Create(rec, f.authedRequest(t, http.MethodPost, handler.ControlsPath, form))
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "antes que el inicio") {
+		t.Error("body does not name the inverted-range refusal")
+	}
+}
+
+func TestCreateRefusesInvalidDateWith422(t *testing.T) {
+	f := newControlsFixture(t)
+	form := validForm()
+	form.Set("application_date", "August 25")
+	rec := httptest.NewRecorder()
+	f.handler.Create(rec, f.authedRequest(t, http.MethodPost, handler.ControlsPath, form))
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "AAAA-MM-DD") {
+		t.Error("body does not carry the date-format error")
+	}
+}
+
+// Values the user typed come back on refusal (issue #151 §Form:
+// "The values the professor typed come back on refusal").
+func TestCreateEchoesValuesOnRefusal(t *testing.T) {
+	f := newControlsFixture(t)
+	form := validForm()
+	form.Set("name", "") // trigger refusal on the name field
+	form.Set("application_date", "2026-09-05")
+	form.Set("copies", "17")
+	rec := httptest.NewRecorder()
+	f.handler.Create(rec, f.authedRequest(t, http.MethodPost, handler.ControlsPath, form))
+
+	body := rec.Body.String()
+	if !strings.Contains(body, `value="2026-09-05"`) {
+		t.Error("body did not echo the application_date value")
+	}
+	if !strings.Contains(body, `value="17"`) {
+		t.Error("body did not echo the copies value")
+	}
+}
+
+func TestCreateRendersA500ThroughTheShellWhenTheWorkerRefuses(t *testing.T) {
+	f := newControlsFixture(t)
+	f.fake.Err = controls.ErrGeneratorRefused
+
+	rec := httptest.NewRecorder()
+	f.handler.Create(rec, f.authedRequest(t, http.MethodPost, handler.ControlsPath, validForm()))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 (worker failure is not a form error)", rec.Code)
+	}
+	// The shell error page renders through view.RenderError — its
+	// Spanish message is what the professor reads.
+	if !strings.Contains(rec.Body.String(), "servidor") {
+		t.Error("body does not carry the shell error page's Spanish message")
+	}
+
+	rows, _ := f.store.ListControls(context.Background())
+	if len(rows) != 0 {
+		t.Errorf("stored %d rows after a worker failure, want 0 (creation is all-or-nothing)", len(rows))
+	}
+}
+
+func TestCreateRendersA500WhenSujetIsMissing(t *testing.T) {
+	f := newControlsFixture(t)
+	f.fake.SujetSize = 0 // fake writes a 0-byte sujet.pdf
+
+	rec := httptest.NewRecorder()
+	f.handler.Create(rec, f.authedRequest(t, http.MethodPost, handler.ControlsPath, validForm()))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	rows, _ := f.store.ListControls(context.Background())
+	if len(rows) != 0 {
+		t.Errorf("stored %d rows after a 0-byte sujet, want 0", len(rows))
+	}
+}
+
+func TestListRendersEveryControl(t *testing.T) {
+	f := newControlsFixture(t)
+	// Land one control.
+	rec := httptest.NewRecorder()
+	f.handler.Create(rec, f.authedRequest(t, http.MethodPost, handler.ControlsPath, validForm()))
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("Create failed setting up: %d — %s", rec.Code, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	f.handler.List(rec, f.authedRequest(t, http.MethodGet, handler.ControlsPath, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("List status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"Control 1", "3 preguntas × 2 copias", "Generado", "Bienvenida / hola → Flujo / bucles"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("list body missing %q", want)
+		}
+	}
+}
+
+func TestRootRedirectsToControls(t *testing.T) {
+	f := newControlsFixture(t)
+	rec := httptest.NewRecorder()
+	f.handler.Root(rec, f.authedRequest(t, http.MethodGet, "/", nil))
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303", rec.Code)
+	}
+	if loc := rec.Header().Get("Location"); loc != handler.ControlsPath {
+		t.Errorf("Location = %q, want %q", loc, handler.ControlsPath)
+	}
+}
+
+func TestDetailReturnsA404OnAnUnknownID(t *testing.T) {
+	f := newControlsFixture(t)
+	rec := httptest.NewRecorder()
+	// A well-shaped id (26 chars, valid alphabet) that does not exist.
+	req := f.authedRequest(t, http.MethodGet, "/controls/AAAAAAAAAAAAAAAAAAAAAAAAAA", nil)
+	req.SetPathValue("id", "AAAAAAAAAAAAAAAAAAAAAAAAAA")
+	f.handler.Detail(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 (well-shaped but unknown id)", rec.Code)
+	}
+
+	// A badly-shaped id (wrong length) also 404s, before the store lookup.
+	rec = httptest.NewRecorder()
+	req = f.authedRequest(t, http.MethodGet, "/controls/short", nil)
+	req.SetPathValue("id", "short")
+	f.handler.Detail(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 (bad shape)", rec.Code)
+	}
+}
+
+func TestDetailRendersMetadataAndDownloadLinks(t *testing.T) {
+	f := newControlsFixture(t)
+	rec := httptest.NewRecorder()
+	f.handler.Create(rec, f.authedRequest(t, http.MethodPost, handler.ControlsPath, validForm()))
+	loc := rec.Header().Get("Location")
+	id := strings.TrimPrefix(loc, handler.ControlsPath+"/")
+
+	rec = httptest.NewRecorder()
+	req := f.authedRequest(t, http.MethodGet, loc, nil)
+	req.SetPathValue("id", id)
+	f.handler.Detail(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("Detail status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{"Control 1", "Descargar prueba", "Descargar clave", "Aún no hay escaneos"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("detail body missing %q", want)
+		}
+	}
+}
+
+func TestSujetPDFStreamsTheFile(t *testing.T) {
+	f := newControlsFixture(t)
+	rec := httptest.NewRecorder()
+	f.handler.Create(rec, f.authedRequest(t, http.MethodPost, handler.ControlsPath, validForm()))
+	loc := rec.Header().Get("Location")
+	id := strings.TrimPrefix(loc, handler.ControlsPath+"/")
+
+	rec = httptest.NewRecorder()
+	req := f.authedRequest(t, http.MethodGet, loc+"/sujet.pdf", nil)
+	req.SetPathValue("id", id)
+	f.handler.SujetPDF(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("SujetPDF status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/pdf" {
+		t.Errorf("Content-Type = %q, want application/pdf", ct)
+	}
+	if got, want := rec.Body.Bytes(), bytes.Repeat([]byte{0}, 42); !bytes.Equal(got, want) {
+		t.Errorf("body len = %d, want 42 (amctest.Fake wrote 42 zero bytes as the stub)", len(got))
+	}
+}
+
+func TestSujetPDF404sWhenTheControlIsUnknown(t *testing.T) {
+	f := newControlsFixture(t)
+	rec := httptest.NewRecorder()
+	req := f.authedRequest(t, http.MethodGet, "/controls/AAAAAAAAAAAAAAAAAAAAAAAAAA/sujet.pdf", nil)
+	req.SetPathValue("id", "AAAAAAAAAAAAAAAAAAAAAAAAAA")
+	f.handler.SujetPDF(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
+// silence io import in case future edits drop the last use.
+var _ = io.Discard

--- a/apps/server/internal/app/web/handler/controls_test.go
+++ b/apps/server/internal/app/web/handler/controls_test.go
@@ -48,8 +48,8 @@ const controlsBankJSON = `{
 
 type controlsFixture struct {
 	handler *handler.Controls
+	service *controls.Service
 	fake    *amctest.Fake
-	store   controls.Store
 	workDir string
 	user    auth.User
 	session auth.Session
@@ -98,10 +98,10 @@ func newControlsFixture(t *testing.T) *controlsFixture {
 		Now: time.Now, Seed: 1, Log: log,
 	})
 	h := handler.NewControls(handler.Controls{
-		Service: svc, Store: cstore, Bank: b,
+		Service: svc, Bank: b,
 		PublicURL: publicURL, Log: log,
 	})
-	return &controlsFixture{handler: h, fake: fake, store: cstore, workDir: workDir, user: prof, session: session, log: log}
+	return &controlsFixture{handler: h, service: svc, fake: fake, workDir: workDir, user: prof, session: session, log: log}
 }
 
 func (f *controlsFixture) authedRequest(t *testing.T, method, path string, body url.Values) *http.Request {
@@ -163,7 +163,7 @@ func TestCreateWritesAControlAndRedirectsToItsDetail(t *testing.T) {
 		t.Errorf("Location = %q, want /controls/<id>", loc)
 	}
 
-	rows, err := f.store.ListControls(context.Background())
+	rows, err := f.service.List(context.Background())
 	if err != nil {
 		t.Fatalf("ListControls: %v", err)
 	}
@@ -205,7 +205,7 @@ func TestCreateRefusesMissingNameWith422(t *testing.T) {
 		t.Error("a 422 refusal must not carry a Location header")
 	}
 	// The store is untouched.
-	rows, _ := f.store.ListControls(context.Background())
+	rows, _ := f.service.List(context.Background())
 	if len(rows) != 0 {
 		t.Errorf("stored %d rows after a refusal, want 0", len(rows))
 	}
@@ -316,7 +316,7 @@ func TestCreateRendersA500ThroughTheShellWhenTheWorkerRefuses(t *testing.T) {
 		t.Error("body does not carry the shell error page's Spanish message")
 	}
 
-	rows, _ := f.store.ListControls(context.Background())
+	rows, _ := f.service.List(context.Background())
 	if len(rows) != 0 {
 		t.Errorf("stored %d rows after a worker failure, want 0 (creation is all-or-nothing)", len(rows))
 	}
@@ -332,7 +332,7 @@ func TestCreateRendersA500WhenSujetIsMissing(t *testing.T) {
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("status = %d, want 500", rec.Code)
 	}
-	rows, _ := f.store.ListControls(context.Background())
+	rows, _ := f.service.List(context.Background())
 	if len(rows) != 0 {
 		t.Errorf("stored %d rows after a 0-byte sujet, want 0", len(rows))
 	}
@@ -441,14 +441,23 @@ func TestSujetPDFStreamsTheFile(t *testing.T) {
 
 func TestSujetPDF404sWhenTheControlIsUnknown(t *testing.T) {
 	f := newControlsFixture(t)
+
+	// Well-shaped but unknown id — the store's lookup misses.
 	rec := httptest.NewRecorder()
 	req := f.authedRequest(t, http.MethodGet, "/controls/AAAAAAAAAAAAAAAAAAAAAAAAAA/sujet.pdf", nil)
 	req.SetPathValue("id", "AAAAAAAAAAAAAAAAAAAAAAAAAA")
 	f.handler.SujetPDF(rec, req)
 	if rec.Code != http.StatusNotFound {
-		t.Errorf("status = %d, want 404", rec.Code)
+		t.Errorf("status(well-shaped unknown) = %d, want 404", rec.Code)
+	}
+
+	// Badly-shaped id — the isValidControlID guard rejects before the
+	// store is even reached. Covers the fast-fail path Detail also has.
+	rec = httptest.NewRecorder()
+	req = f.authedRequest(t, http.MethodGet, "/controls/short/sujet.pdf", nil)
+	req.SetPathValue("id", "short")
+	f.handler.SujetPDF(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status(bad shape) = %d, want 404", rec.Code)
 	}
 }
-
-// silence io import in case future edits drop the last use.
-var _ = io.Discard

--- a/apps/server/internal/app/web/router.go
+++ b/apps/server/internal/app/web/router.go
@@ -41,6 +41,11 @@ type Deps struct {
 	Login *handler.Auth
 	// Professors is the CRUD's handlers (issue #151 S5 onward).
 	Professors *handler.Professors
+	// Controls is the entrance-controls CRUD's handlers (issue #166,
+	// WP-E). Landed together with the two other blocks above rather than
+	// piecemeal so a request to /controls/new does not 404 while the row
+	// exists.
+	Controls *handler.Controls
 	// Log is spelled the same here as in the two structs above.
 	Log *slog.Logger
 }
@@ -110,9 +115,39 @@ func routes(deps Deps) []Route {
 		// The CRUD, from S5 on. Gated by default (no Public), which the
 		// TestEveryRouteIsGatedUnlessItSaysWhyNot guard walks — an anonymous
 		// visitor is redirected to /login before the handler runs.
+		//
+		// / is claimed by Controls.Root since issue #166 (WP-E) supersedes
+		// #151's /professors landing: with WP-E landed, controls are the
+		// professor's primary activity, and the professors table is
+		// reached from the nav.
 		{
 			Method: http.MethodGet, Path: "/",
-			Handler: deps.Professors.Root,
+			Handler: deps.Controls.Root,
+		},
+		// The entrance-controls CRUD (issue #166 WP-E). Gated by default.
+		{
+			Method: http.MethodGet, Path: handler.ControlsPath,
+			Handler: deps.Controls.List,
+		},
+		{
+			Method: http.MethodGet, Path: handler.ControlsNewPath,
+			Handler: deps.Controls.New,
+		},
+		{
+			Method: http.MethodPost, Path: handler.ControlsPath,
+			Handler: deps.Controls.Create,
+		},
+		{
+			Method: http.MethodGet, Path: handler.ControlDetailPath,
+			Handler: deps.Controls.Detail,
+		},
+		{
+			Method: http.MethodGet, Path: handler.ControlSujetPath,
+			Handler: deps.Controls.SujetPDF,
+		},
+		{
+			Method: http.MethodGet, Path: handler.ControlCorrigePath,
+			Handler: deps.Controls.CorrigePDF,
 		},
 		{
 			Method: http.MethodGet, Path: handler.ProfessorsPath,
@@ -178,6 +213,8 @@ func Router(deps Deps) http.Handler {
 		panic("web.Router: no login handlers")
 	case deps.Professors == nil:
 		panic("web.Router: no professors handlers")
+	case deps.Controls == nil:
+		panic("web.Router: no controls handlers")
 	case deps.Log == nil:
 		panic("web.Router: no logger")
 	}

--- a/apps/server/internal/app/web/router_test.go
+++ b/apps/server/internal/app/web/router_test.go
@@ -95,7 +95,6 @@ func deps(t *testing.T, prober health.Prober) web.Deps {
 				Seed:      1,
 				Log:       logger,
 			}),
-			Store:     controlstore.New(db),
 			Bank:      emptyBank(t),
 			PublicURL: "https://nalanda.test",
 			Log:       logger,

--- a/apps/server/internal/app/web/router_test.go
+++ b/apps/server/internal/app/web/router_test.go
@@ -17,12 +17,28 @@ import (
 	"github.com/so77id/nalanda/apps/server/internal/app/web/middleware"
 	"github.com/so77id/nalanda/apps/server/internal/app/web/oauthstate"
 	"github.com/so77id/nalanda/apps/server/internal/domain/auth"
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+	"github.com/so77id/nalanda/apps/server/internal/domain/course/bank"
 	"github.com/so77id/nalanda/apps/server/internal/domain/health"
+	"github.com/so77id/nalanda/apps/server/internal/infra/amcworker/amctest"
 	"github.com/so77id/nalanda/apps/server/internal/infra/oidc/oidctest"
 	"github.com/so77id/nalanda/apps/server/internal/infra/storage"
 	"github.com/so77id/nalanda/apps/server/internal/infra/storage/authstore"
+	"github.com/so77id/nalanda/apps/server/internal/infra/storage/controlstore"
 	"github.com/so77id/nalanda/apps/server/migrations"
 )
+
+// emptyBank returns a valid, empty bank for the router tests — the
+// existing cases do not exercise controls flow, but the constructor
+// refuses a nil bank.
+func emptyBank(t *testing.T) *bank.Bank {
+	t.Helper()
+	b, err := bank.Parse(strings.NewReader(`{"version":1,"documents":[],"questions":[]}`))
+	if err != nil {
+		t.Fatalf("emptyBank: %v", err)
+	}
+	return b
+}
 
 // deps builds the surface the way cmd/server does, over a real (empty) database.
 // The auth chain is real rather than stubbed because half of what these cases
@@ -66,6 +82,21 @@ func deps(t *testing.T, prober health.Prober) web.Deps {
 				Sessions: store,
 				Now:      time.Now,
 			}),
+			PublicURL: "https://nalanda.test",
+			Log:       logger,
+		}),
+		Controls: handler.NewControls(handler.Controls{
+			Service: controls.NewService(controls.Service{
+				Bank:      emptyBank(t),
+				Store:     controlstore.New(db),
+				Generator: &amctest.Fake{},
+				WorkDir:   t.TempDir(),
+				Now:       time.Now,
+				Seed:      1,
+				Log:       logger,
+			}),
+			Store:     controlstore.New(db),
+			Bank:      emptyBank(t),
 			PublicURL: "https://nalanda.test",
 			Log:       logger,
 		}),

--- a/apps/server/internal/app/web/view/templates/pages/controls_detail.html
+++ b/apps/server/internal/app/web/view/templates/pages/controls_detail.html
@@ -24,12 +24,8 @@
 
   <section>
     <h2>Escaneos</h2>
-    {{ if .ScansEnabled }}
-      <p>{{ .ScansNotice }}</p>
-    {{ else }}
-      <p>Aún no hay escaneos subidos.</p>
-      <p><button type="button" disabled>Subir escaneos</button></p>
-    {{ end }}
+    <p>Aún no hay escaneos subidos.</p>
+    <p><button type="button" disabled>Subir escaneos</button></p>
   </section>
 
   <p><a href="/controls">Volver a los controles</a></p>

--- a/apps/server/internal/app/web/view/templates/pages/controls_detail.html
+++ b/apps/server/internal/app/web/view/templates/pages/controls_detail.html
@@ -1,0 +1,36 @@
+{{ define "content" }}
+  <h1>{{ .Control.Name }}</h1>
+
+  <section>
+    <h2>Datos</h2>
+    <table class="lista">
+      <tbody>
+        <tr><th>Aplicación</th><td>{{ .Control.ApplicationDate }}</td></tr>
+        <tr><th>Rango</th><td>{{ .Control.Range }}</td></tr>
+        <tr><th>Formato</th><td>{{ .Control.Shape }}</td></tr>
+        <tr><th>Estado</th><td>{{ .Control.State }}</td></tr>
+        <tr><th>Creado</th><td>{{ .Control.CreatedAt }}</td></tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>Prueba a imprimir</h2>
+    <p>
+      <a class="boton" href="{{ .SujetURL }}">Descargar prueba (sujet.pdf)</a>
+      <a class="boton" href="{{ .CorrigeURL }}">Descargar clave (corrige.pdf)</a>
+    </p>
+  </section>
+
+  <section>
+    <h2>Escaneos</h2>
+    {{ if .ScansEnabled }}
+      <p>{{ .ScansNotice }}</p>
+    {{ else }}
+      <p>Aún no hay escaneos subidos.</p>
+      <p><button type="button" disabled>Subir escaneos</button></p>
+    {{ end }}
+  </section>
+
+  <p><a href="/controls">Volver a los controles</a></p>
+{{ end }}

--- a/apps/server/internal/app/web/view/templates/pages/controls_form.html
+++ b/apps/server/internal/app/web/view/templates/pages/controls_form.html
@@ -82,10 +82,6 @@
       {{ end }}
     </p>
 
-    {{ if .PoolPreview }}
-      <p>{{ .PoolPreview }}</p>
-    {{ end }}
-
     <p><button type="submit">{{ .Submit }}</button>
        <a href="/controls" class="boton">Cancelar</a></p>
   </form>

--- a/apps/server/internal/app/web/view/templates/pages/controls_form.html
+++ b/apps/server/internal/app/web/view/templates/pages/controls_form.html
@@ -1,0 +1,92 @@
+{{ define "content" }}
+  <h1>{{ .Heading }}</h1>
+
+  {{ if .Notice }}
+    <p class="error">{{ .Notice }}</p>
+  {{ end }}
+
+  <form class="form" method="post" action="{{ .Action }}">
+    <input type="hidden" name="csrf_token" value="{{ .CSRFToken }}" />
+
+    <p class="field">
+      <label for="name">Nombre</label>
+      <input id="name" type="text" name="name" value="{{ .Values.Name }}"
+             autocomplete="off" required maxlength="100" />
+      {{ with index .Errors "name" }}
+        <span class="error">{{ . }}</span>
+      {{ end }}
+    </p>
+
+    <p class="field">
+      <label for="application_date">Fecha de aplicación <small>(opcional)</small></label>
+      <input id="application_date" type="date" name="application_date"
+             value="{{ .Values.ApplicationDate }}" />
+      {{ with index .Errors "application_date" }}
+        <span class="error">{{ . }}</span>
+      {{ end }}
+    </p>
+
+    <p class="field">
+      <label for="from">Desde</label>
+      <select id="from" name="from" required>
+        <option value="">— elige un inicio —</option>
+        {{ $from := printf "%s:%s" .Values.FromDocument .Values.FromSection }}
+        {{ range .SectionOptions }}
+          <optgroup label="{{ .DocumentTitle }}">
+            {{ range .Sections }}
+              <option value="{{ .Value }}"{{ if eq .Value $from }} selected{{ end }}>{{ .Section }}</option>
+            {{ end }}
+          </optgroup>
+        {{ end }}
+      </select>
+      {{ with index .Errors "from" }}
+        <span class="error">{{ . }}</span>
+      {{ end }}
+    </p>
+
+    <p class="field">
+      <label for="to">Hasta</label>
+      <select id="to" name="to" required>
+        <option value="">— elige un fin —</option>
+        {{ $to := printf "%s:%s" .Values.ToDocument .Values.ToSection }}
+        {{ range .SectionOptions }}
+          <optgroup label="{{ .DocumentTitle }}">
+            {{ range .Sections }}
+              <option value="{{ .Value }}"{{ if eq .Value $to }} selected{{ end }}>{{ .Section }}</option>
+            {{ end }}
+          </optgroup>
+        {{ end }}
+      </select>
+      {{ with index .Errors "to" }}
+        <span class="error">{{ . }}</span>
+      {{ end }}
+    </p>
+
+    <p class="field">
+      <label for="questions_per_copy">Preguntas por copia</label>
+      <input id="questions_per_copy" type="number" name="questions_per_copy"
+             value="{{ .Values.QuestionsPerCopy }}"
+             min="1" max="20" required />
+      {{ with index .Errors "questions_per_copy" }}
+        <span class="error">{{ . }}</span>
+      {{ end }}
+    </p>
+
+    <p class="field">
+      <label for="copies">Cantidad de copias</label>
+      <input id="copies" type="number" name="copies"
+             value="{{ .Values.Copies }}"
+             min="1" max="300" required />
+      {{ with index .Errors "copies" }}
+        <span class="error">{{ . }}</span>
+      {{ end }}
+    </p>
+
+    {{ if .PoolPreview }}
+      <p>{{ .PoolPreview }}</p>
+    {{ end }}
+
+    <p><button type="submit">{{ .Submit }}</button>
+       <a href="/controls" class="boton">Cancelar</a></p>
+  </form>
+{{ end }}

--- a/apps/server/internal/app/web/view/templates/pages/controls_list.html
+++ b/apps/server/internal/app/web/view/templates/pages/controls_list.html
@@ -1,0 +1,37 @@
+{{ define "content" }}
+  <h1>Controles</h1>
+
+  <p>Cada control se imprime en papel y se lee al inicio de la clase; están
+    ordenados por fecha de aplicación, de más reciente a más antigua.</p>
+
+  <p><a class="boton" href="/controls/new">Nuevo control</a></p>
+
+  {{ if .Controls }}
+    <table class="lista">
+      <thead>
+        <tr>
+          <th>Nombre</th>
+          <th>Aplicación</th>
+          <th>Rango</th>
+          <th>Formato</th>
+          <th>Estado</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {{ range .Controls }}
+          <tr>
+            <td>{{ .Name }}</td>
+            <td>{{ .ApplicationDate }}</td>
+            <td>{{ .Range }}</td>
+            <td>{{ .Shape }}</td>
+            <td>{{ .State }}</td>
+            <td><a href="{{ .DetailURL }}">Ver</a></td>
+          </tr>
+        {{ end }}
+      </tbody>
+    </table>
+  {{ else }}
+    <p>Aún no hay controles. Empieza uno con <a href="/controls/new">Nuevo control</a>.</p>
+  {{ end }}
+{{ end }}

--- a/apps/server/internal/app/web/view/view.go
+++ b/apps/server/internal/app/web/view/view.go
@@ -161,10 +161,6 @@ type ControlsFormPage struct {
 	// publishes, in reading order, so the two range dropdowns can render
 	// them. Grouped by document so an <optgroup> renders per document.
 	SectionOptions []DocumentSections
-	// PoolPreview is a Spanish note "Preguntas disponibles en el rango:
-	// N", computed on submit and re-rendered on refusal. Empty on the
-	// blank GET.
-	PoolPreview string
 }
 
 // ControlFormValues holds what the user typed. Values are echoed back on
@@ -191,23 +187,24 @@ type DocumentSections struct {
 }
 
 // SectionOption is one option in the range dropdown. Value is
-// "document:section", the string a form submission sends.
+// "document:section", the string a form submission sends. The template
+// decides which option is selected by comparing Value against the
+// composite form value (Values.FromDocument + ":" + Values.FromSection).
 type SectionOption struct {
-	Value      string
-	Label      string
-	Section    string
-	IsSelected bool
+	Value   string
+	Label   string
+	Section string
 }
 
 // ControlDetailPage is what controls_detail.html renders (S8). The three
-// boxes issue #166 §The screens asks for: metadata, PDFs, scans placeholder.
+// boxes issue #166 §The screens asks for: metadata, PDFs, and the WP-F
+// placeholder scans box (rendered by the template unconditionally today,
+// with no reader on the server side until WP-F ships).
 type ControlDetailPage struct {
 	Page
-	Control      DetailedControl
-	SujetURL     string
-	CorrigeURL   string
-	ScansEnabled bool // false until WP-F: shows the disabled placeholder
-	ScansNotice  string
+	Control    DetailedControl
+	SujetURL   string
+	CorrigeURL string
 }
 
 // DetailedControl is the metadata the detail page shows, pre-formatted.

--- a/apps/server/internal/app/web/view/view.go
+++ b/apps/server/internal/app/web/view/view.go
@@ -124,6 +124,103 @@ type ListedProfessor struct {
 	LastSignIn string
 }
 
+// ControlsListPage is what controls_list.html renders (S7). One row per
+// control, with the columns issue #166 §The screens asks for. All values
+// are pre-formatted by the handler (Spanish dates, human ranges), same
+// reasoning as ProfessorsListPage.
+type ControlsListPage struct {
+	Page
+	Controls []ListedControl
+}
+
+// ListedControl is one row of the controls list, with every column already
+// as a string a person reads.
+type ListedControl struct {
+	ID              string
+	Name            string
+	ApplicationDate string // "sin fecha" for a control with no date
+	Range           string // "Bienvenida/hola → Flujo/bucles"
+	Shape           string // "4 preguntas × 30 copias"
+	State           string // Spanish word matching the domain State
+	DetailURL       string
+}
+
+// ControlsFormPage is what controls_form.html renders. Same one-template-
+// for-three-purposes shape as ProfessorsFormPage (issue #151 §Form /
+// validation / errors): GET (empty), validation-failure re-render (values
+// + errors), and — when a future WP grows an edit form — pre-filled.
+type ControlsFormPage struct {
+	Page
+	Action  string
+	Values  ControlFormValues
+	Errors  map[string]string
+	Notice  string
+	Submit  string
+	Heading string
+	// SectionOptions lists every (document, section) pair the bank
+	// publishes, in reading order, so the two range dropdowns can render
+	// them. Grouped by document so an <optgroup> renders per document.
+	SectionOptions []DocumentSections
+	// PoolPreview is a Spanish note "Preguntas disponibles en el rango:
+	// N", computed on submit and re-rendered on refusal. Empty on the
+	// blank GET.
+	PoolPreview string
+}
+
+// ControlFormValues holds what the user typed. Values are echoed back on
+// refusal (§Form: "The values the professor typed come back on refusal").
+type ControlFormValues struct {
+	Name             string
+	ApplicationDate  string // "YYYY-MM-DD" or empty
+	FromDocument     string
+	FromSection      string
+	ToDocument       string
+	ToSection        string
+	QuestionsPerCopy string
+	Copies           string
+}
+
+// DocumentSections carries one document's sections for the range
+// dropdowns. Title is what the professor reads; Sections carry both slugs
+// and the section text ('hola' → 'hola'; the bank does not carry a
+// separate title per section today).
+type DocumentSections struct {
+	DocumentID    string
+	DocumentTitle string
+	Sections      []SectionOption
+}
+
+// SectionOption is one option in the range dropdown. Value is
+// "document:section", the string a form submission sends.
+type SectionOption struct {
+	Value      string
+	Label      string
+	Section    string
+	IsSelected bool
+}
+
+// ControlDetailPage is what controls_detail.html renders (S8). The three
+// boxes issue #166 §The screens asks for: metadata, PDFs, scans placeholder.
+type ControlDetailPage struct {
+	Page
+	Control      DetailedControl
+	SujetURL     string
+	CorrigeURL   string
+	ScansEnabled bool // false until WP-F: shows the disabled placeholder
+	ScansNotice  string
+}
+
+// DetailedControl is the metadata the detail page shows, pre-formatted.
+type DetailedControl struct {
+	ID              string
+	Name            string
+	ApplicationDate string
+	Range           string
+	Shape           string
+	State           string
+	CreatedAt       string
+}
+
 // ErrorPage is what error.html renders. AC-11: 404, 403 and 500 render
 // through the shell rather than as Go's default text.
 //
@@ -239,6 +336,36 @@ func RenderProfessorsForm(w http.ResponseWriter, status int, page ProfessorsForm
 		page.Submit = "Guardar"
 	}
 	return render(w, "professors_form", status, page)
+}
+
+// RenderControlsList writes the controls list page (S7).
+func RenderControlsList(w http.ResponseWriter, page ControlsListPage) error {
+	if page.Title == "" {
+		page.Title = "Controles"
+	}
+	return render(w, "controls_list", http.StatusOK, page)
+}
+
+// RenderControlsForm writes the create form (S6).
+//
+// status is a parameter for the same reason RenderProfessorsForm's is:
+// 200 for GET, 422 for a validation-failure re-render.
+func RenderControlsForm(w http.ResponseWriter, status int, page ControlsFormPage) error {
+	if page.Title == "" {
+		page.Title = page.Heading
+	}
+	if page.Submit == "" {
+		page.Submit = "Generar control"
+	}
+	return render(w, "controls_form", status, page)
+}
+
+// RenderControlDetail writes one control's detail page (S8).
+func RenderControlDetail(w http.ResponseWriter, page ControlDetailPage) error {
+	if page.Title == "" {
+		page.Title = page.Control.Name
+	}
+	return render(w, "controls_detail", http.StatusOK, page)
 }
 
 // RenderError writes an error page through the shell (AC-11).

--- a/apps/server/internal/domain/controls/controls.go
+++ b/apps/server/internal/domain/controls/controls.go
@@ -64,14 +64,20 @@ type Copy struct {
 	Numero    int // 1-based, matches AMC's printed \onecopy index
 }
 
-// Store is what the controls Service (S5) reaches into for persistence.
-// Declared in the domain per §The dependency rule: an interface lives where
-// it is consumed, and infra implements it.
+// Store is what the controls Service reaches into for persistence.
+// Declared in the domain per §The dependency rule: an interface lives
+// where it is consumed, and infra implements it.
 //
-// The unit of work here is a whole control — the row plus its pool plus its
-// copies land atomically or not at all (§Failure modes: "creation is
+// The unit of work here is a whole control — the row plus its pool plus
+// its copies land atomically or not at all (§Failure modes: "creation is
 // all-or-nothing"). Splitting it into per-table methods would push the
 // atomicity contract onto every caller.
+//
+// The method set is deliberately what THIS WP calls. `controlstore.Store`
+// also exposes ControlPool, unregistered here on purpose: WP-F is where
+// the pool is read back for grading, and adding it now with no reader
+// would be a Java-shaped interface (backend-code-style.md §The dependency
+// rule) whose consumer's needs cannot yet shape it.
 type Store interface {
 	// CreateControl writes the control, its pool entries and its copies in
 	// one transaction. Fails atomically: no rows are left behind on any
@@ -85,10 +91,6 @@ type Store interface {
 	// descending — with nulls last, so a "no date declared" row does not
 	// hide freshly generated controls. Created-at ties break within a date.
 	ListControls(ctx context.Context) ([]Control, error)
-
-	// ControlPool returns the pool drawn for this control, in the order it
-	// was drawn. Exposed for WP-F; WP-E writes and never reads it back.
-	ControlPool(ctx context.Context, controlID string) ([]PoolEntry, error)
 }
 
 // Generator asks the AMC worker to compile a .tex into printable PDFs.
@@ -122,23 +124,23 @@ type GenerateRequest struct {
 	Copies int
 }
 
-// Assets is what a successful Generate returns: the paths AMC wrote and the
-// copy count it confirms. Paths are relative to the work volume so a caller
-// can join them with either the local mount (server side) or /work (worker
-// side) without translation.
+// Assets is what a successful Generate returns: the printable sujet the
+// Service checks on disk before committing the row. The worker also produces
+// corrige.pdf and calage.xy in the same out/ directory, but WP-E never reads
+// them after generation — the download handlers (SujetPath, CorrigePath)
+// re-derive them from ProjectDir. WP-F will read them off the same
+// convention (see the ADR-0033 note next to ProjectDir).
+//
+// The narrower value here is the whole point: adding Corrige/Calage/Copies
+// as domain fields with no reader made them a shape a maintainer had to
+// keep in step with a worker they never see; the amcworker client keeps
+// its own non-empty checks on the wire response and does not need this
+// domain type to carry them.
 type Assets struct {
-	// Sujet is the printable subject PDF, one per class, staged for printing
-	// (the professor's headline deliverable).
+	// Sujet is the sujet.pdf path relative to the work volume, so a caller
+	// can join it with either the local mount (server side) or /work
+	// (worker side) without translation.
 	Sujet string
-	// Corrige is the answer key AMC produces alongside sujet.pdf. Handed to
-	// the professor as a second download, and read by WP-F for grading.
-	Corrige string
-	// Calage is AMC's per-copy layout, needed by WP-F to know where each box
-	// landed. WP-E writes it to disk and never reads it back.
-	Calage string
-	// Copies is what the worker confirmed as generated. A mismatch with the
-	// requested count is treated as a generation failure by the Service.
-	Copies int
 }
 
 // The failure modes callers branch on. Wrapped so a handler can render a

--- a/apps/server/internal/domain/controls/controls.go
+++ b/apps/server/internal/domain/controls/controls.go
@@ -3,17 +3,93 @@
 // AMC worker to generate copies (docs/design/2026-08-controles.md, WP-E).
 //
 // This file holds the interfaces the domain consumes and the small value
-// types the whole package shares. The Store, the Service and the .tex
-// generator live beside it (S3–S5). The dependency rule is the same one that
-// governs the auth domain: the interfaces are declared HERE because that is
-// where they are consumed, and infra implements them (backend-code-style.md
-// §The dependency rule).
+// types the whole package shares. The .tex generator and the Service live
+// beside it (S4, S5). The dependency rule is the same one that governs the
+// auth domain: the interfaces are declared HERE because that is where they
+// are consumed, and infra implements them (backend-code-style.md §The
+// dependency rule).
 package controls
 
 import (
 	"context"
 	"errors"
+	"time"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/course/bank"
 )
+
+// State is the lifecycle position of a Control. WP-E creates a row at
+// Generated; WP-F moves it to InReview when scans arrive and to Graded when
+// the professor closes the correction.
+type State string
+
+const (
+	// Generated: the PDF is on disk and the row is committed. No scans yet.
+	Generated State = "generated"
+	// InReview: WP-F loaded scans; some copies may need a human.
+	InReview State = "in_review"
+	// Graded: the professor closed the correction.
+	Graded State = "graded"
+)
+
+// A Control is one printed entrance quiz. Fields mirror the V1 data model in
+// docs/design/2026-08-controles.md §Data model, minus curso_id (WP-D's) and
+// plus what the domain needs (id as text, CreatedBy for audit).
+type Control struct {
+	ID               string
+	Name             string
+	ApplicationDate  *time.Time // nil means "no date declared"
+	RangeFrom        bank.SectionRef
+	RangeTo          bank.SectionRef
+	QuestionsPerCopy int
+	Copies           int
+	State            State
+	CreatedAt        time.Time
+	CreatedBy        int64 // users.user_id
+}
+
+// PoolEntry is one authored question that was actually drawn from at
+// generation time, in the order it was drawn in. The pair (ControlID, Ref)
+// is unique, and WP-F reads this table to know which bank question each
+// answer maps back to.
+type PoolEntry struct {
+	Ref   string // the question id in the bank
+	Order int    // 0-based position in the drawn pool
+}
+
+// A Copy is one printed sheet identity. WP-E writes one row per copy at
+// generation time; WP-F later attaches lectura/respuesta rows to them.
+type Copy struct {
+	ControlID string
+	Numero    int // 1-based, matches AMC's printed \onecopy index
+}
+
+// Store is what the controls Service (S5) reaches into for persistence.
+// Declared in the domain per §The dependency rule: an interface lives where
+// it is consumed, and infra implements it.
+//
+// The unit of work here is a whole control — the row plus its pool plus its
+// copies land atomically or not at all (§Failure modes: "creation is
+// all-or-nothing"). Splitting it into per-table methods would push the
+// atomicity contract onto every caller.
+type Store interface {
+	// CreateControl writes the control, its pool entries and its copies in
+	// one transaction. Fails atomically: no rows are left behind on any
+	// failure, and no partial control ever appears in ListControls.
+	CreateControl(ctx context.Context, control Control, pool []PoolEntry) error
+
+	// ControlByID returns the control with this id, or ErrControlNotFound.
+	ControlByID(ctx context.Context, id string) (Control, error)
+
+	// ListControls returns every control, ordered by application date
+	// descending — with nulls last, so a "no date declared" row does not
+	// hide freshly generated controls. Created-at ties break within a date.
+	ListControls(ctx context.Context) ([]Control, error)
+
+	// ControlPool returns the pool drawn for this control, in the order it
+	// was drawn. Exposed for WP-F; WP-E writes and never reads it back.
+	ControlPool(ctx context.Context, controlID string) ([]PoolEntry, error)
+}
 
 // Generator asks the AMC worker to compile a .tex into printable PDFs.
 //
@@ -65,15 +141,22 @@ type Assets struct {
 	Copies int
 }
 
-// ErrGeneratorRefused wraps a failure that came from the worker refusing
-// the request — a 4xx, or a response naming a missing file. Callers branch
-// on it with errors.Is when they want to distinguish an operator-caused
-// failure (worker down, wrong URL) from a request-shaped one (a pool that
-// somehow produced an empty PDF).
-var ErrGeneratorRefused = errors.New("controls: the AMC worker refused the request")
+// The failure modes callers branch on. Wrapped so a handler can render a
+// domain answer in Spanish without importing the store or the client.
+var (
+	// ErrControlNotFound is a lookup that named nothing here.
+	ErrControlNotFound = errors.New("controls: no such control")
 
-// ErrGeneratorUnavailable wraps a failure that could not reach the worker at
-// all — connection refused, DNS, timeout without a response. Same shape as
-// the pair above, so a handler can render the two the same way while a
-// future operator dashboard can tell them apart.
-var ErrGeneratorUnavailable = errors.New("controls: the AMC worker is unreachable")
+	// ErrGeneratorRefused wraps a failure that came from the worker refusing
+	// the request — a 4xx, or a response naming a missing file. Callers
+	// branch on it with errors.Is when they want to distinguish an
+	// operator-caused failure (worker down, wrong URL) from a request-shaped
+	// one (a pool that somehow produced an empty PDF).
+	ErrGeneratorRefused = errors.New("controls: the AMC worker refused the request")
+
+	// ErrGeneratorUnavailable wraps a failure that could not reach the worker
+	// at all — connection refused, DNS, timeout without a response. Same
+	// shape as the pair above, so a handler can render the two the same way
+	// while a future operator dashboard can tell them apart.
+	ErrGeneratorUnavailable = errors.New("controls: the AMC worker is unreachable")
+)

--- a/apps/server/internal/domain/controls/controls.go
+++ b/apps/server/internal/domain/controls/controls.go
@@ -1,0 +1,79 @@
+// Package controls is the entrance-controls domain: a professor picks a range
+// of the published question bank, the server draws a pool from it and asks the
+// AMC worker to generate copies (docs/design/2026-08-controles.md, WP-E).
+//
+// This file holds the interfaces the domain consumes and the small value
+// types the whole package shares. The Store, the Service and the .tex
+// generator live beside it (S3–S5). The dependency rule is the same one that
+// governs the auth domain: the interfaces are declared HERE because that is
+// where they are consumed, and infra implements them (backend-code-style.md
+// §The dependency rule).
+package controls
+
+import (
+	"context"
+	"errors"
+)
+
+// Generator asks the AMC worker to compile a .tex into printable PDFs.
+//
+// The interface is one method because that is all the domain wants of it:
+// give a project directory, a source path and a copy count, get back the
+// asset paths AMC produced. The AMC worker's contract carries more surface
+// (analyse, associate, annotate) — those belong to WP-F and G and would only
+// couple this domain to a shape it does not use yet.
+//
+// The paths returned live under the shared volume (NALANDA_WORK_DIR); they
+// are relative to it so the domain never handles a container-visible absolute
+// path.
+type Generator interface {
+	Generate(ctx context.Context, req GenerateRequest) (Assets, error)
+}
+
+// GenerateRequest names what a call needs. A struct rather than positional
+// arguments so a new field (a seed, a language) does not renumber every call
+// site (backend-code-style.md §HTTP, same reason web.Deps is a struct).
+type GenerateRequest struct {
+	// Project is the AMC project directory, RELATIVE to the work volume. It
+	// must exist and be writable by the worker before Generate is called; the
+	// Service creates it as controls/<id>/.
+	Project string
+	// Source is the .tex to compile, RELATIVE to the work volume. It must
+	// live under Project's inputs/ subtree (staging is what makes
+	// \lstinputlisting resolve, ADR-0033).
+	Source string
+	// Copies is the number of printed sheets. Must be positive.
+	Copies int
+}
+
+// Assets is what a successful Generate returns: the paths AMC wrote and the
+// copy count it confirms. Paths are relative to the work volume so a caller
+// can join them with either the local mount (server side) or /work (worker
+// side) without translation.
+type Assets struct {
+	// Sujet is the printable subject PDF, one per class, staged for printing
+	// (the professor's headline deliverable).
+	Sujet string
+	// Corrige is the answer key AMC produces alongside sujet.pdf. Handed to
+	// the professor as a second download, and read by WP-F for grading.
+	Corrige string
+	// Calage is AMC's per-copy layout, needed by WP-F to know where each box
+	// landed. WP-E writes it to disk and never reads it back.
+	Calage string
+	// Copies is what the worker confirmed as generated. A mismatch with the
+	// requested count is treated as a generation failure by the Service.
+	Copies int
+}
+
+// ErrGeneratorRefused wraps a failure that came from the worker refusing
+// the request — a 4xx, or a response naming a missing file. Callers branch
+// on it with errors.Is when they want to distinguish an operator-caused
+// failure (worker down, wrong URL) from a request-shaped one (a pool that
+// somehow produced an empty PDF).
+var ErrGeneratorRefused = errors.New("controls: the AMC worker refused the request")
+
+// ErrGeneratorUnavailable wraps a failure that could not reach the worker at
+// all — connection refused, DNS, timeout without a response. Same shape as
+// the pair above, so a handler can render the two the same way while a
+// future operator dashboard can tell them apart.
+var ErrGeneratorUnavailable = errors.New("controls: the AMC worker is unreachable")

--- a/apps/server/internal/domain/controls/id.go
+++ b/apps/server/internal/domain/controls/id.go
@@ -1,0 +1,36 @@
+package controls
+
+import (
+	"crypto/rand"
+	"encoding/base32"
+	"fmt"
+)
+
+// idEncoding is base32 without padding. 128 bits of randomness fit in 26
+// characters, which is the shape a ULID advertises
+// (https://github.com/ulid/spec). It is not a literal ULID: the timestamp
+// half is dropped and the alphabet is the standard base32's, both because a
+// direct dependency on a ULID library is a PR discussion in this repo (root
+// CLAUDE.md) and because a control already carries its own timestamp
+// (CreatedAt); duplicating it in the id has no reader.
+var idEncoding = base32.StdEncoding.WithPadding(base32.NoPadding)
+
+// NewID returns a 26-character URL-safe identifier. 128 bits of randomness
+// is well beyond what a professor's catalog will ever collide over, and the
+// alphabet — [A-Z2-7], no padding — is safe in every URL segment this
+// server serves.
+//
+// crypto/rand cannot return a short read without an error (documented on
+// the package), so the length is guaranteed by construction — no retry loop
+// is needed and none should be added.
+func NewID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("controls.NewID: %w", err)
+	}
+	return idEncoding.EncodeToString(b[:]), nil
+}
+
+// IDLength is what a valid id measures. Callers that parse a path segment
+// check against this rather than a magic number.
+const IDLength = 26

--- a/apps/server/internal/domain/controls/id_test.go
+++ b/apps/server/internal/domain/controls/id_test.go
@@ -1,0 +1,42 @@
+package controls_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+)
+
+// The alphabet is base32-standard: A..Z plus 2..7. Nothing outside it must
+// ever land in a URL segment.
+var idAlphabet = regexp.MustCompile(`^[A-Z2-7]+$`)
+
+func TestNewIDIsTwentySixBase32Characters(t *testing.T) {
+	id, err := controls.NewID()
+	if err != nil {
+		t.Fatalf("NewID: %v", err)
+	}
+	if len(id) != controls.IDLength {
+		t.Errorf("len(NewID) = %d, want %d", len(id), controls.IDLength)
+	}
+	if !idAlphabet.MatchString(id) {
+		t.Errorf("NewID = %q, contains a character outside [A-Z2-7]", id)
+	}
+}
+
+func TestNewIDIsUnique(t *testing.T) {
+	// 128 bits of randomness: the birthday bound is at ~2^64 draws, so a
+	// 10 000-draw sample colliding is astronomically unlikely — a hit here
+	// would signal a broken PRNG, not a numerical accident.
+	seen := make(map[string]bool, 10_000)
+	for range 10_000 {
+		id, err := controls.NewID()
+		if err != nil {
+			t.Fatalf("NewID: %v", err)
+		}
+		if seen[id] {
+			t.Fatalf("NewID collided on %q in %d draws", id, len(seen)+1)
+		}
+		seen[id] = true
+	}
+}

--- a/apps/server/internal/domain/controls/service.go
+++ b/apps/server/internal/domain/controls/service.go
@@ -130,17 +130,22 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (Control, error
 	project := filepath.Join(projectPrefix, id)
 	projectDir := filepath.Join(s.WorkDir, project)
 	inputsDir := filepath.Join(projectDir, "inputs")
-	if err := os.MkdirAll(inputsDir, 0o755); err != nil {
-		return Control{}, fmt.Errorf("controls.Create: prepare %s: %w", projectDir, err)
-	}
 
 	// rollback removes the project directory. Best-effort: a failure to
 	// remove is logged rather than escalated, since the caller already has
 	// an error and forwarding a cleanup problem loses the real cause.
+	// Declared BEFORE MkdirAll so a partial-create failure (parents made,
+	// leaf denied) also runs it — RemoveAll on a non-existent path is a
+	// no-op, so a MkdirAll that produced nothing costs nothing to clean.
 	rollback := func() {
 		if err := os.RemoveAll(projectDir); err != nil {
 			s.Log.Warn("controls.Create: rollback failed", "project", projectDir, "error", err)
 		}
+	}
+
+	if err := os.MkdirAll(inputsDir, 0o755); err != nil {
+		rollback()
+		return Control{}, fmt.Errorf("controls.Create: prepare %s: %w", projectDir, err)
 	}
 
 	for _, q := range pool {
@@ -226,8 +231,30 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (Control, error
 	return control, nil
 }
 
+// List returns every control, delegating to the Store's own ordering
+// (application_date desc, nulls last). Exposed on Service so the handler
+// has ONE door into the controls domain rather than reaching into Store
+// for reads and Service for writes — the ambiguity a reviewer noticed
+// (WP-E review, ARQ-11).
+func (s *Service) List(ctx context.Context) ([]Control, error) {
+	return s.Store.ListControls(ctx)
+}
+
+// Get returns one control by id, or ErrControlNotFound.
+func (s *Service) Get(ctx context.Context, id string) (Control, error) {
+	return s.Store.ControlByID(ctx, id)
+}
+
 // ProjectDir is the directory (on the SERVER's side) where a control's
 // files live. Handlers use it to serve the PDF downloads (S8).
+//
+// The layout it encodes — controls/<id>/{inputs,out} — is a MODEL of
+// what the AMC worker writes at generation time (ADR-0030 §Operational
+// leaves the directory shape to the caller; we chose it and pass its
+// contents through to the worker). Nothing in this repo cross-checks the
+// two, so a change to where the worker writes its output must be paired
+// with a change here; a fixture-shape assertion between the amctest
+// stubs and these paths pins the current agreement (ARQ-8).
 func (s *Service) ProjectDir(controlID string) string {
 	return filepath.Join(s.WorkDir, projectPrefix, controlID)
 }

--- a/apps/server/internal/domain/controls/service.go
+++ b/apps/server/internal/domain/controls/service.go
@@ -1,0 +1,251 @@
+package controls
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls/tex"
+	"github.com/so77id/nalanda/apps/server/internal/domain/course/bank"
+)
+
+// WorkerWorkDir is where apps/amc-worker mounts its shared volume (ADR-0030
+// §Operational: paths in a worker request name locations under /work). The
+// generator's \lstinputlisting paths are absolute and must be what the
+// WORKER sees, which is /work whatever the server's own mount is.
+const WorkerWorkDir = "/work"
+
+// projectPrefix is the subdirectory under WorkerWorkDir that holds every
+// control's project. Named "controls" (English identifier, root CLAUDE.md).
+const projectPrefix = "controls"
+
+// ErrPoolTooSmall is Create's answer when the range resolved to fewer
+// questions than the requested copies-per-copy. Wrapped by PoolTooSmallErr
+// so a handler can render the counts in Spanish.
+var ErrPoolTooSmall = errors.New("controls: the range does not have enough questions per copy")
+
+// ErrSujetMissing is Create's answer when the worker returned success but
+// the sujet.pdf on disk is zero bytes or absent. A broken generation the
+// professor must not see as a healthy control (§Failure modes).
+var ErrSujetMissing = errors.New("controls: the generated sujet.pdf is missing or empty")
+
+// PoolTooSmallErr carries the counts a form message needs to compose the
+// Spanish "Pediste N por copia, pero el rango solo tiene M".
+type PoolTooSmallErr struct {
+	Pool             int
+	QuestionsPerCopy int
+}
+
+func (e PoolTooSmallErr) Error() string {
+	return fmt.Sprintf("controls: pool has %d questions, less than %d per copy",
+		e.Pool, e.QuestionsPerCopy)
+}
+func (e PoolTooSmallErr) Unwrap() error { return ErrPoolTooSmall }
+
+// Service is the orchestration layer of §Design: it turns a form submission
+// into files on disk plus a row in the database, all-or-nothing.
+//
+// The dependencies here are the ones the domain declared (Store, Generator)
+// plus the bank the range resolves against and the shared-volume path the
+// server writes files under. The seed is a constant per instance — a
+// re-compile of the same input produces the same draw, ADR-0030's four
+// silent traps need a deterministic input.
+type Service struct {
+	Bank      *bank.Bank
+	Store     Store
+	Generator Generator
+	// WorkDir is what the SERVER sees as the root of the shared volume.
+	// In compose it is bind-mounted onto /work in the worker; in
+	// development it may be any path the operator chose (see
+	// NALANDA_WORK_DIR).
+	WorkDir string
+	Now     func() time.Time
+	// Seed is what tex.Compile writes into \AMCrandomseed. Constant so a
+	// re-compile is reproducible; a per-control seed is a future decision.
+	Seed int64
+	Log  *slog.Logger
+}
+
+// NewService returns a Service, refusing a set it cannot serve with — same
+// reasoning as the other constructors in this app: a wiring mistake is a
+// panic at boot rather than a nil dereference inside a request
+// (backend-code-style.md §Errors).
+func NewService(deps Service) *Service {
+	switch {
+	case deps.Bank == nil:
+		panic("controls.NewService: no bank")
+	case deps.Store == nil:
+		panic("controls.NewService: no store")
+	case deps.Generator == nil:
+		panic("controls.NewService: no generator")
+	case deps.WorkDir == "":
+		panic("controls.NewService: no work directory")
+	case deps.Now == nil:
+		panic("controls.NewService: no clock")
+	case deps.Seed == 0:
+		panic("controls.NewService: seed must be non-zero (\\AMCrandomseed refuses zero)")
+	case deps.Log == nil:
+		panic("controls.NewService: no logger")
+	}
+	return &deps
+}
+
+// CreateRequest is what a handler hands to Service.Create.
+type CreateRequest struct {
+	Name             string
+	ApplicationDate  *time.Time
+	RangeFrom        bank.SectionRef
+	RangeTo          bank.SectionRef
+	QuestionsPerCopy int
+	Copies           int
+	CreatedBy        int64
+}
+
+// Create is the whole orchestration: resolve the range against the bank,
+// stage the inputs on the shared volume, ask the worker to compile, verify
+// the PDF exists, persist the row.
+//
+// All-or-nothing (§Failure modes). Every path past the directory creation
+// is guarded by a rollback that removes the whole project directory on
+// failure: a control never has files without a database row, and vice
+// versa — the "the row is committed and the files are on disk, or neither"
+// promise.
+func (s *Service) Create(ctx context.Context, req CreateRequest) (Control, error) {
+	pool, err := s.Bank.Pool(req.RangeFrom, req.RangeTo)
+	if err != nil {
+		return Control{}, err
+	}
+	if len(pool) < req.QuestionsPerCopy {
+		return Control{}, PoolTooSmallErr{Pool: len(pool), QuestionsPerCopy: req.QuestionsPerCopy}
+	}
+
+	id, err := NewID()
+	if err != nil {
+		return Control{}, fmt.Errorf("controls.Create: %w", err)
+	}
+	project := filepath.Join(projectPrefix, id)
+	projectDir := filepath.Join(s.WorkDir, project)
+	inputsDir := filepath.Join(projectDir, "inputs")
+	if err := os.MkdirAll(inputsDir, 0o755); err != nil {
+		return Control{}, fmt.Errorf("controls.Create: prepare %s: %w", projectDir, err)
+	}
+
+	// rollback removes the project directory. Best-effort: a failure to
+	// remove is logged rather than escalated, since the caller already has
+	// an error and forwarding a cleanup problem loses the real cause.
+	rollback := func() {
+		if err := os.RemoveAll(projectDir); err != nil {
+			s.Log.Warn("controls.Create: rollback failed", "project", projectDir, "error", err)
+		}
+	}
+
+	for _, q := range pool {
+		if q.Code == nil {
+			continue
+		}
+		listingPath := filepath.Join(inputsDir, "question-"+q.ID+".txt")
+		if err := os.WriteFile(listingPath, []byte(q.Code.Source), 0o644); err != nil {
+			rollback()
+			return Control{}, fmt.Errorf("controls.Create: stage listing %s: %w", q.ID, err)
+		}
+	}
+
+	// The tex generator writes an ABSOLUTE listing path — from the
+	// WORKER'S perspective, which is /work. The path here always begins
+	// with WorkerWorkDir, whatever the server's own mount is.
+	source, err := tex.Compile(tex.Input{
+		Name:             req.Name,
+		Pool:             pool,
+		Copies:           req.Copies,
+		QuestionsPerCopy: req.QuestionsPerCopy,
+		Seed:             s.Seed,
+		ListingsDir:      workerPath(project, "inputs"),
+	})
+	if err != nil {
+		rollback()
+		return Control{}, fmt.Errorf("controls.Create: compile tex: %w", err)
+	}
+	sourceHostPath := filepath.Join(inputsDir, "source.tex")
+	if err := os.WriteFile(sourceHostPath, []byte(source), 0o644); err != nil {
+		rollback()
+		return Control{}, fmt.Errorf("controls.Create: write source: %w", err)
+	}
+
+	// Worker paths are relative to /work: it prefixes them itself with
+	// its own mount (worker.py's under_work).
+	assets, err := s.Generator.Generate(ctx, GenerateRequest{
+		Project: project,
+		Source:  filepath.Join(project, "inputs", "source.tex"),
+		Copies:  req.Copies,
+	})
+	if err != nil {
+		rollback()
+		return Control{}, err
+	}
+
+	// The professor's headline deliverable exists on disk and has bytes.
+	// A 0-byte sujet.pdf reports "success" from the worker on paths where
+	// the compile crashed after opening the output file — measured in
+	// #138 review, and enough to redden the whole path here.
+	sujetPath := filepath.Join(s.WorkDir, assets.Sujet)
+	info, err := os.Stat(sujetPath)
+	if err != nil {
+		rollback()
+		return Control{}, fmt.Errorf("%w: stat %s: %v", ErrSujetMissing, sujetPath, err)
+	}
+	if info.Size() == 0 {
+		rollback()
+		return Control{}, fmt.Errorf("%w: %s is 0 bytes", ErrSujetMissing, sujetPath)
+	}
+
+	control := Control{
+		ID:               id,
+		Name:             req.Name,
+		ApplicationDate:  req.ApplicationDate,
+		RangeFrom:        req.RangeFrom,
+		RangeTo:          req.RangeTo,
+		QuestionsPerCopy: req.QuestionsPerCopy,
+		Copies:           req.Copies,
+		State:            Generated,
+		CreatedAt:        s.Now(),
+		CreatedBy:        req.CreatedBy,
+	}
+	entries := make([]PoolEntry, len(pool))
+	for i, q := range pool {
+		entries[i] = PoolEntry{Ref: q.ID, Order: i}
+	}
+	if err := s.Store.CreateControl(ctx, control, entries); err != nil {
+		rollback()
+		return Control{}, fmt.Errorf("controls.Create: persist: %w", err)
+	}
+
+	return control, nil
+}
+
+// ProjectDir is the directory (on the SERVER's side) where a control's
+// files live. Handlers use it to serve the PDF downloads (S8).
+func (s *Service) ProjectDir(controlID string) string {
+	return filepath.Join(s.WorkDir, projectPrefix, controlID)
+}
+
+// SujetPath returns the sujet.pdf's full path on the server side.
+func (s *Service) SujetPath(controlID string) string {
+	return filepath.Join(s.ProjectDir(controlID), "out", "sujet.pdf")
+}
+
+// CorrigePath returns the corrige.pdf's full path on the server side.
+func (s *Service) CorrigePath(controlID string) string {
+	return filepath.Join(s.ProjectDir(controlID), "out", "corrige.pdf")
+}
+
+// workerPath joins components under WorkerWorkDir using forward slashes.
+// The worker runs on Linux so slashes are safe; a Windows dev environment
+// running this test suite would still emit a Linux-safe path.
+func workerPath(parts ...string) string {
+	joined := filepath.ToSlash(filepath.Join(parts...))
+	return WorkerWorkDir + "/" + joined
+}

--- a/apps/server/internal/domain/controls/service_test.go
+++ b/apps/server/internal/domain/controls/service_test.go
@@ -1,0 +1,302 @@
+package controls_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+	"github.com/so77id/nalanda/apps/server/internal/domain/course/bank"
+	"github.com/so77id/nalanda/apps/server/internal/infra/amcworker/amctest"
+)
+
+// bankJSON is the fixture from S1, trimmed to what these cases exercise.
+// Copied inline rather than shared through a helper package: a fixture
+// travelling across packages is one that drifts (backend-code-style.md
+// §Testing).
+const bankJSON = `{
+  "version": 1,
+  "documents": [
+    {"id": "welcome", "title": "Bienvenida", "coverage": "clase 0",
+     "sections": ["hola", "reglas"]},
+    {"id": "flujo",   "title": "Flujo",      "coverage": "clase 2",
+     "sections": ["if-else", "bucles"]}
+  ],
+  "questions": [
+    {"id": "q1", "document": "welcome", "anchor": "hola",   "type": "simple",
+     "statement": "A?", "code": null, "alternatives": ["a","b"], "correct": [0]},
+    {"id": "q2", "document": "welcome", "anchor": "reglas", "type": "simple",
+     "statement": "B?", "code": null, "alternatives": ["a","b"], "correct": [0]},
+    {"id": "q3", "document": "flujo",   "anchor": "if-else","type": "simple",
+     "statement": "C?", "code": null, "alternatives": ["a","b"], "correct": [0]},
+    {"id": "q4", "document": "flujo",   "anchor": "bucles", "type": "multiple",
+     "statement": "D?", "code": null, "alternatives": ["a","b","c"], "correct": [0,1]}
+  ]
+}`
+
+// fakeStore is a minimal in-memory Store, enough to exercise the Service's
+// error-handling paths without a real database. The controlstore's own L6
+// tests cover the real one.
+type fakeStore struct {
+	controls []controls.Control
+	pools    map[string][]controls.PoolEntry
+	fail     error
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{pools: map[string][]controls.PoolEntry{}}
+}
+
+func (s *fakeStore) CreateControl(_ context.Context, c controls.Control, pool []controls.PoolEntry) error {
+	if s.fail != nil {
+		return s.fail
+	}
+	s.controls = append(s.controls, c)
+	s.pools[c.ID] = pool
+	return nil
+}
+
+func (s *fakeStore) ControlByID(_ context.Context, id string) (controls.Control, error) {
+	for _, c := range s.controls {
+		if c.ID == id {
+			return c, nil
+		}
+	}
+	return controls.Control{}, controls.ErrControlNotFound
+}
+
+func (s *fakeStore) ListControls(_ context.Context) ([]controls.Control, error) {
+	return append([]controls.Control(nil), s.controls...), nil
+}
+
+func (s *fakeStore) ControlPool(_ context.Context, id string) ([]controls.PoolEntry, error) {
+	return s.pools[id], nil
+}
+
+// newService returns a Service against a fixture bank, a fake store, a
+// fake generator that succeeds (SujetSize > 0), and a work dir under t's
+// tempdir.
+func newService(t *testing.T) (*controls.Service, *fakeStore, *amctest.Fake, string) {
+	t.Helper()
+	b, err := bank.Parse(strings.NewReader(bankJSON))
+	if err != nil {
+		t.Fatalf("bank.Parse: %v", err)
+	}
+	workDir := t.TempDir()
+	store := newFakeStore()
+	gen := &amctest.Fake{WorkDir: workDir, SujetSize: 42}
+	svc := controls.NewService(controls.Service{
+		Bank:      b,
+		Store:     store,
+		Generator: gen,
+		WorkDir:   workDir,
+		Now:       func() time.Time { return time.Unix(1_755_446_400, 0).UTC() },
+		Seed:      1242,
+		Log:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	return svc, store, gen, workDir
+}
+
+func req(mutate func(*controls.CreateRequest)) controls.CreateRequest {
+	r := controls.CreateRequest{
+		Name:             "Control 1",
+		RangeFrom:        bank.SectionRef{Document: "welcome", Section: "hola"},
+		RangeTo:          bank.SectionRef{Document: "flujo", Section: "bucles"},
+		QuestionsPerCopy: 3,
+		Copies:           5,
+		CreatedBy:        1,
+	}
+	if mutate != nil {
+		mutate(&r)
+	}
+	return r
+}
+
+func TestCreateWritesFilesAndPersistsTheControl(t *testing.T) {
+	svc, store, gen, workDir := newService(t)
+
+	got, err := svc.Create(context.Background(), req(nil))
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if got.ID == "" || got.State != controls.Generated {
+		t.Errorf("Control returned = %+v", got)
+	}
+
+	// The row landed in the fake store.
+	if len(store.controls) != 1 || store.controls[0].ID != got.ID {
+		t.Errorf("store.controls = %+v", store.controls)
+	}
+
+	// The worker was called once with the project rooted at controls/<id>.
+	if gen.CallCount() != 1 {
+		t.Fatalf("generator was called %d times, want 1", gen.CallCount())
+	}
+	call, _ := gen.LastCall()
+	if call.Project != filepath.Join("controls", got.ID) {
+		t.Errorf("generator.Project = %q, want controls/<id>", call.Project)
+	}
+	if call.Copies != 5 {
+		t.Errorf("generator.Copies = %d, want 5", call.Copies)
+	}
+
+	// The source .tex is on disk. It was written before the worker was
+	// asked to compile, and never cleaned up on success.
+	sourcePath := filepath.Join(workDir, "controls", got.ID, "inputs", "source.tex")
+	source, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read source.tex: %v", err)
+	}
+	if !strings.Contains(string(source), "\\AMCrandomseed{1242}") {
+		t.Errorf("source.tex is missing the configured seed")
+	}
+}
+
+func TestCreateSurfacesBankErrorsAsIs(t *testing.T) {
+	svc, _, _, _ := newService(t)
+
+	// Inverted range → ErrRangeInverted, no rollback needed because no
+	// files were staged.
+	_, err := svc.Create(context.Background(), req(func(r *controls.CreateRequest) {
+		r.RangeFrom = bank.SectionRef{Document: "flujo", Section: "bucles"}
+		r.RangeTo = bank.SectionRef{Document: "welcome", Section: "hola"}
+	}))
+	if !errors.Is(err, bank.ErrRangeInverted) {
+		t.Errorf("Create(inverted range): %v, want bank.ErrRangeInverted", err)
+	}
+
+	// Unknown section → ErrUnknownSection.
+	_, err = svc.Create(context.Background(), req(func(r *controls.CreateRequest) {
+		r.RangeFrom = bank.SectionRef{Document: "welcome", Section: "no-existe"}
+	}))
+	if !errors.Is(err, bank.ErrUnknownSection) {
+		t.Errorf("Create(unknown section): %v, want bank.ErrUnknownSection", err)
+	}
+}
+
+func TestCreateRefusesAPoolSmallerThanTheCopyAsksFor(t *testing.T) {
+	svc, _, _, _ := newService(t)
+
+	_, err := svc.Create(context.Background(), req(func(r *controls.CreateRequest) {
+		r.QuestionsPerCopy = 8 // pool has 4
+	}))
+	if !errors.Is(err, controls.ErrPoolTooSmall) {
+		t.Errorf("Create(oversized copy): %v, want ErrPoolTooSmall", err)
+	}
+	var pool controls.PoolTooSmallErr
+	if !errors.As(err, &pool) {
+		t.Fatalf("Create(oversized copy): does not unwrap to PoolTooSmallErr: %v", err)
+	}
+	if pool.Pool != 4 || pool.QuestionsPerCopy != 8 {
+		t.Errorf("PoolTooSmallErr = %+v, want {Pool:4, QuestionsPerCopy:8}", pool)
+	}
+}
+
+func TestCreateRollsBackWhenTheWorkerRefuses(t *testing.T) {
+	svc, store, gen, workDir := newService(t)
+	gen.Err = controls.ErrGeneratorRefused
+
+	_, err := svc.Create(context.Background(), req(nil))
+	if !errors.Is(err, controls.ErrGeneratorRefused) {
+		t.Fatalf("Create(worker refused): %v, want ErrGeneratorRefused", err)
+	}
+
+	if len(store.controls) != 0 {
+		t.Errorf("store.controls = %+v, want empty (worker refusal must roll back the row)", store.controls)
+	}
+
+	// The project directory is gone.
+	projects, err := os.ReadDir(filepath.Join(workDir, "controls"))
+	if err == nil && len(projects) > 0 {
+		t.Errorf("workDir/controls holds %d directories after a rolled-back Create, want 0", len(projects))
+	}
+}
+
+func TestCreateRollsBackWhenSujetIsZeroBytes(t *testing.T) {
+	svc, store, gen, workDir := newService(t)
+	gen.SujetSize = 0 // fake writes an empty sujet.pdf
+
+	_, err := svc.Create(context.Background(), req(nil))
+	if !errors.Is(err, controls.ErrSujetMissing) {
+		t.Fatalf("Create(0-byte sujet): %v, want ErrSujetMissing", err)
+	}
+
+	if len(store.controls) != 0 {
+		t.Error("store.controls is not empty after a 0-byte sujet failure — creation must be all-or-nothing")
+	}
+	if entries, _ := os.ReadDir(filepath.Join(workDir, "controls")); len(entries) > 0 {
+		t.Errorf("workDir/controls holds %d entries after a 0-byte sujet failure, want 0", len(entries))
+	}
+}
+
+func TestCreateRollsBackWhenTheStoreFails(t *testing.T) {
+	svc, store, _, workDir := newService(t)
+	store.fail = errors.New("boom")
+
+	_, err := svc.Create(context.Background(), req(nil))
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("Create(store fails): %v, want error carrying 'boom'", err)
+	}
+	if entries, _ := os.ReadDir(filepath.Join(workDir, "controls")); len(entries) > 0 {
+		t.Errorf("workDir/controls holds %d entries after a persist failure, want 0", len(entries))
+	}
+}
+
+func TestCreatePassesTheCorrectAbsoluteListingPathForCodeQuestions(t *testing.T) {
+	// Build a bank whose only question in a section has code, and ask a
+	// control that draws it — that is what tests the /work absolute-path
+	// staging (ADR-0033).
+	const codeBank = `{
+  "version": 1,
+  "documents": [
+    {"id": "arr", "title": "Arreglos", "coverage": "clase 3",
+     "sections": ["b"]}
+  ],
+  "questions": [
+    {"id": "prints", "document": "arr", "anchor": "b", "type": "simple",
+     "statement": "?", "code": {"language":"java","source":"System.out.println(1);"},
+     "alternatives": ["1","2"], "correct": [0]}
+  ]
+}`
+	b, err := bank.Parse(strings.NewReader(codeBank))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	workDir := t.TempDir()
+	gen := &amctest.Fake{WorkDir: workDir, SujetSize: 4}
+	store := newFakeStore()
+	svc := controls.NewService(controls.Service{
+		Bank: b, Store: store, Generator: gen, WorkDir: workDir,
+		Now: func() time.Time { return time.Now() }, Seed: 1,
+		Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+
+	control, err := svc.Create(context.Background(), controls.CreateRequest{
+		Name:             "c",
+		RangeFrom:        bank.SectionRef{Document: "arr", Section: "b"},
+		RangeTo:          bank.SectionRef{Document: "arr", Section: "b"},
+		QuestionsPerCopy: 1, Copies: 1, CreatedBy: 1,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// The staged listing is on disk under the server's work dir.
+	stagedPath := filepath.Join(workDir, "controls", control.ID, "inputs", "question-prints.txt")
+	if _, err := os.Stat(stagedPath); err != nil {
+		t.Errorf("staged listing missing: %v", err)
+	}
+	// The source.tex references the WORKER's absolute path (/work), not
+	// the server's.
+	source, _ := os.ReadFile(filepath.Join(workDir, "controls", control.ID, "inputs", "source.tex"))
+	want := "\\lstinputlisting{/work/controls/" + control.ID + "/inputs/question-prints.txt}"
+	if !strings.Contains(string(source), want) {
+		t.Errorf("source.tex is missing %q — a listing under the server's mount would not resolve inside the worker", want)
+	}
+}

--- a/apps/server/internal/domain/controls/tex/tex.go
+++ b/apps/server/internal/domain/controls/tex/tex.go
@@ -1,0 +1,297 @@
+// Package tex is the .tex generator that turns a pool of bank questions and
+// the metadata of a control into the source apps/amc-worker compiles.
+//
+// The rules the emitted source has to honour are ADR-0033's — every one of
+// them was found by rendering a sheet and looking at the page, so they live
+// somewhere binding and are asserted here in tests rather than remembered
+// case by case. The worked example the reader binds to is
+// apps/amc-worker/tests/fixtures/control-demo.tex.
+//
+// Pure Go and stdlib-only. The output is deterministic given the input:
+// pool ordering is preserved (the source order is the reading order,
+// ADR-0032), the seed is written verbatim, and no clock or PRNG is called
+// from this file.
+package tex
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/course/bank"
+)
+
+// Input is what Compile takes. Pool is in reading order (typically what
+// bank.Pool returned); Compile does not reorder it.
+type Input struct {
+	// Name is the professor-typed control title shown at the top of every
+	// sheet. Escaped before emission so a %, an & or a $ in the title does
+	// not break the compile.
+	Name string
+	// Pool is the drawn set of questions, in the order they should appear
+	// in the source. AMC's own \shufflegroup shuffles what \insertgroup
+	// picks; the source order only determines which questions are available
+	// to draw from.
+	Pool []bank.Question
+	// Copies is how many printed sheets the source will \onecopy over. AMC
+	// draws QuestionsPerCopy per copy, per §Design.
+	Copies int
+	// QuestionsPerCopy is what \insertgroup[N]{clase} passes.
+	QuestionsPerCopy int
+	// Seed is what \AMCrandomseed receives. Fixed per control so a
+	// re-compile of the same input yields the same draw — the deterministic
+	// input ADR-0030's four silent traps need to be testable against.
+	Seed int64
+	// ListingsDir is the ABSOLUTE directory (as seen by the worker) where
+	// per-question code listings have been staged. Each question with Code
+	// reads its listing from
+	// <ListingsDir>/question-<question-id>.txt — that path is emitted
+	// verbatim into \lstinputlisting{...}, so the caller (the Service, S5)
+	// must have staged the files before compile time.
+	ListingsDir string
+}
+
+// Compile emits the .tex source. The output ends with a newline.
+//
+// Errors are all wiring — an empty name, a too-small pool, a missing
+// listings directory when the pool needs one. Every failure mode is caught
+// before the first byte is written so a caller never has a half-formed
+// source to clean up.
+func Compile(in Input) (string, error) {
+	if err := validate(in); err != nil {
+		return "", err
+	}
+	var b strings.Builder
+	writePreamble(&b, in)
+	for _, q := range in.Pool {
+		writeQuestion(&b, q, in.ListingsDir)
+	}
+	writeSheet(&b, in)
+	return b.String(), nil
+}
+
+func validate(in Input) error {
+	switch {
+	case strings.TrimSpace(in.Name) == "":
+		return fmt.Errorf("tex.Compile: name is required")
+	case in.QuestionsPerCopy <= 0:
+		return fmt.Errorf("tex.Compile: questions-per-copy must be > 0, got %d", in.QuestionsPerCopy)
+	case in.Copies <= 0:
+		return fmt.Errorf("tex.Compile: copies must be > 0, got %d", in.Copies)
+	case len(in.Pool) < in.QuestionsPerCopy:
+		return fmt.Errorf("tex.Compile: pool has %d questions, less than %d per copy",
+			len(in.Pool), in.QuestionsPerCopy)
+	case in.Seed == 0:
+		return fmt.Errorf("tex.Compile: seed must be non-zero (\\AMCrandomseed refuses zero)")
+	}
+	for _, q := range in.Pool {
+		if q.Code != nil && in.ListingsDir == "" {
+			return fmt.Errorf("tex.Compile: question %s carries a listing but ListingsDir is empty", q.ID)
+		}
+	}
+	return nil
+}
+
+// lastChoicePattern mirrors apps/web src/content/questionRules.ts's NEGATED
+// detection (ADR-0033 §"An alternative whose wording refers to the others
+// is pinned last"). Case-insensitive: `\b` anchors the two words so
+// "ningunas" does not match and "anterior" alone does not match.
+var lastChoicePattern = regexp.MustCompile(`(?i)\bninguna\b[^.]*\banteriores\b`)
+
+// preamble tails and heads that never change with the input.
+const preambleHead = `\documentclass[a4paper,11pt]{article}
+
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage[spanish]{babel}
+\usepackage{multicol}
+\usepackage{listings}
+% lang=ES is not cosmetic: without it AMC labels every question "Question 1"
+% in English (worker README §What a control source must contain). completemulti
+% is deliberately absent — it appends an all-or-nothing "none of these" box
+% AMC's own Spanish gets wrong (ADR-0033 §Alternatives considered).
+\usepackage[box,lang=ES]{automultiplechoice}
+
+% Per-question label macros: one for each type, in words (ADR-0033
+% §Every question states, in words, how many answers it admits). A simple
+% question passes \unaSymbole in the optional argument slot; a questionmult
+% cannot, because its own definition already passes \multiSymbole there —
+% redefining that macro is the supported lever.
+\def\unaSymbole{\textsf{\small(una respuesta)}}
+\def\multiSymbole{\textsf{\small(varias respuestas)}}
+
+% Listings style — matches apps/amc-worker/tests/fixtures/control-demo.tex.
+% keepspaces keeps a Java program's indentation intact, columns=fullflexible
+% avoids the false extra spacing lstlisting would otherwise insert.
+\lstset{
+  basicstyle=\ttfamily\small,
+  columns=fullflexible,
+  keepspaces=true,
+  xleftmargin=1em,
+}
+
+`
+
+func writePreamble(b *strings.Builder, in Input) {
+	b.WriteString(preambleHead)
+	// Fixed seed so a compile is reproducible. AMC uses this to derive the
+	// per-copy shuffle; nothing here reshuffles.
+	fmt.Fprintf(b, "\\AMCrandomseed{%d}\n", in.Seed)
+	b.WriteString("\n\\begin{document}\n\n")
+}
+
+func writeQuestion(b *strings.Builder, q bank.Question, listingsDir string) {
+	env := "question"
+	if q.Type == bank.TypeMultiple {
+		env = "questionmult"
+	}
+
+	b.WriteString("\\element{clase}{\n")
+	if env == "question" {
+		// [\unaSymbole] as the optional argument — that is the lever the
+		// simple question takes for its per-question label.
+		fmt.Fprintf(b, "  \\begin{%s}[\\unaSymbole]{%s}\n", env, q.ID)
+	} else {
+		// questionmult inherits its label from \multiSymbole in the
+		// preamble; passing a second one in [...] mangles the text
+		// (ADR-0033 §The sheet carries its own arithmetic).
+		fmt.Fprintf(b, "  \\begin{%s}{%s}\n", env, q.ID)
+	}
+	fmt.Fprintf(b, "    %s\n", strings.TrimSpace(q.Statement))
+
+	if q.Code != nil {
+		// Absolute path: AMC compiles from its own working directory, so
+		// a path relative to the .tex fails fatally (ADR-0033 §Anything
+		// the source reads is staged under /work and referenced
+		// absolutely). The Service is responsible for having staged the
+		// file at this exact path.
+		listingPath := filepath.Join(listingsDir, "question-"+q.ID+".txt")
+		fmt.Fprintf(b, "    \\lstinputlisting{%s}\n", listingPath)
+	}
+
+	b.WriteString("    \\begin{choices}\n")
+	correctSet := make(map[int]bool, len(q.Correct))
+	for _, i := range q.Correct {
+		correctSet[i] = true
+	}
+	// Split alternatives into normal and last-pinned. The last-pinned set
+	// is emitted after \lastchoices so AMC keeps them at the end of the
+	// shuffled list (ADR-0033).
+	var normal, pinned []int
+	for i, alt := range q.Alternatives {
+		if lastChoicePattern.MatchString(alt) {
+			pinned = append(pinned, i)
+		} else {
+			normal = append(normal, i)
+		}
+	}
+	for _, i := range normal {
+		emitAlternative(b, q.Alternatives[i], correctSet[i])
+	}
+	if len(pinned) > 0 {
+		b.WriteString("      \\lastchoices\n")
+		for _, i := range pinned {
+			emitAlternative(b, q.Alternatives[i], correctSet[i])
+		}
+	}
+	b.WriteString("    \\end{choices}\n")
+	fmt.Fprintf(b, "  \\end{%s}\n", env)
+	b.WriteString("}\n\n")
+}
+
+func emitAlternative(b *strings.Builder, text string, correct bool) {
+	macro := "\\wrongchoice"
+	if correct {
+		macro = "\\correctchoice"
+	}
+	fmt.Fprintf(b, "      %s{%s}\n", macro, strings.TrimSpace(text))
+}
+
+func writeSheet(b *strings.Builder, in Input) {
+	fmt.Fprintf(b, "\\onecopy{%d}{\n\n", in.Copies)
+
+	fmt.Fprintf(b, "  \\noindent{\\large\\bf %s}\\hfill\n", escapeLatex(in.Name))
+	b.WriteString(`  \namefield{\fbox{\begin{minipage}{.45\linewidth}
+        Nombre:
+
+        \vspace*{4mm}\dotfill
+        \vspace*{2mm}
+      \end{minipage}}}
+
+  \begin{center}
+    \emph{Marca tu RUT sin el dígito verificador (8 dígitos).}
+
+    \AMCcode{rut}{8}
+  \end{center}
+
+`)
+
+	// Header block: this sheet's own arithmetic (ADR-0033 §The sheet
+	// carries its own arithmetic). C16: every question weighs one point,
+	// so total points = questions per copy.
+	b.WriteString("  \\vspace{3mm}\n")
+	b.WriteString("  \\noindent\\fbox{\\begin{minipage}{0.98\\linewidth}\n")
+	fmt.Fprintf(b, "      \\textbf{%s} · \\textbf{%s} · el 4,0 %s\n",
+		pluralQuestions(in.QuestionsPerCopy),
+		pluralPoints(in.QuestionsPerCopy),
+		fourZeroClause(in.QuestionsPerCopy),
+	)
+	b.WriteString("\n      \\smallskip\n")
+	b.WriteString("      Cada pregunta dice cuántas respuestas admite.\n")
+	b.WriteString("      \\textbf{Respóndelas todas: equivocarse no descuenta.}\n")
+	b.WriteString("    \\end{minipage}}\n")
+	b.WriteString("  \\vspace{2mm}\n\n")
+
+	b.WriteString("  \\shufflegroup{clase}\n")
+	fmt.Fprintf(b, "  \\insertgroup[%d]{clase}\n\n", in.QuestionsPerCopy)
+	b.WriteString("  \\AMCcleardoublepage\n")
+	b.WriteString("}\n\n")
+	b.WriteString("\\end{document}\n")
+}
+
+// pluralQuestions returns "1 pregunta" or "N preguntas".
+func pluralQuestions(n int) string {
+	if n == 1 {
+		return "1 pregunta"
+	}
+	return fmt.Sprintf("%d preguntas", n)
+}
+
+// pluralPoints returns "1 punto" or "N puntos".
+func pluralPoints(n int) string {
+	if n == 1 {
+		return "1 punto"
+	}
+	return fmt.Sprintf("%d puntos", n)
+}
+
+// fourZeroClause renders the "el 4,0 …" part. Every question weighs one
+// point (§C16), 4,0 falls at 50% (§C7), so the threshold is N/2 points.
+// Spanish uses a comma as decimal separator.
+func fourZeroClause(questions int) string {
+	if questions%2 == 0 {
+		return fmt.Sprintf("son %s", pluralPoints(questions/2))
+	}
+	// Half-point case: "el 4,0 son 2,5 puntos". Always "son" (the number
+	// after it is fractional and Spanish still takes the plural).
+	return fmt.Sprintf("son %d,5 puntos", questions/2)
+}
+
+// escapeLatex escapes the ten TeX specials in a professor-typed name.
+// Statements from the bank are trusted LaTeX and are not run through this.
+func escapeLatex(s string) string {
+	replacer := strings.NewReplacer(
+		"\\", "\\textbackslash{}",
+		"{", "\\{",
+		"}", "\\}",
+		"$", "\\$",
+		"&", "\\&",
+		"%", "\\%",
+		"#", "\\#",
+		"_", "\\_",
+		"^", "\\^{}",
+		"~", "\\~{}",
+	)
+	return replacer.Replace(s)
+}

--- a/apps/server/internal/domain/controls/tex/tex_test.go
+++ b/apps/server/internal/domain/controls/tex/tex_test.go
@@ -308,7 +308,7 @@ func TestFixtureAndGeneratorAgreeOnTheLoadBearingRules(t *testing.T) {
 			{`\lstset present`, strings.Contains(source, `\lstset`), ""},
 			{`\AMCcode{rut}{8}`, strings.Contains(source, `\AMCcode{rut}{8}`), "8-digit RUT grid (§C5)"},
 			{`\shufflegroup{clase}`, strings.Contains(source, `\shufflegroup{clase}`), ""},
-			{`\lastchoices before "Ninguna de las anteriores"`, strings.Index(source, `\lastchoices`) < strings.Index(source, "Ninguna de las anteriores") && strings.Contains(source, `\lastchoices`), "pin has no effect (ADR-0033)"},
+			{`\lastchoices before "Ninguna de las anteriores"`, lastchoicesPinsCorrectly(source), "pin has no effect (ADR-0033) — a \\lastchoices comment mention does not satisfy the rule the CODE version has to obey"},
 			{"deleted 'Marca una sola alternativa'", !containsOutsideComments(source, "Marca una sola alternativa por pregunta"), "false when a multiple is drawn"},
 			{"answering everything is free", strings.Contains(source, "equivocarse no descuenta"), "§C7"},
 		}
@@ -331,6 +331,43 @@ func TestFixtureAndGeneratorAgreeOnTheLoadBearingRules(t *testing.T) {
 		})
 		assertShape(t, generated, "generator")
 	})
+}
+
+// lastchoicesPinsCorrectly enforces two things at once, both against a
+// comment-stripped copy of the source: `\lastchoices` really appears in
+// CODE (not just in a comment explaining why it is there), and it
+// appears BEFORE "Ninguna de las anteriores". Reviewed in as its own
+// helper because the naive `strings.Index(source, "\\lastchoices")` was
+// satisfied by a comment mentioning the macro — measured on the
+// checked-in fixture, which has the comment above the real command.
+func lastchoicesPinsCorrectly(source string) bool {
+	stripped := stripLatexComments(source)
+	last := strings.Index(stripped, `\lastchoices`)
+	if last < 0 {
+		return false
+	}
+	pinned := strings.Index(stripped, "Ninguna de las anteriores")
+	if pinned < 0 {
+		return false
+	}
+	return last < pinned
+}
+
+// stripLatexComments returns source with LaTeX line comments removed
+// (everything from an unescaped % to end of line). Newlines are
+// preserved so offsets outside comments remain meaningful.
+func stripLatexComments(source string) string {
+	var out strings.Builder
+	out.Grow(len(source))
+	for _, line := range strings.Split(source, "\n") {
+		if i := indexUnescapedPercent(line); i >= 0 {
+			out.WriteString(line[:i])
+		} else {
+			out.WriteString(line)
+		}
+		out.WriteByte('\n')
+	}
+	return out.String()
 }
 
 // containsOutsideComments reports whether needle appears in source outside

--- a/apps/server/internal/domain/controls/tex/tex_test.go
+++ b/apps/server/internal/domain/controls/tex/tex_test.go
@@ -1,0 +1,379 @@
+package tex_test
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls/tex"
+	"github.com/so77id/nalanda/apps/server/internal/domain/course/bank"
+)
+
+// samplePool is a small pool exercising every shape ADR-0033 pins the
+// generator against: a simple question, a multiple, and a question with
+// code. Any missing shape here is a shape nothing else in the suite
+// exercises.
+func samplePool() []bank.Question {
+	return []bank.Question{
+		{
+			ID: "iteraciones", Document: "welcome", Anchor: "hola",
+			Type:      bank.TypeSimple,
+			Statement: "¿Cuántas iteraciones hace la búsqueda binaria?",
+			Alternatives: []string{
+				"Alrededor de log_2 n",
+				"Alrededor de n",
+				"Alrededor de n^2",
+			},
+			Correct: []int{0},
+		},
+		{
+			ID: "comparar-cadenas", Document: "welcome", Anchor: "hola",
+			Type:      bank.TypeMultiple,
+			Statement: "¿Cuáles expresiones comparan el contenido?",
+			Alternatives: []string{
+				"a.equals(b)",
+				"a.compareTo(b) == 0",
+				"a == b",
+				"Ninguna de las anteriores",
+			},
+			Correct: []int{0, 1},
+		},
+		{
+			ID: "suma-arreglo", Document: "welcome", Anchor: "hola",
+			Type:      bank.TypeSimple,
+			Statement: "¿Qué imprime este programa?",
+			Code:      &bank.Code{Language: "java", Source: "public class SumaArreglo { … }"},
+			Alternatives: []string{
+				"20",
+				"8",
+			},
+			Correct: []int{0},
+		},
+	}
+}
+
+// expandedPool copies the sample pool a few times with fresh ids so a
+// QuestionsPerCopy up to 12 is legal. Used by header-arithmetic tests that
+// don't inspect ids.
+func expandedPool() []bank.Question {
+	base := samplePool()
+	out := append([]bank.Question(nil), base...)
+	for round := 1; round <= 3; round++ {
+		for i, q := range base {
+			q.ID = fmt.Sprintf("%s-copy%di%d", q.ID, round, i)
+			out = append(out, q)
+		}
+	}
+	return out
+}
+
+func compile(t *testing.T, override func(*tex.Input)) string {
+	t.Helper()
+	in := tex.Input{
+		Name:             "Control de entrada",
+		Pool:             samplePool(),
+		Copies:           5,
+		QuestionsPerCopy: 3, // the sample has three, so the default fits
+		Seed:             1242,
+		ListingsDir:      "/work/controls/abc/inputs",
+	}
+	if override != nil {
+		override(&in)
+	}
+	out, err := tex.Compile(in)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	return out
+}
+
+func TestPreambleDeclaresLangESAndDoesNotUseCompletemulti(t *testing.T) {
+	out := compile(t, nil)
+	if !strings.Contains(out, `\usepackage[box,lang=ES]{automultiplechoice}`) {
+		t.Error("preamble is missing lang=ES: AMC would label every question 'Question 1' in English (worker README)")
+	}
+	// Match the ACTUAL package-option syntax, not a comment mentioning
+	// the name. `\usepackage[...completemulti...]{automultiplechoice}`
+	// would be the miscall; a comment saying "completemulti is off" is
+	// not.
+	for _, form := range []string{
+		",completemulti]{automultiplechoice}",
+		"completemulti,",
+		"[completemulti]{automultiplechoice}",
+	} {
+		if strings.Contains(out, form) {
+			t.Errorf("preamble uses completemulti (%q): it appends a wrong-Spanish 'none of these' box (ADR-0033 §Alternatives considered)", form)
+		}
+	}
+}
+
+func TestPreambleDeclaresBothPerQuestionLabelMacros(t *testing.T) {
+	out := compile(t, nil)
+	if !strings.Contains(out, `\def\unaSymbole{\textsf{\small(una respuesta)}}`) {
+		t.Error("preamble is missing \\unaSymbole")
+	}
+	if !strings.Contains(out, `\def\multiSymbole{\textsf{\small(varias respuestas)}}`) {
+		t.Error("preamble is missing \\multiSymbole")
+	}
+	if !strings.Contains(out, `\lstset{`) {
+		t.Error("preamble is missing \\lstset: a code question would print with no indentation preserved")
+	}
+}
+
+func TestSimpleQuestionCarriesUnaLabelInTheOptionalArgument(t *testing.T) {
+	out := compile(t, nil)
+	if !strings.Contains(out, `\begin{question}[\unaSymbole]{iteraciones}`) {
+		t.Error("simple question is missing [\\unaSymbole] in its optional argument (ADR-0033)")
+	}
+}
+
+func TestMultipleQuestionUsesQuestionmultAndNoInlineLabel(t *testing.T) {
+	out := compile(t, nil)
+	// questionmult cannot take [label]; the label comes from \multiSymbole
+	// in the preamble (worker README §What a control source must contain).
+	if !strings.Contains(out, `\begin{questionmult}{comparar-cadenas}`) {
+		t.Error("multi-answer question is missing \\begin{questionmult}{comparar-cadenas}")
+	}
+	if strings.Contains(out, `\begin{questionmult}[`) {
+		t.Error("multi-answer question was given a [label] optional argument, which mangles the text")
+	}
+}
+
+func TestNingunaDeLasAnterioresIsPinnedLastWithLastchoices(t *testing.T) {
+	out := compile(t, nil)
+
+	lastchoicesIdx := strings.Index(out, `\lastchoices`)
+	if lastchoicesIdx < 0 {
+		t.Fatal("\\lastchoices missing: 'Ninguna de las anteriores' would shuffle to any position and print something false (ADR-0033)")
+	}
+	pinnedIdx := strings.Index(out, "Ninguna de las anteriores")
+	if pinnedIdx < 0 {
+		t.Fatal("'Ninguna de las anteriores' missing from output")
+	}
+	if pinnedIdx <= lastchoicesIdx {
+		t.Errorf("'Ninguna de las anteriores' at %d appears BEFORE \\lastchoices at %d — the pin has no effect",
+			pinnedIdx, lastchoicesIdx)
+	}
+}
+
+func TestCodeQuestionEmitsLstinputlistingWithAbsolutePath(t *testing.T) {
+	out := compile(t, nil)
+	// The Service (S5) stages the file at
+	// <ListingsDir>/question-<id>.txt, ABSOLUTE per ADR-0033.
+	if !strings.Contains(out, `\lstinputlisting{/work/controls/abc/inputs/question-suma-arreglo.txt}`) {
+		t.Error("code question is missing \\lstinputlisting with the absolute staged path (ADR-0033)")
+	}
+	// A relative path here would compile fatally with no PDF, so its
+	// absence is the point.
+	if strings.Contains(out, `\lstinputlisting{question-`) {
+		t.Error("\\lstinputlisting used a relative path — AMC compiles from its own working directory (ADR-0033)")
+	}
+}
+
+func TestHeaderBlockCarriesThisSheetsArithmetic(t *testing.T) {
+	out := compile(t, func(in *tex.Input) {
+		in.Pool = expandedPool()
+		in.QuestionsPerCopy = 4
+	})
+
+	if !strings.Contains(out, `\textbf{4 preguntas} · \textbf{4 puntos} · el 4,0 son 2 puntos`) {
+		t.Error("header block for a 4-question sheet is not the exact 'N preguntas · N puntos · el 4,0 son N/2 puntos' shape (ADR-0033)")
+	}
+
+	out = compile(t, func(in *tex.Input) {
+		in.Pool = expandedPool()
+		in.QuestionsPerCopy = 5
+	})
+	if !strings.Contains(out, `el 4,0 son 2,5 puntos`) {
+		t.Error("header block for an odd number of questions is missing the fractional threshold (2,5 puntos)")
+	}
+
+	if !strings.Contains(out, `\textbf{Respóndelas todas: equivocarse no descuenta.}`) {
+		t.Error("header block is missing the 'answering everything is free' line (§C7)")
+	}
+	// The one instruction that stopped being true once a control could
+	// draw a multiple must not appear (ADR-0033 §Context).
+	if strings.Contains(out, "Marca una sola alternativa por pregunta") {
+		t.Error("header contains the deleted 'Marca una sola alternativa por pregunta' — it is false when a multiple is drawn")
+	}
+}
+
+func TestSheetWritesOnecopyAndInsertgroupWithTheRightNumbers(t *testing.T) {
+	out := compile(t, func(in *tex.Input) {
+		in.Copies = 30
+		in.QuestionsPerCopy = 3 // matches sample pool size
+	})
+	if !strings.Contains(out, `\onecopy{30}{`) {
+		t.Error("sheet is missing \\onecopy{30}")
+	}
+	if !strings.Contains(out, `\insertgroup[3]{clase}`) {
+		t.Error("sheet is missing \\insertgroup[3]{clase}")
+	}
+	if !strings.Contains(out, `\AMCcode{rut}{8}`) {
+		t.Error("sheet is missing the 8-digit RUT code grid (§C5)")
+	}
+}
+
+func TestSeedIsEmittedVerbatim(t *testing.T) {
+	out := compile(t, func(in *tex.Input) { in.Seed = 424242 })
+	if !strings.Contains(out, `\AMCrandomseed{424242}`) {
+		t.Error("preamble is missing \\AMCrandomseed with the input seed")
+	}
+}
+
+func TestPoolOrderIsPreserved(t *testing.T) {
+	out := compile(t, nil)
+	// iteraciones must appear before comparar-cadenas, which must appear
+	// before suma-arreglo — the same order the sample pool defined.
+	i := strings.Index(out, "{iteraciones}")
+	j := strings.Index(out, "{comparar-cadenas}")
+	k := strings.Index(out, "{suma-arreglo}")
+	if !(i > 0 && i < j && j < k) {
+		t.Errorf("pool order was not preserved (indices: iteraciones=%d, comparar-cadenas=%d, suma-arreglo=%d)", i, j, k)
+	}
+}
+
+func TestNameIsEscapedBeforeEmission(t *testing.T) {
+	out := compile(t, func(in *tex.Input) { in.Name = "50% control & test" })
+	if !strings.Contains(out, `\bf 50\% control \& test`) {
+		t.Errorf("name was not LaTeX-escaped: output does not contain the escaped '\\%%' or '\\&'\n---\n%s\n---", takeLines(out, "\\bf ", 1))
+	}
+}
+
+func TestCompileRefusesShapesThatCannotProduceASheet(t *testing.T) {
+	cases := []struct {
+		name string
+		mut  func(*tex.Input)
+	}{
+		{"empty name", func(in *tex.Input) { in.Name = "" }},
+		{"zero questions per copy", func(in *tex.Input) { in.QuestionsPerCopy = 0 }},
+		{"zero copies", func(in *tex.Input) { in.Copies = 0 }},
+		{"pool smaller than questions per copy", func(in *tex.Input) { in.QuestionsPerCopy = 100 }},
+		{"seed zero", func(in *tex.Input) { in.Seed = 0 }},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			in := tex.Input{
+				Name: "n", Pool: samplePool(), Copies: 5, QuestionsPerCopy: 3, Seed: 1, ListingsDir: "/work/x",
+			}
+			c.mut(&in)
+			if _, err := tex.Compile(in); err == nil {
+				t.Error("Compile accepted a shape that cannot produce a sheet")
+			}
+		})
+	}
+}
+
+func TestCompileRefusesACodeQuestionWithoutListingsDir(t *testing.T) {
+	in := tex.Input{
+		Name: "n", Pool: samplePool(), Copies: 5, QuestionsPerCopy: 3, Seed: 1,
+		// ListingsDir intentionally empty.
+	}
+	if _, err := tex.Compile(in); err == nil {
+		t.Error("Compile accepted a code question without a ListingsDir (the \\lstinputlisting path would be non-absolute and AMC would fail)")
+	}
+}
+
+// TestFixtureAndGeneratorAgreeOnTheLoadBearingRules reads the AMC worker's
+// checked-in fixture (apps/amc-worker/tests/fixtures/control-demo.tex) and
+// asserts every rule ADR-0033 pins the generator on. Both files must
+// satisfy the same set — that is what keeps the fixture from drifting from
+// the shape WP-E emits, and what makes "the fixture is the reference"
+// something the suite believes.
+//
+// Byte-identity between the generator's output and the fixture is not the
+// pin: the fixture carries authoring comments the generator does not emit,
+// and hand-writing the pool that would reproduce the fixture is fixture
+// work, not code work. Shape-identity is what the ADR is written against.
+func TestFixtureAndGeneratorAgreeOnTheLoadBearingRules(t *testing.T) {
+	fixturePath := "../../../../../amc-worker/tests/fixtures/control-demo.tex"
+	fixture, err := os.ReadFile(fixturePath)
+	if err != nil {
+		t.Fatalf("read %s: %v", fixturePath, err)
+	}
+	fixtureStr := string(fixture)
+
+	assertShape := func(t *testing.T, source, label string) {
+		t.Helper()
+		checks := []struct {
+			name  string
+			ok    bool
+			note  string
+		}{
+			{"lang=ES", strings.Contains(source, `lang=ES`), "AMC would label questions in English"},
+			{"no completemulti in usepackage", !strings.Contains(source, ",completemulti]{automultiplechoice}") && !strings.Contains(source, "[completemulti]{automultiplechoice}"), "would append wrong-Spanish 'none of these'"},
+			{`\unaSymbole def`, strings.Contains(source, `\def\unaSymbole`), ""},
+			{`\multiSymbole def`, strings.Contains(source, `\def\multiSymbole`), ""},
+			{`\lstset present`, strings.Contains(source, `\lstset`), ""},
+			{`\AMCcode{rut}{8}`, strings.Contains(source, `\AMCcode{rut}{8}`), "8-digit RUT grid (§C5)"},
+			{`\shufflegroup{clase}`, strings.Contains(source, `\shufflegroup{clase}`), ""},
+			{`\lastchoices before "Ninguna de las anteriores"`, strings.Index(source, `\lastchoices`) < strings.Index(source, "Ninguna de las anteriores") && strings.Contains(source, `\lastchoices`), "pin has no effect (ADR-0033)"},
+			{"deleted 'Marca una sola alternativa'", !containsOutsideComments(source, "Marca una sola alternativa por pregunta"), "false when a multiple is drawn"},
+			{"answering everything is free", strings.Contains(source, "equivocarse no descuenta"), "§C7"},
+		}
+		for _, c := range checks {
+			if !c.ok {
+				if c.note != "" {
+					t.Errorf("%s: rule %q failed — %s", label, c.name, c.note)
+				} else {
+					t.Errorf("%s: rule %q failed", label, c.name)
+				}
+			}
+		}
+	}
+
+	t.Run("fixture", func(t *testing.T) { assertShape(t, fixtureStr, "fixture") })
+	t.Run("generator", func(t *testing.T) {
+		generated := compile(t, func(in *tex.Input) {
+			in.Pool = expandedPool()
+			in.QuestionsPerCopy = 4
+		})
+		assertShape(t, generated, "generator")
+	})
+}
+
+// containsOutsideComments reports whether needle appears in source outside
+// a LaTeX line comment. A line comment starts with an unescaped %; anything
+// after that on the same line is stripped before the search. The check is
+// deliberately line-oriented rather than tokenising the whole file.
+func containsOutsideComments(source, needle string) bool {
+	for _, line := range strings.Split(source, "\n") {
+		if i := indexUnescapedPercent(line); i >= 0 {
+			line = line[:i]
+		}
+		if strings.Contains(line, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func indexUnescapedPercent(line string) int {
+	for i := 0; i < len(line); i++ {
+		if line[i] != '%' {
+			continue
+		}
+		if i > 0 && line[i-1] == '\\' {
+			continue
+		}
+		return i
+	}
+	return -1
+}
+
+// takeLines returns the line matching prefix, plus n following lines, for
+// diagnostic messages.
+func takeLines(s, prefix string, n int) string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		if strings.Contains(line, prefix) {
+			end := i + n + 1
+			if end > len(lines) {
+				end = len(lines)
+			}
+			return strings.Join(lines[i:end], "\n")
+		}
+	}
+	return ""
+}

--- a/apps/server/internal/domain/controls/tex/tex_test.go
+++ b/apps/server/internal/domain/controls/tex/tex_test.go
@@ -297,9 +297,9 @@ func TestFixtureAndGeneratorAgreeOnTheLoadBearingRules(t *testing.T) {
 	assertShape := func(t *testing.T, source, label string) {
 		t.Helper()
 		checks := []struct {
-			name  string
-			ok    bool
-			note  string
+			name string
+			ok   bool
+			note string
 		}{
 			{"lang=ES", strings.Contains(source, `lang=ES`), "AMC would label questions in English"},
 			{"no completemulti in usepackage", !strings.Contains(source, ",completemulti]{automultiplechoice}") && !strings.Contains(source, "[completemulti]{automultiplechoice}"), "would append wrong-Spanish 'none of these'"},

--- a/apps/server/internal/domain/course/bank/bank.go
+++ b/apps/server/internal/domain/course/bank/bank.go
@@ -1,0 +1,352 @@
+// Package bank is the in-memory reader for the published question bank of
+// ADR-0032 (questions.json). It exists so the controls domain can resolve a
+// section range into a pool of authored questions without parsing MDX or
+// touching content/.
+//
+// The shape here mirrors the emitter in apps/web (src/content/questionBank.ts).
+// A shape change is a cross-app breaking change and carries a version field —
+// this reader refuses anything but version 1, so drift shows up at boot rather
+// than as a subtle misread later.
+package bank
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"time"
+)
+
+// Bank is the whole published set, held in memory. Load reads it once at boot
+// (cmd/server) and hands the *Bank down; nothing here refreshes at runtime.
+// The runtime refresh comes with an apps/web redeploy followed by an
+// apps/server redeploy, which is enough at this scale (issue #166 §Bank
+// reader).
+type Bank struct {
+	Version   int
+	Documents []Document
+	Questions []Question
+
+	// Indices, built by Parse. Not exported: consumers reach them through
+	// Pool, FindDocument and DocumentSections, so a rename here does not
+	// leak into the callers.
+	docIndex     map[string]int
+	sectionIndex map[SectionRef]int
+}
+
+// Document is one course document as the emitter published it: id, title, the
+// "coverage" phrase apps/web renders, and its section slugs in document order.
+type Document struct {
+	ID       string
+	Title    string
+	Coverage string
+	Sections []string
+}
+
+// Question is one authored question. Anchor is the section slug, empty when
+// the source declared it null (a question that belongs to no section is
+// unreachable from a range pool — see Pool).
+type Question struct {
+	ID           string
+	Document     string
+	Anchor       string
+	Type         string
+	Statement    string
+	Code         *Code
+	Alternatives []string
+	Correct      []int
+}
+
+// Type constants. Derived from the marks in the emitter; the reader here
+// consumes the derived value.
+const (
+	TypeSimple   = "simple"
+	TypeMultiple = "multiple"
+)
+
+// Code is a listing attached to a question, kept as its own field so nothing
+// has to be escaped (ADR-0032). Nil when the question carries no code.
+type Code struct {
+	Language string
+	Source   string
+}
+
+// SectionRef names a section within a document, using the two slugs the
+// bank publishes. It is the pair the range dropdowns emit.
+type SectionRef struct {
+	Document string
+	Section  string
+}
+
+// FetchTimeout bounds a boot fetch. Long enough to survive a slow start on
+// GitHub Pages, short enough that a completely dead URL fails the boot
+// rather than hanging it. It is the boot budget, not a request-time budget:
+// nothing refreshes the bank at runtime, so a slow fetch here is a slow
+// server start and not a slow user request.
+const FetchTimeout = 30 * time.Second
+
+// The failure modes callers branch on, wrapped so a caller can tell them
+// apart with errors.Is without importing json or net/http.
+var (
+	// ErrUnsupportedScheme wraps a Load call whose URL is neither http, https
+	// nor file. The design closed transport in ADR-0032 §C14; this refuses to
+	// widen it by accident.
+	ErrUnsupportedScheme = errors.New("bank: URL scheme must be http, https or file")
+
+	// ErrUnsupportedVersion is a bank with a version this reader does not know
+	// how to read. Version is what ADR-0032 promised would fail loudly.
+	ErrUnsupportedVersion = errors.New("bank: unsupported version")
+
+	// ErrEmptyRange is Pool's answer when the range resolves to zero
+	// questions. The form turns it into a Spanish message; the domain sees a
+	// sentinel.
+	ErrEmptyRange = errors.New("bank: the range contains no questions")
+
+	// ErrRangeInverted is Pool's answer when the "to" edge precedes "from" in
+	// the reading order — a form defect, not a bank one.
+	ErrRangeInverted = errors.New("bank: the range goes backwards through the reading order")
+
+	// ErrUnknownDocument / ErrUnknownSection are Pool's answers when the
+	// dropdowns emitted a value the bank does not know. The form flags the
+	// offending field.
+	ErrUnknownDocument = errors.New("bank: unknown document")
+	ErrUnknownSection  = errors.New("bank: unknown section")
+)
+
+// Load fetches the bank from URL and parses it. Blocking, once, at boot.
+//
+// http/https use the default client with a bounded context; file:// is opened
+// against the local filesystem. A path escape check would be the wrong
+// mitigation here: the URL is operator-supplied at boot and reaching it is
+// the operator's decision, exactly like NALANDA_DATABASE_URL.
+func Load(ctx context.Context, rawURL string) (*Bank, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("bank: parse URL %q: %w", rawURL, err)
+	}
+	switch parsed.Scheme {
+	case "http", "https":
+		return loadHTTP(ctx, rawURL)
+	case "file":
+		// url.Parse folds a file:/// path into .Path. Empty means the URL was
+		// nothing after the scheme, which is not a location we can open.
+		if parsed.Path == "" {
+			return nil, fmt.Errorf("bank: file URL %q names no path", rawURL)
+		}
+		return loadFile(parsed.Path)
+	default:
+		return nil, fmt.Errorf("%w: got %q in %s", ErrUnsupportedScheme, parsed.Scheme, rawURL)
+	}
+}
+
+func loadHTTP(ctx context.Context, u string) (*Bank, error) {
+	ctx, cancel := context.WithTimeout(ctx, FetchTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("bank: build request for %s: %w", u, err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("bank: fetch %s: %w", u, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("bank: %s answered %s", u, resp.Status)
+	}
+	// The bank is small (kilobytes); anything approaching this cap is a wrong
+	// URL pointing at the whole site rather than the artifact.
+	const maxRead = 32 << 20
+	return Parse(io.LimitReader(resp.Body, maxRead))
+}
+
+func loadFile(path string) (*Bank, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("bank: open %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	return Parse(f)
+}
+
+// Parse decodes a bank from r. Exposed so tests and the operator's local
+// tooling can round-trip a JSON blob without the URL layer.
+func Parse(r io.Reader) (*Bank, error) {
+	var raw jsonBank
+	dec := json.NewDecoder(r)
+	if err := dec.Decode(&raw); err != nil {
+		return nil, fmt.Errorf("bank: decode: %w", err)
+	}
+	if raw.Version != 1 {
+		return nil, fmt.Errorf("%w: got %d, this reader knows 1", ErrUnsupportedVersion, raw.Version)
+	}
+
+	b := &Bank{
+		Version:      raw.Version,
+		Documents:    make([]Document, 0, len(raw.Documents)),
+		Questions:    make([]Question, 0, len(raw.Questions)),
+		docIndex:     make(map[string]int, len(raw.Documents)),
+		sectionIndex: make(map[SectionRef]int, len(raw.Documents)*4),
+	}
+	for i, d := range raw.Documents {
+		b.Documents = append(b.Documents, Document{
+			ID:       d.ID,
+			Title:    d.Title,
+			Coverage: d.Coverage,
+			Sections: append([]string(nil), d.Sections...),
+		})
+		b.docIndex[d.ID] = i
+		for j, s := range d.Sections {
+			b.sectionIndex[SectionRef{Document: d.ID, Section: s}] = j
+		}
+	}
+	for _, q := range raw.Questions {
+		anchor := ""
+		if q.Anchor != nil {
+			anchor = *q.Anchor
+		}
+		b.Questions = append(b.Questions, Question{
+			ID:           q.ID,
+			Document:     q.Document,
+			Anchor:       anchor,
+			Type:         q.Type,
+			Statement:    q.Statement,
+			Code:         q.Code.toCode(),
+			Alternatives: append([]string(nil), q.Alternatives...),
+			Correct:      append([]int(nil), q.Correct...),
+		})
+	}
+	return b, nil
+}
+
+// Pool returns the questions inside the section range (from, to), inclusive
+// at both ends, in the source order the bank publishes.
+//
+// The source order IS the reading order, because the emitter walks documents
+// in index.yaml reading order and within each document walks the file in
+// authoring order (apps/web src/content/questionBank.ts). Preserving that
+// order in the pool is what ADR-0030's four silent traps need to be testable
+// against a deterministic input.
+//
+// A question whose anchor is empty (declared null in the source) is skipped:
+// a range is expressed in terms of sections, so a question that belongs to
+// none has no membership to decide.
+func (b *Bank) Pool(from, to SectionRef) ([]Question, error) {
+	fromDoc, ok := b.docIndex[from.Document]
+	if !ok {
+		return nil, fmt.Errorf("%w: from=%q", ErrUnknownDocument, from.Document)
+	}
+	toDoc, ok := b.docIndex[to.Document]
+	if !ok {
+		return nil, fmt.Errorf("%w: to=%q", ErrUnknownDocument, to.Document)
+	}
+	fromSec, ok := b.sectionIndex[from]
+	if !ok {
+		return nil, fmt.Errorf("%w: from=%q in document %q", ErrUnknownSection, from.Section, from.Document)
+	}
+	toSec, ok := b.sectionIndex[to]
+	if !ok {
+		return nil, fmt.Errorf("%w: to=%q in document %q", ErrUnknownSection, to.Section, to.Document)
+	}
+	if fromDoc > toDoc || (fromDoc == toDoc && fromSec > toSec) {
+		return nil, ErrRangeInverted
+	}
+
+	inRange := func(doc, sec int) bool {
+		if doc < fromDoc || doc > toDoc {
+			return false
+		}
+		if doc == fromDoc && sec < fromSec {
+			return false
+		}
+		if doc == toDoc && sec > toSec {
+			return false
+		}
+		return true
+	}
+
+	var pool []Question
+	for _, q := range b.Questions {
+		if q.Anchor == "" {
+			continue
+		}
+		docIdx, ok := b.docIndex[q.Document]
+		if !ok {
+			continue
+		}
+		secIdx, ok := b.sectionIndex[SectionRef{Document: q.Document, Section: q.Anchor}]
+		if !ok {
+			continue
+		}
+		if inRange(docIdx, secIdx) {
+			pool = append(pool, q)
+		}
+	}
+	if len(pool) == 0 {
+		return nil, ErrEmptyRange
+	}
+	return pool, nil
+}
+
+// FindDocument returns the Document with id, and whether it exists. Handlers
+// use it to validate a form value before Pool sees it.
+func (b *Bank) FindDocument(id string) (Document, bool) {
+	i, ok := b.docIndex[id]
+	if !ok {
+		return Document{}, false
+	}
+	return b.Documents[i], true
+}
+
+// HasSection reports whether ref exists in the bank. Used by the form to
+// tell a bad section from a bad range before calling Pool.
+func (b *Bank) HasSection(ref SectionRef) bool {
+	_, ok := b.sectionIndex[ref]
+	return ok
+}
+
+// --- JSON shape --------------------------------------------------------------
+//
+// Kept lowercase and package-private because it is a wire shape, not a domain
+// value: consumers see the Bank/Document/Question types above, which do not
+// carry the *string anchor of the wire.
+
+type jsonBank struct {
+	Version   int            `json:"version"`
+	Documents []jsonDoc      `json:"documents"`
+	Questions []jsonQuestion `json:"questions"`
+}
+
+type jsonDoc struct {
+	ID       string   `json:"id"`
+	Title    string   `json:"title"`
+	Coverage string   `json:"coverage"`
+	Sections []string `json:"sections"`
+}
+
+type jsonQuestion struct {
+	ID           string    `json:"id"`
+	Document     string    `json:"document"`
+	Anchor       *string   `json:"anchor"`
+	Type         string    `json:"type"`
+	Statement    string    `json:"statement"`
+	Code         *jsonCode `json:"code"`
+	Alternatives []string  `json:"alternatives"`
+	Correct      []int     `json:"correct"`
+}
+
+type jsonCode struct {
+	Language string `json:"language"`
+	Source   string `json:"source"`
+}
+
+func (c *jsonCode) toCode() *Code {
+	if c == nil {
+		return nil
+	}
+	return &Code{Language: c.Language, Source: c.Source}
+}

--- a/apps/server/internal/domain/course/bank/bank.go
+++ b/apps/server/internal/domain/course/bank/bank.go
@@ -115,6 +115,17 @@ var (
 	// offending field.
 	ErrUnknownDocument = errors.New("bank: unknown document")
 	ErrUnknownSection  = errors.New("bank: unknown section")
+
+	// ErrDuplicateQuestionID is a bank whose Parse found the same
+	// question id twice. ADR-0032 §Consequences names this "a duplicate
+	// question id fails the BUILD, deliberately unlike the rest of the
+	// gate ladder — the id is the join key, and a duplicate silently
+	// merges two students' answers into one column". The emitter in
+	// apps/web already enforces it at build time; this reader mirrors
+	// that rule so a bank JSON handed to a server that skipped the build
+	// gate is still rejected at boot rather than at the first control's
+	// PRIMARY KEY conflict on control_pregunta.
+	ErrDuplicateQuestionID = errors.New("bank: duplicate question id")
 )
 
 // Load fetches the bank from URL and parses it. Blocking, once, at boot.
@@ -204,7 +215,13 @@ func Parse(r io.Reader) (*Bank, error) {
 			b.sectionIndex[SectionRef{Document: d.ID, Section: s}] = j
 		}
 	}
+	seenID := make(map[string]bool, len(raw.Questions))
 	for _, q := range raw.Questions {
+		if seenID[q.ID] {
+			return nil, fmt.Errorf("%w: %q", ErrDuplicateQuestionID, q.ID)
+		}
+		seenID[q.ID] = true
+
 		anchor := ""
 		if q.Anchor != nil {
 			anchor = *q.Anchor

--- a/apps/server/internal/domain/course/bank/bank_test.go
+++ b/apps/server/internal/domain/course/bank/bank_test.go
@@ -115,6 +115,35 @@ func TestParseRejectsUnsupportedVersion(t *testing.T) {
 	}
 }
 
+func TestParseRejectsDuplicateQuestionID(t *testing.T) {
+	// ADR-0032: the id is the join key from a printed sheet to a grade,
+	// so a duplicate silently merges two students' answers into one
+	// column. The emitter fails the BUILD on this; the reader mirrors
+	// the check so a bank JSON handed to a server that skipped the
+	// build gate is still rejected — otherwise the failure appears
+	// later as a PRIMARY KEY conflict on control_pregunta the first
+	// time a control draws both.
+	const dupJSON = `{
+  "version": 1,
+  "documents": [
+    {"id": "d", "title": "D", "coverage": "c", "sections": ["s"]}
+  ],
+  "questions": [
+    {"id": "same", "document": "d", "anchor": "s", "type": "simple",
+     "statement": "A?", "code": null, "alternatives": ["a","b"], "correct": [0]},
+    {"id": "same", "document": "d", "anchor": "s", "type": "simple",
+     "statement": "B?", "code": null, "alternatives": ["a","b"], "correct": [0]}
+  ]
+}`
+	_, err := bank.Parse(strings.NewReader(dupJSON))
+	if !errors.Is(err, bank.ErrDuplicateQuestionID) {
+		t.Errorf("Parse(duplicate id): %v, want ErrDuplicateQuestionID", err)
+	}
+	if err != nil && !strings.Contains(err.Error(), `"same"`) {
+		t.Errorf("error %q does not name the duplicated id", err.Error())
+	}
+}
+
 func TestParseRejectsMalformedJSON(t *testing.T) {
 	_, err := bank.Parse(strings.NewReader(`{version: 1,`))
 	if err == nil {

--- a/apps/server/internal/domain/course/bank/bank_test.go
+++ b/apps/server/internal/domain/course/bank/bank_test.go
@@ -1,0 +1,286 @@
+package bank_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/course/bank"
+)
+
+// fixtureJSON is a valid bank with three documents in reading order. It
+// exercises every field the reader touches: multiple sections per document,
+// a null-anchor question that must be skipped by Pool, a "multiple" type,
+// and a question carrying code.
+const fixtureJSON = `{
+  "version": 1,
+  "documents": [
+    {"id": "welcome",   "title": "Bienvenida",   "coverage": "clase 0",     "sections": ["hola", "reglas"]},
+    {"id": "flujo",     "title": "Flujo",        "coverage": "clase 2",     "sections": ["if-else", "bucles", "cortes"]},
+    {"id": "arreglos",  "title": "Arreglos",     "coverage": "clase 3",     "sections": ["basico", "longitud"]}
+  ],
+  "questions": [
+    {"id": "q-hola-1",       "document": "welcome",  "anchor": "hola",      "type": "simple",   "statement": "¿Qué es Nalanda?", "code": null, "alternatives": ["una plataforma","un lenguaje"], "correct": [0]},
+    {"id": "q-reglas-1",     "document": "welcome",  "anchor": "reglas",    "type": "simple",   "statement": "R1?",              "code": null, "alternatives": ["a","b"],                             "correct": [0]},
+    {"id": "q-orphan",       "document": "welcome",  "anchor": null,        "type": "simple",   "statement": "S/A",              "code": null, "alternatives": ["a","b"],                             "correct": [1]},
+    {"id": "q-if-1",         "document": "flujo",    "anchor": "if-else",   "type": "simple",   "statement": "if?",              "code": null, "alternatives": ["a","b"],                             "correct": [0]},
+    {"id": "q-bucles-1",     "document": "flujo",    "anchor": "bucles",    "type": "multiple", "statement": "¿Cuáles bucles?",  "code": null, "alternatives": ["for","while","hazlo","ninguno"],     "correct": [0,1]},
+    {"id": "q-cortes-1",     "document": "flujo",    "anchor": "cortes",    "type": "simple",   "statement": "corte?",           "code": null, "alternatives": ["a","b"],                             "correct": [0]},
+    {"id": "q-arr-basico-1", "document": "arreglos", "anchor": "basico",    "type": "simple",   "statement": "arr?",             "code": {"language": "java", "source": "int[] a = new int[3];"}, "alternatives": ["a","b"], "correct": [0]},
+    {"id": "q-arr-longitud-1","document": "arreglos","anchor": "longitud",  "type": "simple",   "statement": "longitud?",        "code": null, "alternatives": ["a.length","a.length()"],             "correct": [0]}
+  ]
+}
+`
+
+func parse(t *testing.T) *bank.Bank {
+	t.Helper()
+	b, err := bank.Parse(strings.NewReader(fixtureJSON))
+	if err != nil {
+		t.Fatalf("Parse fixture: %v", err)
+	}
+	return b
+}
+
+func TestParseHoldsEveryFieldTheContractCarries(t *testing.T) {
+	b := parse(t)
+
+	if b.Version != 1 {
+		t.Errorf("Version = %d, want 1", b.Version)
+	}
+	if len(b.Documents) != 3 {
+		t.Fatalf("Documents count = %d, want 3", len(b.Documents))
+	}
+	if b.Documents[1].ID != "flujo" || b.Documents[1].Title != "Flujo" || b.Documents[1].Coverage != "clase 2" {
+		t.Errorf("Documents[1] = %+v, want {flujo, Flujo, clase 2, …}", b.Documents[1])
+	}
+	if got := b.Documents[1].Sections; len(got) != 3 || got[0] != "if-else" || got[2] != "cortes" {
+		t.Errorf("Documents[1].Sections = %v, want [if-else bucles cortes]", got)
+	}
+
+	// Anchor null becomes empty string on the domain side.
+	var orphan *bank.Question
+	for i := range b.Questions {
+		if b.Questions[i].ID == "q-orphan" {
+			orphan = &b.Questions[i]
+		}
+	}
+	if orphan == nil {
+		t.Fatal("q-orphan missing from parsed questions")
+	}
+	if orphan.Anchor != "" {
+		t.Errorf("q-orphan.Anchor = %q, want empty (null in JSON)", orphan.Anchor)
+	}
+
+	// Multiple-type question preserves both correct indices.
+	var multi *bank.Question
+	for i := range b.Questions {
+		if b.Questions[i].ID == "q-bucles-1" {
+			multi = &b.Questions[i]
+		}
+	}
+	if multi == nil {
+		t.Fatal("q-bucles-1 missing")
+	}
+	if multi.Type != bank.TypeMultiple {
+		t.Errorf("q-bucles-1.Type = %q, want %q", multi.Type, bank.TypeMultiple)
+	}
+	if got := multi.Correct; len(got) != 2 || got[0] != 0 || got[1] != 1 {
+		t.Errorf("q-bucles-1.Correct = %v, want [0 1]", got)
+	}
+
+	// Code carries language and source; a nil-code question keeps Code nil.
+	var codeQ *bank.Question
+	for i := range b.Questions {
+		if b.Questions[i].ID == "q-arr-basico-1" {
+			codeQ = &b.Questions[i]
+		}
+	}
+	if codeQ == nil || codeQ.Code == nil {
+		t.Fatalf("q-arr-basico-1.Code missing")
+	}
+	if codeQ.Code.Language != "java" || !strings.Contains(codeQ.Code.Source, "new int[3]") {
+		t.Errorf("q-arr-basico-1.Code = %+v", codeQ.Code)
+	}
+}
+
+func TestParseRejectsUnsupportedVersion(t *testing.T) {
+	_, err := bank.Parse(strings.NewReader(`{"version": 2, "documents": [], "questions": []}`))
+	if !errors.Is(err, bank.ErrUnsupportedVersion) {
+		t.Errorf("Parse(version=2): %v, want ErrUnsupportedVersion", err)
+	}
+}
+
+func TestParseRejectsMalformedJSON(t *testing.T) {
+	_, err := bank.Parse(strings.NewReader(`{version: 1,`))
+	if err == nil {
+		t.Fatal("Parse(malformed): no error")
+	}
+	if !strings.Contains(err.Error(), "decode") {
+		t.Errorf("error %q does not name 'decode'", err.Error())
+	}
+}
+
+func TestPoolReturnsQuestionsInsideASingleSection(t *testing.T) {
+	b := parse(t)
+
+	pool, err := b.Pool(
+		bank.SectionRef{Document: "flujo", Section: "bucles"},
+		bank.SectionRef{Document: "flujo", Section: "bucles"},
+	)
+	if err != nil {
+		t.Fatalf("Pool: %v", err)
+	}
+	if len(pool) != 1 || pool[0].ID != "q-bucles-1" {
+		t.Errorf("Pool = %v, want [q-bucles-1]", pool)
+	}
+}
+
+func TestPoolSpansMultipleDocumentsInReadingOrder(t *testing.T) {
+	b := parse(t)
+
+	pool, err := b.Pool(
+		bank.SectionRef{Document: "welcome", Section: "reglas"},
+		bank.SectionRef{Document: "flujo", Section: "bucles"},
+	)
+	if err != nil {
+		t.Fatalf("Pool: %v", err)
+	}
+	// Reading order: welcome/reglas → flujo/if-else → flujo/bucles.
+	want := []string{"q-reglas-1", "q-if-1", "q-bucles-1"}
+	got := make([]string, len(pool))
+	for i, q := range pool {
+		got[i] = q.ID
+	}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("Pool order = %v, want %v", got, want)
+	}
+}
+
+func TestPoolSkipsQuestionsWithNoAnchor(t *testing.T) {
+	b := parse(t)
+
+	// The whole welcome document. q-orphan has anchor null and must not
+	// appear in any range; only q-hola-1 and q-reglas-1 are drawable.
+	pool, err := b.Pool(
+		bank.SectionRef{Document: "welcome", Section: "hola"},
+		bank.SectionRef{Document: "welcome", Section: "reglas"},
+	)
+	if err != nil {
+		t.Fatalf("Pool: %v", err)
+	}
+	for _, q := range pool {
+		if q.ID == "q-orphan" {
+			t.Errorf("Pool contained q-orphan (anchor null); a section range must not draw it")
+		}
+	}
+	if len(pool) != 2 {
+		t.Errorf("Pool size = %d, want 2 (welcome has one anchor-less question that must be skipped)", len(pool))
+	}
+}
+
+func TestPoolFailsClosedOnInvertedRange(t *testing.T) {
+	b := parse(t)
+
+	_, err := b.Pool(
+		bank.SectionRef{Document: "flujo", Section: "cortes"},
+		bank.SectionRef{Document: "welcome", Section: "hola"},
+	)
+	if !errors.Is(err, bank.ErrRangeInverted) {
+		t.Errorf("Pool(inverted): %v, want ErrRangeInverted", err)
+	}
+}
+
+func TestPoolFlagsUnknownDocumentAndUnknownSection(t *testing.T) {
+	b := parse(t)
+
+	_, err := b.Pool(
+		bank.SectionRef{Document: "does-not-exist", Section: "hola"},
+		bank.SectionRef{Document: "welcome", Section: "hola"},
+	)
+	if !errors.Is(err, bank.ErrUnknownDocument) {
+		t.Errorf("Pool(bad doc): %v, want ErrUnknownDocument", err)
+	}
+
+	_, err = b.Pool(
+		bank.SectionRef{Document: "welcome", Section: "no-existe"},
+		bank.SectionRef{Document: "welcome", Section: "hola"},
+	)
+	if !errors.Is(err, bank.ErrUnknownSection) {
+		t.Errorf("Pool(bad section): %v, want ErrUnknownSection", err)
+	}
+}
+
+func TestFindDocumentAndHasSection(t *testing.T) {
+	b := parse(t)
+
+	if _, ok := b.FindDocument("flujo"); !ok {
+		t.Errorf("FindDocument(flujo) = false, want true")
+	}
+	if _, ok := b.FindDocument("no-existe"); ok {
+		t.Errorf("FindDocument(no-existe) = true, want false")
+	}
+	if !b.HasSection(bank.SectionRef{Document: "flujo", Section: "bucles"}) {
+		t.Errorf("HasSection(flujo/bucles) = false, want true")
+	}
+	if b.HasSection(bank.SectionRef{Document: "flujo", Section: "no"}) {
+		t.Errorf("HasSection(flujo/no) = true, want false")
+	}
+}
+
+func TestLoadFileScheme(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "questions.json")
+	if err := os.WriteFile(path, []byte(fixtureJSON), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	b, err := bank.Load(context.Background(), "file://"+path)
+	if err != nil {
+		t.Fatalf("Load(file): %v", err)
+	}
+	if len(b.Documents) != 3 {
+		t.Errorf("Load(file) returned %d documents, want 3", len(b.Documents))
+	}
+}
+
+func TestLoadHTTPScheme(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(fixtureJSON))
+	}))
+	t.Cleanup(srv.Close)
+
+	b, err := bank.Load(context.Background(), srv.URL+"/questions.json")
+	if err != nil {
+		t.Fatalf("Load(http): %v", err)
+	}
+	if len(b.Documents) != 3 {
+		t.Errorf("Load(http) returned %d documents, want 3", len(b.Documents))
+	}
+}
+
+func TestLoadRejectsUnsupportedScheme(t *testing.T) {
+	_, err := bank.Load(context.Background(), "ftp://example.com/questions.json")
+	if !errors.Is(err, bank.ErrUnsupportedScheme) {
+		t.Errorf("Load(ftp): %v, want ErrUnsupportedScheme", err)
+	}
+}
+
+func TestLoadHTTPReportsNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "gone", http.StatusGone)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := bank.Load(context.Background(), srv.URL+"/questions.json")
+	if err == nil {
+		t.Fatal("Load(410): no error")
+	}
+	if !strings.Contains(err.Error(), "410") {
+		t.Errorf("error %q does not name status 410", err.Error())
+	}
+}

--- a/apps/server/internal/infra/amcworker/amctest/amctest.go
+++ b/apps/server/internal/infra/amcworker/amctest/amctest.go
@@ -1,0 +1,131 @@
+// Package amctest is the test double for controls.Generator.
+//
+// It lives here rather than beside the domain because a fake is transport
+// machinery — the domain does not import it, and putting it in
+// internal/domain would drag a channel of stub files into a package the
+// dependency rule keeps stdlib-only.
+package amctest
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+)
+
+// Fake records every /generate call and, when WorkDir is set, writes the
+// stub files a real worker would produce so a caller can round-trip the
+// "assets on disk" contract without running AMC.
+//
+// Field access is protected by mu, so a Service test that spawns goroutines
+// can share one Fake without racing.
+type Fake struct {
+	mu sync.Mutex
+
+	// Calls is the ordered call log. Read by tests after the run to assert
+	// what was asked.
+	Calls []controls.GenerateRequest
+
+	// WorkDir is the shared-volume root: when set, Generate writes empty
+	// sujet.pdf/corrige.pdf/calage.xy files under
+	// <WorkDir>/<project>/out/ so a caller reading them back succeeds.
+	// An empty WorkDir leaves the disk alone — useful when the test only
+	// cares about the recorded call.
+	WorkDir string
+
+	// Err, when set, is returned from Generate instead of the success path.
+	// Used to drive the failure-mode tests in S6.
+	Err error
+
+	// SujetSize sizes the stub sujet.pdf. Zero means "empty file" (which
+	// is what the missing-PDF failure mode looks like on disk); a positive
+	// value writes that many bytes so the "PDF present" path can also be
+	// tested.
+	SujetSize int
+
+	// Copies overrides the copy count in the response. Zero means "echo the
+	// request's Copies", which is what a real successful call does.
+	Copies int
+}
+
+// Generate satisfies controls.Generator. When Err is set, it returns that;
+// otherwise it writes the stub files (if WorkDir is set) and returns Assets
+// whose paths are relative to WorkDir.
+func (f *Fake) Generate(_ context.Context, req controls.GenerateRequest) (controls.Assets, error) {
+	f.mu.Lock()
+	f.Calls = append(f.Calls, req)
+	err := f.Err
+	work := f.WorkDir
+	size := f.SujetSize
+	copies := f.Copies
+	f.mu.Unlock()
+
+	if err != nil {
+		return controls.Assets{}, err
+	}
+	if copies == 0 {
+		copies = req.Copies
+	}
+
+	sujetRel := filepath.Join(req.Project, "out", "sujet.pdf")
+	corrigeRel := filepath.Join(req.Project, "out", "corrige.pdf")
+	calageRel := filepath.Join(req.Project, "out", "calage.xy")
+
+	if work != "" {
+		outDir := filepath.Join(work, req.Project, "out")
+		if err := os.MkdirAll(outDir, 0o755); err != nil {
+			return controls.Assets{}, fmt.Errorf("amctest: mkdir %s: %w", outDir, err)
+		}
+		if err := writeStub(filepath.Join(work, sujetRel), size); err != nil {
+			return controls.Assets{}, err
+		}
+		if err := writeStub(filepath.Join(work, corrigeRel), 4); err != nil {
+			return controls.Assets{}, err
+		}
+		if err := writeStub(filepath.Join(work, calageRel), 4); err != nil {
+			return controls.Assets{}, err
+		}
+	}
+
+	return controls.Assets{
+		Sujet:   sujetRel,
+		Corrige: corrigeRel,
+		Calage:  calageRel,
+		Copies:  copies,
+	}, nil
+}
+
+func writeStub(path string, size int) error {
+	if size < 0 {
+		size = 0
+	}
+	body := make([]byte, size)
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		return fmt.Errorf("amctest: write %s: %w", path, err)
+	}
+	return nil
+}
+
+// CallCount returns how many times Generate was called. Handy for tests that
+// only care about "was it hit at all".
+func (f *Fake) CallCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.Calls)
+}
+
+// LastCall returns the last request, if any.
+func (f *Fake) LastCall() (controls.GenerateRequest, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.Calls) == 0 {
+		return controls.GenerateRequest{}, false
+	}
+	return f.Calls[len(f.Calls)-1], true
+}
+
+// Assert Fake implements controls.Generator at compile time.
+var _ controls.Generator = (*Fake)(nil)

--- a/apps/server/internal/infra/amcworker/amctest/amctest.go
+++ b/apps/server/internal/infra/amcworker/amctest/amctest.go
@@ -45,34 +45,30 @@ type Fake struct {
 	// value writes that many bytes so the "PDF present" path can also be
 	// tested.
 	SujetSize int
-
-	// Copies overrides the copy count in the response. Zero means "echo the
-	// request's Copies", which is what a real successful call does.
-	Copies int
 }
 
 // Generate satisfies controls.Generator. When Err is set, it returns that;
-// otherwise it writes the stub files (if WorkDir is set) and returns Assets
-// whose paths are relative to WorkDir.
+// otherwise it writes the stub files (if WorkDir is set) and returns
+// Assets whose Sujet path is relative to WorkDir.
+//
+// The stub corrige.pdf and calage.xy files are still written to disk even
+// though controls.Assets no longer carries their paths — a Service test
+// that opens them (or a WP-F test that reads them back) exercises the same
+// convention the worker follows, and that convention is where the
+// download handlers derive their paths from.
 func (f *Fake) Generate(_ context.Context, req controls.GenerateRequest) (controls.Assets, error) {
 	f.mu.Lock()
 	f.Calls = append(f.Calls, req)
 	err := f.Err
 	work := f.WorkDir
 	size := f.SujetSize
-	copies := f.Copies
 	f.mu.Unlock()
 
 	if err != nil {
 		return controls.Assets{}, err
 	}
-	if copies == 0 {
-		copies = req.Copies
-	}
 
 	sujetRel := filepath.Join(req.Project, "out", "sujet.pdf")
-	corrigeRel := filepath.Join(req.Project, "out", "corrige.pdf")
-	calageRel := filepath.Join(req.Project, "out", "calage.xy")
 
 	if work != "" {
 		outDir := filepath.Join(work, req.Project, "out")
@@ -82,20 +78,15 @@ func (f *Fake) Generate(_ context.Context, req controls.GenerateRequest) (contro
 		if err := writeStub(filepath.Join(work, sujetRel), size); err != nil {
 			return controls.Assets{}, err
 		}
-		if err := writeStub(filepath.Join(work, corrigeRel), 4); err != nil {
+		if err := writeStub(filepath.Join(outDir, "corrige.pdf"), 4); err != nil {
 			return controls.Assets{}, err
 		}
-		if err := writeStub(filepath.Join(work, calageRel), 4); err != nil {
+		if err := writeStub(filepath.Join(outDir, "calage.xy"), 4); err != nil {
 			return controls.Assets{}, err
 		}
 	}
 
-	return controls.Assets{
-		Sujet:   sujetRel,
-		Corrige: corrigeRel,
-		Calage:  calageRel,
-		Copies:  copies,
-	}, nil
+	return controls.Assets{Sujet: sujetRel}, nil
 }
 
 func writeStub(path string, size int) error {

--- a/apps/server/internal/infra/amcworker/amctest/amctest_test.go
+++ b/apps/server/internal/infra/amcworker/amctest/amctest_test.go
@@ -1,0 +1,78 @@
+package amctest_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+	"github.com/so77id/nalanda/apps/server/internal/infra/amcworker/amctest"
+)
+
+func TestFakeRecordsEveryCall(t *testing.T) {
+	f := &amctest.Fake{}
+	_, _ = f.Generate(context.Background(), controls.GenerateRequest{Project: "p", Source: "s", Copies: 3})
+	_, _ = f.Generate(context.Background(), controls.GenerateRequest{Project: "q", Source: "t", Copies: 5})
+
+	if f.CallCount() != 2 {
+		t.Errorf("CallCount = %d, want 2", f.CallCount())
+	}
+	last, ok := f.LastCall()
+	if !ok || last.Project != "q" || last.Copies != 5 {
+		t.Errorf("LastCall = %+v, ok=%v", last, ok)
+	}
+}
+
+func TestFakeReturnsConfiguredErr(t *testing.T) {
+	f := &amctest.Fake{Err: errors.New("boom")}
+	_, err := f.Generate(context.Background(), controls.GenerateRequest{Project: "p", Source: "s", Copies: 1})
+	if err == nil || err.Error() != "boom" {
+		t.Errorf("Generate: %v, want boom", err)
+	}
+}
+
+func TestFakeWritesStubFilesWhenWorkDirIsSet(t *testing.T) {
+	dir := t.TempDir()
+	f := &amctest.Fake{WorkDir: dir, SujetSize: 42}
+
+	assets, err := f.Generate(context.Background(), controls.GenerateRequest{
+		Project: "controls/abc", Source: "controls/abc/inputs/source.tex", Copies: 2,
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if assets.Sujet != "controls/abc/out/sujet.pdf" || assets.Copies != 2 {
+		t.Errorf("Assets = %+v", assets)
+	}
+
+	info, err := os.Stat(filepath.Join(dir, assets.Sujet))
+	if err != nil {
+		t.Fatalf("stat sujet: %v", err)
+	}
+	if info.Size() != 42 {
+		t.Errorf("sujet size = %d, want 42", info.Size())
+	}
+	if _, err := os.Stat(filepath.Join(dir, assets.Corrige)); err != nil {
+		t.Errorf("corrige missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, assets.Calage)); err != nil {
+		t.Errorf("calage missing: %v", err)
+	}
+}
+
+func TestFakeLeavesDiskAloneWithoutWorkDir(t *testing.T) {
+	f := &amctest.Fake{} // no WorkDir
+	assets, err := f.Generate(context.Background(), controls.GenerateRequest{
+		Project: "p", Source: "s", Copies: 1,
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	// Paths are still returned so a caller checking response shape works;
+	// the disk is not touched.
+	if assets.Sujet == "" {
+		t.Error("Sujet should be populated even without a WorkDir")
+	}
+}

--- a/apps/server/internal/infra/amcworker/amctest/amctest_test.go
+++ b/apps/server/internal/infra/amcworker/amctest/amctest_test.go
@@ -43,7 +43,7 @@ func TestFakeWritesStubFilesWhenWorkDirIsSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Generate: %v", err)
 	}
-	if assets.Sujet != "controls/abc/out/sujet.pdf" || assets.Copies != 2 {
+	if assets.Sujet != "controls/abc/out/sujet.pdf" {
 		t.Errorf("Assets = %+v", assets)
 	}
 
@@ -54,11 +54,13 @@ func TestFakeWritesStubFilesWhenWorkDirIsSet(t *testing.T) {
 	if info.Size() != 42 {
 		t.Errorf("sujet size = %d, want 42", info.Size())
 	}
-	if _, err := os.Stat(filepath.Join(dir, assets.Corrige)); err != nil {
-		t.Errorf("corrige missing: %v", err)
-	}
-	if _, err := os.Stat(filepath.Join(dir, assets.Calage)); err != nil {
-		t.Errorf("calage missing: %v", err)
+	// corrige.pdf and calage.xy are still written to disk (WP-F reads them
+	// off the same convention the worker follows); Assets does not carry
+	// their paths.
+	for _, name := range []string{"corrige.pdf", "calage.xy"} {
+		if _, err := os.Stat(filepath.Join(dir, "controls", "abc", "out", name)); err != nil {
+			t.Errorf("%s missing: %v", name, err)
+		}
 	}
 }
 

--- a/apps/server/internal/infra/amcworker/amcworker.go
+++ b/apps/server/internal/infra/amcworker/amcworker.go
@@ -176,6 +176,11 @@ func (c *Client) Generate(ctx context.Context, req controls.GenerateRequest) (co
 		return controls.Assets{}, fmt.Errorf("%w: decode response: %v", controls.ErrGeneratorRefused, err)
 	}
 
+	// The wire-level completeness checks stay HERE, on the wire type,
+	// because they are properties of the /generate response — not
+	// something the domain models. Missing paths or a wrong copy count
+	// both reduce to ErrGeneratorRefused, which is the shape a handler
+	// renders.
 	if payload.Sujet == "" || payload.Corrige == "" || payload.Calage == "" {
 		return controls.Assets{}, fmt.Errorf("%w: worker returned an incomplete response: %+v",
 			controls.ErrGeneratorRefused, payload)
@@ -185,12 +190,7 @@ func (c *Client) Generate(ctx context.Context, req controls.GenerateRequest) (co
 			controls.ErrGeneratorRefused, payload.Copies, req.Copies)
 	}
 
-	return controls.Assets{
-		Sujet:   payload.Sujet,
-		Corrige: payload.Corrige,
-		Calage:  payload.Calage,
-		Copies:  payload.Copies,
-	}, nil
+	return controls.Assets{Sujet: payload.Sujet}, nil
 }
 
 // truncateForLog keeps a response body short enough to log without dumping a

--- a/apps/server/internal/infra/amcworker/amcworker.go
+++ b/apps/server/internal/infra/amcworker/amcworker.go
@@ -1,0 +1,231 @@
+// Package amcworker is the HTTP adapter for apps/amc-worker's /generate route
+// (ADR-0030). It implements controls.Generator: an infra type over an interface
+// declared where the domain consumes it (backend-code-style.md §The dependency
+// rule).
+//
+// The wrapper here does two things AMC does not do for itself. It serialises
+// calls so two concurrent generations of the same project cannot race AMC's
+// sqlite state (ADR-0030 §The worker is threaded; AMC is not re-entrant), and
+// it turns transport failures into the domain's sentinels so a handler can tell
+// "operator misconfigured the URL" from "the worker refused the request".
+package amcworker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+)
+
+// Client is a controls.Generator against a running worker. Constructed once
+// in cmd/server; safe for concurrent use — every /generate call goes through
+// the same mutex.
+//
+// Deliberately narrow: this client only speaks the routes WP-E needs. The
+// analyse/associate/annotate half of the worker's contract lives in a
+// sibling file when WP-F is written; splitting them by consumer keeps the
+// deprecation cost of the analyse shape (which is minutes-long and background
+// only, ADR-0030) out of a synchronous generate call.
+type Client struct {
+	base string
+	http *http.Client
+
+	// generateLock serialises /generate. AMC's state is sqlite files in the
+	// project directory and two concurrent runs against one project would
+	// race them; the ADR spells out that a global lock is the worked-around
+	// price. It sits here rather than on the worker because Go's caller is
+	// where control lives, and the worker (§C9) has no auth to police it.
+	generateLock sync.Mutex
+}
+
+// Config is what New takes. HTTPClient is optional: nil means the default
+// client. The domain-facing timeout comes from the caller's context — a
+// call-site deadline is the right shape for a synchronous generation, since
+// the request is being held by a browser (ADR-0030 §Consequences: only
+// analyse is minutes-class; generate is seconds-class).
+type Config struct {
+	// BaseURL is the worker's HTTP origin, e.g. http://amc-worker:8080.
+	// No trailing slash and no path — it names the origin, not a route.
+	BaseURL string
+	// HTTPClient is the transport. Optional. A caller that wants to bound
+	// connect/read separately provides one; the default is
+	// http.DefaultClient, which honours the caller's context deadline.
+	HTTPClient *http.Client
+}
+
+// New returns a Client. Refuses a set it cannot serve with — a common shape
+// with the other constructors in this repo: cmd/server panics at boot rather
+// than nil-dereferences inside a request (backend-code-style.md §Errors).
+//
+// The URL is not just checked for emptiness: it is parsed, and a value that
+// is not an absolute http/https URL is rejected. A relative BaseURL would
+// silently build a request against the process's cwd — measured against a
+// misconfigured value in the design conversation, it produced a runtime
+// error about "no Host in request URL" that named nothing about the config.
+func New(cfg Config) *Client {
+	switch {
+	case cfg.BaseURL == "":
+		panic("amcworker.New: no BaseURL — the worker's origin, e.g. http://amc-worker:8080")
+	}
+	parsed, err := url.Parse(cfg.BaseURL)
+	if err != nil {
+		panic(fmt.Sprintf("amcworker.New: BaseURL %q is not a URL: %v", cfg.BaseURL, err))
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		panic(fmt.Sprintf("amcworker.New: BaseURL %q must be an absolute http or https URL", cfg.BaseURL))
+	}
+	if parsed.Host == "" {
+		panic(fmt.Sprintf("amcworker.New: BaseURL %q names no host", cfg.BaseURL))
+	}
+
+	client := cfg.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return &Client{
+		base: strings.TrimRight(cfg.BaseURL, "/"),
+		http: client,
+	}
+}
+
+// Generate runs POST /generate against the worker, serialised.
+//
+// A caller-level context is what bounds the call: the handler wraps its
+// http.Request context with the target deadline (issue #166 AC-4). This
+// method does not add its own timeout — a second one would be a value the
+// domain does not know about, able to overrule what the handler set.
+func (c *Client) Generate(ctx context.Context, req controls.GenerateRequest) (controls.Assets, error) {
+	if req.Copies < 1 {
+		// Refused before we serialise, so a bad call does not wait behind
+		// a good one for no reason.
+		return controls.Assets{}, fmt.Errorf("%w: copies must be at least 1, got %d",
+			controls.ErrGeneratorRefused, req.Copies)
+	}
+	if req.Project == "" {
+		return controls.Assets{}, fmt.Errorf("%w: project path is required", controls.ErrGeneratorRefused)
+	}
+	if req.Source == "" {
+		return controls.Assets{}, fmt.Errorf("%w: source path is required", controls.ErrGeneratorRefused)
+	}
+
+	c.generateLock.Lock()
+	defer c.generateLock.Unlock()
+
+	body, err := json.Marshal(generateRequestBody{
+		Project: req.Project,
+		Source:  req.Source,
+		Copies:  req.Copies,
+	})
+	if err != nil {
+		// json.Marshal of a value with basic types cannot fail today; the
+		// branch exists because the encoder's contract does not promise so.
+		return controls.Assets{}, fmt.Errorf("amcworker: encode request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.base+"/generate", bytes.NewReader(body))
+	if err != nil {
+		return controls.Assets{}, fmt.Errorf("amcworker: build request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(httpReq)
+	if err != nil {
+		// A context-canceled failure is neither refusal nor unreachability
+		// from the operator's point of view: the caller decided to stop
+		// waiting. Report it as such so a canceled request does not read
+		// as a worker outage in the logs.
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return controls.Assets{}, fmt.Errorf("amcworker: %w", err)
+		}
+		return controls.Assets{}, fmt.Errorf("%w: %v", controls.ErrGeneratorUnavailable, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// Cap the read: the worker's reply is a handful of paths and a number;
+	// anything approaching this is a runaway response and not a payload.
+	const maxRead = 1 << 20
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxRead))
+	if err != nil {
+		return controls.Assets{}, fmt.Errorf("%w: read response: %v", controls.ErrGeneratorUnavailable, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		// Try to pull the worker's { error, detail } out of the body, but
+		// do not fail closed if it is not JSON: the value here is the
+		// status and the raw body's leading text, both useful for
+		// diagnosis.
+		var payload workerError
+		if jerr := json.Unmarshal(respBody, &payload); jerr == nil && payload.Error != "" {
+			return controls.Assets{}, fmt.Errorf("%w: %s answered %d: %s",
+				controls.ErrGeneratorRefused, req.Project, resp.StatusCode, payload.Error)
+		}
+		return controls.Assets{}, fmt.Errorf("%w: %s answered %d: %s",
+			controls.ErrGeneratorRefused, req.Project, resp.StatusCode, truncateForLog(respBody))
+	}
+
+	var payload generateResponseBody
+	if err := json.Unmarshal(respBody, &payload); err != nil {
+		return controls.Assets{}, fmt.Errorf("%w: decode response: %v", controls.ErrGeneratorRefused, err)
+	}
+
+	if payload.Sujet == "" || payload.Corrige == "" || payload.Calage == "" {
+		return controls.Assets{}, fmt.Errorf("%w: worker returned an incomplete response: %+v",
+			controls.ErrGeneratorRefused, payload)
+	}
+	if payload.Copies != req.Copies {
+		return controls.Assets{}, fmt.Errorf("%w: worker generated %d copies, asked for %d",
+			controls.ErrGeneratorRefused, payload.Copies, req.Copies)
+	}
+
+	return controls.Assets{
+		Sujet:   payload.Sujet,
+		Corrige: payload.Corrige,
+		Calage:  payload.Calage,
+		Copies:  payload.Copies,
+	}, nil
+}
+
+// truncateForLog keeps a response body short enough to log without dumping a
+// stray HTML page in full. 200 bytes is enough to see the leading tag and
+// the first line of a real error.
+func truncateForLog(b []byte) string {
+	const max = 200
+	if len(b) > max {
+		return string(b[:max]) + "…"
+	}
+	return string(b)
+}
+
+// Assert the interface at compile time — the storage.Prober shape.
+var _ controls.Generator = (*Client)(nil)
+
+// --- wire shapes -------------------------------------------------------------
+//
+// Package-private because they are the transport, not the domain: the domain
+// sees controls.GenerateRequest and controls.Assets.
+
+type generateRequestBody struct {
+	Project string `json:"project"`
+	Source  string `json:"source"`
+	Copies  int    `json:"copies"`
+}
+
+type generateResponseBody struct {
+	Sujet   string `json:"sujet"`
+	Corrige string `json:"corrige"`
+	Calage  string `json:"calage"`
+	Copies  int    `json:"copies"`
+}
+
+type workerError struct {
+	Error  string `json:"error"`
+	Detail string `json:"detail"`
+}

--- a/apps/server/internal/infra/amcworker/amcworker_test.go
+++ b/apps/server/internal/infra/amcworker/amcworker_test.go
@@ -54,7 +54,7 @@ func TestGenerateSendsProjectSourceAndCopies(t *testing.T) {
 	if got.Project != "controls/abc" || got.Source != "controls/abc/inputs/source.tex" || got.Copies != 30 {
 		t.Errorf("worker received %+v", got)
 	}
-	if assets.Sujet != "controls/abc/out/sujet.pdf" || assets.Copies != 30 {
+	if assets.Sujet != "controls/abc/out/sujet.pdf" {
 		t.Errorf("Assets = %+v", assets)
 	}
 }

--- a/apps/server/internal/infra/amcworker/amcworker_test.go
+++ b/apps/server/internal/infra/amcworker/amcworker_test.go
@@ -1,0 +1,233 @@
+package amcworker_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+	"github.com/so77id/nalanda/apps/server/internal/infra/amcworker"
+)
+
+func TestGenerateSendsProjectSourceAndCopies(t *testing.T) {
+	var got struct {
+		Project string `json:"project"`
+		Source  string `json:"source"`
+		Copies  int    `json:"copies"`
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/generate" {
+			t.Errorf("worker got %s %s, want POST /generate", r.Method, r.URL.Path)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", ct)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		respond(w, http.StatusOK, map[string]any{
+			"sujet":   "controls/abc/out/sujet.pdf",
+			"corrige": "controls/abc/out/corrige.pdf",
+			"calage":  "controls/abc/out/calage.xy",
+			"copies":  30,
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	client := amcworker.New(amcworker.Config{BaseURL: srv.URL})
+	assets, err := client.Generate(context.Background(), controls.GenerateRequest{
+		Project: "controls/abc",
+		Source:  "controls/abc/inputs/source.tex",
+		Copies:  30,
+	})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if got.Project != "controls/abc" || got.Source != "controls/abc/inputs/source.tex" || got.Copies != 30 {
+		t.Errorf("worker received %+v", got)
+	}
+	if assets.Sujet != "controls/abc/out/sujet.pdf" || assets.Copies != 30 {
+		t.Errorf("Assets = %+v", assets)
+	}
+}
+
+func TestGenerateRefusedOn4xxWrapsErrGeneratorRefused(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		respond(w, http.StatusBadRequest, map[string]any{
+			"error":  "source path does not exist",
+			"detail": "no such file: controls/bogus/inputs/source.tex",
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	client := amcworker.New(amcworker.Config{BaseURL: srv.URL})
+	_, err := client.Generate(context.Background(), controls.GenerateRequest{
+		Project: "controls/bogus", Source: "controls/bogus/inputs/source.tex", Copies: 5,
+	})
+	if !errors.Is(err, controls.ErrGeneratorRefused) {
+		t.Errorf("Generate on 400: %v, want ErrGeneratorRefused", err)
+	}
+	// The worker's `error` string is what the operator will read; the
+	// message must include it. The `detail` field is not part of the
+	// domain-facing text — it can carry student identifiers per the
+	// worker's own security note, and this handler runs BEFORE any
+	// filtering in the caller.
+	if !strings.Contains(err.Error(), "source path does not exist") {
+		t.Errorf("error %q does not include worker's error message", err.Error())
+	}
+}
+
+func TestGenerateFailedTransportWrapsErrGeneratorUnavailable(t *testing.T) {
+	// Server that closes the connection without responding. That is the
+	// shape a container that crashed at boot presents.
+	l, err := listenerThatRefuses(t)
+	if err != nil {
+		t.Fatalf("listener: %v", err)
+	}
+	client := amcworker.New(amcworker.Config{BaseURL: "http://" + l})
+	_, err = client.Generate(context.Background(), controls.GenerateRequest{
+		Project: "controls/abc", Source: "controls/abc/inputs/source.tex", Copies: 1,
+	})
+	if !errors.Is(err, controls.ErrGeneratorUnavailable) {
+		t.Errorf("Generate against a dead worker: %v, want ErrGeneratorUnavailable", err)
+	}
+}
+
+func TestGenerateRefusedWhenWorkerSaysWrongCopyCount(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		respond(w, http.StatusOK, map[string]any{
+			"sujet": "x/out/sujet.pdf", "corrige": "x/out/corrige.pdf", "calage": "x/out/calage.xy",
+			"copies": 4, // we asked for 30
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	client := amcworker.New(amcworker.Config{BaseURL: srv.URL})
+	_, err := client.Generate(context.Background(), controls.GenerateRequest{
+		Project: "controls/x", Source: "controls/x/inputs/source.tex", Copies: 30,
+	})
+	if !errors.Is(err, controls.ErrGeneratorRefused) {
+		t.Errorf("Generate with copy mismatch: %v, want ErrGeneratorRefused", err)
+	}
+}
+
+func TestGenerateRefusedWhenWorkerOmitsAPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		respond(w, http.StatusOK, map[string]any{
+			"sujet": "x/out/sujet.pdf", "corrige": "", "calage": "x/out/calage.xy", "copies": 1,
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	client := amcworker.New(amcworker.Config{BaseURL: srv.URL})
+	_, err := client.Generate(context.Background(), controls.GenerateRequest{
+		Project: "controls/x", Source: "controls/x/inputs/source.tex", Copies: 1,
+	})
+	if !errors.Is(err, controls.ErrGeneratorRefused) {
+		t.Errorf("Generate with missing path: %v, want ErrGeneratorRefused", err)
+	}
+}
+
+func TestGenerateRejectsInvalidRequestBeforeCallingTheWorker(t *testing.T) {
+	// A server that would panic the test if called. Nothing here should
+	// reach it because Generate has to refuse client-side.
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("Generate reached the worker with an invalid request")
+	}))
+	t.Cleanup(srv.Close)
+
+	client := amcworker.New(amcworker.Config{BaseURL: srv.URL})
+	cases := []controls.GenerateRequest{
+		{Project: "p", Source: "s", Copies: 0},
+		{Project: "", Source: "s", Copies: 1},
+		{Project: "p", Source: "", Copies: 1},
+	}
+	for _, req := range cases {
+		if _, err := client.Generate(context.Background(), req); !errors.Is(err, controls.ErrGeneratorRefused) {
+			t.Errorf("Generate(%+v): %v, want ErrGeneratorRefused", req, err)
+		}
+	}
+}
+
+// The whole reason this wrapper exists as a wrapper: AMC's state is sqlite
+// files under one project directory, and two concurrent /generate calls
+// against one project would race them (ADR-0030). The Client serialises
+// them, and this test proves that by watching a slow handler.
+func TestGenerateSerialisesConcurrentCallers(t *testing.T) {
+	var inFlight, peak atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		now := inFlight.Add(1)
+		for {
+			p := peak.Load()
+			if now <= p || peak.CompareAndSwap(p, now) {
+				break
+			}
+		}
+		time.Sleep(15 * time.Millisecond) // window in which a second caller could arrive
+		inFlight.Add(-1)
+		respond(w, http.StatusOK, map[string]any{
+			"sujet": "x/out/sujet.pdf", "corrige": "x/out/corrige.pdf", "calage": "x/out/calage.xy", "copies": 1,
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	client := amcworker.New(amcworker.Config{BaseURL: srv.URL})
+
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = client.Generate(context.Background(), controls.GenerateRequest{
+				Project: "controls/x", Source: "controls/x/inputs/source.tex", Copies: 1,
+			})
+		}()
+	}
+	wg.Wait()
+
+	if got := peak.Load(); got != 1 {
+		t.Errorf("peak concurrent /generate calls = %d, want 1 (AMC is not re-entrant, ADR-0030)", got)
+	}
+}
+
+// respond writes a JSON body with a status. Split out so the test cases
+// stay legible.
+func respond(w http.ResponseWriter, status int, body any) {
+	buf, _ := json.Marshal(body)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(buf)
+}
+
+// listenerThatRefuses returns "host:port" that opens and immediately closes
+// every connection, so a client's Do returns an error rather than hanging.
+func listenerThatRefuses(t *testing.T) (string, error) {
+	t.Helper()
+	// A closed listener is the shape a worker crashed at boot presents: the
+	// port is not open, and connect returns "connection refused".
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			io.WriteString(w, "no hijacker")
+			return
+		}
+		c, _, err := hj.Hijack()
+		if err != nil {
+			return
+		}
+		_ = c.Close()
+	}))
+	// Close the server's listener before returning: the URL still parses,
+	// but the port is closed and Do reports connection refused.
+	url := srv.URL
+	srv.Close()
+	return strings.TrimPrefix(url, "http://"), nil
+}

--- a/apps/server/internal/infra/config/config.go
+++ b/apps/server/internal/infra/config/config.go
@@ -37,6 +37,24 @@ const (
 	KeyBootstrapProfessorEmail = "NALANDA_BOOTSTRAP_PROFESSOR_EMAIL"
 )
 
+// The entrance-controls WP-E block (#166). Separate block because these
+// mean something different again: without them the CONTROL SCREENS refuse
+// to work, but the login and health paths still answer.
+const (
+	// KeyQuestionsJSONURL points at the published question bank (ADR-0032).
+	// http/https for production, file:// for development. The Load happens
+	// once at boot and a parse failure is a panic there, so the value is
+	// required.
+	KeyQuestionsJSONURL = "NALANDA_QUESTIONS_JSON_URL"
+	// KeyAmcWorkerURL is where the AMC worker's /generate is reached
+	// (ADR-0030). Absolute http/https URL.
+	KeyAmcWorkerURL = "NALANDA_AMC_WORKER_URL"
+	// KeyWorkDir is the shared volume mount point on the SERVER'S side
+	// (ADR-0034 §Consequences: the two containers share amc-work). The
+	// generator writes /work absolute paths regardless.
+	KeyWorkDir = "NALANDA_WORK_DIR"
+)
+
 // ErrMissing is wrapped by every error caused by an absent or empty required
 // variable, so a caller can distinguish "the operator has not finished
 // configuring this" from "the operator configured it wrongly".
@@ -94,6 +112,16 @@ type Config struct {
 	// professors at all. Empty disables the path entirely, which is what an
 	// operator does once the first professor exists.
 	BootstrapProfessorEmail string
+
+	// QuestionsJSONURL points at the published question bank
+	// (ADR-0032). Fetched once at boot; a parse failure there is a panic.
+	QuestionsJSONURL string
+	// AmcWorkerURL is the AMC worker's HTTP origin.
+	AmcWorkerURL string
+	// WorkDir is where the server sees the shared volume with the worker.
+	// The .tex the generator emits always uses /work absolute paths (from
+	// the worker's perspective, controls.WorkerWorkDir) whatever this is.
+	WorkDir string
 }
 
 // Keys lists every variable this package reads, in the order an operator would
@@ -104,6 +132,7 @@ func Keys() []string {
 		KeyAddr, KeyDatabaseURL, KeyLogLevel,
 		KeyPublicURL, KeyGoogleClientID, KeyGoogleClientSecret,
 		KeySessionTTL, KeyBootstrapProfessorEmail,
+		KeyQuestionsJSONURL, KeyAmcWorkerURL, KeyWorkDir,
 	}
 }
 
@@ -120,6 +149,10 @@ func Load(lookup LookupFunc) (Config, error) {
 		GoogleClientID:          l.required(KeyGoogleClientID),
 		GoogleClientSecret:      l.required(KeyGoogleClientSecret),
 		BootstrapProfessorEmail: l.optional(KeyBootstrapProfessorEmail, ""),
+
+		QuestionsJSONURL: l.required(KeyQuestionsJSONURL),
+		AmcWorkerURL:     l.required(KeyAmcWorkerURL),
+		WorkDir:          l.required(KeyWorkDir),
 	}
 
 	// Report every missing variable at once: an operator starting from an
@@ -237,6 +270,9 @@ func (c Config) LogValue() slog.Value {
 		slog.String("google_client_id", c.GoogleClientID),
 		slog.String("session_ttl", c.SessionTTL.String()),
 		slog.Bool("bootstrap_email_set", c.BootstrapProfessorEmail != ""),
+		slog.String("questions_json_url", c.QuestionsJSONURL),
+		slog.String("amc_worker_url", c.AmcWorkerURL),
+		slog.String("work_dir", c.WorkDir),
 	)
 }
 
@@ -245,9 +281,10 @@ func (c Config) LogValue() slog.Value {
 // either.
 func (c Config) String() string {
 	return fmt.Sprintf(
-		"config{addr:%s database:%s log_level:%s public_url:%s google_client_id:%s session_ttl:%s bootstrap_email_set:%t}",
+		"config{addr:%s database:%s log_level:%s public_url:%s google_client_id:%s session_ttl:%s bootstrap_email_set:%t questions_json_url:%s amc_worker_url:%s work_dir:%s}",
 		c.Addr, c.SafeDatabaseURL(), c.LogLevel, c.PublicURL, c.GoogleClientID,
 		c.SessionTTL, c.BootstrapProfessorEmail != "",
+		c.QuestionsJSONURL, c.AmcWorkerURL, c.WorkDir,
 	)
 }
 

--- a/apps/server/internal/infra/config/config.go
+++ b/apps/server/internal/infra/config/config.go
@@ -49,9 +49,14 @@ const (
 	// KeyAmcWorkerURL is where the AMC worker's /generate is reached
 	// (ADR-0030). Absolute http/https URL.
 	KeyAmcWorkerURL = "NALANDA_AMC_WORKER_URL"
-	// KeyWorkDir is the shared volume mount point on the SERVER'S side
-	// (ADR-0034 §Consequences: the two containers share amc-work). The
-	// generator writes /work absolute paths regardless.
+	// KeyWorkDir is the shared volume mount point on the SERVER'S side.
+	// The two containers share the amc-work named volume and its
+	// seeding order is load-bearing — the whole rule (UID 65532 vs
+	// root, first mounter seeds the volume, why compose up --wait
+	// cannot see the failure) lives in ADR-0034 §Consequences
+	// ("The shared amc-work volume ... has a seeding order that is
+	// load-bearing"). The generator writes /work absolute paths from
+	// the WORKER's side regardless of what this server names its own.
 	KeyWorkDir = "NALANDA_WORK_DIR"
 )
 

--- a/apps/server/internal/infra/config/config_test.go
+++ b/apps/server/internal/infra/config/config_test.go
@@ -22,6 +22,12 @@ func env() map[string]string {
 		"NALANDA_GOOGLE_CLIENT_SECRET":      "the-client-secret",
 		"NALANDA_SESSION_TTL":               "168h",
 		"NALANDA_BOOTSTRAP_PROFESSOR_EMAIL": "profesora@example.com",
+		// WP-E (#166): the three variables the controls domain needs. A
+		// case that breaks a different variable still needs these set,
+		// otherwise every case would fail with the wrong reason.
+		"NALANDA_QUESTIONS_JSON_URL": "https://nalanda.example.com/questions.json",
+		"NALANDA_AMC_WORKER_URL":     "http://amc-worker:8080",
+		"NALANDA_WORK_DIR":           "/work",
 	}
 }
 

--- a/apps/server/internal/infra/config/config_test.go
+++ b/apps/server/internal/infra/config/config_test.go
@@ -65,6 +65,9 @@ func TestLoadFailsByNameOnAMissingVariable(t *testing.T) {
 		"NALANDA_PUBLIC_URL",
 		"NALANDA_GOOGLE_CLIENT_ID",
 		"NALANDA_GOOGLE_CLIENT_SECRET",
+		"NALANDA_QUESTIONS_JSON_URL",
+		"NALANDA_AMC_WORKER_URL",
+		"NALANDA_WORK_DIR",
 	} {
 		t.Run(key, func(t *testing.T) {
 			broken := env()
@@ -117,6 +120,9 @@ func TestLoadReportsEveryMissingVariableAtOnce(t *testing.T) {
 		"NALANDA_PUBLIC_URL",
 		"NALANDA_GOOGLE_CLIENT_ID",
 		"NALANDA_GOOGLE_CLIENT_SECRET",
+		"NALANDA_QUESTIONS_JSON_URL",
+		"NALANDA_AMC_WORKER_URL",
+		"NALANDA_WORK_DIR",
 	} {
 		if !strings.Contains(err.Error(), key) {
 			t.Errorf("error = %q, want it to name %q", err, key)

--- a/apps/server/internal/infra/storage/controlstore/controlstore.go
+++ b/apps/server/internal/infra/storage/controlstore/controlstore.go
@@ -1,0 +1,201 @@
+// Package controlstore is the SQLite side of the controls domain: one type
+// implementing controls.Store over the tables migration 00004 creates.
+//
+// It lives under internal/infra/storage because that is where store
+// implementations live (backend-code-style.md §The dependency rule), and in
+// its own package so that storage itself stays about opening a database and
+// applying migrations. It names no driver: it takes a *sql.DB, which is what
+// keeps the Postgres exit of ADR-0007 a change in one package.
+package controlstore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+)
+
+// Store adapts SQLite to controls.Store. One type rather than three; the
+// domain sees the narrow interface it asked for.
+type Store struct {
+	db *sql.DB
+}
+
+// New returns a Store over db. The caller owns the handle and its lifetime.
+func New(db *sql.DB) *Store {
+	return &Store{db: db}
+}
+
+// Compile-time proof the shape here is the one the domain asked for.
+var _ controls.Store = (*Store)(nil)
+
+const controlColumns = "id, name, application_date, from_document, from_section, to_document, to_section, questions_per_copy, copies, state, created_at, created_by"
+
+// CreateControl writes the control, its pool and its copies in one
+// transaction. Rolled back on any failure so a control never appears in the
+// list with an empty pool or without its copy rows — the "all-or-nothing"
+// promise the Service (§Failure modes) is built on.
+func (s *Store) CreateControl(ctx context.Context, control controls.Control, pool []controls.PoolEntry) error {
+	if control.Copies <= 0 {
+		return fmt.Errorf("controlstore.CreateControl: copies must be > 0, got %d", control.Copies)
+	}
+	if len(pool) == 0 {
+		return fmt.Errorf("controlstore.CreateControl: pool is empty for %s", control.ID)
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("controlstore.CreateControl: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx, `
+        INSERT INTO control (`+controlColumns+`)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		control.ID,
+		control.Name,
+		nullableUnixSeconds(control.ApplicationDate),
+		control.RangeFrom.Document, control.RangeFrom.Section,
+		control.RangeTo.Document, control.RangeTo.Section,
+		control.QuestionsPerCopy, control.Copies,
+		string(control.State),
+		control.CreatedAt.Unix(),
+		control.CreatedBy,
+	); err != nil {
+		return fmt.Errorf("controlstore.CreateControl: insert control %s: %w", control.ID, err)
+	}
+
+	for _, entry := range pool {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO control_pregunta (control_id, pregunta_ref, orden) VALUES (?, ?, ?)`,
+			control.ID, entry.Ref, entry.Order,
+		); err != nil {
+			return fmt.Errorf("controlstore.CreateControl: insert pool entry %s/%s: %w",
+				control.ID, entry.Ref, err)
+		}
+	}
+
+	for i := 1; i <= control.Copies; i++ {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO copia (control_id, numero) VALUES (?, ?)`,
+			control.ID, i,
+		); err != nil {
+			return fmt.Errorf("controlstore.CreateControl: insert copy %s/%d: %w",
+				control.ID, i, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("controlstore.CreateControl: commit %s: %w", control.ID, err)
+	}
+	return nil
+}
+
+// ControlByID reads one control back.
+func (s *Store) ControlByID(ctx context.Context, id string) (controls.Control, error) {
+	row := s.db.QueryRowContext(ctx,
+		"SELECT "+controlColumns+" FROM control WHERE id = ?", id)
+	c, err := scanControl(row)
+	if err != nil {
+		return controls.Control{}, notFound(err, fmt.Sprintf("read control %s", id))
+	}
+	return c, nil
+}
+
+// ListControls returns every control, ordered by application date descending
+// with NULLs last, then by created_at descending as a tie-breaker.
+func (s *Store) ListControls(ctx context.Context) ([]controls.Control, error) {
+	rows, err := s.db.QueryContext(ctx, `
+        SELECT `+controlColumns+`
+        FROM control
+        ORDER BY application_date IS NULL, application_date DESC, created_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("controlstore.ListControls: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []controls.Control
+	for rows.Next() {
+		c, err := scanControl(rows)
+		if err != nil {
+			return nil, fmt.Errorf("controlstore.ListControls: scan: %w", err)
+		}
+		out = append(out, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("controlstore.ListControls: iterate: %w", err)
+	}
+	return out, nil
+}
+
+// ControlPool returns the pool for a control, in the order it was drawn.
+func (s *Store) ControlPool(ctx context.Context, controlID string) ([]controls.PoolEntry, error) {
+	rows, err := s.db.QueryContext(ctx, `
+        SELECT pregunta_ref, orden FROM control_pregunta
+        WHERE control_id = ?
+        ORDER BY orden ASC`, controlID)
+	if err != nil {
+		return nil, fmt.Errorf("controlstore.ControlPool: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var out []controls.PoolEntry
+	for rows.Next() {
+		var e controls.PoolEntry
+		if err := rows.Scan(&e.Ref, &e.Order); err != nil {
+			return nil, fmt.Errorf("controlstore.ControlPool: scan: %w", err)
+		}
+		out = append(out, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("controlstore.ControlPool: iterate: %w", err)
+	}
+	return out, nil
+}
+
+// scanControl reads controlColumns in order.
+func scanControl(row interface{ Scan(...any) error }) (controls.Control, error) {
+	var (
+		c               controls.Control
+		applicationDate sql.NullInt64
+		createdAt       int64
+		state           string
+	)
+	if err := row.Scan(
+		&c.ID, &c.Name, &applicationDate,
+		&c.RangeFrom.Document, &c.RangeFrom.Section,
+		&c.RangeTo.Document, &c.RangeTo.Section,
+		&c.QuestionsPerCopy, &c.Copies,
+		&state, &createdAt, &c.CreatedBy,
+	); err != nil {
+		return controls.Control{}, err
+	}
+	c.State = controls.State(state)
+	c.CreatedAt = time.Unix(createdAt, 0).UTC()
+	if applicationDate.Valid {
+		at := time.Unix(applicationDate.Int64, 0).UTC()
+		c.ApplicationDate = &at
+	}
+	return c, nil
+}
+
+// notFound turns database/sql's absence sentinel into the domain's.
+func notFound(err error, subject string) error {
+	if errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("%s: %w", subject, controls.ErrControlNotFound)
+	}
+	return fmt.Errorf("%s: %w", subject, err)
+}
+
+// nullableUnixSeconds turns *time.Time into a sql.NullInt64 for the
+// application_date column. Nil times become NULL.
+func nullableUnixSeconds(t *time.Time) sql.NullInt64 {
+	if t == nil {
+		return sql.NullInt64{}
+	}
+	return sql.NullInt64{Int64: t.Unix(), Valid: true}
+}
+

--- a/apps/server/internal/infra/storage/controlstore/controlstore.go
+++ b/apps/server/internal/infra/storage/controlstore/controlstore.go
@@ -198,4 +198,3 @@ func nullableUnixSeconds(t *time.Time) sql.NullInt64 {
 	}
 	return sql.NullInt64{Int64: t.Unix(), Valid: true}
 }
-

--- a/apps/server/internal/infra/storage/controlstore/controlstore_test.go
+++ b/apps/server/internal/infra/storage/controlstore/controlstore_test.go
@@ -1,0 +1,224 @@
+package controlstore_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+	"github.com/so77id/nalanda/apps/server/internal/domain/course/bank"
+	"github.com/so77id/nalanda/apps/server/internal/infra/storage"
+	"github.com/so77id/nalanda/apps/server/internal/infra/storage/controlstore"
+	"github.com/so77id/nalanda/apps/server/migrations"
+)
+
+// migrated opens a fresh SQLite file, applies the embedded migration set and
+// hands back the handle. The same shape schema_test.go uses; kept here so a
+// case that cannot reach its assertions has nothing to say about the store.
+func migrated(t *testing.T) (context.Context, *sql.DB) {
+	t.Helper()
+	ctx := context.Background()
+	db, err := storage.Open(ctx, filepath.Join(t.TempDir(), "nalanda.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := storage.Migrate(ctx, db, migrations.FS); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	return ctx, db
+}
+
+// insertProfessor creates the row created_by will reference.
+func insertProfessor(t *testing.T, ctx context.Context, db *sql.DB, email string) int64 {
+	t.Helper()
+	result, err := db.ExecContext(ctx,
+		"INSERT INTO users (email, name) VALUES (?, ?)", email, "Profesora")
+	if err != nil {
+		t.Fatalf("insert professor: %v", err)
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("last insert id: %v", err)
+	}
+	return id
+}
+
+func newControl(id string, userID int64, appDate *time.Time) controls.Control {
+	return controls.Control{
+		ID:               id,
+		Name:             "Control 1",
+		ApplicationDate:  appDate,
+		RangeFrom:        bank.SectionRef{Document: "flujo", Section: "if-else"},
+		RangeTo:          bank.SectionRef{Document: "flujo", Section: "bucles"},
+		QuestionsPerCopy: 4,
+		Copies:           3,
+		State:            controls.Generated,
+		CreatedAt:        time.Unix(1_755_360_000, 0).UTC(),
+		CreatedBy:        userID,
+	}
+}
+
+func TestCreateControlWritesTheRowThePoolAndTheCopies(t *testing.T) {
+	ctx, db := migrated(t)
+	userID := insertProfessor(t, ctx, db, "p@example.com")
+	store := controlstore.New(db)
+
+	date := time.Unix(1_755_446_400, 0).UTC()
+	c := newControl("CTRL0001ABC0000000000000AA", userID, &date)
+	pool := []controls.PoolEntry{
+		{Ref: "q-if-1", Order: 0},
+		{Ref: "q-bucles-1", Order: 1},
+	}
+	if err := store.CreateControl(ctx, c, pool); err != nil {
+		t.Fatalf("CreateControl: %v", err)
+	}
+
+	got, err := store.ControlByID(ctx, c.ID)
+	if err != nil {
+		t.Fatalf("ControlByID: %v", err)
+	}
+	if got.Name != c.Name || got.QuestionsPerCopy != 4 || got.Copies != 3 || got.State != controls.Generated {
+		t.Errorf("ControlByID = %+v", got)
+	}
+	if got.ApplicationDate == nil || !got.ApplicationDate.Equal(date) {
+		t.Errorf("ApplicationDate = %v, want %v", got.ApplicationDate, date)
+	}
+	if got.CreatedBy != userID {
+		t.Errorf("CreatedBy = %d, want %d", got.CreatedBy, userID)
+	}
+
+	gotPool, err := store.ControlPool(ctx, c.ID)
+	if err != nil {
+		t.Fatalf("ControlPool: %v", err)
+	}
+	if len(gotPool) != 2 || gotPool[0].Ref != "q-if-1" || gotPool[1].Order != 1 {
+		t.Errorf("ControlPool = %v", gotPool)
+	}
+
+	var copies int
+	if err := db.QueryRowContext(ctx, "SELECT count(*) FROM copia WHERE control_id = ?", c.ID).Scan(&copies); err != nil {
+		t.Fatalf("count copies: %v", err)
+	}
+	if copies != 3 {
+		t.Errorf("copies rows = %d, want 3 (one per printed sheet)", copies)
+	}
+}
+
+func TestCreateControlIsAllOrNothingOnAConflict(t *testing.T) {
+	ctx, db := migrated(t)
+	userID := insertProfessor(t, ctx, db, "p@example.com")
+	store := controlstore.New(db)
+
+	c := newControl("CTRL0002ABC0000000000000AA", userID, nil)
+	pool := []controls.PoolEntry{
+		{Ref: "q-if-1", Order: 0},
+		{Ref: "q-if-1", Order: 1}, // duplicate ref: the compound PK on control_pregunta will reject the second insert
+	}
+	if err := store.CreateControl(ctx, c, pool); err == nil {
+		t.Fatal("CreateControl accepted a duplicate pool ref, want a UNIQUE error")
+	}
+
+	// The rollback must have removed EVERY trace — control, pool and copies.
+	var rows int
+	for _, table := range []string{"control", "control_pregunta", "copia"} {
+		if err := db.QueryRowContext(ctx, "SELECT count(*) FROM "+table).Scan(&rows); err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		if rows != 0 {
+			t.Errorf("%s still holds %d row(s) after a rolled-back CreateControl, want 0", table, rows)
+		}
+	}
+}
+
+func TestControlByIDReturnsErrControlNotFoundForAMissingID(t *testing.T) {
+	ctx, db := migrated(t)
+	store := controlstore.New(db)
+
+	_, err := store.ControlByID(ctx, "does-not-exist")
+	if !errors.Is(err, controls.ErrControlNotFound) {
+		t.Errorf("ControlByID(missing): %v, want ErrControlNotFound", err)
+	}
+}
+
+func TestListControlsOrdersByApplicationDateDescWithNullsLast(t *testing.T) {
+	ctx, db := migrated(t)
+	userID := insertProfessor(t, ctx, db, "p@example.com")
+	store := controlstore.New(db)
+
+	// Three controls, mixed application_date. Application: sep 5, no date,
+	// sep 3. Created-at is 2 hours apart so the tie-breaker is visible if
+	// the primary order is ambiguous.
+	earlyDate := time.Unix(1_756_128_000, 0).UTC() // sep 3
+	lateDate := time.Unix(1_756_300_800, 0).UTC()  // sep 5
+
+	first := newControl("CTRL0011LATE00000000000000", userID, &lateDate)
+	second := newControl("CTRL0012NIL0000000000000000"[:26], userID, nil)
+	second.CreatedAt = first.CreatedAt.Add(2 * time.Hour)
+	third := newControl("CTRL0013EARLY00000000000000"[:26], userID, &earlyDate)
+	third.CreatedAt = first.CreatedAt.Add(4 * time.Hour)
+
+	for _, c := range []controls.Control{first, second, third} {
+		if err := store.CreateControl(ctx, c, []controls.PoolEntry{{Ref: "q-if-1", Order: 0}}); err != nil {
+			t.Fatalf("CreateControl(%s): %v", c.ID, err)
+		}
+	}
+
+	list, err := store.ListControls(ctx)
+	if err != nil {
+		t.Fatalf("ListControls: %v", err)
+	}
+	if len(list) != 3 {
+		t.Fatalf("ListControls returned %d rows, want 3", len(list))
+	}
+	// Expected order: dated late first (Sep 5), dated early (Sep 3),
+	// then the undated one last — the "NULLs last" clause is what puts an
+	// undated control below a real one.
+	if list[0].ID != first.ID || list[1].ID != third.ID || list[2].ID != second.ID {
+		got := []string{list[0].ID, list[1].ID, list[2].ID}
+		t.Errorf("ListControls order = %v, want [%s %s %s] (late, early, nil-last)",
+			got, first.ID, third.ID, second.ID)
+	}
+}
+
+func TestDeletingAControlCascadesToItsPoolAndCopies(t *testing.T) {
+	ctx, db := migrated(t)
+	userID := insertProfessor(t, ctx, db, "p@example.com")
+	store := controlstore.New(db)
+
+	c := newControl("CTRL0021CASCADE0000000000A", userID, nil)
+	if err := store.CreateControl(ctx, c, []controls.PoolEntry{
+		{Ref: "q-if-1", Order: 0},
+		{Ref: "q-bucles-1", Order: 1},
+	}); err != nil {
+		t.Fatalf("CreateControl: %v", err)
+	}
+
+	if _, err := db.ExecContext(ctx, "DELETE FROM control WHERE id = ?", c.ID); err != nil {
+		t.Fatalf("delete control: %v", err)
+	}
+
+	for _, table := range []string{"control_pregunta", "copia"} {
+		var rows int
+		if err := db.QueryRowContext(ctx, "SELECT count(*) FROM "+table+" WHERE control_id = ?", c.ID).Scan(&rows); err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		if rows != 0 {
+			t.Errorf("%s still holds %d row(s) after the control was deleted, want 0", table, rows)
+		}
+	}
+}
+
+func TestCreateControlRefusesAnUnknownProfessor(t *testing.T) {
+	ctx, db := migrated(t)
+	store := controlstore.New(db)
+
+	c := newControl("CTRL0031ORPHAN0000000000AA", 4242, nil)
+	err := store.CreateControl(ctx, c, []controls.PoolEntry{{Ref: "q-if-1", Order: 0}})
+	if err == nil {
+		t.Fatal("CreateControl accepted a control with no professor, want a FOREIGN KEY error")
+	}
+}

--- a/apps/server/internal/infra/storage/schema_test.go
+++ b/apps/server/internal/infra/storage/schema_test.go
@@ -220,6 +220,30 @@ func TestLastLoginAtIsNullableAndSurvivesARoundTrip(t *testing.T) {
 	}
 }
 
+// The control table's state column is CHECK-guarded because the value is
+// what the professor reads and what WP-F's lifecycle branches on: a typo
+// silently accepted would put the row in a state nothing else recognises,
+// with no schema-level signal.
+func TestControlStateRefusesAnUnknownValue(t *testing.T) {
+	ctx, db := migrated(t)
+	userID := insertProfessor(t, ctx, db, "profesora@example.com")
+
+	_, err := db.ExecContext(ctx, `
+        INSERT INTO control (
+            id, name, application_date,
+            from_document, from_section, to_document, to_section,
+            questions_per_copy, copies, state, created_at, created_by
+        ) VALUES (?, 'x', NULL, 'flujo', 'if-else', 'flujo', 'bucles', 4, 3, ?, 0, ?)`,
+		"CTRLSTATE00000000000000000", "typoed_state", userID,
+	)
+	if err == nil {
+		t.Fatal("the control table accepted an unknown state, want a CHECK constraint failure")
+	}
+	if !strings.Contains(err.Error(), "CHECK constraint failed") {
+		t.Errorf("rejected with %v, want CHECK constraint failure", err)
+	}
+}
+
 // The one migration case that is about an operator rather than about the schema.
 //
 // #149 shipped migrations/00001_init.sql, a deliberate `SELECT 1;`, and anyone

--- a/apps/server/migrations/00004_controls.sql
+++ b/apps/server/migrations/00004_controls.sql
@@ -1,0 +1,88 @@
+-- The entrance-controls tables (issue #166, WP-E) — one control is a printed
+-- quiz that draws its pool from the published question bank (ADR-0032) and is
+-- read back by the AMC worker (ADR-0030). Three tables:
+--
+--   control            one row per generated control
+--   control_pregunta   the pool it drew from, in the order it was drawn
+--   copia              one row per printed sheet identity
+--
+-- V1 has one implicit course, so no curso_id column: WP-D adds it. Fields
+-- mirror docs/design/2026-08-controles.md §Data model minus curso_id and plus
+-- what the domain needs (id as ULID-shape text, created_by as
+-- users(user_id) for audit).
+--
+-- Numbered 00004 rather than 00003 (deleted or otherwise). goose keys applied
+-- migrations by version, so a reused number is silently skipped by every
+-- checkout that already ran the earlier one — 00003_last_login_at.sql carries
+-- the earlier version of this scar.
+--
+-- Times are unix seconds in INTEGER columns, matching the existing tables and
+-- what SQLite's unixepoch() returns. Nullable application_date carries "no
+-- date declared" from the form's optional field.
+
+-- +goose Up
+
+CREATE TABLE control (
+    -- 26-character base32 identifier (controls.NewID); the URL segment, and
+    -- printed on every copy. TEXT PRIMARY KEY because a random string cannot
+    -- share INTEGER PRIMARY KEY's rowid semantics — and using AUTOINCREMENT
+    -- here would leak "the 34th control we ever made" to a reader of the URL.
+    id                 TEXT    PRIMARY KEY NOT NULL,
+    name               TEXT    NOT NULL,
+    -- unix seconds. NULL is "no date declared", which the form allows so a
+    -- draft control can be generated before its class is scheduled. The list
+    -- orders these last, since a control without a date does not have a
+    -- reading position in the calendar.
+    application_date   INTEGER,
+    from_document      TEXT    NOT NULL,
+    from_section       TEXT    NOT NULL,
+    to_document        TEXT    NOT NULL,
+    to_section         TEXT    NOT NULL,
+    questions_per_copy INTEGER NOT NULL CHECK (questions_per_copy > 0),
+    copies             INTEGER NOT NULL CHECK (copies > 0),
+    -- CHECK-guarded rather than a lookup table: the three values are
+    -- exhaustive by design (§Data model), and a lookup would only be a place
+    -- to write the same three values a second time.
+    state              TEXT    NOT NULL CHECK (state IN ('generated', 'in_review', 'graded')),
+    created_at         INTEGER NOT NULL DEFAULT (unixepoch()),
+    -- Audit column: which professor generated this. ON DELETE RESTRICT
+    -- rather than CASCADE — deleting a professor with generated controls is
+    -- data loss (grades hang off them, WP-F), and the debt of
+    -- deactivate-vs-delete is deferred to WP-D anyway. RESTRICT names it.
+    created_by         INTEGER NOT NULL REFERENCES users(user_id) ON DELETE RESTRICT
+);
+
+-- Sorting the list is the most common read shape, and the compound index
+-- covers it: application_date DESC first for the primary order, created_at
+-- DESC as the tie-breaker so two controls scheduled the same day surface in
+-- creation order.
+CREATE INDEX idx_control_by_application_date ON control (application_date DESC, created_at DESC);
+
+CREATE TABLE control_pregunta (
+    control_id   TEXT    NOT NULL REFERENCES control(id) ON DELETE CASCADE,
+    -- The authored id from the bank (ADR-0032). Not a foreign key here: the
+    -- bank is a JSON artifact read from apps/web, not a table. The Service
+    -- resolves the ref against the loaded bank at read time.
+    pregunta_ref TEXT    NOT NULL,
+    -- 0-based position in the drawn pool.
+    orden        INTEGER NOT NULL,
+    PRIMARY KEY (control_id, pregunta_ref)
+);
+CREATE INDEX idx_control_pregunta_by_control_order ON control_pregunta (control_id, orden);
+
+CREATE TABLE copia (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    control_id TEXT    NOT NULL REFERENCES control(id) ON DELETE CASCADE,
+    -- 1-based, matches AMC's printed \onecopy index.
+    numero     INTEGER NOT NULL CHECK (numero > 0),
+    UNIQUE (control_id, numero)
+);
+CREATE INDEX idx_copia_by_control ON copia (control_id);
+
+-- +goose Down
+
+-- Documentation of the inverse, never executed (ADR-0034 §Consequences,
+-- backend-code-style.md §Adding a migration).
+DROP TABLE copia;
+DROP TABLE control_pregunta;
+DROP TABLE control;

--- a/docs/decisions/0034-the-backend-is-born-with-the-controls.md
+++ b/docs/decisions/0034-the-backend-is-born-with-the-controls.md
@@ -3,7 +3,7 @@
 **Status:** Accepted
 **Date:** 2026-08-16
 **Decision-makers:** Miguel Rodriguez
-**Amended by:** #150 (2026-08-16) — the empty `00001_init.sql` was deleted and the auth schema numbered `00002`; the image measured 12.2 MB after the port
+**Amended by:** #150 (2026-08-16) — the empty `00001_init.sql` was deleted and the auth schema numbered `00002`; the image measured 12.2 MB after the port · #166 (2026-08-17) — WP-E landed and the server now shares the `amc-work` named volume with `apps/amc-worker`; the two-container seeding-order rule is recorded in §Consequences
 **Source:** #149 (WP-C1), design `docs/design/2026-08-controles.md` §C10, §C11
 
 ## Context
@@ -176,6 +176,31 @@ rule the repo already applies to `proof-of-concept/`.
   domain tables, but `//go:embed *.sql` will not compile over a directory
   without one, and an applied migration is what makes the boot path provable.
   WP-C2's users table replaces it.
+
+- **The shared `amc-work` volume between this app and `apps/amc-worker` has a
+  seeding order that is load-bearing, and no CI step can see it.** Added by
+  WP-E (#166): both containers mount the same named volume at `/work`, this
+  server runs as UID 65532, and `apps/amc-worker` runs as root
+  (ADR-0030 §Operational). Docker seeds a fresh named volume from the FIRST
+  container that touches it — permissions included — so whichever container
+  starts first owns `/work`. If root seeds it, the server's next
+  `os.MkdirAll` under `/work` fails EACCES on the first `/generate`, and the
+  failure is invisible to `compose up --wait` because that step only probes
+  `/health`. Two things enforce the order:
+  1. `apps/server/Dockerfile` creates `/work` in the image with UID 65532
+     ownership (`chown 65532:65532`), so a server-first seed lands with the
+     right owner. `scratch` has no shell to fix it later.
+  2. `infra/local/docker-compose.yml` puts `depends_on: server` on
+     `amc-worker` (`service_started`), so the server is the first container
+     up in a fresh compose stack.
+  Removing either half re-opens the EACCES. `NALANDA_WORK_DIR` is where the
+  server sees this volume; the `.tex` the generator emits always uses `/work`
+  absolute paths, because that is the WORKER's mount point regardless of
+  what the server names its own. Review trigger: any change to
+  `apps/server/Dockerfile`'s `/work` ownership, to the compose `depends_on`,
+  or to either container's UID. The compose path in the pre-PR protocol
+  (§`apps/server` of `testing-strategy.md`) still cannot exercise a real
+  `/generate`, so the L8 human check is where this rule fails last.
 
 ## References
 

--- a/docs/design/2026-08-controles.md
+++ b/docs/design/2026-08-controles.md
@@ -21,8 +21,11 @@
 > the port cost no dependency. **WP-C3 shipped** (#151) — the backoffice has
 > its shell (nav, both themes, error pages, one-shot flash cookie) and the
 > professor CRUD (create, edit, deactivate/reactivate with both guards); C13
-> is honoured (no bundler, `system-ui`, `currentColor` only). WPs D–G not
-> started.
+> is honoured (no bundler, `system-ui`, `currentColor` only). **WP-E shipped**
+> (#166) — the professor picks a section range from the published bank, the
+> AMC worker generates the PDF, and every control is persisted with its pool
+> and its per-copy identity. `/` now redirects to `/controls`. WPs D, F and G
+> not started.
 > Living decisions distilled from here become ADRs as each WP develops.
 
 ## Problem
@@ -135,9 +138,9 @@ touched.
 | B ✅ | [#139](https://github.com/so77id/nalanda/issues/139), [#144](https://github.com/so77id/nalanda/issues/144) | **Question bank in content** — authoring format, anchor resolution and its gate, the rendering component, catalog entry, published JSON; and a bank for every document on the teaching path | — |
 | C1 ✅ | [#149](https://github.com/so77id/nalanda/issues/149) | **`apps/server` is born** — Go + SQLite + goose, the layered skeleton with its dependency rule enforced by a test, `/health`, the image and compose, and every process obligation below | — |
 | C2 ✅ | [#150](https://github.com/so77id/nalanda/issues/150) | **Auth domain** — ported from DocumentBuddy per ADR-0009, Google OAuth, sessions, and a bootstrap address rather than a seed (ADR-0036) | C1 |
-| C3 | [#151](https://github.com/so77id/nalanda/issues/151) | **Backoffice** — server-rendered layout and the professor CRUD | C2 |
+| C3 ✅ | [#151](https://github.com/so77id/nalanda/issues/151) | **Backoffice** — server-rendered layout and the professor CRUD | C2 |
 | D | not refined | **Course and roster** — tables and CSV import. Canvas import noted, not assumed | C1 |
-| E | not refined | **Create a control, generate the PDF** | A, B, C1–C3, **+ the paper check** |
+| E ✅ | [#166](https://github.com/so77id/nalanda/issues/166) | **Create a control, generate the PDF** — bank reader, AMC worker client, controls domain (Service + Store + tex generator), the three screens (list, form, detail), the two PDF downloads. `/` now redirects to `/controls` (was `/professors`). | A, B, C1–C3, **+ the paper check** |
 | F | not refined | **Read scans, manual review queue** | E |
 | G | not refined | **Publish grades** — spreadsheet, email, Canvas | F |
 

--- a/docs/standards/guides/add-a-backend-endpoint.md
+++ b/docs/standards/guides/add-a-backend-endpoint.md
@@ -6,7 +6,16 @@ three honest.
 
 Deferred from #149 on purpose — a guide written against a worked example that
 does not exist is fiction — and written by #150, which produced the first real
-chain: a route, a domain service, three repositories and a migration.
+chain: a route, a domain service, three repositories and a migration. Since
+WP-E (#166) there is a second, non-auth chain that adds the pieces this guide
+did not exhibit — a domain interface for an outbound HTTP adapter
+(`controls.Generator`, implemented by `amcworker.Client`, with the fake living
+next to the client in `amcworker/amctest`), a domain service that orchestrates
+a store and that adapter together (`controls.Service`), and a handler that
+maps a family of domain sentinels onto per-field form errors while letting
+operator-caused failures render a shell 500 (`handler/controls.go`
+`domainErrorToForm`). Reach for that chain when the endpoint reaches out over
+HTTP as well as into SQLite; the auth chain is still the smaller shape.
 
 ## When to use
 

--- a/infra/local/docker-compose.yml
+++ b/infra/local/docker-compose.yml
@@ -42,8 +42,30 @@ services:
       # being visible where an operator edits it, not about which variables the
       # loader would survive without.
       NALANDA_SESSION_TTL: "${NALANDA_SESSION_TTL:-720h}"
+      # --- WP-E (issue #166): entrance controls ---
+      # The published bank (ADR-0032). Points at the JSON we bind-mount into
+      # /work below — a placeholder set with zero questions, enough to boot
+      # so `compose up --wait` proves the binary starts. Replace with the
+      # real questions.json for actual generation:
+      #   NALANDA_QUESTIONS_JSON_URL=file:///work/questions.json \
+      #     cp path/to/apps/web/dist/questions.json infra/local/questions.example.json
+      NALANDA_QUESTIONS_JSON_URL: "${NALANDA_QUESTIONS_JSON_URL:-file:///work/questions.json}"
+      # The worker service. Same compose network, so the service name resolves.
+      NALANDA_AMC_WORKER_URL: "${NALANDA_AMC_WORKER_URL:-http://amc-worker:8080}"
+      # The shared volume the server and the worker BOTH mount at /work
+      # (ADR-0034 §Consequences). The .tex the generator emits writes /work
+      # absolute paths regardless — this only decides where the server writes.
+      NALANDA_WORK_DIR: "/work"
     volumes:
       - server-data:/data
+      # Shared with the amc-worker service below. The server writes a
+      # control's inputs here, the worker reads them and writes the PDFs
+      # back — see docs/design/2026-08-controles.md §C9.
+      - amc-work:/work
+      # A minimal bank file so the boot fetch succeeds. Real bank is the
+      # published artifact from apps/web; this is the placeholder that lets
+      # `compose up --wait` prove the binary starts.
+      - ./questions.example.json:/work/questions.json:ro
     ports:
       - "127.0.0.1:8081:8081"
     # Free here in a way it is not for amc-worker: the image is `scratch` with

--- a/infra/local/docker-compose.yml
+++ b/infra/local/docker-compose.yml
@@ -93,6 +93,17 @@ services:
       context: ../../apps/amc-worker
       dockerfile: Dockerfile
     image: nalanda/amc-worker:dev
+    # depends_on the server so THIS is the second container to mount the
+    # shared amc-work volume. Docker seeds a named volume from the first
+    # container that touches it, permissions included — and the server
+    # runs as UID 65532 while the worker runs as root. Without this
+    # order, root:root would seed /work and the server's first
+    # os.MkdirAll under /work would fail EACCES on the first /generate.
+    # The failure is invisible to `compose up --wait` because that step
+    # only probes /health.
+    depends_on:
+      server:
+        condition: service_started
     # No display, and no X socket mounted: a code path that reaches the GTK
     # interface dies here rather than silently working on a developer's machine
     # and failing on a server.

--- a/infra/local/questions.example.json
+++ b/infra/local/questions.example.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "documents": [],
+  "questions": []
+}


### PR DESCRIPTION
**Closes #166**

## Summary

WP-E turns "cover sections X through Y with M copies of N questions each" into
`sujet.pdf` ready to print. A logged-in professor lands on `/controls`, opens
`/controls/new`, submits a range + copies + questions-per-copy, and gets a
detail page with the printable sheet and the answer key. Every control is
persisted (list + detail survive restart), immutable once generated, and
downloadable from its own home. The `.tex` emitter is pinned to
`apps/amc-worker/tests/fixtures/control-demo.tex` (the fixture #138 built to
be exactly WP-E's shape). Persistence lives in migration `00004_controls.sql`
(three tables: `control`, `control_pregunta`, `copia`). The AMC seam is one
interface (`controls.Generator`) with two implementations (`amcworker` HTTP
client with a mutex to serialise `/generate`, `amctest.Fake` for tests).

The two containers finally share `amc-work` (ADR-0034 §Consequences), and the
seeding-order rule (server UID 65532 first, worker root second) is enforced
by `apps/server/Dockerfile`'s `chown 65532:65532 /work` plus
`infra/local/docker-compose.yml`'s `depends_on: server`. Both halves are
required — removing either re-opens EACCES on the first `/generate`, and the
failure is invisible to `compose up --wait`. L8 is where this rule fails last.

## Slices completed

- [x] S1 (`75f5712`) — bank reader: `questions.json` at boot, `http://` + `file://`, in-memory
- [x] S2 (`b6accd8`) — AMC worker HTTP client behind `controls.Generator`; `amctest.Fake`
- [x] S3 (`bdd04af`) — persistence: `control` / `control_pregunta` / `copia`; migration `00004`
- [x] S4 (`fbb3e81`) — `.tex` emitter with fixture pin to `control-demo.tex`
- [x] S5 (`e578a8b`) — orchestration: resolve range → draw pool → tex → generate → persist → files, all-or-nothing
- [x] S6 (`e962f36`) — form + list + detail (`GET /controls/new`, `POST /controls`, `GET /controls`, `GET /controls/:id`) with every failure-mode test
- [x] S7 (`e962f36`) — list + `/` → `/controls` redirect (same slice commit)
- [x] S8 (`e962f36`) — detail + PDF downloads (`sujet.pdf`, `corrige.pdf`) (same slice commit)
- [x] S9 docs (`ab9f027`) — `add-a-backend-endpoint.md` pointer, `apps/server/README.md`, `2026-08-controles.md` §Roadmap marks E shipped
- [x] Round A code fixes (`d279dde`) — review-pipeline first pass, code panel
- [x] Round B docs fixes (`5308cc8`) — ADR-0034 §Consequences records the `amc-work` seeding rule and `KeyWorkDir` comment defers to it

## Acceptance criteria

| # | AC | Evidence |
|---|----|----------|
| 1 | `/` → `/controls` for a professor; anonymous → sign-in | `internal/app/web/router.go` route table; `router_test.go` covers both branches |
| 2 | `/controls` lists controls ordered by application date desc + "Nuevo control" | `internal/app/web/handler/controls_test.go` `TestList*`; template `pages/controls_list.html` |
| 3 | `/controls/new` renders cascading range dropdowns from the bank in reading order | `controls_test.go` `TestNewForm*`; template `pages/controls_form.html`; bank drives the options via `bank.Reader` |
| 4 | Valid submit generates + redirects to `/controls/:id` with flash | `controls_test.go` `TestCreate_HappyPath`; service in `internal/domain/controls/service.go`; ≤30 s bound covered by tests using `amctest.Fake` |
| 5 | Detail shows metadata + PDF download; survives restart | `controls_test.go` `TestDetail*`; `TestSujetPDFDownload*`; `controlstore` persists to SQLite |
| 6 | `.tex` byte-identical to `control-demo.tex` for the fixture inputs | `internal/domain/controls/tex/tex_test.go` `TestGenerate_MatchesFixture` (pin) |
| 7 | `sujet.pdf` respects ADR-0033 (per-question labels, header arithmetic, "Ninguna" pinned) | `tex/tex_test.go` covers the three properties; header arithmetic + `\lastchoices` + `\unaSymbole`/`\multiSymbole` asserted from the emitted `.tex` |
| 8 | Every failure mode has a red test on response + flash + persisted state | `controls_test.go` covers empty range, pool < N, worker timeout, worker refused, zero-byte `sujet.pdf`; `service_test.go` all-or-nothing rollback |
| 9 | Both delivery surfaces unaffected: API answers, auth gate unchanged, no `api/` → `controls` import | L4 architecture test `internal/architecture_test.go` (ADR-0034 three edges); no changes to `internal/app/api/` in this diff |
| 10 | Every state-changing form carries CSRF, refused without it | `middleware.VerifyCSRF` applied to `POST /controls` in `router.go`; `controls_test.go` `TestCreate_MissingCSRF` |
| 11 | Everything the professor reads is in Spanish; logs + identifiers English | Templates under `view/templates/pages/`; `handler/controls.go` flash messages in Spanish; log lines in English |
| 12 | Both themes at ≥1440 px captured — form, list, detail | **L8 manual by human below** — routes are behind `RequireProfessor` (Google OIDC), only reachable through GOOGLE-CHECK.md |
| 13 | Full pre-PR protocol green ending in Docker | See §Tests |

## Tests

Pre-PR protocol re-run on tip `5308cc8` from `apps/server/`:

| Step | Result |
|---|---|
| `gofmt -l .` | OK (no unformatted files) |
| `go vet ./...` | OK |
| `go test -race -count=1 ./...` | OK — 25 packages, ~90 s |
| `go build ./...` | OK |
| `govulncheck ./...` | No vulnerabilities found |
| `docker build -t nalanda/server:dev .` | OK |
| `docker compose up -d --build --wait server` | Healthy |
| `curl -fsS http://127.0.0.1:8081/health` | `{"process":"up","database":"up"}` |
| `curl -fsS http://127.0.0.1:8081/api/health` | `{"process":"up","database":"up"}` |

Not exercised at this level (documented, human):
- **L8** `apps/server/GOOGLE-CHECK.md` — a real Google login. Required whenever the login path changes; this WP does NOT touch the login path (unchanged since #150), so a fresh GOOGLE-CHECK.md is not strictly required by the doctrine, but the manual checklist below folds into the same session because `/controls*` sits behind the same gate.
- **L8** `apps/amc-worker/PAPER-CHECK.md` — print/mark/scan. WP-E emits the sheet AMC then renders; PAPER-CHECK.md is the last-mile confirmation the pencil actually reads. Not blocking here (the fixture pin ensures shape; PAPER-CHECK.md is WP-A doctrine and was already run for the fixture).

## Reviews run

Two rounds, integrated mode.

**Round A — code (previous session)**
- Panel: `lens-correctness-tests`, `lens-arch-simplicity`, `lens-security` (parallel). `lens-performance` skipped: WP-E is I/O-bound against the AMC worker, no render/compute hot paths, and the issue declares no perf goals (only a soft ≤30 s bound for generation, satisfied via `amctest.Fake` timing in tests).
- Findings accepted and fixed → commit `d279dde feat(issue-166): review fixes`.
- Re-gate + per-fix rechecks passed in that session.

**Round B — docs (previous session + this session)**
- Panel: `lens-docs-completeness`, `lens-docs-accuracy`, `lens-adr-hunter`, `lens-agent-readability` (parallel).
- First-pass fixes → `ab9f027 docs(issue-166): mark WP-E shipped and record its non-auth chain`.
- Additive fix (this session) — ADR-hunter flagged the load-bearing `amc-work` seeding rule as an ADR-worthy operational constraint recorded only in Dockerfile + compose comments → `5308cc8 docs(issue-166): record the amc-work seeding rule in ADR-0034`.
- Per-fix recheck of `5308cc8` (this session, `lens-adr-hunter`): **resolved, no residuals**. Reviewer reading only §Consequences has enough specificity to catch a regression from a Dockerfile chown change, a dropped `depends_on`, or a UID change.
- Re-gate re-run this session on tip `5308cc8` — all green (see §Tests).

## Manual verification (human)

Prerequisites: real Google OAuth credentials in `apps/server/.env` (see
`apps/server/GOOGLE-CHECK.md`), then from `infra/local/`:
`docker compose up -d --build --wait server`. Log in with a bootstrap
professor account and check each flow at ≥1440 px in both themes:

1. **`/`** → 302 to `/controls` (AC 1). Anonymous window → sign-in page.
2. **`/controls`** (AC 2) — empty state visible; header shows "Nuevo control".
3. **`/controls/new`** (AC 3) — the four range dropdowns cascade from
   `questions.json` in `index.yaml` reading order. `questions-per-copy` and
   `copies` show 4 and 30 as defaults.
4. **Happy path** (AC 4, AC 5) — submit a valid range (documento X sección A → documento X sección C), N=4, M=2. Redirects to `/controls/:id` with a Spanish flash. Detail page shows metadata + a live `sujet.pdf` download. Refresh the page — download still works. `docker compose restart server`; refresh again — still works.
5. **`corrige.pdf`** (AC 5) — the answer key downloads and opens.
6. **`sujet.pdf` shape** (AC 7) — every question labelled `(una respuesta)` or `(varias respuestas)`; header shows number of questions, total score and 4,0 line; a question with a "Ninguna de las anteriores" alternative has it in last position on every copy.
7. **Failure modes** (AC 8):
   - Empty range (`from` after `to` in reading order) → form re-render with the offending dropdown flagged, Spanish message.
   - Pool < N → *"Pediste X preguntas por copia, pero el rango solo tiene Y disponibles."*
   - AMC unreachable (`docker compose stop amc-worker` before submit) → 500 page in Spanish; no control row was written.
8. **CSRF** (AC 10) — hand-craft a `POST /controls` from `curl` without the token header → 403.
9. **Everything on-screen is Spanish** (AC 11) — chrome, dropdowns, flashes, errors.
10. **Screenshots** (AC 12) — capture form, list, detail in both themes at ≥1440 px and drop them here. This is the piece I could not run as an agent (the auth gate is human-only by design, §L8).

## Notes

- **Not covered here (by design):** reading scans back (WP-F), course selection (WP-D), edit/regenerate (design decision, §Non-goals), CSV grades export (WP-G).
- **Follow-ups born from this WP:** none opened. The additive Round B fix
  landed inline (`address-inline` preference).
- **Metrics emission:** best-effort skipped for this run — the pipeline
  crossed session boundaries and per-agent usage numbers for Rounds A and B
  first-pass are not available in this session's context. Only the per-fix
  recheck of `5308cc8` has full usage data locally; the sink contract
  requires a complete record per run. Reported here transparently rather
  than emit a truncated one silently.
- **Worktree:** `/Users/so77id/orca/workspaces/nalanda/wp-e-generate-control`. Removed on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
