### PR TITLE
feat: read scans, review queue, close corrections (WP-F, #167)

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -116,6 +116,7 @@ jobs:
             -e NALANDA_QUESTIONS_JSON_URL=file:///work/questions.json \
             -e NALANDA_AMC_WORKER_URL=http://amc-worker-placeholder:8080 \
             -e NALANDA_WORK_DIR=/work \
+            -e NALANDA_MAX_SCAN_MB=100 \
             -v "$GITHUB_WORKSPACE/ci-work:/work:ro" \
             -p 127.0.0.1:8081:8081 \
             nalanda/server:ci

--- a/apps/amc-worker/README.md
+++ b/apps/amc-worker/README.md
@@ -56,10 +56,24 @@ GET  /health                                          → { ok, amc }
 POST /generate      { project, source, copies }       → { sujet, corrige, calage, copies }
 POST /analyse       { project, scan_pdf, source }     → { pages, scoring, copies, needs_review }
                     ⏱ MINUTES-CLASS — background job only, see below
+POST /reanalyse     { project, ticked, unsure }       → { pages, scoring, copies, needs_review }
 POST /associate     { project, roster, code, key }    → { associations, refused_codes }
 POST /associate/set { project, copy, id }             → { copy, id, source }
 POST /annotate      { project, roster, key, out,      → { pdfs, unidentified }
                       [name_column], [verdict] }
+```
+
+**Named files under `<project>/` that the worker produces and callers open
+directly** (ADR-0037 — this naming is part of the contract, the same class
+of promise as `/generate`'s response paths):
+
+```
+<project>/out/sujet.pdf         printed set, from /generate
+<project>/out/corrige.pdf       answer key, from /generate
+<project>/out/calage.xy         layout coordinates, from /generate
+<project>/scans/copy-N-page-M.png
+                                one image per scanned page, from /analyse's
+                                getimages step (N = copy number, M = page)
 ```
 
 **A refusal is not a crash.** The reader refuses a project it cannot score —

--- a/apps/amc-worker/worker.py
+++ b/apps/amc-worker/worker.py
@@ -213,6 +213,24 @@ def analyse(body):
     return read_capture.read(data, TICKED, UNSURE)
 
 
+def reanalyse(body):
+    """Re-read a captured project at new thresholds, without a new capture.
+
+    Same project directory as `/analyse`, no scan_pdf: the read runs against
+    the sqlite files AMC already wrote and only the darkness verdicts move.
+    The scores stay where `note` left them, and the report's `scoring.stale`
+    is the caller's cue (ADR-0031 §The report says which threshold).
+    """
+    _project, data = project_paths(body)
+    ticked = float(body.get("ticked", TICKED))
+    unsure = float(body.get("unsure", UNSURE))
+    if not 0 < ticked < 1:
+        raise Failed(f"ticked must be in (0, 1), got {ticked}")
+    if not 0 <= unsure < ticked:
+        raise Failed(f"unsure must be in [0, ticked), got {unsure} vs ticked {ticked}")
+    return read_capture.read(data, ticked, unsure)
+
+
 def associate(body):
     """Match the codes AMC assembled against the course roster."""
     _project, data = project_paths(body)
@@ -308,6 +326,7 @@ ROUTES = {
     ("GET", "/health"): health,
     ("POST", "/generate"): generate,
     ("POST", "/analyse"): analyse,
+    ("POST", "/reanalyse"): reanalyse,
     ("POST", "/associate"): associate,
     ("POST", "/associate/set"): associate_set,
     ("POST", "/annotate"): annotate,

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -92,3 +92,9 @@ NALANDA_AMC_WORKER_URL=http://amc-worker:8080
 # the server writes its files. In compose it is /work (the shared
 # amc-work volume, mounted into both services).
 NALANDA_WORK_DIR=/work
+
+# The largest scan PDF the upload handler will accept, in whole megabytes
+# (WP-F, issue #167). Optional — defaults to 100. A 4-page control scanned
+# at 300 dpi is roughly 3–5 MB, so 100 fits a large class with room to
+# spare and refuses a runaway upload before it enters the worker.
+NALANDA_MAX_SCAN_MB=100

--- a/apps/server/CLAUDE.md
+++ b/apps/server/CLAUDE.md
@@ -9,7 +9,12 @@ SQLite underneath. Born with the entrance-controls subsystem
 
 Since WP-C3 (#151) the backoffice has its shell (nav, both themes, error
 pages, one-shot flash cookie) and the professor CRUD. The login round trip
-and the session gate arrived earlier with WP-C2 (#150).
+and the session gate arrived earlier with WP-C2 (#150). WP-E (#166) added
+the entrance-controls screens (list, create, detail with the printable PDF
+downloads); WP-F (#167) turned the Escaneos box live with the whole
+reader loop — upload → analyse → results table → side-by-side review
+page → re-leer con otra sensibilidad → *Cerrar corrección*. The routes
+table in `README.md` is the current inventory.
 
 Commands, stack, configuration and layout live in `README.md` — one home per
 fact.
@@ -30,10 +35,11 @@ fact.
   route here: which surface it belongs to, the handler → domain → repository
   chain, and the middleware a state-changing route needs.
 - `README.md` §"What is not here yet" — before adding anything, check whether
-  the work belongs to WP-D (roster) or WP-E (control creation). **WP-C1,
-  WP-C2 and WP-C3 are closed**: the layered layout (#149), the login round
-  trip + session gate (#150), and the backoffice shell + professor CRUD
-  (#151) all live here.
+  the work belongs to WP-D (roster) or WP-G (publish grades). **WP-C1,
+  WP-C2, WP-C3, WP-E and WP-F are closed**: the layered layout (#149), the
+  login round trip + session gate (#150), the backoffice shell + professor
+  CRUD (#151), control creation with the PDF pipeline (#166) and the
+  scans + review flow (#167) all live here.
 
 ## Language
 

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -43,6 +43,7 @@ Environment variables, read once at boot. A required variable that is absent
 | `NALANDA_QUESTIONS_JSON_URL` | yes | The published question bank (ADR-0032). `http://`, `https://` or `file://`. Fetched **once at boot** and held in memory; a parse failure is a panic there. WP-E |
 | `NALANDA_AMC_WORKER_URL` | yes | The AMC worker's HTTP origin, e.g. `http://amc-worker:8080` in compose. Absolute http/https URL, no path. WP-E |
 | `NALANDA_WORK_DIR` | yes | Where the server sees the shared volume. The `.tex` generator emits `/work` absolute paths regardless (that is the worker's mount); this only decides where the server writes its files. WP-E |
+| `NALANDA_MAX_SCAN_MB` | no (`100`) | Largest scan PDF the upload handler accepts, in whole MB. A 4-page control at 300 dpi is roughly 3–5 MB; 100 fits a large class and refuses a runaway upload before it enters the worker. WP-F |
 
 ## Commands
 

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -228,6 +228,7 @@ Deliberately, and each with an owner:
 |---|---|
 | Courses, students, enrolment — any domain table | WP-D |
 | JSON contracts, CORS, WebSocket on `/api` | with a consumer (ADR-0008) |
+| A per-control upload quota (batches per control, or total bytes) — today `NALANDA_MAX_SCAN_MB` bounds ONE upload | when an operator wants a ceiling on abuse by an authenticated professor |
 | Publishing grades (CSV export, Canvas, email) | WP-G |
 | Bulk download of annotated PDFs as a ZIP | when the pile is large enough — captured in #167 §Notes |
 | Regenerating the annotated PDF after a manual override | #167 §Non-goals; the annotated stays a view of what AMC read, overrides live in the DB |

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -189,8 +189,13 @@ Routes today:
 | `GET /` | Redirects to `/controls` (an anonymous request lands in `/login` first, via the gate). Superseded #151's redirect to `/professors` when WP-E landed |
 | `GET /controls` | The list, ordered by application_date desc with nulls last |
 | `GET /controls/new` · `POST /controls` | Pick a section range, generate the PDF |
-| `GET /controls/{id}` | Detail: metadata, PDF downloads, the WP-F placeholder Escaneos box |
+| `GET /controls/{id}` | Detail: metadata, PDF downloads, the Escaneos upload form, the Resultados table and (after upload) the *Cerrar corrección* button |
 | `GET /controls/{id}/sujet.pdf` · `GET /controls/{id}/corrige.pdf` | Streamed from the shared volume |
+| `POST /controls/{id}/scans` | Multipart PDF upload — hands the file to the worker's `/analyse`, persists the report, flips the state to `in_review` |
+| `POST /controls/{id}/reanalyze` | Re-reads the stored captures at new `ticked`/`unsure` thresholds without a new capture |
+| `POST /controls/{id}/close` | Moves the control to `graded` when every failure kind is resolved (WP-F S8) |
+| `GET /controls/{id}/copies/{copy}/review` · `POST` | Split view — scanned image + editable form; POST saves overrides through `answer_override` / `rut_override` |
+| `GET /controls/{id}/copies/{copy}/page/{n}` | Streams the scanned page image from the shared volume |
 | `GET /professors` | The list: address, name, state, created, last sign-in |
 | `GET /professors/new` · `POST /professors` | Create by address and name — the `Authenticate` path (2) round trip |
 | `GET /professors/{id}/edit` · `POST /professors/{id}` | Rename. The address is not editable |
@@ -223,7 +228,10 @@ Deliberately, and each with an owner:
 |---|---|
 | Courses, students, enrolment — any domain table | WP-D |
 | JSON contracts, CORS, WebSocket on `/api` | with a consumer (ADR-0008) |
-| Reading scans back, per-question grades, review queue | WP-F |
+| Publishing grades (CSV export, Canvas, email) | WP-G |
+| Bulk download of annotated PDFs as a ZIP | when the pile is large enough — captured in #167 §Notes |
+| Regenerating the annotated PDF after a manual override | #167 §Non-goals; the annotated stays a view of what AMC read, overrides live in the DB |
+| Roster / student names, isolation between professors | V2 / #163 |
 | Deploy, hosting, secrets | deferred (`2026-08-controles.md` §C15) |
 | Deleting or re-addressing a professor who has never signed in | WP that reopens the mistyped-address debt (#151 §Notes) |
 | An audit trail of who did what | The WP that gains a second class of actor (#151 §Non-goals) |

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -242,7 +242,11 @@ and **#150 deleted it** with the first real migration, as planned. The auth
 schema is numbered `00002` even so: goose keys applied migrations by version, so
 a file reusing number 1 would be considered already applied by every checkout
 that had run the server, and the schema would never arrive. WP-C3 added
-`00003_last_login_at.sql`.
+`00003_last_login_at.sql`. WP-E (#166) added `00004_controls.sql` with the
+three tables the controls domain reads (`control`, `control_pregunta`,
+`copia`); WP-F (#167) added `00005_readings.sql` with the four the
+reading half needs (`reading`, `answer`, `answer_override`,
+`rut_override`).
 
 ## Signing in
 

--- a/apps/server/cmd/server/main.go
+++ b/apps/server/cmd/server/main.go
@@ -160,6 +160,8 @@ func run(logger *slog.Logger) error {
 		Bank:      loadedBank,
 		Store:     controlStore,
 		Generator: amcClient,
+		Analyzer:  amcClient,
+		Readings:  controlStore,
 		WorkDir:   cfg.WorkDir,
 		Now:       time.Now,
 		// Constant seed for reproducibility (tex.Compile refuses zero).
@@ -192,10 +194,11 @@ func run(logger *slog.Logger) error {
 			Log:       logger,
 		}),
 		Controls: handler.NewControls(handler.Controls{
-			Service:   controlsService,
-			Bank:      loadedBank,
-			PublicURL: cfg.PublicURL,
-			Log:       logger,
+			Service:      controlsService,
+			Bank:         loadedBank,
+			PublicURL:    cfg.PublicURL,
+			MaxScanBytes: cfg.MaxScanBytes,
+			Log:          logger,
 		}),
 		Login: handler.NewAuth(handler.Auth{
 			Login: login,

--- a/apps/server/cmd/server/main_test.go
+++ b/apps/server/cmd/server/main_test.go
@@ -88,15 +88,21 @@ func composed(t *testing.T, prober health.Prober) (http.Handler, *authstore.Stor
 			Log:       logger,
 		}),
 		Controls: handler.NewControls(handler.Controls{
-			Service: controls.NewService(controls.Service{
-				Bank:      emptyBank(t),
-				Store:     controlstore.New(db),
-				Generator: &amctest.Fake{},
-				WorkDir:   t.TempDir(),
-				Now:       time.Now,
-				Seed:      1,
-				Log:       logger,
-			}),
+			Service: func() *controls.Service {
+				cstore := controlstore.New(db)
+				fake := &amctest.Fake{}
+				return controls.NewService(controls.Service{
+					Bank:      emptyBank(t),
+					Store:     cstore,
+					Generator: fake,
+					Analyzer:  fake,
+					Readings:  cstore,
+					WorkDir:   t.TempDir(),
+					Now:       time.Now,
+					Seed:      1,
+					Log:       logger,
+				})
+			}(),
 			Bank:      emptyBank(t),
 			PublicURL: "https://nalanda.test",
 			Log:       logger,

--- a/apps/server/internal/app/web/handler/controls.go
+++ b/apps/server/internal/app/web/handler/controls.go
@@ -19,7 +19,8 @@ import (
 )
 
 // The controls routes (issue #166 §The screens). URL paths in English like
-// every other route in this surface (issue #151 §Routes).
+// every other route in this surface (issue #151 §Routes). WP-F extends the
+// set with the scan-upload target (ControlScansPath in scans.go).
 const (
 	ControlsPath       = "/controls"
 	ControlsNewPath    = "/controls/new"
@@ -51,7 +52,11 @@ type Controls struct {
 	Service   *controls.Service
 	Bank      *bank.Bank
 	PublicURL string
-	Log       *slog.Logger
+	// MaxScanBytes is the largest scan upload the handler accepts. Comes
+	// from config.MaxScanBytes so main is the only place the byte value
+	// is composed (backend-code-style.md §Configuration).
+	MaxScanBytes int64
+	Log          *slog.Logger
 
 	secureCookie bool
 }
@@ -172,6 +177,25 @@ func (h *Controls) Detail(w http.ResponseWriter, r *http.Request) {
 		Control:    toDetailedControl(c, h.Bank),
 		SujetURL:   controlSujetURL(c.ID),
 		CorrigeURL: controlCorrigeURL(c.ID),
+		ScansURL:   controlScansURL(c.ID),
+		MaxScanMB:  h.MaxScanBytes >> 20,
+	}
+	// The results table (S4) is populated when at least one reading
+	// exists. An empty list keeps the "Aún no hay escaneos" copy the
+	// WP-E template already showed, without a Resultados section.
+	if h.Service != nil {
+		readings, err := h.Service.ReadingsFor(r.Context(), c.ID)
+		if err != nil {
+			h.Log.Error("listing readings", "control", c.ID, "error", err)
+			middleware.WriteError(w, r, http.StatusInternalServerError,
+				"Algo se rompió en el servidor. Vuelve a intentarlo en unos segundos.")
+			return
+		}
+		if len(readings) > 0 {
+			page.QuestionColumns = perQuestionColumns(c.QuestionsPerCopy)
+			page.Readings = toReadingRows(c, readings)
+			page.Summary = summarise(readings)
+		}
 	}
 	page.Flash = flash.Consume(w, r, h.secureCookie)
 
@@ -443,6 +467,220 @@ func controlSujetURL(id string) string {
 
 func controlCorrigeURL(id string) string {
 	return controlDetailURL(id) + "/corrige.pdf"
+}
+
+func controlScansURL(id string) string {
+	return controlDetailURL(id) + "/scans"
+}
+
+// perQuestionColumns returns the "P1, P2, …" header labels for the results
+// table, one per question the control drew.
+func perQuestionColumns(n int) []string {
+	out := make([]string, n)
+	for i := range out {
+		out[i] = fmt.Sprintf("P%d", i+1)
+	}
+	return out
+}
+
+// toReadingRows turns each Reading into the pre-formatted table row.
+// Grade math and the estado collapse live here so the template does no
+// arithmetic.
+func toReadingRows(c controls.Control, readings []controls.Reading) []view.ReadingRow {
+	out := make([]view.ReadingRow, 0, len(readings))
+	for _, r := range readings {
+		out = append(out, toReadingRow(c, r))
+	}
+	return out
+}
+
+func toReadingRow(c controls.Control, r controls.Reading) view.ReadingRow {
+	row := view.ReadingRow{
+		CopyNumber:  r.CopyNumber,
+		PerQuestion: renderPerQuestion(c.QuestionsPerCopy, r),
+		ReviewURL:   controlReviewURL(c.ID, r.CopyNumber),
+	}
+	row.RUT, row.Edited = renderRUT(r)
+	row.Estado, row.EstadoClass = estadoFor(r)
+	row.TotalRaw, row.Grade = totalAndGrade(c.QuestionsPerCopy, r)
+	return row
+}
+
+// controlReviewURL is the URL of one copy's review page (S5).
+func controlReviewURL(controlID string, copyNumber int) string {
+	return fmt.Sprintf("%s/copies/%d/review", controlDetailURL(controlID), copyNumber)
+}
+
+func renderRUT(r controls.Reading) (string, bool) {
+	if r.RUTOverride != nil {
+		return r.RUTOverride.RUT, true
+	}
+	if r.RUTStatus == controls.RUTStatusOK && r.RUTRead != nil {
+		return *r.RUTRead, false
+	}
+	// Unreadable / not_present with no override.
+	return "", r.RUTOverride != nil
+}
+
+// renderPerQuestion aligns answers to the P1..PN columns. Missing entries
+// become "—" and doubtful/blank/ambiguous become "⚠".
+func renderPerQuestion(cols int, r controls.Reading) []string {
+	out := make([]string, cols)
+	for i := range out {
+		out[i] = "—"
+	}
+	if r.CopyStatus == controls.CopyStatusNotPresent {
+		return out
+	}
+	// Answers are per-copy and their count equals the drawn questions;
+	// alignment is by index, one to one.
+	for i, a := range r.Answers {
+		if i >= cols {
+			break
+		}
+		if a.Override != nil {
+			out[i] = renderAnswerCell(a.Override.Status, a.Score, a.Max, true, a.QuestionType == controls.QuestionMultiple)
+			continue
+		}
+		out[i] = renderAnswerCell(a.Status, a.Score, a.Max, false, a.QuestionType == controls.QuestionMultiple)
+	}
+	return out
+}
+
+func renderAnswerCell(status controls.AnswerStatus, score, max float64, edited, multiple bool) string {
+	if status == controls.AnswerStatusBlank ||
+		status == controls.AnswerStatusAmbiguous ||
+		status == controls.AnswerStatusDoubtful {
+		return "⚠"
+	}
+	if max <= 0 {
+		return "—"
+	}
+	rel := score / max
+	if multiple {
+		return fmt.Sprintf("%.2f", rel)
+	}
+	if rel == 1 {
+		return "1"
+	}
+	if rel == 0 {
+		return "0"
+	}
+	return fmt.Sprintf("%.2f", rel)
+}
+
+func estadoFor(r controls.Reading) (string, string) {
+	switch r.CopyStatus {
+	case controls.CopyStatusNotPresent:
+		return "no rendida", "estado-no-rendida"
+	case controls.CopyStatusIncomplete:
+		return "⚠ página faltante", "estado-incompleta"
+	}
+	if r.RUTStatus == controls.RUTStatusUnreadable && r.RUTOverride == nil {
+		return "⚠ RUT ilegible", "estado-rut"
+	}
+	for _, a := range r.Answers {
+		effective := effectiveAnswerStatus(a)
+		if effective == controls.AnswerStatusDoubtful ||
+			effective == controls.AnswerStatusAmbiguous ||
+			effective == controls.AnswerStatusBlank {
+			return "⚠ marca dudosa", "estado-dudosa"
+		}
+	}
+	return "ok", "estado-ok"
+}
+
+// effectiveAnswerStatus is the status the professor's decision (if any)
+// left the answer at.
+func effectiveAnswerStatus(a controls.Answer) controls.AnswerStatus {
+	if a.Override != nil {
+		return a.Override.Status
+	}
+	return a.Status
+}
+
+// totalAndGrade computes "Σ relative / N" over the drawn questions, plus
+// the 1,0–7,0 mark (§C7: 4,0 at 50%, linear either side). Returns raw
+// like "3.50/4" and grade like "5.5", or "—/—" for a not_present copy.
+func totalAndGrade(questions int, r controls.Reading) (string, string) {
+	if r.CopyStatus == controls.CopyStatusNotPresent {
+		return "—", "—"
+	}
+	// Any unresolved failure leaves the total unknown until the review
+	// is done — the estado column carries the reason.
+	if r.RUTStatus == controls.RUTStatusUnreadable && r.RUTOverride == nil {
+		return "—", "—"
+	}
+	total := 0.0
+	for _, a := range r.Answers {
+		effective := effectiveAnswerStatus(a)
+		if effective == controls.AnswerStatusDoubtful || effective == controls.AnswerStatusAmbiguous {
+			return "—", "—"
+		}
+		if effective == controls.AnswerStatusBlank {
+			continue
+		}
+		if a.Override != nil {
+			// Overrides do not carry per-question scores; a corrected
+			// answer earns the whole point (§AC-4 override contract).
+			total += 1.0
+			continue
+		}
+		if a.Max > 0 {
+			total += a.Score / a.Max
+		}
+	}
+	if questions == 0 {
+		return "—", "—"
+	}
+	return fmt.Sprintf("%.2f/%d", total, questions), formatGrade(total, questions)
+}
+
+// formatGrade maps a fraction onto the 1,0–7,0 scale: 4,0 at 50%, linear
+// on either side (§C7). Rounded to one decimal.
+func formatGrade(total float64, questions int) string {
+	if questions == 0 {
+		return "—"
+	}
+	pct := total / float64(questions)
+	grade := 1.0
+	if pct <= 0 {
+		grade = 1.0
+	} else if pct <= 0.5 {
+		grade = 1.0 + 6.0*pct // 0.0→1.0, 0.5→4.0
+	} else if pct >= 1.0 {
+		grade = 7.0
+	} else {
+		grade = 4.0 + 6.0*(pct-0.5) // 0.5→4.0, 1.0→7.0
+	}
+	return fmt.Sprintf("%.1f", grade)
+}
+
+// summarise counts each collapse bucket for the results-table footer.
+func summarise(readings []controls.Reading) string {
+	if len(readings) == 0 {
+		return ""
+	}
+	printed := len(readings)
+	corregidas := 0
+	revisar := 0
+	noRendidas := 0
+	for _, r := range readings {
+		switch r.CopyStatus {
+		case controls.CopyStatusNotPresent:
+			noRendidas++
+			continue
+		}
+		estado, _ := estadoFor(r)
+		switch estado {
+		case "ok":
+			corregidas++
+		default:
+			revisar++
+		}
+	}
+	return fmt.Sprintf("%d copias impresas · %d corregidas · %d requieren revisión · %d no rendidas",
+		printed, corregidas, revisar, noRendidas)
 }
 
 // toListedControls turns domain values into rows the template can render

--- a/apps/server/internal/app/web/handler/controls.go
+++ b/apps/server/internal/app/web/handler/controls.go
@@ -546,7 +546,7 @@ func toReadingRow(c controls.Control, r controls.Reading) view.ReadingRow {
 	}
 	row.RUT, row.Edited = renderRUT(r)
 	row.Estado, row.EstadoClass = estadoFor(r)
-	row.TotalRaw, row.Grade = totalAndGrade(c.QuestionsPerCopy, r)
+	row.TotalRaw, row.Grade = controls.TotalAndGrade(c.QuestionsPerCopy, r)
 	return row
 }
 
@@ -643,71 +643,6 @@ func effectiveAnswerStatus(a controls.Answer) controls.AnswerStatus {
 		return a.Override.Status
 	}
 	return a.Status
-}
-
-// totalAndGrade computes "Σ relative / N" over the drawn questions, plus
-// the 1,0–7,0 mark (§C7: 4,0 at 50%, linear either side). Returns raw
-// like "3.50/4" and grade like "5.5", or "—/—" for a not_present copy.
-func totalAndGrade(questions int, r controls.Reading) (string, string) {
-	if r.CopyStatus == controls.CopyStatusNotPresent {
-		return "—", "—"
-	}
-	// Any unresolved failure leaves the total unknown until the review
-	// is done — the estado column carries the reason.
-	if r.RUTStatus == controls.RUTStatusUnreadable && r.RUTOverride == nil {
-		return "—", "—"
-	}
-	total := 0.0
-	for _, a := range r.Answers {
-		effective := effectiveAnswerStatus(a)
-		if effective == controls.AnswerStatusDoubtful || effective == controls.AnswerStatusAmbiguous {
-			return "—", "—"
-		}
-		if effective == controls.AnswerStatusBlank {
-			continue
-		}
-		if a.Override != nil {
-			// Overrides do not carry per-question scores; a corrected
-			// answer earns the whole point (§AC-4). By construction: the
-			// override stands for "the professor decided this is the
-			// right answer" — comparing it against the bank's `correct`
-			// set would double-decide, and the WP explicitly leaves that
-			// out of scope. A wrong-answer override therefore also earns
-			// 1.0; that is the same trust model as manual grading.
-			total += 1.0
-			continue
-		}
-		if a.Max > 0 {
-			total += a.Score / a.Max
-		}
-	}
-	if questions == 0 {
-		return "—", "—"
-	}
-	return fmt.Sprintf("%.2f/%d", total, questions), formatGrade(total, questions)
-}
-
-// formatGrade maps a fraction onto the 1,0–7,0 scale: 4,0 at 50%, linear
-// on either side (§C7). Rounded to one decimal. Negative or >1 fractions
-// are clamped — either would only appear from a scoring bug upstream, and
-// a grade outside 1–7 has no reader.
-func formatGrade(total float64, questions int) string {
-	if questions == 0 {
-		return "—"
-	}
-	pct := total / float64(questions)
-	var grade float64
-	switch {
-	case pct <= 0:
-		grade = 1.0
-	case pct <= 0.5:
-		grade = 1.0 + 6.0*pct // 0.0→1.0, 0.5→4.0
-	case pct >= 1.0:
-		grade = 7.0
-	default:
-		grade = 4.0 + 6.0*(pct-0.5) // 0.5→4.0, 1.0→7.0
-	}
-	return fmt.Sprintf("%.1f", grade)
 }
 
 // summarise counts each collapse bucket for the results-table footer.

--- a/apps/server/internal/app/web/handler/controls.go
+++ b/apps/server/internal/app/web/handler/controls.go
@@ -173,16 +173,18 @@ func (h *Controls) Detail(w http.ResponseWriter, r *http.Request) {
 	}
 
 	page := view.ControlDetailPage{
-		Page:       middleware.PageFor(r, c.Name),
-		Control:    toDetailedControl(c, h.Bank),
-		SujetURL:   controlSujetURL(c.ID),
-		CorrigeURL: controlCorrigeURL(c.ID),
-		ScansURL:   controlScansURL(c.ID),
-		MaxScanMB:  h.MaxScanBytes >> 20,
+		Page:          middleware.PageFor(r, c.Name),
+		Control:       toDetailedControl(c, h.Bank),
+		SujetURL:      controlSujetURL(c.ID),
+		CorrigeURL:    controlCorrigeURL(c.ID),
+		ScansURL:      controlScansURL(c.ID),
+		ReanalyzeURL:  controlReanalyzeURL(c.ID),
+		CloseURL:      controlCloseURL(c.ID),
+		MaxScanMB:     h.MaxScanBytes >> 20,
+		CurrentTicked: defaultTicked,
+		CurrentUnsure: defaultUnsure,
+		Graded:        c.State == controls.Graded,
 	}
-	// The results table (S4) is populated when at least one reading
-	// exists. An empty list keeps the "Aún no hay escaneos" copy the
-	// WP-E template already showed, without a Resultados section.
 	if h.Service != nil {
 		readings, err := h.Service.ReadingsFor(r.Context(), c.ID)
 		if err != nil {
@@ -195,6 +197,7 @@ func (h *Controls) Detail(w http.ResponseWriter, r *http.Request) {
 			page.QuestionColumns = perQuestionColumns(c.QuestionsPerCopy)
 			page.Readings = toReadingRows(c, readings)
 			page.Summary = summarise(readings)
+			page.CanClose, page.CloseBlockedReason = closeGate(c, readings)
 		}
 	}
 	page.Flash = flash.Consume(w, r, h.secureCookie)
@@ -471,6 +474,52 @@ func controlCorrigeURL(id string) string {
 
 func controlScansURL(id string) string {
 	return controlDetailURL(id) + "/scans"
+}
+
+func controlReanalyzeURL(id string) string {
+	return controlDetailURL(id) + "/reanalyze"
+}
+
+func controlCloseURL(id string) string {
+	return controlDetailURL(id) + "/close"
+}
+
+// closeGate implements the S8 rule: enabled when no reading holds an
+// unresolved failure kind. Returns the reason otherwise, in Spanish, for
+// the disabled button's hint.
+func closeGate(c controls.Control, readings []controls.Reading) (bool, string) {
+	if c.State == controls.Graded {
+		return false, ""
+	}
+	blockingIncomplete := 0
+	blockingRUT := 0
+	blockingDoubtful := 0
+	for _, r := range readings {
+		if r.CopyStatus == controls.CopyStatusNotPresent {
+			continue
+		}
+		if r.CopyStatus == controls.CopyStatusIncomplete {
+			blockingIncomplete++
+			continue
+		}
+		if r.RUTStatus == controls.RUTStatusUnreadable && r.RUTOverride == nil {
+			blockingRUT++
+		}
+		for _, a := range r.Answers {
+			st := effectiveAnswerStatus(a)
+			if st == controls.AnswerStatusDoubtful || st == controls.AnswerStatusAmbiguous {
+				if a.Override == nil {
+					blockingDoubtful++
+					break
+				}
+			}
+		}
+	}
+	total := blockingIncomplete + blockingRUT + blockingDoubtful
+	if total == 0 {
+		return true, ""
+	}
+	return false, fmt.Sprintf("Faltan %d revisiones antes de cerrar.", total)
 }
 
 // perQuestionColumns returns the "P1, P2, …" header labels for the results

--- a/apps/server/internal/app/web/handler/controls.go
+++ b/apps/server/internal/app/web/handler/controls.go
@@ -185,20 +185,18 @@ func (h *Controls) Detail(w http.ResponseWriter, r *http.Request) {
 		CurrentUnsure: defaultUnsure,
 		Graded:        c.State == controls.Graded,
 	}
-	if h.Service != nil {
-		readings, err := h.Service.ReadingsFor(r.Context(), c.ID)
-		if err != nil {
-			h.Log.Error("listing readings", "control", c.ID, "error", err)
-			middleware.WriteError(w, r, http.StatusInternalServerError,
-				"Algo se rompió en el servidor. Vuelve a intentarlo en unos segundos.")
-			return
-		}
-		if len(readings) > 0 {
-			page.QuestionColumns = perQuestionColumns(c.QuestionsPerCopy)
-			page.Readings = toReadingRows(c, readings)
-			page.Summary = summarise(readings)
-			page.CanClose, page.CloseBlockedReason = closeGate(c, readings)
-		}
+	readings, err := h.Service.ReadingsFor(r.Context(), c.ID)
+	if err != nil {
+		h.Log.Error("listing readings", "control", c.ID, "error", err)
+		middleware.WriteError(w, r, http.StatusInternalServerError,
+			"Algo se rompió en el servidor. Vuelve a intentarlo en unos segundos.")
+		return
+	}
+	if len(readings) > 0 {
+		page.QuestionColumns = perQuestionColumns(c.QuestionsPerCopy)
+		page.Readings = toReadingRows(c, readings)
+		page.Summary = summarise(readings)
+		page.CanClose, page.CloseBlockedReason = closeGate(c, readings)
 	}
 	page.Flash = flash.Consume(w, r, h.secureCookie)
 
@@ -486,40 +484,37 @@ func controlCloseURL(id string) string {
 
 // closeGate implements the S8 rule: enabled when no reading holds an
 // unresolved failure kind. Returns the reason otherwise, in Spanish, for
-// the disabled button's hint.
+// the disabled button's hint. The rules mirror
+// controls.Service.CloseCorrection so the disabled UI and the server-side
+// guard agree.
 func closeGate(c controls.Control, readings []controls.Reading) (bool, string) {
 	if c.State == controls.Graded {
 		return false, ""
 	}
-	blockingIncomplete := 0
-	blockingRUT := 0
-	blockingDoubtful := 0
+	blocking := 0
 	for _, r := range readings {
 		if r.CopyStatus == controls.CopyStatusNotPresent {
 			continue
 		}
 		if r.CopyStatus == controls.CopyStatusIncomplete {
-			blockingIncomplete++
+			blocking++
 			continue
 		}
 		if r.RUTStatus == controls.RUTStatusUnreadable && r.RUTOverride == nil {
-			blockingRUT++
+			blocking++
 		}
 		for _, a := range r.Answers {
 			st := effectiveAnswerStatus(a)
 			if st == controls.AnswerStatusDoubtful || st == controls.AnswerStatusAmbiguous {
-				if a.Override == nil {
-					blockingDoubtful++
-					break
-				}
+				blocking++
+				break
 			}
 		}
 	}
-	total := blockingIncomplete + blockingRUT + blockingDoubtful
-	if total == 0 {
+	if blocking == 0 {
 		return true, ""
 	}
-	return false, fmt.Sprintf("Faltan %d revisiones antes de cerrar.", total)
+	return false, fmt.Sprintf("Faltan %d revisiones antes de cerrar.", blocking)
 }
 
 // perQuestionColumns returns the "P1, P2, …" header labels for the results
@@ -568,7 +563,7 @@ func renderRUT(r controls.Reading) (string, bool) {
 		return *r.RUTRead, false
 	}
 	// Unreadable / not_present with no override.
-	return "", r.RUTOverride != nil
+	return "", false
 }
 
 // renderPerQuestion aligns answers to the P1..PN columns. Missing entries
@@ -582,21 +577,23 @@ func renderPerQuestion(cols int, r controls.Reading) []string {
 		return out
 	}
 	// Answers are per-copy and their count equals the drawn questions;
-	// alignment is by index, one to one.
+	// alignment is by index, one to one. A row-level "editado" marker
+	// beside the RUT is what surfaces overrides; per-question cells
+	// display the same shape whether AMC or a human wrote them.
 	for i, a := range r.Answers {
 		if i >= cols {
 			break
 		}
+		status := a.Status
 		if a.Override != nil {
-			out[i] = renderAnswerCell(a.Override.Status, a.Score, a.Max, true, a.QuestionType == controls.QuestionMultiple)
-			continue
+			status = a.Override.Status
 		}
-		out[i] = renderAnswerCell(a.Status, a.Score, a.Max, false, a.QuestionType == controls.QuestionMultiple)
+		out[i] = renderAnswerCell(status, a.Score, a.Max, a.QuestionType == controls.QuestionMultiple)
 	}
 	return out
 }
 
-func renderAnswerCell(status controls.AnswerStatus, score, max float64, edited, multiple bool) string {
+func renderAnswerCell(status controls.AnswerStatus, score, max float64, multiple bool) string {
 	if status == controls.AnswerStatusBlank ||
 		status == controls.AnswerStatusAmbiguous ||
 		status == controls.AnswerStatusDoubtful {
@@ -671,7 +668,12 @@ func totalAndGrade(questions int, r controls.Reading) (string, string) {
 		}
 		if a.Override != nil {
 			// Overrides do not carry per-question scores; a corrected
-			// answer earns the whole point (§AC-4 override contract).
+			// answer earns the whole point (§AC-4). By construction: the
+			// override stands for "the professor decided this is the
+			// right answer" — comparing it against the bank's `correct`
+			// set would double-decide, and the WP explicitly leaves that
+			// out of scope. A wrong-answer override therefore also earns
+			// 1.0; that is the same trust model as manual grading.
 			total += 1.0
 			continue
 		}
@@ -686,20 +688,23 @@ func totalAndGrade(questions int, r controls.Reading) (string, string) {
 }
 
 // formatGrade maps a fraction onto the 1,0–7,0 scale: 4,0 at 50%, linear
-// on either side (§C7). Rounded to one decimal.
+// on either side (§C7). Rounded to one decimal. Negative or >1 fractions
+// are clamped — either would only appear from a scoring bug upstream, and
+// a grade outside 1–7 has no reader.
 func formatGrade(total float64, questions int) string {
 	if questions == 0 {
 		return "—"
 	}
 	pct := total / float64(questions)
-	grade := 1.0
-	if pct <= 0 {
+	var grade float64
+	switch {
+	case pct <= 0:
 		grade = 1.0
-	} else if pct <= 0.5 {
+	case pct <= 0.5:
 		grade = 1.0 + 6.0*pct // 0.0→1.0, 0.5→4.0
-	} else if pct >= 1.0 {
+	case pct >= 1.0:
 		grade = 7.0
-	} else {
+	default:
 		grade = 4.0 + 6.0*(pct-0.5) // 0.5→4.0, 1.0→7.0
 	}
 	return fmt.Sprintf("%.1f", grade)
@@ -715,8 +720,7 @@ func summarise(readings []controls.Reading) string {
 	revisar := 0
 	noRendidas := 0
 	for _, r := range readings {
-		switch r.CopyStatus {
-		case controls.CopyStatusNotPresent:
+		if r.CopyStatus == controls.CopyStatusNotPresent {
 			noRendidas++
 			continue
 		}

--- a/apps/server/internal/app/web/handler/controls_test.go
+++ b/apps/server/internal/app/web/handler/controls_test.go
@@ -94,12 +94,13 @@ func newControlsFixture(t *testing.T) *controlsFixture {
 
 	cstore := controlstore.New(db)
 	svc := controls.NewService(controls.Service{
-		Bank: b, Store: cstore, Generator: fake, WorkDir: workDir,
-		Now: time.Now, Seed: 1, Log: log,
+		Bank: b, Store: cstore, Generator: fake, Analyzer: fake, Readings: cstore,
+		WorkDir: workDir,
+		Now:     time.Now, Seed: 1, Log: log,
 	})
 	h := handler.NewControls(handler.Controls{
 		Service: svc, Bank: b,
-		PublicURL: publicURL, Log: log,
+		PublicURL: publicURL, MaxScanBytes: 5 << 20, Log: log,
 	})
 	return &controlsFixture{handler: h, service: svc, fake: fake, workDir: workDir, user: prof, session: session, log: log}
 }

--- a/apps/server/internal/app/web/handler/grade_internal_test.go
+++ b/apps/server/internal/app/web/handler/grade_internal_test.go
@@ -1,0 +1,97 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+)
+
+// The grade math (§C7 + ADR-0031) is load-bearing and the results-table
+// tests only exercised the estado column. This file pins the numeric
+// outputs at the boundary values.
+
+func TestFormatGradeMapsPercentageOntoTheChileanScale(t *testing.T) {
+	cases := []struct {
+		total     float64
+		questions int
+		want      string
+	}{
+		{total: 0, questions: 4, want: "1.0"},  // 0%
+		{total: 2, questions: 4, want: "4.0"},  // 50%
+		{total: 4, questions: 4, want: "7.0"},  // 100%
+		{total: 1, questions: 4, want: "2.5"},  // 25%
+		{total: 3, questions: 4, want: "5.5"},  // 75%
+		{total: 0, questions: 0, want: "—"},    // guard: no questions drawn
+		{total: 5, questions: 4, want: "7.0"},  // out-of-range clamp (defensive)
+		{total: -1, questions: 4, want: "1.0"}, // negative → clamp low
+	}
+	for _, c := range cases {
+		if got := formatGrade(c.total, c.questions); got != c.want {
+			t.Errorf("formatGrade(%v, %d) = %q, want %q", c.total, c.questions, got, c.want)
+		}
+	}
+}
+
+func TestTotalAndGradeSumsRelativeScores(t *testing.T) {
+	// A copy with q1 simple (1.0 relative) and q2 multiple (3/4 = 0.75)
+	// totals 1.75/2 → 87.5% → 6.25 rounded to 6.3.
+	r := controls.Reading{
+		RUTStatus: controls.RUTStatusOK,
+		Answers: []controls.Answer{
+			{QuestionRef: "q1", QuestionType: controls.QuestionSimple,
+				Status: controls.AnswerStatusOK, Score: 1, Max: 1},
+			{QuestionRef: "q2", QuestionType: controls.QuestionMultiple,
+				Status: controls.AnswerStatusOK, Score: 3, Max: 4},
+		},
+	}
+	total, grade := totalAndGrade(2, r)
+	// pct = 0.875 → 4 + 6*(0.375) = 6.25, rendered with %.1f (IEEE 754
+	// nearest-even) → 6.2.
+	if total != "1.75/2" || grade != "6.2" {
+		t.Errorf("totalAndGrade = (%s, %s), want (1.75/2, 6.2)", total, grade)
+	}
+}
+
+func TestTotalAndGradeReturnsDashesWhenAnswerIsDoubtfulWithoutOverride(t *testing.T) {
+	r := controls.Reading{
+		RUTStatus: controls.RUTStatusOK,
+		Answers: []controls.Answer{
+			{QuestionRef: "q1", QuestionType: controls.QuestionSimple,
+				Status: controls.AnswerStatusDoubtful, Score: 0, Max: 1},
+		},
+	}
+	total, grade := totalAndGrade(1, r)
+	if total != "—" || grade != "—" {
+		t.Errorf("totalAndGrade = (%s, %s), want (—, —)", total, grade)
+	}
+}
+
+func TestTotalAndGradeOverrideAwardsFullPoint(t *testing.T) {
+	// AC-4 override contract: an override earns the whole point,
+	// regardless of AMC's own score. Documented behaviour, not a bug.
+	r := controls.Reading{
+		RUTStatus: controls.RUTStatusOK,
+		Answers: []controls.Answer{
+			{QuestionRef: "q1", QuestionType: controls.QuestionMultiple,
+				Status: controls.AnswerStatusOK, Score: 3, Max: 4,
+				Override: &controls.AnswerOverride{
+					Marked: []int{1, 2}, Status: controls.AnswerStatusOK,
+				}},
+		},
+	}
+	total, _ := totalAndGrade(1, r)
+	if total != "1.00/1" {
+		t.Errorf("overridden answer total = %s, want 1.00/1", total)
+	}
+}
+
+func TestTotalAndGradeReturnsDashesForNotPresent(t *testing.T) {
+	r := controls.Reading{
+		CopyStatus: controls.CopyStatusNotPresent,
+		RUTStatus:  controls.RUTStatusNotPresent,
+	}
+	total, grade := totalAndGrade(4, r)
+	if total != "—" || grade != "—" {
+		t.Errorf("totalAndGrade(not_present) = (%s, %s), want (—, —)", total, grade)
+	}
+}

--- a/apps/server/internal/app/web/handler/results_test.go
+++ b/apps/server/internal/app/web/handler/results_test.go
@@ -1,0 +1,140 @@
+package handler_test
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+)
+
+func readCloser(b []byte) io.ReadCloser {
+	return io.NopCloser(bytes.NewReader(b))
+}
+
+// The results-table cases verify the estado collapse rules and the
+// not_present row (issue #167 §The results table). Each case sets up a
+// specific report shape, uploads it, and renders /controls/:id.
+
+func TestResultsTableRendersEveryEstadoCollapse(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control results", 4)
+
+	// A report with four distinct kinds:
+	//   copy 1 — ok
+	//   copy 2 — RUT unreadable (unreadable + ok answers)
+	//   copy 3 — marca dudosa (one doubtful answer)
+	//   copy 4 — incomplete (missing page)
+	// Copy 5 is not printed here since we asked for 4. MarkMissingAsNotPresent
+	// runs for a copy the report never mentioned — but we sent all four,
+	// so no not_present row today. We test not_present with a
+	// separate case below.
+	f.fake.AnalyzeReports = []controls.Report{
+		{Copies: map[string]controls.ReportCopy{
+			"1": okCopy("20100001"),
+			"2": {RUT: "20?00002", RUTStatus: controls.RUTStatusUnreadable, Status: controls.CopyStatusNeedsReview,
+				ExpectedQuestions: 2, SeenQuestions: 2,
+				Answers: []controls.ReportAnswer{
+					{Question: 1, Name: "q3", Type: controls.QuestionSimple, Marked: []int{1},
+						Status: controls.AnswerStatusOK, Score: 1, Max: 1},
+					{Question: 2, Name: "q4", Type: controls.QuestionMultiple, Marked: []int{1, 2},
+						Status: controls.AnswerStatusOK, Score: 4, Max: 4},
+				}},
+			"3": {RUT: "20100003", RUTStatus: controls.RUTStatusOK, Status: controls.CopyStatusNeedsReview,
+				ExpectedQuestions: 2, SeenQuestions: 2,
+				Answers: []controls.ReportAnswer{
+					{Question: 1, Name: "q3", Type: controls.QuestionSimple, Marked: nil,
+						Doubtful: []controls.Doubtful{{Answer: 1, Darkness: 0.18}},
+						Status:   controls.AnswerStatusDoubtful, Score: 0, Max: 1},
+					{Question: 2, Name: "q4", Type: controls.QuestionMultiple, Marked: []int{1},
+						Status: controls.AnswerStatusOK, Score: 3, Max: 4},
+				}},
+			"4": {RUT: "20100004", RUTStatus: controls.RUTStatusOK, Status: controls.CopyStatusIncomplete,
+				ExpectedQuestions: 2, SeenQuestions: 1, MissingQuestions: []string{"q4"},
+				Answers: []controls.ReportAnswer{
+					{Question: 1, Name: "q3", Type: controls.QuestionSimple, Marked: []int{1},
+						Status: controls.AnswerStatusOK, Score: 1, Max: 1},
+				}},
+		}},
+	}
+
+	uploadOnce(t, f, controlID)
+	body := getDetail(t, f, controlID)
+
+	for _, want := range []string{
+		"ok",
+		"⚠ RUT ilegible",
+		"⚠ marca dudosa",
+		"⚠ página faltante",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("results table does not render %q\n--- body ---\n%s", want, body)
+		}
+	}
+	// The footer summarises the four buckets.
+	if !strings.Contains(body, "4 copias impresas") {
+		t.Errorf("summary missing from body")
+	}
+}
+
+func TestResultsTableRendersNotPresentRow(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control not present", 3)
+
+	// Upload a report covering only copy 1 — copies 2 and 3 become
+	// not_present via MarkMissingAsNotPresent.
+	f.fake.AnalyzeReports = []controls.Report{
+		{Copies: map[string]controls.ReportCopy{"1": okCopy("20111111")}},
+	}
+	uploadOnce(t, f, controlID)
+	body := getDetail(t, f, controlID)
+
+	if !strings.Contains(body, "no rendida") {
+		t.Errorf("not_present row not rendered\n--- body ---\n%s", body)
+	}
+	if !strings.Contains(body, "2 no rendidas") {
+		t.Errorf("summary should count 2 no rendidas")
+	}
+}
+
+func okCopy(rut string) controls.ReportCopy {
+	return controls.ReportCopy{
+		RUT: rut, RUTStatus: controls.RUTStatusOK, Status: controls.CopyStatusOK,
+		ExpectedQuestions: 2, SeenQuestions: 2,
+		Answers: []controls.ReportAnswer{
+			{Question: 1, Name: "q3", Type: controls.QuestionSimple, Marked: []int{1},
+				Status: controls.AnswerStatusOK, Score: 1, Max: 1},
+			{Question: 2, Name: "q4", Type: controls.QuestionMultiple, Marked: []int{1},
+				Status: controls.AnswerStatusOK, Score: 4, Max: 4},
+		},
+	}
+}
+
+func uploadOnce(t *testing.T, f *controlsFixture, controlID string) {
+	t.Helper()
+	body, ct := buildScanUpload(t, "batch.pdf", "application/pdf", []byte("%PDF"))
+	req := f.authedRequest(t, http.MethodPost, "/controls/"+controlID+"/scans", nil)
+	req.Body = readCloser(body.Bytes())
+	req.Header.Set("Content-Type", ct)
+	req.SetPathValue("id", controlID)
+	rec := httptest.NewRecorder()
+	f.handler.UploadScan(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("upload status = %d, want 303", rec.Code)
+	}
+}
+
+func getDetail(t *testing.T, f *controlsFixture, controlID string) string {
+	t.Helper()
+	req := f.authedRequest(t, http.MethodGet, "/controls/"+controlID, nil)
+	req.SetPathValue("id", controlID)
+	rec := httptest.NewRecorder()
+	f.handler.Detail(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("detail status = %d\nbody: %s", rec.Code, rec.Body.String())
+	}
+	return rec.Body.String()
+}

--- a/apps/server/internal/app/web/handler/review.go
+++ b/apps/server/internal/app/web/handler/review.go
@@ -1,0 +1,238 @@
+package handler
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/so77id/nalanda/apps/server/internal/app/web/flash"
+	"github.com/so77id/nalanda/apps/server/internal/app/web/middleware"
+	"github.com/so77id/nalanda/apps/server/internal/app/web/view"
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+	"github.com/so77id/nalanda/apps/server/internal/domain/course/bank"
+)
+
+// The review routes.
+const (
+	CopyReviewPath = "/controls/{id}/copies/{copy}/review"
+	CopyPageImage  = "/controls/{id}/copies/{copy}/page/{n}"
+)
+
+// Review renders the split-view page for one copy: the scanned image on
+// the left, the editable form on the right.
+func (h *Controls) Review(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	copyNumber, ok := parseCopyPathValue(r.PathValue("copy"))
+	if !isValidControlID(id) || !ok {
+		middleware.WriteError(w, r, http.StatusNotFound, "Esa página no existe.")
+		return
+	}
+	control, err := h.Service.Get(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, controls.ErrControlNotFound) {
+			middleware.WriteError(w, r, http.StatusNotFound, "Ese control no existe.")
+			return
+		}
+		h.Log.Error("review: reading control", "error", err, "id", id)
+		middleware.WriteError(w, r, http.StatusInternalServerError,
+			"Algo se rompió en el servidor. Vuelve a intentarlo en unos segundos.")
+		return
+	}
+	reading, err := h.Service.ReadingFor(r.Context(), id, copyNumber)
+	if err != nil {
+		if errors.Is(err, controls.ErrReadingNotFound) {
+			middleware.WriteError(w, r, http.StatusNotFound,
+				"Aún no hay una lectura para esta copia. Sube el escaneo primero.")
+			return
+		}
+		h.Log.Error("review: reading not found", "error", err, "id", id, "copy", copyNumber)
+		middleware.WriteError(w, r, http.StatusInternalServerError,
+			"Algo se rompió en el servidor. Vuelve a intentarlo en unos segundos.")
+		return
+	}
+
+	page := view.ReviewPage{
+		Page:       middleware.PageFor(r, fmt.Sprintf("Copia %d", copyNumber)),
+		ControlID:  id,
+		Name:       control.Name,
+		CopyNumber: copyNumber,
+		BackURL:    controlDetailURL(id),
+		ImageURL:   controlPageImageURL(id, copyNumber, 1),
+		SaveURL:    controlReviewURL(id, copyNumber),
+		Graded:     control.State == controls.Graded,
+		RUT:        toReviewRUT(reading),
+		Questions:  toReviewQuestions(reading, h.Bank),
+	}
+	page.Flash = flash.Consume(w, r, h.secureCookie)
+	if err := view.RenderReview(w, page); err != nil {
+		h.Log.Error("rendering review", "error", err)
+	}
+}
+
+// PageImage serves the scanned page image for a copy. Path convention:
+// <workdir>/controls/<id>/scans/copy-<copy>-page-<n>.png. The naming is a
+// MODEL of what apps/amc-worker's getimages produces — the WP-F ADR-0031
+// note about "we depend on the engine's private storage" applies here
+// too. When the file is not on disk (which happens today because the
+// worker's actual naming is not yet pinned), the endpoint answers 404 and
+// the review page shows a broken-image icon rather than failing the
+// whole page.
+func (h *Controls) PageImage(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	copyNumber, okCopy := parseCopyPathValue(r.PathValue("copy"))
+	pageNumber, okPage := parseCopyPathValue(r.PathValue("n"))
+	if !isValidControlID(id) || !okCopy || !okPage {
+		middleware.WriteError(w, r, http.StatusNotFound, "Ese archivo no existe.")
+		return
+	}
+	// Bound the sanity check: absolutely never a 3-digit page number here,
+	// and never a copy number above the config max. Same reason the
+	// review page number lives in a path segment: the mux does not know.
+	if pageNumber < 1 || pageNumber > 99 || copyNumber < 1 || copyNumber > maxCopies {
+		middleware.WriteError(w, r, http.StatusNotFound, "Ese archivo no existe.")
+		return
+	}
+	// The lookup ensures the row is real — a scan image for a
+	// non-existent control never resolves.
+	if _, err := h.Service.Get(r.Context(), id); err != nil {
+		middleware.WriteError(w, r, http.StatusNotFound, "Ese control no existe.")
+		return
+	}
+	path := filepath.Join(h.Service.ProjectDir(id), "scans",
+		fmt.Sprintf("copy-%d-page-%d.png", copyNumber, pageNumber))
+	f, err := os.Open(path)
+	if err != nil {
+		middleware.WriteError(w, r, http.StatusNotFound, "La imagen escaneada no está disponible.")
+		return
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		middleware.WriteError(w, r, http.StatusInternalServerError, "")
+		return
+	}
+	w.Header().Set("Content-Type", "image/png")
+	http.ServeContent(w, r, "page.png", info.ModTime(), f)
+}
+
+// parseCopyPathValue turns a path segment into a positive int. Empty and
+// negative reject.
+func parseCopyPathValue(raw string) (int, bool) {
+	if raw == "" {
+		return 0, false
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 1 {
+		return 0, false
+	}
+	return n, true
+}
+
+func controlPageImageURL(id string, copyNumber, pageNumber int) string {
+	return fmt.Sprintf("%s/copies/%d/page/%d", controlDetailURL(id), copyNumber, pageNumber)
+}
+
+func toReviewRUT(r controls.Reading) view.ReviewRUT {
+	rut := view.ReviewRUT{
+		Status:  string(r.RUTStatus),
+		WasRead: r.RUTRead != nil,
+	}
+	if r.RUTOverride != nil {
+		rut.Value = r.RUTOverride.RUT
+		rut.Overridden = true
+	} else if r.RUTRead != nil {
+		rut.Value = *r.RUTRead
+	}
+	if r.RUTRead != nil {
+		rut.OriginalRead = *r.RUTRead
+	}
+	return rut
+}
+
+func toReviewQuestions(r controls.Reading, b *bank.Bank) []view.ReviewQuestion {
+	out := make([]view.ReviewQuestion, 0, len(r.Answers))
+	for i, a := range r.Answers {
+		q := view.ReviewQuestion{
+			Index:        i + 1,
+			QuestionRef:  a.QuestionRef,
+			Statement:    lookupStatement(b, a.QuestionRef),
+			Type:         string(a.QuestionType),
+			Alternatives: alternativesFor(a, lookupAlternatives(b, a.QuestionRef)),
+			OriginalRead: originalReadLabel(a),
+		}
+		if a.Override != nil {
+			q.Overridden = true
+			q.Selected = a.Override.Marked
+			q.Status = string(a.Override.Status)
+		} else {
+			q.Selected = a.Marked
+			q.Status = string(a.Status)
+		}
+		out = append(out, q)
+	}
+	return out
+}
+
+func alternativesFor(a controls.Answer, labels []string) []view.ReviewAlternative {
+	// If we have no bank info, still render one option per marked slot so
+	// the form remains editable.
+	max := len(labels)
+	if max == 0 {
+		max = int(a.Max)
+	}
+	if max == 0 {
+		max = 4 // sensible default; a professor can still edit
+	}
+	out := make([]view.ReviewAlternative, max)
+	for i := 0; i < max; i++ {
+		label := fmt.Sprintf("Opción %d", i+1)
+		if i < len(labels) {
+			label = labels[i]
+		}
+		out[i] = view.ReviewAlternative{Index: i + 1, Label: label}
+	}
+	return out
+}
+
+func lookupStatement(b *bank.Bank, ref string) string {
+	if b == nil {
+		return ref
+	}
+	for _, q := range b.Questions {
+		if q.ID == ref {
+			return q.Statement
+		}
+	}
+	return ref
+}
+
+func lookupAlternatives(b *bank.Bank, ref string) []string {
+	if b == nil {
+		return nil
+	}
+	for _, q := range b.Questions {
+		if q.ID == ref {
+			return q.Alternatives
+		}
+	}
+	return nil
+}
+
+func originalReadLabel(a controls.Answer) string {
+	if a.Override == nil {
+		return ""
+	}
+	// "AMC leyó: 2" or "AMC leyó: 1,3" or "AMC leyó: —"
+	if len(a.Marked) == 0 {
+		return "AMC leyó: —"
+	}
+	parts := make([]string, len(a.Marked))
+	for i, m := range a.Marked {
+		parts[i] = strconv.Itoa(m)
+	}
+	return "AMC leyó: " + strings.Join(parts, ",")
+}

--- a/apps/server/internal/app/web/handler/review.go
+++ b/apps/server/internal/app/web/handler/review.go
@@ -225,13 +225,13 @@ func statusFor(marks []int, qtype controls.QuestionType) controls.AnswerStatus {
 }
 
 // PageImage serves the scanned page image for a copy. Path convention:
-// <workdir>/controls/<id>/scans/copy-<copy>-page-<n>.png. The naming is a
-// MODEL of what apps/amc-worker's getimages produces — the WP-F ADR-0031
-// note about "we depend on the engine's private storage" applies here
-// too. When the file is not on disk (which happens today because the
-// worker's actual naming is not yet pinned), the endpoint answers 404 and
-// the review page shows a broken-image icon rather than failing the
-// whole page.
+// <workdir>/controls/<id>/scans/copy-<copy>-page-<n>.png. This shape is
+// part of the WORKER CONTRACT (ADR-0037) — the same class of promise
+// as /generate's response paths — so a fallback engine has to satisfy
+// the same names. The paper check (ADR-0030 §Not yet proven) is what
+// pins the exact filename against real AMC output. Until then the
+// endpoint answers 404 when the file is not on disk and the review
+// page shows a broken-image icon rather than failing the whole page.
 func (h *Controls) PageImage(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	copyNumber, okCopy := parseCopyPathValue(r.PathValue("copy"))

--- a/apps/server/internal/app/web/handler/review.go
+++ b/apps/server/internal/app/web/handler/review.go
@@ -104,10 +104,23 @@ func (h *Controls) SaveReview(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	rut := strings.TrimSpace(r.PostFormValue("rut"))
+	// SEC-1: the template's pattern="[0-9]{8}" is client-side; the
+	// professor's form goes to the RUT override table verbatim, so an
+	// arbitrary string would persist. Reject anything that is not eight
+	// digits — the review handler is authenticated but a defensive server
+	// check is cheap and stops the field from carrying garbage the rest
+	// of the surface treats as an 8-digit id.
+	if rut != "" && !isValidRUT(rut) {
+		flash.Set(w, h.secureCookie, "El RUT debe tener 8 dígitos.")
+		http.Redirect(w, r, controlReviewURL(id, copyNumber), http.StatusSeeOther)
+		return
+	}
+
 	req := controls.SaveOverridesRequest{
 		ControlID:  id,
 		CopyNumber: copyNumber,
-		RUT:        strings.TrimSpace(r.PostFormValue("rut")),
+		RUT:        rut,
 	}
 	blank := r.PostFormValue("blank") // "" or one question_ref
 	for _, a := range reading.Answers {
@@ -118,7 +131,14 @@ func (h *Controls) SaveReview(w http.ResponseWriter, r *http.Request) {
 		} else {
 			field := "q" + a.QuestionRef
 			values := r.PostForm[field]
-			marks, err := parseAnswerValues(values)
+			// SEC-2: cap the mark index at the answer's known alternative
+			// count — the form was never generated with options past
+			// a.Max, so anything higher is data pollution.
+			maxMark := int(a.Max)
+			if maxMark < 1 {
+				maxMark = 26 // fallback cap (a professor cannot author more)
+			}
+			marks, err := parseAnswerValues(values, maxMark)
 			if err != nil {
 				flash.Set(w, h.secureCookie, "El formulario tiene un valor inválido.")
 				http.Redirect(w, r, controlReviewURL(id, copyNumber), http.StatusSeeOther)
@@ -144,9 +164,11 @@ func (h *Controls) SaveReview(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
 }
 
-// parseAnswerValues turns form values ("1", "3") into a sorted int slice.
-// Empty is legal (a blank answer).
-func parseAnswerValues(values []string) ([]int, error) {
+// parseAnswerValues turns form values ("1", "3") into an int slice,
+// preserving the order the form submitted. Empty is legal (a blank
+// answer). Anything above maxMark is refused — the form was never
+// generated with those options.
+func parseAnswerValues(values []string, maxMark int) ([]int, error) {
 	if len(values) == 0 {
 		return nil, nil
 	}
@@ -161,6 +183,9 @@ func parseAnswerValues(values []string) ([]int, error) {
 		if err != nil || n < 1 {
 			return nil, fmt.Errorf("bad value %q", v)
 		}
+		if n > maxMark {
+			return nil, fmt.Errorf("value %d exceeds this question's alternatives (%d)", n, maxMark)
+		}
 		if seen[n] {
 			continue
 		}
@@ -168,6 +193,21 @@ func parseAnswerValues(values []string) ([]int, error) {
 		out = append(out, n)
 	}
 	return out, nil
+}
+
+// isValidRUT: exactly 8 digits. The check the client-side pattern
+// makes, moved to the server so a hand-crafted POST cannot store
+// arbitrary bytes in the RUT override table.
+func isValidRUT(s string) bool {
+	if len(s) != 8 {
+		return false
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // statusFor decides the AnswerStatus a saved edit lands at. For a simple
@@ -267,12 +307,13 @@ func toReviewRUT(r controls.Reading) view.ReviewRUT {
 func toReviewQuestions(r controls.Reading, b *bank.Bank) []view.ReviewQuestion {
 	out := make([]view.ReviewQuestion, 0, len(r.Answers))
 	for i, a := range r.Answers {
+		bq, hasBank := lookupQuestion(b, a.QuestionRef)
 		q := view.ReviewQuestion{
 			Index:        i + 1,
 			QuestionRef:  a.QuestionRef,
-			Statement:    lookupStatement(b, a.QuestionRef),
+			Statement:    statementOr(bq, hasBank, a.QuestionRef),
 			Type:         string(a.QuestionType),
-			Alternatives: alternativesFor(a, lookupAlternatives(b, a.QuestionRef)),
+			Alternatives: alternativesFor(a, bq, hasBank),
 			OriginalRead: originalReadLabel(a),
 		}
 		if a.Override != nil {
@@ -288,9 +329,28 @@ func toReviewQuestions(r controls.Reading, b *bank.Bank) []view.ReviewQuestion {
 	return out
 }
 
-func alternativesFor(a controls.Answer, labels []string) []view.ReviewAlternative {
-	// If we have no bank info, still render one option per marked slot so
-	// the form remains editable.
+// lookupQuestion resolves a bank ref through the O(1) FindQuestion added
+// for WP-F. Returns hasBank=false when the bank is nil (test paths) or the
+// ref is not authored — callers fall back to a generic label.
+func lookupQuestion(b *bank.Bank, ref string) (bank.Question, bool) {
+	if b == nil {
+		return bank.Question{}, false
+	}
+	return b.FindQuestion(ref)
+}
+
+func statementOr(q bank.Question, has bool, ref string) string {
+	if has {
+		return q.Statement
+	}
+	return ref
+}
+
+func alternativesFor(a controls.Answer, q bank.Question, has bool) []view.ReviewAlternative {
+	labels := q.Alternatives
+	if !has {
+		labels = nil
+	}
 	max := len(labels)
 	if max == 0 {
 		max = int(a.Max)
@@ -307,30 +367,6 @@ func alternativesFor(a controls.Answer, labels []string) []view.ReviewAlternativ
 		out[i] = view.ReviewAlternative{Index: i + 1, Label: label}
 	}
 	return out
-}
-
-func lookupStatement(b *bank.Bank, ref string) string {
-	if b == nil {
-		return ref
-	}
-	for _, q := range b.Questions {
-		if q.ID == ref {
-			return q.Statement
-		}
-	}
-	return ref
-}
-
-func lookupAlternatives(b *bank.Bank, ref string) []string {
-	if b == nil {
-		return nil
-	}
-	for _, q := range b.Questions {
-		if q.ID == ref {
-			return q.Alternatives
-		}
-	}
-	return nil
 }
 
 func originalReadLabel(a controls.Answer) string {

--- a/apps/server/internal/app/web/handler/review.go
+++ b/apps/server/internal/app/web/handler/review.go
@@ -73,6 +73,117 @@ func (h *Controls) Review(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// SaveReview handles POST /controls/:id/copies/:copy/review. Reads the
+// form values, hands them to the Service, and flashes back to the detail
+// page.
+func (h *Controls) SaveReview(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	copyNumber, ok := parseCopyPathValue(r.PathValue("copy"))
+	if !isValidControlID(id) || !ok {
+		middleware.WriteError(w, r, http.StatusNotFound, "Esa página no existe.")
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		flash.Set(w, h.secureCookie, "No se pudo leer el formulario. Inténtalo de nuevo.")
+		http.Redirect(w, r, controlReviewURL(id, copyNumber), http.StatusSeeOther)
+		return
+	}
+	// Load the reading so we know which question refs live on it — the
+	// form fields are named `q<ref>`, and enumerating them from the
+	// reading avoids trusting the client with the set of refs.
+	reading, err := h.Service.ReadingFor(r.Context(), id, copyNumber)
+	if err != nil {
+		if errors.Is(err, controls.ErrReadingNotFound) {
+			middleware.WriteError(w, r, http.StatusNotFound,
+				"Aún no hay una lectura para esta copia. Sube el escaneo primero.")
+			return
+		}
+		h.Log.Error("save review: reading", "error", err, "id", id, "copy", copyNumber)
+		middleware.WriteError(w, r, http.StatusInternalServerError,
+			"Algo se rompió en el servidor. Vuelve a intentarlo en unos segundos.")
+		return
+	}
+
+	req := controls.SaveOverridesRequest{
+		ControlID:  id,
+		CopyNumber: copyNumber,
+		RUT:        strings.TrimSpace(r.PostFormValue("rut")),
+	}
+	blank := r.PostFormValue("blank") // "" or one question_ref
+	for _, a := range reading.Answers {
+		edit := controls.AnswerEdit{QuestionRef: a.QuestionRef}
+		if a.QuestionRef == blank {
+			edit.Marked = nil
+			edit.Status = controls.AnswerStatusBlank
+		} else {
+			field := "q" + a.QuestionRef
+			values := r.PostForm[field]
+			marks, err := parseAnswerValues(values)
+			if err != nil {
+				flash.Set(w, h.secureCookie, "El formulario tiene un valor inválido.")
+				http.Redirect(w, r, controlReviewURL(id, copyNumber), http.StatusSeeOther)
+				return
+			}
+			edit.Marked = marks
+			edit.Status = statusFor(marks, a.QuestionType)
+		}
+		req.Answers = append(req.Answers, edit)
+	}
+
+	if err := h.Service.SaveOverrides(r.Context(), req); err != nil {
+		h.Log.Error("save review", "error", err, "id", id, "copy", copyNumber)
+		middleware.WriteError(w, r, http.StatusInternalServerError,
+			"El servidor no pudo guardar los cambios. Vuelve a intentarlo.")
+		return
+	}
+	if blank != "" {
+		flash.Set(w, h.secureCookie, fmt.Sprintf("Pregunta %s marcada en blanco.", blank))
+	} else {
+		flash.Set(w, h.secureCookie, "Cambios guardados.")
+	}
+	http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
+}
+
+// parseAnswerValues turns form values ("1", "3") into a sorted int slice.
+// Empty is legal (a blank answer).
+func parseAnswerValues(values []string) ([]int, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	out := make([]int, 0, len(values))
+	seen := map[int]bool{}
+	for _, v := range values {
+		v = strings.TrimSpace(v)
+		if v == "" {
+			continue
+		}
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 1 {
+			return nil, fmt.Errorf("bad value %q", v)
+		}
+		if seen[n] {
+			continue
+		}
+		seen[n] = true
+		out = append(out, n)
+	}
+	return out, nil
+}
+
+// statusFor decides the AnswerStatus a saved edit lands at. For a simple
+// question with more than one mark the professor has produced something
+// impossible via the form — but leaving the branch in matches the report's
+// own contract.
+func statusFor(marks []int, qtype controls.QuestionType) controls.AnswerStatus {
+	if len(marks) == 0 {
+		return controls.AnswerStatusBlank
+	}
+	if qtype == controls.QuestionSimple && len(marks) > 1 {
+		return controls.AnswerStatusAmbiguous
+	}
+	return controls.AnswerStatusOK
+}
+
 // PageImage serves the scanned page image for a copy. Path convention:
 // <workdir>/controls/<id>/scans/copy-<copy>-page-<n>.png. The naming is a
 // MODEL of what apps/amc-worker's getimages produces — the WP-F ADR-0031

--- a/apps/server/internal/app/web/handler/review_test.go
+++ b/apps/server/internal/app/web/handler/review_test.go
@@ -1,0 +1,131 @@
+package handler_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+)
+
+func TestReviewPageRendersEditableFormForACopy(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control review", 2)
+
+	f.fake.AnalyzeReports = []controls.Report{
+		{Copies: map[string]controls.ReportCopy{
+			"1": {RUT: "20123456", RUTStatus: controls.RUTStatusOK, Status: controls.CopyStatusOK,
+				ExpectedQuestions: 2, SeenQuestions: 2,
+				Answers: []controls.ReportAnswer{
+					{Question: 1, Name: "q3", Type: controls.QuestionSimple, Marked: []int{1},
+						Status: controls.AnswerStatusOK, Score: 1, Max: 1},
+					{Question: 2, Name: "q4", Type: controls.QuestionMultiple, Marked: []int{1, 2},
+						Status: controls.AnswerStatusOK, Score: 4, Max: 4},
+				}},
+		}},
+	}
+	uploadOnce(t, f, controlID)
+
+	req := f.authedRequest(t, http.MethodGet, "/controls/"+controlID+"/copies/1/review", nil)
+	req.SetPathValue("id", controlID)
+	req.SetPathValue("copy", "1")
+	rec := httptest.NewRecorder()
+	f.handler.Review(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d\nbody: %s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		"copia 1",
+		"20123456",
+		"form",
+		`name="csrf_token"`,
+		`type="radio"`,    // simple question
+		`type="checkbox"`, // multiple question
+		"Marcar en blanco",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("review page missing %q\n--- body ---\n%s", want, body)
+		}
+	}
+}
+
+func TestReviewPageReturnsErrorForACopyWithoutAReading(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control no reads", 2)
+
+	req := f.authedRequest(t, http.MethodGet, "/controls/"+controlID+"/copies/1/review", nil)
+	req.SetPathValue("id", controlID)
+	req.SetPathValue("copy", "1")
+	rec := httptest.NewRecorder()
+	f.handler.Review(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestPageImageServesPngWhenPresent(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control image", 1)
+
+	scansDir := filepath.Join(f.workDir, "controls", controlID, "scans")
+	if err := os.MkdirAll(scansDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(scansDir, "copy-1-page-1.png"), fakePNG(), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	req := f.authedRequest(t, http.MethodGet, "/controls/"+controlID+"/copies/1/page/1", nil)
+	req.SetPathValue("id", controlID)
+	req.SetPathValue("copy", "1")
+	req.SetPathValue("n", "1")
+	rec := httptest.NewRecorder()
+	f.handler.PageImage(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d\nbody: %s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "image/png" {
+		t.Errorf("Content-Type = %q, want image/png", ct)
+	}
+	if rec.Body.Len() == 0 {
+		t.Error("empty body")
+	}
+}
+
+func TestPageImageReturns404WhenNotOnDisk(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control image missing", 1)
+
+	req := f.authedRequest(t, http.MethodGet, "/controls/"+controlID+"/copies/1/page/1", nil)
+	req.SetPathValue("id", controlID)
+	req.SetPathValue("copy", "1")
+	req.SetPathValue("n", "1")
+	rec := httptest.NewRecorder()
+	f.handler.PageImage(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
+// fakePNG returns the smallest valid PNG (1x1 transparent).
+func fakePNG() []byte {
+	return []byte{
+		0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+		0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+		0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+		0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+		0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41,
+		0x54, 0x78, 0x9C, 0x63, 0x00, 0x01, 0x00, 0x00,
+		0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00,
+		0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
+		0x42, 0x60, 0x82,
+	}
+}

--- a/apps/server/internal/app/web/handler/save_review_test.go
+++ b/apps/server/internal/app/web/handler/save_review_test.go
@@ -1,0 +1,113 @@
+package handler_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+)
+
+func TestSaveReviewOverridesLandAndFlashConfirms(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control save", 1)
+
+	// A doubtful mark on the simple question — the professor will
+	// override it to a confident answer.
+	f.fake.AnalyzeReports = []controls.Report{
+		{Copies: map[string]controls.ReportCopy{
+			"1": {RUT: "20111111", RUTStatus: controls.RUTStatusOK, Status: controls.CopyStatusNeedsReview,
+				ExpectedQuestions: 2, SeenQuestions: 2,
+				Answers: []controls.ReportAnswer{
+					{Question: 1, Name: "q3", Type: controls.QuestionSimple,
+						Marked: nil, Status: controls.AnswerStatusDoubtful,
+						Doubtful: []controls.Doubtful{{Answer: 1, Darkness: 0.15}},
+						Score:    0, Max: 1},
+					{Question: 2, Name: "q4", Type: controls.QuestionMultiple,
+						Marked: []int{1}, Status: controls.AnswerStatusOK, Score: 4, Max: 4},
+				}},
+		}},
+	}
+	uploadOnce(t, f, controlID)
+
+	// Simulate the form: RUT unchanged, override q3 to option 1.
+	values := url.Values{}
+	values.Set("rut", "20111111")
+	values.Set("qq3", "1") // simple: one value
+	values.Set("qq4", "1") // multiple: unchanged (still option 1)
+	values.Set("save", "1")
+
+	req := httptest.NewRequest(http.MethodPost, "/controls/"+controlID+"/copies/1/review",
+		strings.NewReader(values.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetPathValue("id", controlID)
+	req.SetPathValue("copy", "1")
+	req = req.WithContext(f.authedRequest(t, http.MethodPost, "/", nil).Context())
+	rec := httptest.NewRecorder()
+	f.handler.SaveReview(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("save status = %d\nbody: %s", rec.Code, rec.Body.String())
+	}
+	// The override landed — the reading now carries an override on q3.
+	reading, err := f.service.ReadingFor(f.authedRequest(t, http.MethodGet, "/", nil).Context(), controlID, 1)
+	if err != nil {
+		t.Fatalf("ReadingFor: %v", err)
+	}
+	var q3 *controls.Answer
+	for i := range reading.Answers {
+		if reading.Answers[i].QuestionRef == "q3" {
+			q3 = &reading.Answers[i]
+		}
+	}
+	if q3 == nil || q3.Override == nil {
+		t.Fatalf("q3 override = %+v", q3)
+	}
+	if q3.Override.Status != controls.AnswerStatusOK || len(q3.Override.Marked) != 1 || q3.Override.Marked[0] != 1 {
+		t.Errorf("q3 override wrong = %+v", q3.Override)
+	}
+}
+
+func TestSaveReviewBlankButtonClearsAnswer(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control blank", 1)
+	f.fake.AnalyzeReports = []controls.Report{
+		{Copies: map[string]controls.ReportCopy{
+			"1": {RUT: "20111111", RUTStatus: controls.RUTStatusOK, Status: controls.CopyStatusNeedsReview,
+				ExpectedQuestions: 2, SeenQuestions: 2,
+				Answers: []controls.ReportAnswer{
+					{Question: 1, Name: "q3", Type: controls.QuestionSimple, Marked: []int{1},
+						Status: controls.AnswerStatusOK, Score: 1, Max: 1},
+					{Question: 2, Name: "q4", Type: controls.QuestionMultiple, Marked: []int{1},
+						Status: controls.AnswerStatusOK, Score: 4, Max: 4},
+				}},
+		}},
+	}
+	uploadOnce(t, f, controlID)
+
+	values := url.Values{}
+	values.Set("rut", "20111111")
+	values.Set("blank", "q3")
+	req := httptest.NewRequest(http.MethodPost, "/controls/"+controlID+"/copies/1/review",
+		strings.NewReader(values.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetPathValue("id", controlID)
+	req.SetPathValue("copy", "1")
+	req = req.WithContext(f.authedRequest(t, http.MethodPost, "/", nil).Context())
+	rec := httptest.NewRecorder()
+	f.handler.SaveReview(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("save status = %d", rec.Code)
+	}
+	reading, _ := f.service.ReadingFor(f.authedRequest(t, http.MethodGet, "/", nil).Context(), controlID, 1)
+	for _, a := range reading.Answers {
+		if a.QuestionRef == "q3" {
+			if a.Override == nil || a.Override.Status != controls.AnswerStatusBlank {
+				t.Errorf("q3 not blanked: %+v", a.Override)
+			}
+		}
+	}
+}

--- a/apps/server/internal/app/web/handler/scans.go
+++ b/apps/server/internal/app/web/handler/scans.go
@@ -4,6 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/so77id/nalanda/apps/server/internal/app/web/flash"
 	"github.com/so77id/nalanda/apps/server/internal/app/web/middleware"
@@ -192,8 +195,8 @@ func parseFloatField(raw string, fallback float64) float64 {
 	if raw == "" {
 		return fallback
 	}
-	var v float64
-	if _, err := fmt.Sscanf(raw, "%f", &v); err != nil {
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
 		return fallback
 	}
 	return v
@@ -206,7 +209,7 @@ func looksLikePDF(filename, contentType string) bool {
 		return true
 	}
 	// A missing content-type is common when the browser cannot infer one;
-	// the filename is what saves the round trip.
-	n := len(filename)
-	return n >= 4 && (filename[n-4:] == ".pdf" || filename[n-4:] == ".PDF")
+	// the filename is what saves the round trip. EqualFold catches .Pdf,
+	// .PDF and friends.
+	return strings.EqualFold(filepath.Ext(filename), ".pdf")
 }

--- a/apps/server/internal/app/web/handler/scans.go
+++ b/apps/server/internal/app/web/handler/scans.go
@@ -1,0 +1,114 @@
+package handler
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/so77id/nalanda/apps/server/internal/app/web/flash"
+	"github.com/so77id/nalanda/apps/server/internal/app/web/middleware"
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+)
+
+// ControlScansPath is POST target for the upload form on /controls/:id.
+const ControlScansPath = "/controls/{id}/scans"
+
+// scanFormField is the multipart field the upload form posts under.
+const scanFormField = "scan"
+
+// UploadScan reads the multipart form, streams the PDF onto disk through the
+// Service, and redirects back to /controls/:id with a flash message. Failure
+// modes are visible to the professor as a redirect + flash; the 500 shell is
+// reserved for the "operator has to look" ones (unknown control, worker
+// unreachable).
+func (h *Controls) UploadScan(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if !isValidControlID(id) {
+		middleware.WriteError(w, r, http.StatusNotFound, "Ese control no existe.")
+		return
+	}
+
+	// http.MaxBytesReader wraps r.Body so any read past MaxScanBytes returns
+	// an error. FormFile below reads it, so the limit is enforced there.
+	if h.MaxScanBytes > 0 {
+		r.Body = http.MaxBytesReader(w, r.Body, h.MaxScanBytes)
+	}
+
+	// ParseMultipartForm decides how many bytes are kept in memory; the rest
+	// spills to a temp file. 32 MiB matches Go's default and is comfortably
+	// above a single-copy scan.
+	if err := r.ParseMultipartForm(32 << 20); err != nil {
+		var mbe *http.MaxBytesError
+		if errors.As(err, &mbe) {
+			flash.Set(w, h.secureCookie,
+				fmt.Sprintf("El PDF excede el máximo de %d MB.", h.MaxScanBytes>>20))
+			http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
+			return
+		}
+		flash.Set(w, h.secureCookie, "No se pudo leer el formulario. Vuelve a intentarlo.")
+		http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
+		return
+	}
+
+	file, header, err := r.FormFile(scanFormField)
+	if err != nil {
+		flash.Set(w, h.secureCookie, "Elige un PDF antes de subir.")
+		http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
+		return
+	}
+	// FormFile's returned reader honours the same body limit MaxBytesReader
+	// wrapped above — a file the header claims is small but reads long is
+	// still refused.
+
+	// A minimal content-type / filename sniff. The worker refuses non-PDFs
+	// itself, but a nicer message here saves a round trip when a professor
+	// picks the wrong file.
+	if !looksLikePDF(header.Filename, header.Header.Get("Content-Type")) {
+		_ = file.Close()
+		flash.Set(w, h.secureCookie, "El archivo debe ser un PDF.")
+		http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
+		return
+	}
+
+	result, err := h.Service.UploadScan(r.Context(), controls.UploadRequest{
+		ControlID: id,
+		Filename:  header.Filename,
+		Content:   file,
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, controls.ErrControlNotFound):
+			middleware.WriteError(w, r, http.StatusNotFound, "Ese control no existe.")
+		case errors.Is(err, controls.ErrAnalyzerRefused):
+			h.Log.Warn("controls: worker refused scan", "control", id, "error", err)
+			flash.Set(w, h.secureCookie,
+				"El motor de lectura rechazó el archivo. Revisa que sea un escaneo del control correcto.")
+			http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
+		case errors.Is(err, controls.ErrAnalyzerUnavailable):
+			h.Log.Error("controls: worker unreachable", "control", id, "error", err)
+			middleware.WriteError(w, r, http.StatusInternalServerError,
+				"El motor de lectura no está disponible. Vuelve a intentarlo en unos minutos; si el problema persiste, avisa a infraestructura.")
+		default:
+			h.Log.Error("controls: upload failed", "control", id, "error", err)
+			middleware.WriteError(w, r, http.StatusInternalServerError,
+				"El servidor no pudo procesar el escaneo. Vuelve a intentarlo en unos minutos.")
+		}
+		return
+	}
+
+	flash.Set(w, h.secureCookie,
+		fmt.Sprintf("Escaneo %d procesado (%d copias leídas).", result.BatchNumber, len(result.Report.Copies)))
+	http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
+}
+
+// looksLikePDF is a defensive check the professor sees a nice message
+// against — the worker refuses non-PDFs itself.
+func looksLikePDF(filename, contentType string) bool {
+	if contentType == "application/pdf" {
+		return true
+	}
+	// A missing content-type is common when the browser cannot infer one;
+	// the filename is what saves the round trip.
+	n := len(filename)
+	return n >= 4 && (filename[n-4:] == ".pdf" || filename[n-4:] == ".PDF")
+}

--- a/apps/server/internal/app/web/handler/scans.go
+++ b/apps/server/internal/app/web/handler/scans.go
@@ -13,6 +13,19 @@ import (
 // ControlScansPath is POST target for the upload form on /controls/:id.
 const ControlScansPath = "/controls/{id}/scans"
 
+// ControlReanalyzePath is POST target for the "re-leer con otra
+// sensibilidad" form.
+const ControlReanalyzePath = "/controls/{id}/reanalyze"
+
+// ControlClosePath is POST target for "Cerrar corrección" (S8).
+const ControlClosePath = "/controls/{id}/close"
+
+// Defaults for the reanalyze form, mirroring apps/amc-worker.
+const (
+	defaultTicked = 0.30
+	defaultUnsure = 0.10
+)
+
 // scanFormField is the multipart field the upload form posts under.
 const scanFormField = "scan"
 
@@ -99,6 +112,91 @@ func (h *Controls) UploadScan(w http.ResponseWriter, r *http.Request) {
 	flash.Set(w, h.secureCookie,
 		fmt.Sprintf("Escaneo %d procesado (%d copias leídas).", result.BatchNumber, len(result.Report.Copies)))
 	http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
+}
+
+// ReanalyzeScans handles POST /controls/:id/reanalyze. Reads ticked/unsure
+// from the form (defaults if empty), asks the Service to re-read the
+// captured project at those thresholds, and redirects to detail with a
+// flash.
+func (h *Controls) ReanalyzeScans(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if !isValidControlID(id) {
+		middleware.WriteError(w, r, http.StatusNotFound, "Ese control no existe.")
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		flash.Set(w, h.secureCookie, "No se pudo leer el formulario.")
+		http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
+		return
+	}
+	ticked := parseFloatField(r.PostFormValue("ticked"), defaultTicked)
+	unsure := parseFloatField(r.PostFormValue("unsure"), defaultUnsure)
+	if ticked <= 0 || ticked >= 1 || unsure < 0 || unsure >= ticked {
+		flash.Set(w, h.secureCookie,
+			"Los umbrales deben cumplir 0 < inseguro < marcado < 1.")
+		http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
+		return
+	}
+	if _, err := h.Service.Reanalyze(r.Context(), id, ticked, unsure); err != nil {
+		switch {
+		case errors.Is(err, controls.ErrControlNotFound):
+			middleware.WriteError(w, r, http.StatusNotFound, "Ese control no existe.")
+		case errors.Is(err, controls.ErrAnalyzerRefused):
+			h.Log.Warn("controls: worker refused reanalyze", "control", id, "error", err)
+			flash.Set(w, h.secureCookie,
+				"El motor rechazó re-leer. Puede que aún no haya escaneos subidos.")
+			http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
+		case errors.Is(err, controls.ErrAnalyzerUnavailable):
+			h.Log.Error("controls: worker unreachable during reanalyze", "control", id, "error", err)
+			middleware.WriteError(w, r, http.StatusInternalServerError,
+				"El motor no está disponible. Vuelve a intentarlo en unos minutos.")
+		default:
+			h.Log.Error("controls: reanalyze failed", "control", id, "error", err)
+			middleware.WriteError(w, r, http.StatusInternalServerError,
+				"El servidor no pudo re-leer el lote.")
+		}
+		return
+	}
+	flash.Set(w, h.secureCookie,
+		fmt.Sprintf("Lote re-leído (marcado: %.2f, inseguro: %.2f).", ticked, unsure))
+	http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
+}
+
+// CloseCorrection handles POST /controls/:id/close.
+func (h *Controls) CloseCorrection(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if !isValidControlID(id) {
+		middleware.WriteError(w, r, http.StatusNotFound, "Ese control no existe.")
+		return
+	}
+	if err := h.Service.CloseCorrection(r.Context(), id); err != nil {
+		switch {
+		case errors.Is(err, controls.ErrControlNotFound):
+			middleware.WriteError(w, r, http.StatusNotFound, "Ese control no existe.")
+		case errors.Is(err, controls.ErrCloseBlocked):
+			flash.Set(w, h.secureCookie,
+				"No se puede cerrar todavía: aún hay copias sin resolver.")
+			http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
+		default:
+			h.Log.Error("close correction", "control", id, "error", err)
+			middleware.WriteError(w, r, http.StatusInternalServerError,
+				"El servidor no pudo cerrar la corrección.")
+		}
+		return
+	}
+	flash.Set(w, h.secureCookie, "Corrección cerrada.")
+	http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
+}
+
+func parseFloatField(raw string, fallback float64) float64 {
+	if raw == "" {
+		return fallback
+	}
+	var v float64
+	if _, err := fmt.Sscanf(raw, "%f", &v); err != nil {
+		return fallback
+	}
+	return v
 }
 
 // looksLikePDF is a defensive check the professor sees a nice message

--- a/apps/server/internal/app/web/handler/scans_test.go
+++ b/apps/server/internal/app/web/handler/scans_test.go
@@ -1,0 +1,151 @@
+package handler_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+	"github.com/so77id/nalanda/apps/server/internal/domain/course/bank"
+)
+
+// createControl runs the domain Service to make a real control with N
+// copies and returns its id. Handler tests hang off this so a scan test
+// starts from a valid on-disk project rather than a hand-built fixture.
+func (f *controlsFixture) createControl(t *testing.T, name string, copies int) string {
+	t.Helper()
+	ctx := context.Background()
+	c, err := f.service.Create(ctx, controls.CreateRequest{
+		Name:             name,
+		RangeFrom:        bank.SectionRef{Document: "flujo", Section: "if-else"},
+		RangeTo:          bank.SectionRef{Document: "flujo", Section: "bucles"},
+		QuestionsPerCopy: 2,
+		Copies:           copies,
+		CreatedBy:        f.user.ID,
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	return c.ID
+}
+
+// buildScanUpload writes a multipart body with a single PDF part.
+func buildScanUpload(t *testing.T, filename, contentType string, body []byte) (*bytes.Buffer, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	partHeader := make(map[string][]string)
+	partHeader["Content-Disposition"] = []string{
+		fmt.Sprintf(`form-data; name="scan"; filename="%s"`, filename),
+	}
+	if contentType != "" {
+		partHeader["Content-Type"] = []string{contentType}
+	}
+	part, err := w.CreatePart(partHeader)
+	if err != nil {
+		t.Fatalf("CreatePart: %v", err)
+	}
+	if _, err := part.Write(body); err != nil {
+		t.Fatalf("write body: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("close writer: %v", err)
+	}
+	return &buf, w.FormDataContentType()
+}
+
+func TestUploadScanCallsAnalyzerAndFlashesSuccess(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control 1", 3)
+
+	// Pre-load a report so the fake returns it.
+	f.fake.AnalyzeReports = []controls.Report{
+		{Copies: map[string]controls.ReportCopy{
+			"1": {RUT: "20123456", RUTStatus: controls.RUTStatusOK, Status: controls.CopyStatusOK,
+				ExpectedQuestions: 2, SeenQuestions: 2,
+				Answers: []controls.ReportAnswer{
+					{Question: 1, Name: "q3", Type: controls.QuestionSimple,
+						Marked: []int{1}, Status: controls.AnswerStatusOK, Score: 1, Max: 1},
+					{Question: 2, Name: "q4", Type: controls.QuestionMultiple,
+						Marked: []int{1}, Status: controls.AnswerStatusOK, Score: 4, Max: 4},
+				}},
+		}},
+	}
+
+	body, ct := buildScanUpload(t, "batch.pdf", "application/pdf", []byte("%PDF-fake"))
+	req := f.authedRequest(t, http.MethodPost, "/controls/"+controlID+"/scans", nil)
+	req.Body = io.NopCloser(body)
+	req.Header.Set("Content-Type", ct)
+	req.ContentLength = int64(body.Len())
+	req.SetPathValue("id", controlID)
+
+	rec := httptest.NewRecorder()
+	f.handler.UploadScan(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303", rec.Code)
+	}
+	if got := rec.Header().Get("Location"); got != "/controls/"+controlID {
+		t.Errorf("Location = %q", got)
+	}
+	if count := f.fake.AnalyzeCallCount(); count != 1 {
+		t.Errorf("AnalyzeCallCount = %d, want 1", count)
+	}
+	last, _ := f.fake.LastAnalyzeCall()
+	if !strings.HasPrefix(last.Project, "controls/") {
+		t.Errorf("Analyze project = %q, want prefix controls/", last.Project)
+	}
+	// The uploaded PDF landed on disk.
+	uploads := filepath.Join(f.workDir, "controls", controlID, "uploads")
+	entries, _ := os.ReadDir(uploads)
+	if len(entries) != 1 || entries[0].Name() != "batch-1.pdf" {
+		t.Errorf("uploads dir = %v", entries)
+	}
+}
+
+func TestUploadScanRejectsNonPDF(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control 2", 2)
+
+	body, ct := buildScanUpload(t, "notes.txt", "text/plain", []byte("hello"))
+	req := f.authedRequest(t, http.MethodPost, "/controls/"+controlID+"/scans", nil)
+	req.Body = io.NopCloser(body)
+	req.Header.Set("Content-Type", ct)
+	req.ContentLength = int64(body.Len())
+	req.SetPathValue("id", controlID)
+
+	rec := httptest.NewRecorder()
+	f.handler.UploadScan(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303 (flash + redirect back)", rec.Code)
+	}
+	if f.fake.AnalyzeCallCount() != 0 {
+		t.Errorf("Analyze called for non-PDF: %d", f.fake.AnalyzeCallCount())
+	}
+}
+
+// TestUploadScanUnknownControlIs404 keeps the URL boundary honest.
+func TestUploadScanUnknownControlIs404(t *testing.T) {
+	f := newControlsFixture(t)
+	body, ct := buildScanUpload(t, "batch.pdf", "application/pdf", []byte("%PDF"))
+
+	req := f.authedRequest(t, http.MethodPost, "/controls/CTRLBADIDBADIDBADIDBADIDID/scans", nil)
+	req.Body = io.NopCloser(body)
+	req.Header.Set("Content-Type", ct)
+	req.SetPathValue("id", "CTRLBADIDBADIDBADIDBADIDID")
+
+	rec := httptest.NewRecorder()
+	f.handler.UploadScan(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}

--- a/apps/server/internal/app/web/router.go
+++ b/apps/server/internal/app/web/router.go
@@ -155,6 +155,15 @@ func routes(deps Deps) []Route {
 			Method: http.MethodPost, Path: handler.ControlScansPath,
 			Handler: deps.Controls.UploadScan,
 		},
+		// WP-F: the review page and its scanned-image endpoint.
+		{
+			Method: http.MethodGet, Path: handler.CopyReviewPath,
+			Handler: deps.Controls.Review,
+		},
+		{
+			Method: http.MethodGet, Path: handler.CopyPageImage,
+			Handler: deps.Controls.PageImage,
+		},
 		{
 			Method: http.MethodGet, Path: handler.ProfessorsPath,
 			Handler: deps.Professors.List,

--- a/apps/server/internal/app/web/router.go
+++ b/apps/server/internal/app/web/router.go
@@ -161,6 +161,10 @@ func routes(deps Deps) []Route {
 			Handler: deps.Controls.Review,
 		},
 		{
+			Method: http.MethodPost, Path: handler.CopyReviewPath,
+			Handler: deps.Controls.SaveReview,
+		},
+		{
 			Method: http.MethodGet, Path: handler.CopyPageImage,
 			Handler: deps.Controls.PageImage,
 		},

--- a/apps/server/internal/app/web/router.go
+++ b/apps/server/internal/app/web/router.go
@@ -155,6 +155,14 @@ func routes(deps Deps) []Route {
 			Method: http.MethodPost, Path: handler.ControlScansPath,
 			Handler: deps.Controls.UploadScan,
 		},
+		{
+			Method: http.MethodPost, Path: handler.ControlReanalyzePath,
+			Handler: deps.Controls.ReanalyzeScans,
+		},
+		{
+			Method: http.MethodPost, Path: handler.ControlClosePath,
+			Handler: deps.Controls.CloseCorrection,
+		},
 		// WP-F: the review page and its scanned-image endpoint.
 		{
 			Method: http.MethodGet, Path: handler.CopyReviewPath,

--- a/apps/server/internal/app/web/router.go
+++ b/apps/server/internal/app/web/router.go
@@ -149,6 +149,12 @@ func routes(deps Deps) []Route {
 			Method: http.MethodGet, Path: handler.ControlCorrigePath,
 			Handler: deps.Controls.CorrigePDF,
 		},
+		// WP-F: the upload target. Gated by default (no Public), CSRF
+		// enforced because the method is POST.
+		{
+			Method: http.MethodPost, Path: handler.ControlScansPath,
+			Handler: deps.Controls.UploadScan,
+		},
 		{
 			Method: http.MethodGet, Path: handler.ProfessorsPath,
 			Handler: deps.Professors.List,

--- a/apps/server/internal/app/web/router_test.go
+++ b/apps/server/internal/app/web/router_test.go
@@ -86,15 +86,21 @@ func deps(t *testing.T, prober health.Prober) web.Deps {
 			Log:       logger,
 		}),
 		Controls: handler.NewControls(handler.Controls{
-			Service: controls.NewService(controls.Service{
-				Bank:      emptyBank(t),
-				Store:     controlstore.New(db),
-				Generator: &amctest.Fake{},
-				WorkDir:   t.TempDir(),
-				Now:       time.Now,
-				Seed:      1,
-				Log:       logger,
-			}),
+			Service: func() *controls.Service {
+				cstore := controlstore.New(db)
+				fake := &amctest.Fake{}
+				return controls.NewService(controls.Service{
+					Bank:      emptyBank(t),
+					Store:     cstore,
+					Generator: fake,
+					Analyzer:  fake,
+					Readings:  cstore,
+					WorkDir:   t.TempDir(),
+					Now:       time.Now,
+					Seed:      1,
+					Log:       logger,
+				})
+			}(),
 			Bank:      emptyBank(t),
 			PublicURL: "https://nalanda.test",
 			Log:       logger,

--- a/apps/server/internal/app/web/view/templates/pages/controls_detail.html
+++ b/apps/server/internal/app/web/view/templates/pages/controls_detail.html
@@ -24,9 +24,51 @@
 
   <section>
     <h2>Escaneos</h2>
-    <p>Aún no hay escaneos subidos.</p>
-    <p><button type="button" disabled>Subir escaneos</button></p>
+    {{ if not .Readings }}
+      <p>Aún no hay escaneos subidos.</p>
+    {{ else }}
+      <p>Sube otro PDF para añadir páginas al lote existente.</p>
+    {{ end }}
+    <form method="post" action="{{ .ScansURL }}" enctype="multipart/form-data">
+      <input type="hidden" name="csrf_token" value="{{ .CSRFToken }}">
+      <p>
+        <label for="scan">Archivo PDF (máximo {{ .MaxScanMB }} MB):</label><br>
+        <input type="file" id="scan" name="scan" accept="application/pdf" required>
+      </p>
+      <p><button type="submit">Subir escaneos</button></p>
+    </form>
   </section>
+
+  {{ if .Readings }}
+    <section>
+      <h2>Resultados</h2>
+      <table class="lista">
+        <thead>
+          <tr>
+            <th>RUT</th>
+            {{ range .QuestionColumns }}<th>{{ . }}</th>{{ end }}
+            <th>Total</th>
+            <th>Nota</th>
+            <th>Estado</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {{ range .Readings }}
+            <tr class="{{ .EstadoClass }}">
+              <td>{{ if .RUT }}{{ .RUT }}{{ else }}—{{ end }}{{ if .Edited }} <small>(editado)</small>{{ end }}</td>
+              {{ range .PerQuestion }}<td>{{ . }}</td>{{ end }}
+              <td>{{ .TotalRaw }}</td>
+              <td>{{ .Grade }}</td>
+              <td>{{ .Estado }}</td>
+              <td><a href="{{ .ReviewURL }}">[revisar]</a></td>
+            </tr>
+          {{ end }}
+        </tbody>
+      </table>
+      {{ if .Summary }}<p>{{ .Summary }}</p>{{ end }}
+    </section>
+  {{ end }}
 
   <p><a href="/controls">Volver a los controles</a></p>
 {{ end }}

--- a/apps/server/internal/app/web/view/templates/pages/controls_detail.html
+++ b/apps/server/internal/app/web/view/templates/pages/controls_detail.html
@@ -42,6 +42,32 @@
   {{ if .Readings }}
     <section>
       <h2>Resultados</h2>
+      {{ if .Graded }}
+        <p class="aviso">Este control fue marcado como <strong>Corregido</strong>. Puedes editar copias todavía, pero cualquier cambio queda en un control cerrado.</p>
+      {{ else }}
+        <form method="post" action="{{ .CloseURL }}" style="display:inline">
+          <input type="hidden" name="csrf_token" value="{{ .CSRFToken }}">
+          {{ if .CanClose }}
+            <button type="submit">Cerrar corrección</button>
+          {{ else }}
+            <button type="submit" disabled>Cerrar corrección</button>
+            {{ if .CloseBlockedReason }}<small>{{ .CloseBlockedReason }}</small>{{ end }}
+          {{ end }}
+        </form>
+      {{ end }}
+
+      <details style="margin-top:0.5em">
+        <summary>Re-leer con otra sensibilidad</summary>
+        <form method="post" action="{{ .ReanalyzeURL }}">
+          <input type="hidden" name="csrf_token" value="{{ .CSRFToken }}">
+          <p>
+            <label>Marcado (0–1): <input type="number" name="ticked" min="0.01" max="0.99" step="0.01" value="{{ printf "%.2f" .CurrentTicked }}"></label>
+            <label>Inseguro (0–marcado): <input type="number" name="unsure" min="0" max="0.99" step="0.01" value="{{ printf "%.2f" .CurrentUnsure }}"></label>
+            <button type="submit">Re-leer</button>
+          </p>
+        </form>
+      </details>
+
       <table class="lista">
         <thead>
           <tr>

--- a/apps/server/internal/app/web/view/templates/pages/review.html
+++ b/apps/server/internal/app/web/view/templates/pages/review.html
@@ -1,0 +1,69 @@
+{{ define "content" }}
+  <h1>{{ .Name }} — copia {{ .CopyNumber }}</h1>
+  <p><a href="{{ .BackURL }}">Volver a los resultados</a></p>
+
+  {{ if .Graded }}
+    <p class="aviso">Estás editando un control cerrado. Los cambios se guardan igual, pero la corrección ya fue marcada como <strong>Corregida</strong>.</p>
+  {{ end }}
+
+  <div class="review-split">
+    <section class="review-image">
+      <h2>Escaneo</h2>
+      <p><img src="{{ .ImageURL }}" alt="Escaneo de la copia {{ .CopyNumber }}"></p>
+    </section>
+
+    <section class="review-form">
+      <h2>Corrección</h2>
+      <form method="post" action="{{ .SaveURL }}">
+        <input type="hidden" name="csrf_token" value="{{ .CSRFToken }}">
+
+        <fieldset>
+          <legend>RUT</legend>
+          <p>
+            <label for="rut">RUT (8 dígitos):</label>
+            <input type="text" id="rut" name="rut" value="{{ .RUT.Value }}"
+                   pattern="[0-9]{8}" maxlength="8" inputmode="numeric">
+            {{ if .RUT.Overridden }}<small>(editado por ti)</small>{{ end }}
+            {{ if and .RUT.WasRead .RUT.Overridden }}
+              <br><small>AMC leyó: {{ .RUT.OriginalRead }}</small>
+            {{ end }}
+          </p>
+        </fieldset>
+
+        {{ range $q := .Questions }}
+          <fieldset>
+            <legend>P{{ $q.Index }} ({{ if eq $q.Type "multiple" }}varias respuestas{{ else }}una respuesta{{ end }})</legend>
+            <p>{{ $q.Statement }}</p>
+            {{ range $a := $q.Alternatives }}
+              <p>
+                {{ if eq $q.Type "multiple" }}
+                  <input type="checkbox" id="q{{ $q.Index }}-a{{ $a.Index }}"
+                         name="q{{ $q.QuestionRef }}"
+                         value="{{ $a.Index }}"
+                         {{ if $q.IsSelected $a.Index }}checked{{ end }}>
+                {{ else }}
+                  <input type="radio" id="q{{ $q.Index }}-a{{ $a.Index }}"
+                         name="q{{ $q.QuestionRef }}"
+                         value="{{ $a.Index }}"
+                         {{ if $q.IsSelected $a.Index }}checked{{ end }}>
+                {{ end }}
+                <label for="q{{ $q.Index }}-a{{ $a.Index }}">{{ $a.Label }}</label>
+              </p>
+            {{ end }}
+            <p>
+              <button type="submit" name="blank" value="{{ $q.QuestionRef }}">
+                Marcar en blanco
+              </button>
+              {{ if $q.Overridden }}<small>{{ $q.OriginalRead }}</small>{{ end }}
+            </p>
+          </fieldset>
+        {{ end }}
+
+        <p>
+          <a class="boton" href="{{ .BackURL }}">Cancelar</a>
+          <button type="submit" name="save" value="1">Guardar cambios</button>
+        </p>
+      </form>
+    </section>
+  </div>
+{{ end }}

--- a/apps/server/internal/app/web/view/view.go
+++ b/apps/server/internal/app/web/view/view.go
@@ -220,6 +220,23 @@ type ControlDetailPage struct {
 	// QuestionColumns is the header row for the per-question columns
 	// (P1, P2, …), sized to control.QuestionsPerCopy.
 	QuestionColumns []string
+	// ReanalyzeURL is the POST target for "re-leer con otra sensibilidad".
+	ReanalyzeURL string
+	// CurrentTicked / CurrentUnsure pre-fill the reanalyze form with the
+	// last thresholds used (or the defaults for a first read).
+	CurrentTicked float64
+	CurrentUnsure float64
+	// CanClose is true when the state gate for "Cerrar corrección" is
+	// satisfied. WP-F S8 populates it.
+	CanClose bool
+	// CloseBlockedReason is the Spanish sentence explaining what stops
+	// the professor from closing yet, empty when CanClose is true.
+	CloseBlockedReason string
+	// CloseURL is the POST target for "Cerrar corrección".
+	CloseURL string
+	// Graded is true when control.state = graded — the template surfaces
+	// the "correction was closed" line above the results table.
+	Graded bool
 }
 
 // ReadingRow is one row of the results table. Everything is pre-formatted

--- a/apps/server/internal/app/web/view/view.go
+++ b/apps/server/internal/app/web/view/view.go
@@ -196,15 +196,58 @@ type SectionOption struct {
 	Section string
 }
 
-// ControlDetailPage is what controls_detail.html renders (S8). The three
-// boxes issue #166 §The screens asks for: metadata, PDFs, and the WP-F
-// placeholder scans box (rendered by the template unconditionally today,
-// with no reader on the server side until WP-F ships).
+// ControlDetailPage is what controls_detail.html renders. It grows with
+// each WP: WP-E landed the three boxes (§The screens); WP-F fills the
+// Escaneos box with an upload form and appends a Resultados table when
+// readings exist.
 type ControlDetailPage struct {
 	Page
 	Control    DetailedControl
 	SujetURL   string
 	CorrigeURL string
+	// ScansURL is the POST target of the upload form.
+	ScansURL string
+	// MaxScanMB is what the Spanish "máximo N MB" hint says on the
+	// form. The unit is megabytes — the handler enforces the byte
+	// value.
+	MaxScanMB int64
+	// Readings is the list of copies known so far (empty for a control
+	// with no uploads). WP-F S4 renders the results table off this.
+	Readings []ReadingRow
+	// Summary is the "N impresas · M corregidas · K requieren revisión · L no rendidas"
+	// line under the table. Empty when Readings is empty.
+	Summary string
+	// QuestionColumns is the header row for the per-question columns
+	// (P1, P2, …), sized to control.QuestionsPerCopy.
+	QuestionColumns []string
+}
+
+// ReadingRow is one row of the results table. Everything is pre-formatted
+// for the template so it does no arithmetic (issue #167 §The results
+// table).
+type ReadingRow struct {
+	CopyNumber int
+	// RUT is the eight digits to render, or empty when unreadable /
+	// not-present.
+	RUT string
+	// PerQuestion is per-question cells (already formatted with the
+	// relative or "⚠" or "—"), aligned to QuestionColumns.
+	PerQuestion []string
+	// TotalRaw is like "3.5/4" or "—".
+	TotalRaw string
+	// Grade is like "6.5" or "—".
+	Grade string
+	// Estado is the Spanish estado word / phrase per §The results
+	// table's collapse rules.
+	Estado string
+	// EstadoClass is the CSS class the row applies for coloring.
+	EstadoClass string
+	// ReviewURL is the "[revisar]" link — always present, WP-F allows
+	// review of any row.
+	ReviewURL string
+	// Edited is true when the row carries at least one override; the
+	// template renders a subtle marker.
+	Edited bool
 }
 
 // DetailedControl is the metadata the detail page shows, pre-formatted.

--- a/apps/server/internal/app/web/view/view.go
+++ b/apps/server/internal/app/web/view/view.go
@@ -261,6 +261,61 @@ type DetailedControl struct {
 	CreatedAt       string
 }
 
+// ReviewPage is what review.html renders (WP-F §The screens). Split view:
+// scanned image on the left, editable form on the right.
+type ReviewPage struct {
+	Page
+	ControlID  string
+	Name       string
+	CopyNumber int
+	BackURL    string
+	ImageURL   string
+	SaveURL    string
+	Graded     bool // when true the template shows the "editing a closed correction" warning
+	RUT        ReviewRUT
+	Questions  []ReviewQuestion
+}
+
+// ReviewRUT is the top row of the form — the RUT block.
+type ReviewRUT struct {
+	Value        string
+	OriginalRead string
+	Status       string
+	Overridden   bool
+	WasRead      bool
+}
+
+// ReviewQuestion is one row of the review form.
+type ReviewQuestion struct {
+	Index        int
+	QuestionRef  string
+	Statement    string
+	Type         string // "simple" | "multiple"
+	Alternatives []ReviewAlternative
+	Selected     []int
+	Status       string
+	Overridden   bool
+	OriginalRead string // "AMC leyó: …" — empty when unedited
+}
+
+// ReviewAlternative is one option a professor can pick.
+type ReviewAlternative struct {
+	Index int
+	Label string
+}
+
+// IsSelected is a helper the template calls — Go html/template's `in`
+// operator does not exist, and a template-level map lookup on []int is
+// awkward. One method per test keeps the template readable.
+func (q ReviewQuestion) IsSelected(index int) bool {
+	for _, s := range q.Selected {
+		if s == index {
+			return true
+		}
+	}
+	return false
+}
+
 // ErrorPage is what error.html renders. AC-11: 404, 403 and 500 render
 // through the shell rather than as Go's default text.
 //
@@ -406,6 +461,14 @@ func RenderControlDetail(w http.ResponseWriter, page ControlDetailPage) error {
 		page.Title = page.Control.Name
 	}
 	return render(w, "controls_detail", http.StatusOK, page)
+}
+
+// RenderReview writes the WP-F review page.
+func RenderReview(w http.ResponseWriter, page ReviewPage) error {
+	if page.Title == "" {
+		page.Title = fmt.Sprintf("Copia %d — %s", page.CopyNumber, page.Name)
+	}
+	return render(w, "review", http.StatusOK, page)
 }
 
 // RenderError writes an error page through the shell (AC-11).

--- a/apps/server/internal/domain/controls/grade.go
+++ b/apps/server/internal/domain/controls/grade.go
@@ -1,0 +1,85 @@
+package controls
+
+import "fmt"
+
+// The grade math for a Reading, both surfaces of apps/server call it.
+// Lives here so WP-G (publish grades, potentially on the JSON surface)
+// and any future caller do not have to import internal/app/web to
+// compute the same number. The pair (§C7 mapping + ADR-0031
+// normalisation) is engine-independent and survives a change of engine
+// unchanged, which is one of the two reasons ADR-0031 exists.
+
+// TotalAndGrade computes the "Σ relative / N" total and its 1,0–7,0
+// grade for a Reading over `questions` drawn slots. The rules mirror
+// ADR-0031 §Every question weighs one point and 2026-08-controles.md
+// §C7:
+//
+//   - a doubtful/ambiguous answer with no override → both dashes
+//     ("—"/"—"): the number is unknown until the review is done.
+//   - an unreadable RUT with no override → same reason, same output.
+//   - a not_present copy → dashes.
+//   - a blank answer → contributes 0 to the total (correctly zero, not
+//     unknown).
+//   - a normal answer → score/max fraction; max travels with the answer
+//     because a multiple's max is its alternative count, not a constant.
+//   - an overridden answer → 1.0 (the professor's decision is a whole
+//     point, regardless of AMC's own score — the trust model of manual
+//     grading).
+//
+// Returns raw like "1.75/2" and grade like "6.2", or "—"/"—" when
+// unknown.
+func TotalAndGrade(questions int, r Reading) (string, string) {
+	if r.CopyStatus == CopyStatusNotPresent {
+		return "—", "—"
+	}
+	if r.RUTStatus == RUTStatusUnreadable && r.RUTOverride == nil {
+		return "—", "—"
+	}
+	total := 0.0
+	for _, a := range r.Answers {
+		effective := a.Status
+		if a.Override != nil {
+			effective = a.Override.Status
+		}
+		if effective == AnswerStatusDoubtful || effective == AnswerStatusAmbiguous {
+			return "—", "—"
+		}
+		if effective == AnswerStatusBlank {
+			continue
+		}
+		if a.Override != nil {
+			total += 1.0
+			continue
+		}
+		if a.Max > 0 {
+			total += a.Score / a.Max
+		}
+	}
+	if questions == 0 {
+		return "—", "—"
+	}
+	return fmt.Sprintf("%.2f/%d", total, questions), FormatGrade(total, questions)
+}
+
+// FormatGrade maps a fraction onto the 1,0–7,0 scale: 4,0 at 50%,
+// linear on either side (§C7). Rounded to one decimal. Negative or >1
+// fractions are clamped — either would only appear from a scoring bug
+// upstream, and a grade outside 1–7 has no reader.
+func FormatGrade(total float64, questions int) string {
+	if questions == 0 {
+		return "—"
+	}
+	pct := total / float64(questions)
+	var grade float64
+	switch {
+	case pct <= 0:
+		grade = 1.0
+	case pct <= 0.5:
+		grade = 1.0 + 6.0*pct // 0.0→1.0, 0.5→4.0
+	case pct >= 1.0:
+		grade = 7.0
+	default:
+		grade = 4.0 + 6.0*(pct-0.5) // 0.5→4.0, 1.0→7.0
+	}
+	return fmt.Sprintf("%.1f", grade)
+}

--- a/apps/server/internal/domain/controls/grade_test.go
+++ b/apps/server/internal/domain/controls/grade_test.go
@@ -1,4 +1,4 @@
-package handler
+package controls_test
 
 import (
 	"testing"
@@ -6,9 +6,9 @@ import (
 	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
 )
 
-// The grade math (§C7 + ADR-0031) is load-bearing and the results-table
-// tests only exercised the estado column. This file pins the numeric
-// outputs at the boundary values.
+// The grade math (§C7 + ADR-0031) is load-bearing; this pins the
+// boundary values so a future edit that shifts the rounding, the
+// clamp direction or the override contract turns the suite red.
 
 func TestFormatGradeMapsPercentageOntoTheChileanScale(t *testing.T) {
 	cases := []struct {
@@ -22,19 +22,19 @@ func TestFormatGradeMapsPercentageOntoTheChileanScale(t *testing.T) {
 		{total: 1, questions: 4, want: "2.5"},  // 25%
 		{total: 3, questions: 4, want: "5.5"},  // 75%
 		{total: 0, questions: 0, want: "—"},    // guard: no questions drawn
-		{total: 5, questions: 4, want: "7.0"},  // out-of-range clamp (defensive)
+		{total: 5, questions: 4, want: "7.0"},  // out-of-range clamp high
 		{total: -1, questions: 4, want: "1.0"}, // negative → clamp low
 	}
 	for _, c := range cases {
-		if got := formatGrade(c.total, c.questions); got != c.want {
-			t.Errorf("formatGrade(%v, %d) = %q, want %q", c.total, c.questions, got, c.want)
+		if got := controls.FormatGrade(c.total, c.questions); got != c.want {
+			t.Errorf("FormatGrade(%v, %d) = %q, want %q", c.total, c.questions, got, c.want)
 		}
 	}
 }
 
 func TestTotalAndGradeSumsRelativeScores(t *testing.T) {
 	// A copy with q1 simple (1.0 relative) and q2 multiple (3/4 = 0.75)
-	// totals 1.75/2 → 87.5% → 6.25 rounded to 6.3.
+	// totals 1.75/2 → 87.5% → 6.25 rendered with %.1f → 6.2.
 	r := controls.Reading{
 		RUTStatus: controls.RUTStatusOK,
 		Answers: []controls.Answer{
@@ -44,11 +44,9 @@ func TestTotalAndGradeSumsRelativeScores(t *testing.T) {
 				Status: controls.AnswerStatusOK, Score: 3, Max: 4},
 		},
 	}
-	total, grade := totalAndGrade(2, r)
-	// pct = 0.875 → 4 + 6*(0.375) = 6.25, rendered with %.1f (IEEE 754
-	// nearest-even) → 6.2.
+	total, grade := controls.TotalAndGrade(2, r)
 	if total != "1.75/2" || grade != "6.2" {
-		t.Errorf("totalAndGrade = (%s, %s), want (1.75/2, 6.2)", total, grade)
+		t.Errorf("TotalAndGrade = (%s, %s), want (1.75/2, 6.2)", total, grade)
 	}
 }
 
@@ -60,15 +58,15 @@ func TestTotalAndGradeReturnsDashesWhenAnswerIsDoubtfulWithoutOverride(t *testin
 				Status: controls.AnswerStatusDoubtful, Score: 0, Max: 1},
 		},
 	}
-	total, grade := totalAndGrade(1, r)
+	total, grade := controls.TotalAndGrade(1, r)
 	if total != "—" || grade != "—" {
-		t.Errorf("totalAndGrade = (%s, %s), want (—, —)", total, grade)
+		t.Errorf("TotalAndGrade = (%s, %s), want (—, —)", total, grade)
 	}
 }
 
 func TestTotalAndGradeOverrideAwardsFullPoint(t *testing.T) {
-	// AC-4 override contract: an override earns the whole point,
-	// regardless of AMC's own score. Documented behaviour, not a bug.
+	// AC-4: an override earns the whole point regardless of AMC's own
+	// score. Documented behaviour, not a bug.
 	r := controls.Reading{
 		RUTStatus: controls.RUTStatusOK,
 		Answers: []controls.Answer{
@@ -79,7 +77,7 @@ func TestTotalAndGradeOverrideAwardsFullPoint(t *testing.T) {
 				}},
 		},
 	}
-	total, _ := totalAndGrade(1, r)
+	total, _ := controls.TotalAndGrade(1, r)
 	if total != "1.00/1" {
 		t.Errorf("overridden answer total = %s, want 1.00/1", total)
 	}
@@ -90,8 +88,8 @@ func TestTotalAndGradeReturnsDashesForNotPresent(t *testing.T) {
 		CopyStatus: controls.CopyStatusNotPresent,
 		RUTStatus:  controls.RUTStatusNotPresent,
 	}
-	total, grade := totalAndGrade(4, r)
+	total, grade := controls.TotalAndGrade(4, r)
 	if total != "—" || grade != "—" {
-		t.Errorf("totalAndGrade(not_present) = (%s, %s), want (—, —)", total, grade)
+		t.Errorf("TotalAndGrade(not_present) = (%s, %s), want (—, —)", total, grade)
 	}
 }

--- a/apps/server/internal/domain/controls/reading.go
+++ b/apps/server/internal/domain/controls/reading.go
@@ -20,6 +20,11 @@ const (
 	// RUTStatusUnreadable: a column is blank or holds more than one digit.
 	// Repair: type the eight digits into the review queue.
 	RUTStatusUnreadable RUTStatus = "unreadable"
+	// RUTStatusNotPresent: WP-F extension, not in the wire report — used on
+	// reading rows for copies (copia) that were printed but never captured.
+	// The rut_read column is NULL for these; the row exists so the results
+	// table has an entry to render as "no rendida".
+	RUTStatusNotPresent RUTStatus = "not_present"
 )
 
 // CopyStatus collapses what happened to a copy.
@@ -165,8 +170,12 @@ var (
 // A Reading is one copy's stored state. WP-F persists this beside the
 // existing copia rows; grades are computed on the fly from the answers
 // under any overrides.
+//
+// The identity here is (ControlID, CopyNumber): every copia gets at most
+// one reading. ID is the surrogate the answer table and the override
+// tables reference — it comes from the store on Upsert.
 type Reading struct {
-	ID           string
+	ID           int64
 	ControlID    string
 	CopyNumber   int
 	RUTRead      *string // nil when unreadable or not present
@@ -174,16 +183,17 @@ type Reading struct {
 	Answers      []Answer
 	CopyStatus   CopyStatus
 	ReadAt       time.Time
-	LastEditedAt *time.Time // set on any manual override
+	LastEditedAt *time.Time   // set on any manual override
+	RUTOverride  *RUTOverride // eagerly loaded by ReadingsByControl and ReadingByCopy
 }
 
 // Answer is one question of a Reading, with the engine's numbers beside
-// the optional professor override.
+// the optional professor override. The natural key is (ReadingID,
+// QuestionRef), which is what the override table uses — there is no
+// separate answer_id column.
 type Answer struct {
-	ID           string
-	ReadingID    string
-	QuestionRef  string // the bank id resolved from the layout name
-	QuestionType QuestionType
+	QuestionRef  string       // the bank id resolved from the layout name
+	QuestionType QuestionType // never assumed; comes from the report
 	Marked       []int
 	Doubtful     []Doubtful
 	Status       AnswerStatus
@@ -207,3 +217,56 @@ type RUTOverride struct {
 	RUT      string
 	EditedAt time.Time
 }
+
+// ReadingStore is the persistence side of the reading domain. Declared
+// here per §The dependency rule and separate from Store because the two
+// families of writes have different transaction shapes — the read half
+// of a WP-F flow (upsert a whole report, mark missing copies, load a
+// reading with overrides) does not benefit from being wedged into
+// CreateControl's atomicity contract.
+type ReadingStore interface {
+	// UpsertReadingsFromReport persists a Report against controlID. For
+	// each copy in the report, the reading row is inserted or updated by
+	// (control_id, copy_number). The existing answer rows for that
+	// reading are replaced by the report's; the override tables are
+	// LEFT INTACT — a re-read must not wipe manual decisions
+	// (§Reading with different thresholds).
+	UpsertReadingsFromReport(ctx context.Context, controlID string, report Report, now time.Time) error
+
+	// MarkMissingAsNotPresent inserts a reading with copy_status
+	// not_present and rut_status not_present for every printed copia
+	// row without a reading. Idempotent — a copy that already has a
+	// reading is left alone whatever its status.
+	MarkMissingAsNotPresent(ctx context.Context, controlID string, now time.Time) error
+
+	// ReadingsByControl returns every reading for a control, ordered
+	// by copy_number ascending, with overrides eagerly attached.
+	ReadingsByControl(ctx context.Context, controlID string) ([]Reading, error)
+
+	// ReadingByCopy returns one reading (with overrides), or
+	// ErrReadingNotFound.
+	ReadingByCopy(ctx context.Context, controlID string, copyNumber int) (Reading, error)
+
+	// SetAnswerOverride upserts an override for one (reading,
+	// question_ref) and stamps the reading's last_edited_at.
+	SetAnswerOverride(ctx context.Context, readingID int64, questionRef string, override AnswerOverride) error
+
+	// ClearAnswerOverride deletes the override for (reading,
+	// question_ref), if any.
+	ClearAnswerOverride(ctx context.Context, readingID int64, questionRef string) error
+
+	// SetRUTOverride upserts the RUT override for a reading and stamps
+	// last_edited_at.
+	SetRUTOverride(ctx context.Context, readingID int64, rut string, editedAt time.Time) error
+
+	// ClearRUTOverride deletes the RUT override, if any.
+	ClearRUTOverride(ctx context.Context, readingID int64) error
+
+	// SetControlState updates control.state. Named on this interface
+	// because the reading half is where the state moves — WP-F flips
+	// to InReview on the first upload and to Graded on close.
+	SetControlState(ctx context.Context, controlID string, state State) error
+}
+
+// ErrReadingNotFound is a lookup that named nothing.
+var ErrReadingNotFound = errors.New("controls: no such reading")

--- a/apps/server/internal/domain/controls/reading.go
+++ b/apps/server/internal/domain/controls/reading.go
@@ -1,0 +1,209 @@
+package controls
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// The reading report is engine-independent (ADR-0031) — the same shape survives
+// swapping AMC for OMRChecker. Everything below models what the worker's
+// /analyse returns, with the failure kinds kept apart because they need
+// different repairs.
+
+// RUTStatus is whether the eight-column RUT block was read cleanly.
+type RUTStatus string
+
+const (
+	// RUTStatusOK: eight digits, one per column, at or above `ticked`.
+	RUTStatusOK RUTStatus = "ok"
+	// RUTStatusUnreadable: a column is blank or holds more than one digit.
+	// Repair: type the eight digits into the review queue.
+	RUTStatusUnreadable RUTStatus = "unreadable"
+)
+
+// CopyStatus collapses what happened to a copy.
+type CopyStatus string
+
+const (
+	// CopyStatusOK: every answer is `ok` and no page is missing.
+	CopyStatusOK CopyStatus = "ok"
+	// CopyStatusNeedsReview: at least one answer needs a human.
+	CopyStatusNeedsReview CopyStatus = "needs_review"
+	// CopyStatusIncomplete: pages this copy printed never reached the
+	// scanner. Repair: find the sheet and scan it again.
+	CopyStatusIncomplete CopyStatus = "incomplete"
+	// CopyStatusNotPresent: WP-F extension, not in the wire report — set by
+	// the Service for printed copies (copia rows) that never had a reading.
+	// Rendered as "no rendida" and does not count as "corregidas" or
+	// "requieren revisión".
+	CopyStatusNotPresent CopyStatus = "not_present"
+)
+
+// QuestionType is which of AMC's two shapes a question was scored under.
+// A question is `simple` if it admits one alternative, `multiple` if several
+// (ADR-0031 §A question says which kind it is).
+type QuestionType string
+
+const (
+	QuestionSimple   QuestionType = "simple"
+	QuestionMultiple QuestionType = "multiple"
+)
+
+// AnswerStatus is what the reader made of one answer.
+type AnswerStatus string
+
+const (
+	// AnswerStatusOK: the answer is final, no human needed.
+	AnswerStatusOK AnswerStatus = "ok"
+	// AnswerStatusBlank: nothing is marked. Repair: a human decides.
+	AnswerStatusBlank AnswerStatus = "blank"
+	// AnswerStatusAmbiguous: several marks on a `simple` question.
+	AnswerStatusAmbiguous AnswerStatus = "ambiguous"
+	// AnswerStatusDoubtful: a mark faint enough to worry about.
+	AnswerStatusDoubtful AnswerStatus = "doubtful"
+)
+
+// Doubtful is one mark below `ticked` but at or above `unsure`, with the
+// measured darkness so the review queue can rank them.
+type Doubtful struct {
+	Answer   int
+	Darkness float64
+}
+
+// ReportAnswer is one question in a copy's reading.
+type ReportAnswer struct {
+	Question int          // the layout's question index (used to align with the pool)
+	Name     string       // AMC's layout_question.name (bank ref)
+	Type     QuestionType // simple | multiple
+	Marked   []int        // confident ticks
+	Doubtful []Doubtful   // dark-enough marks that did not count
+	Status   AnswerStatus
+	Score    float64 // engine per-question score
+	Max      float64 // 1 for simple; alternative count for multiple
+}
+
+// ReportCopy is one copy's reading.
+type ReportCopy struct {
+	RUT               string
+	RUTStatus         RUTStatus
+	Answers           []ReportAnswer
+	ExpectedQuestions int
+	SeenQuestions     int
+	MissingQuestions  []string
+	Status            CopyStatus
+}
+
+// Pages counts what got in.
+type Pages struct {
+	Captured int
+	Failed   int
+}
+
+// Scoring names the two thresholds and whether they diverge. `Stale: true`
+// means the scores were computed at a different threshold from the one this
+// report's marks used — the report and the grade would disagree in silence
+// otherwise (ADR-0031 §The report says which threshold).
+type Scoring struct {
+	Seuil  float64 // what AMC's `note` scored at
+	Ticked float64 // what this reading used
+	Stale  bool
+}
+
+// Report is the whole reply from /analyse or /reanalyse.
+type Report struct {
+	Pages       Pages
+	Scoring     Scoring
+	Copies      map[string]ReportCopy // key is the copy number as decimal string, mirroring AMC
+	NeedsReview []string
+}
+
+// AnalyzeRequest is what a caller hands to Analyzer.Analyze. Every path is
+// RELATIVE to the shared work volume, matching Generator's conventions.
+type AnalyzeRequest struct {
+	Project string // AMC project directory, relative to /work
+	ScanPDF string // the batch to read, relative to /work
+	Source  string // the .tex the control was generated from, relative to /work
+}
+
+// ReanalyzeRequest re-reads the SAME captures at different thresholds.
+// Nothing on the paper changes — only the verdict on how dark each box has
+// to be to count as a mark.
+type ReanalyzeRequest struct {
+	Project string
+	Ticked  float64 // at or above this the box is a confident mark
+	Unsure  float64 // at or above this the box is reported as doubtful
+}
+
+// Analyzer is what the controls domain reaches into for the AMC worker's
+// scan-reading half. Declared here per §The dependency rule; the amcworker
+// package implements it and the amctest package fakes it.
+//
+// A separate interface from Generator on purpose (see amcworker.Client's
+// docstring): analyse is minutes-class and background, generate is
+// seconds-class and synchronous, and splitting the two keeps a change to
+// one from renaming callers of the other.
+type Analyzer interface {
+	Analyze(ctx context.Context, req AnalyzeRequest) (Report, error)
+	Reanalyze(ctx context.Context, req ReanalyzeRequest) (Report, error)
+}
+
+// The failure modes callers branch on. Same shape as ErrGeneratorRefused /
+// ErrGeneratorUnavailable so a handler can render an analyse failure the
+// same way it renders a generate failure.
+var (
+	// ErrAnalyzerRefused wraps a failure that came from the worker refusing
+	// the request — a 4xx or a report the worker considers invalid (missing
+	// scoring, empty layout, damaged PDF).
+	ErrAnalyzerRefused = errors.New("controls: the AMC worker refused to analyse")
+
+	// ErrAnalyzerUnavailable wraps a transport failure — the worker is not
+	// reachable at all.
+	ErrAnalyzerUnavailable = errors.New("controls: the AMC worker is unreachable")
+)
+
+// A Reading is one copy's stored state. WP-F persists this beside the
+// existing copia rows; grades are computed on the fly from the answers
+// under any overrides.
+type Reading struct {
+	ID           string
+	ControlID    string
+	CopyNumber   int
+	RUTRead      *string // nil when unreadable or not present
+	RUTStatus    RUTStatus
+	Answers      []Answer
+	CopyStatus   CopyStatus
+	ReadAt       time.Time
+	LastEditedAt *time.Time // set on any manual override
+}
+
+// Answer is one question of a Reading, with the engine's numbers beside
+// the optional professor override.
+type Answer struct {
+	ID           string
+	ReadingID    string
+	QuestionRef  string // the bank id resolved from the layout name
+	QuestionType QuestionType
+	Marked       []int
+	Doubtful     []Doubtful
+	Status       AnswerStatus
+	Score        float64
+	Max          float64
+	Override     *AnswerOverride
+}
+
+// AnswerOverride sits BESIDE Answer rather than replacing it, so the UI
+// can render both what AMC read and what the professor decided
+// (§The domain, note on Override).
+type AnswerOverride struct {
+	Marked   []int
+	Status   AnswerStatus
+	EditedAt time.Time
+}
+
+// RUTOverride is the professor's typed RUT for a copy whose RUT block was
+// unreadable (or one the professor decided to correct).
+type RUTOverride struct {
+	RUT      string
+	EditedAt time.Time
+}

--- a/apps/server/internal/domain/controls/scans.go
+++ b/apps/server/internal/domain/controls/scans.go
@@ -236,6 +236,52 @@ func (s *Service) SaveOverrides(ctx context.Context, req SaveOverridesRequest) e
 	return nil
 }
 
+// CloseCorrection moves a control to Graded, refusing when the gate is
+// not satisfied. The rules mirror closeGate in the handler; enforcing
+// them here means a request that skipped the disabled-button UI still
+// hits the same guard.
+func (s *Service) CloseCorrection(ctx context.Context, controlID string) error {
+	if s.Readings == nil {
+		return errors.New("controls.CloseCorrection: service is not configured for WP-F")
+	}
+	control, err := s.Store.ControlByID(ctx, controlID)
+	if err != nil {
+		return err
+	}
+	if control.State == Graded {
+		return nil // already closed — idempotent
+	}
+	readings, err := s.Readings.ReadingsByControl(ctx, controlID)
+	if err != nil {
+		return err
+	}
+	for _, r := range readings {
+		if r.CopyStatus == CopyStatusNotPresent {
+			continue
+		}
+		if r.CopyStatus == CopyStatusIncomplete {
+			return ErrCloseBlocked
+		}
+		if r.RUTStatus == RUTStatusUnreadable && r.RUTOverride == nil {
+			return ErrCloseBlocked
+		}
+		for _, a := range r.Answers {
+			effective := a.Status
+			if a.Override != nil {
+				effective = a.Override.Status
+			}
+			if (effective == AnswerStatusDoubtful || effective == AnswerStatusAmbiguous) && a.Override == nil {
+				return ErrCloseBlocked
+			}
+		}
+	}
+	return s.Readings.SetControlState(ctx, controlID, Graded)
+}
+
+// ErrCloseBlocked is returned when CloseCorrection refuses because a
+// failure kind is still unresolved.
+var ErrCloseBlocked = errors.New("controls: the correction cannot close while a failure kind is unresolved")
+
 // SaveOverridesRequest carries the whole edit atomically.
 type SaveOverridesRequest struct {
 	ControlID  string

--- a/apps/server/internal/domain/controls/scans.go
+++ b/apps/server/internal/domain/controls/scans.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
-	"time"
 )
 
 // uploadsDir is the subdirectory under a control's project where uploaded
@@ -66,9 +66,6 @@ type UploadResult struct {
 // not; there is no partial commit, because UpsertReadingsFromReport uses
 // a single transaction.
 func (s *Service) UploadScan(ctx context.Context, req UploadRequest) (UploadResult, error) {
-	if s.Analyzer == nil || s.Readings == nil {
-		return UploadResult{}, errors.New("controls.UploadScan: service is not configured for WP-F")
-	}
 	control, err := s.Store.ControlByID(ctx, req.ControlID)
 	if err != nil {
 		return UploadResult{}, err
@@ -137,9 +134,6 @@ func (s *Service) UploadScan(ctx context.Context, req UploadRequest) (UploadResu
 // Reanalyze re-reads the existing captures at new thresholds. Fails cleanly
 // when no scans have been uploaded yet (nothing to re-read).
 func (s *Service) Reanalyze(ctx context.Context, controlID string, ticked, unsure float64) (Report, error) {
-	if s.Analyzer == nil || s.Readings == nil {
-		return Report{}, errors.New("controls.Reanalyze: service is not configured for WP-F")
-	}
 	control, err := s.Store.ControlByID(ctx, controlID)
 	if err != nil {
 		return Report{}, err
@@ -161,17 +155,11 @@ func (s *Service) Reanalyze(ctx context.Context, controlID string, ticked, unsur
 // The handler decorates them with per-question detail for the results
 // table (S4).
 func (s *Service) ReadingsFor(ctx context.Context, controlID string) ([]Reading, error) {
-	if s.Readings == nil {
-		return nil, errors.New("controls.ReadingsFor: service is not configured for WP-F")
-	}
 	return s.Readings.ReadingsByControl(ctx, controlID)
 }
 
 // ReadingFor returns one reading (with overrides).
 func (s *Service) ReadingFor(ctx context.Context, controlID string, copyNumber int) (Reading, error) {
-	if s.Readings == nil {
-		return Reading{}, errors.New("controls.ReadingFor: service is not configured for WP-F")
-	}
 	return s.Readings.ReadingByCopy(ctx, controlID, copyNumber)
 }
 
@@ -182,9 +170,6 @@ func (s *Service) ReadingFor(ctx context.Context, controlID string, copyNumber i
 // what AMC read for that question clears any prior override; anything
 // else upserts one. The RUT logic is symmetric.
 func (s *Service) SaveOverrides(ctx context.Context, req SaveOverridesRequest) error {
-	if s.Readings == nil {
-		return errors.New("controls.SaveOverrides: service is not configured for WP-F")
-	}
 	reading, err := s.Readings.ReadingByCopy(ctx, req.ControlID, req.CopyNumber)
 	if err != nil {
 		return err
@@ -241,9 +226,6 @@ func (s *Service) SaveOverrides(ctx context.Context, req SaveOverridesRequest) e
 // them here means a request that skipped the disabled-button UI still
 // hits the same guard.
 func (s *Service) CloseCorrection(ctx context.Context, controlID string) error {
-	if s.Readings == nil {
-		return errors.New("controls.CloseCorrection: service is not configured for WP-F")
-	}
 	control, err := s.Store.ControlByID(ctx, controlID)
 	if err != nil {
 		return err
@@ -270,7 +252,11 @@ func (s *Service) CloseCorrection(ctx context.Context, controlID string) error {
 			if a.Override != nil {
 				effective = a.Override.Status
 			}
-			if (effective == AnswerStatusDoubtful || effective == AnswerStatusAmbiguous) && a.Override == nil {
+			// Blocks on the EFFECTIVE status — an override that itself lands
+			// doubtful/ambiguous is not resolution. Reachable today because
+			// statusFor() can produce Ambiguous for a simple question with
+			// two marks.
+			if effective == AnswerStatusDoubtful || effective == AnswerStatusAmbiguous {
 				return ErrCloseBlocked
 			}
 		}
@@ -282,7 +268,12 @@ func (s *Service) CloseCorrection(ctx context.Context, controlID string) error {
 // failure kind is still unresolved.
 var ErrCloseBlocked = errors.New("controls: the correction cannot close while a failure kind is unresolved")
 
-// SaveOverridesRequest carries the whole edit atomically.
+// SaveOverridesRequest carries the whole edit the professor's form
+// produced. NOT atomic across per-question override upserts: each
+// Set/Clear is its own transaction (readings.SetAnswerOverride uses
+// BeginTx), so a mid-loop store failure leaves the earlier edits and
+// the RUT edit persisted. A follow-up WP that wants strict atomicity
+// would widen ReadingStore with a single-tx SaveOverrides.
 type SaveOverridesRequest struct {
 	ControlID  string
 	CopyNumber int
@@ -328,10 +319,11 @@ func matchesRead(a Answer, edit AnswerEdit) bool {
 	return true
 }
 
-// nextBatchNumber walks the uploads/ directory and picks the smallest
-// unused batch-N.pdf. Deterministic — a delete-then-upload puts the new
-// scan under a lower number than a fresh one would — which is what a
-// test that asserts against filenames wants.
+// nextBatchNumber walks the uploads/ directory and returns one past the
+// highest existing batch-N.pdf (max+1). Empty dir → 1. If the highest
+// batch is deleted the next number goes back to fill the gap — the
+// uploads dir is the persisted state and no counter lives outside it.
+// Names that do not match batch-<positive int>.pdf are ignored.
 func nextBatchNumber(dir string) (int, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -346,9 +338,9 @@ func nextBatchNumber(dir string) (int, error) {
 		if !strings.HasPrefix(name, scanFilePrefix) || !strings.HasSuffix(name, scanFileExt) {
 			continue
 		}
-		var n int
 		trimmed := strings.TrimSuffix(strings.TrimPrefix(name, scanFilePrefix), scanFileExt)
-		if _, err := fmt.Sscanf(trimmed, "%d", &n); err != nil {
+		n, err := strconv.Atoi(trimmed)
+		if err != nil {
 			continue
 		}
 		if n > 0 {
@@ -382,6 +374,3 @@ func writeUpload(path string, r io.ReadCloser) error {
 	}
 	return nil
 }
-
-// Placeholder to reserve time.Time until other callers land.
-var _ = time.Time{}

--- a/apps/server/internal/domain/controls/scans.go
+++ b/apps/server/internal/domain/controls/scans.go
@@ -1,0 +1,234 @@
+package controls
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// uploadsDir is the subdirectory under a control's project where uploaded
+// scan PDFs land, one per upload. Kept separate from AMC's own scans/ (which
+// getimages populates) so a re-upload does not clobber prior batches on
+// disk — the on-disk record is what a debug session would look at.
+const uploadsDir = "uploads"
+
+// scanFilePrefix / scanFileExt name the uploaded scan PDFs. batch-1.pdf,
+// batch-2.pdf, … in upload order.
+const (
+	scanFilePrefix = "batch-"
+	scanFileExt    = ".pdf"
+)
+
+// UploadRequest is what a handler hands to Service.UploadScan. The bytes
+// are streamed to disk and never held whole in memory — a 40-copy batch
+// is ~10 MB and would work either way, but the upper bound in Config is
+// 100 MB.
+type UploadRequest struct {
+	ControlID string
+	// Filename is the ORIGINAL filename from the multipart part, used only
+	// for logging and error messages. The stored name is derived from the
+	// batch number.
+	Filename string
+	// Content is where the bytes come from. The Service closes it when it
+	// has copied them (or on any failure).
+	Content io.ReadCloser
+}
+
+// UploadResult reports what the upload produced. Not consumed today, but a
+// handler that renders the result table wants to know which copies just
+// changed and by how many the total moved — a follow-up test hangs off
+// this.
+type UploadResult struct {
+	BatchNumber int
+	ScanPath    string // relative to WorkDir
+	Report      Report
+}
+
+// UploadScan is the whole scan pipeline: save the PDF to a batch file
+// under the control's uploads/ directory, call /analyse, persist the
+// report, mark missing copies as not_present, and flip the control to
+// InReview (unless it is already Graded — a re-upload after close still
+// updates the readings but does not un-close the correction).
+//
+// Failure modes:
+//   - No such control → ErrControlNotFound.
+//   - Copying the upload to disk failed → wraps the io error.
+//   - /analyse refused or was unreachable → wraps ErrAnalyzer* and rolls
+//     back the batch file so the disk shows no evidence of a failed run.
+//
+// All-or-nothing on the DB side: the report either persists or it does
+// not; there is no partial commit, because UpsertReadingsFromReport uses
+// a single transaction.
+func (s *Service) UploadScan(ctx context.Context, req UploadRequest) (UploadResult, error) {
+	if s.Analyzer == nil || s.Readings == nil {
+		return UploadResult{}, errors.New("controls.UploadScan: service is not configured for WP-F")
+	}
+	control, err := s.Store.ControlByID(ctx, req.ControlID)
+	if err != nil {
+		return UploadResult{}, err
+	}
+
+	projectDir := s.ProjectDir(control.ID)
+	uploads := filepath.Join(projectDir, uploadsDir)
+	if err := os.MkdirAll(uploads, 0o755); err != nil {
+		return UploadResult{}, fmt.Errorf("controls.UploadScan: prepare %s: %w", uploads, err)
+	}
+	batch, err := nextBatchNumber(uploads)
+	if err != nil {
+		return UploadResult{}, fmt.Errorf("controls.UploadScan: %w", err)
+	}
+	batchName := fmt.Sprintf("%s%d%s", scanFilePrefix, batch, scanFileExt)
+	batchHostPath := filepath.Join(uploads, batchName)
+
+	if err := writeUpload(batchHostPath, req.Content); err != nil {
+		return UploadResult{}, fmt.Errorf("controls.UploadScan: %w", err)
+	}
+
+	rollbackFile := func() {
+		if err := os.Remove(batchHostPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+			s.Log.Warn("controls.UploadScan: rollback failed", "path", batchHostPath, "error", err)
+		}
+	}
+
+	project := filepath.Join(projectPrefix, control.ID)
+	report, err := s.Analyzer.Analyze(ctx, AnalyzeRequest{
+		Project: project,
+		ScanPDF: filepath.ToSlash(filepath.Join(project, uploadsDir, batchName)),
+		Source:  filepath.ToSlash(filepath.Join(project, "inputs", "source.tex")),
+	})
+	if err != nil {
+		rollbackFile()
+		return UploadResult{}, err
+	}
+
+	now := s.Now()
+	if err := s.Readings.UpsertReadingsFromReport(ctx, control.ID, report, now); err != nil {
+		rollbackFile()
+		return UploadResult{}, fmt.Errorf("controls.UploadScan: persist: %w", err)
+	}
+	if err := s.Readings.MarkMissingAsNotPresent(ctx, control.ID, now); err != nil {
+		rollbackFile()
+		return UploadResult{}, fmt.Errorf("controls.UploadScan: mark missing: %w", err)
+	}
+
+	// Move the control forward — but never backwards. A re-upload to a
+	// graded control leaves state=graded (S8 renders the "editing a closed
+	// correction" warning); the readings still land.
+	if control.State == Generated {
+		if err := s.Readings.SetControlState(ctx, control.ID, InReview); err != nil {
+			// The DB writes above already succeeded; this is a warning.
+			s.Log.Warn("controls.UploadScan: state transition failed", "control", control.ID, "error", err)
+		}
+	}
+
+	return UploadResult{
+		BatchNumber: batch,
+		ScanPath:    filepath.Join(projectPrefix, control.ID, uploadsDir, batchName),
+		Report:      report,
+	}, nil
+}
+
+// Reanalyze re-reads the existing captures at new thresholds. Fails cleanly
+// when no scans have been uploaded yet (nothing to re-read).
+func (s *Service) Reanalyze(ctx context.Context, controlID string, ticked, unsure float64) (Report, error) {
+	if s.Analyzer == nil || s.Readings == nil {
+		return Report{}, errors.New("controls.Reanalyze: service is not configured for WP-F")
+	}
+	control, err := s.Store.ControlByID(ctx, controlID)
+	if err != nil {
+		return Report{}, err
+	}
+	project := filepath.Join(projectPrefix, control.ID)
+	report, err := s.Analyzer.Reanalyze(ctx, ReanalyzeRequest{
+		Project: project, Ticked: ticked, Unsure: unsure,
+	})
+	if err != nil {
+		return Report{}, err
+	}
+	if err := s.Readings.UpsertReadingsFromReport(ctx, control.ID, report, s.Now()); err != nil {
+		return Report{}, fmt.Errorf("controls.Reanalyze: persist: %w", err)
+	}
+	return report, nil
+}
+
+// Readings returns every reading for a control, ordered by copy_number.
+// The handler decorates them with per-question detail for the results
+// table (S4).
+func (s *Service) ReadingsFor(ctx context.Context, controlID string) ([]Reading, error) {
+	if s.Readings == nil {
+		return nil, errors.New("controls.ReadingsFor: service is not configured for WP-F")
+	}
+	return s.Readings.ReadingsByControl(ctx, controlID)
+}
+
+// ReadingFor returns one reading (with overrides).
+func (s *Service) ReadingFor(ctx context.Context, controlID string, copyNumber int) (Reading, error) {
+	if s.Readings == nil {
+		return Reading{}, errors.New("controls.ReadingFor: service is not configured for WP-F")
+	}
+	return s.Readings.ReadingByCopy(ctx, controlID, copyNumber)
+}
+
+// nextBatchNumber walks the uploads/ directory and picks the smallest
+// unused batch-N.pdf. Deterministic — a delete-then-upload puts the new
+// scan under a lower number than a fresh one would — which is what a
+// test that asserts against filenames wants.
+func nextBatchNumber(dir string) (int, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0, fmt.Errorf("read %s: %w", dir, err)
+	}
+	used := map[int]bool{}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasPrefix(name, scanFilePrefix) || !strings.HasSuffix(name, scanFileExt) {
+			continue
+		}
+		var n int
+		trimmed := strings.TrimSuffix(strings.TrimPrefix(name, scanFilePrefix), scanFileExt)
+		if _, err := fmt.Sscanf(trimmed, "%d", &n); err != nil {
+			continue
+		}
+		if n > 0 {
+			used[n] = true
+		}
+	}
+	if len(used) == 0 {
+		return 1, nil
+	}
+	nums := make([]int, 0, len(used))
+	for n := range used {
+		nums = append(nums, n)
+	}
+	sort.Ints(nums)
+	return nums[len(nums)-1] + 1, nil
+}
+
+func writeUpload(path string, r io.ReadCloser) error {
+	defer func() { _ = r.Close() }()
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", path, err)
+	}
+	if _, err := io.Copy(f, r); err != nil {
+		_ = f.Close()
+		_ = os.Remove(path)
+		return fmt.Errorf("copy to %s: %w", path, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close %s: %w", path, err)
+	}
+	return nil
+}
+
+// Placeholder to reserve time.Time until other callers land.
+var _ = time.Time{}

--- a/apps/server/internal/domain/controls/scans.go
+++ b/apps/server/internal/domain/controls/scans.go
@@ -175,6 +175,113 @@ func (s *Service) ReadingFor(ctx context.Context, controlID string, copyNumber i
 	return s.Readings.ReadingByCopy(ctx, controlID, copyNumber)
 }
 
+// SaveOverrides applies a professor's edits to a single reading. The
+// request carries the RUT (empty means "no change" — the review handler
+// enforces its own precondition) and one entry per question in the
+// reading's pool with the new marked set. A submitted set that MATCHES
+// what AMC read for that question clears any prior override; anything
+// else upserts one. The RUT logic is symmetric.
+func (s *Service) SaveOverrides(ctx context.Context, req SaveOverridesRequest) error {
+	if s.Readings == nil {
+		return errors.New("controls.SaveOverrides: service is not configured for WP-F")
+	}
+	reading, err := s.Readings.ReadingByCopy(ctx, req.ControlID, req.CopyNumber)
+	if err != nil {
+		return err
+	}
+	now := s.Now()
+
+	// RUT — the override is what shows up beside the AMC read on the
+	// review page; setting it back to what AMC read clears the override.
+	rutMatchesRead := reading.RUTRead != nil && *reading.RUTRead == req.RUT
+	switch {
+	case req.RUT == "":
+		// Empty submission is ignored — the review form always sends the
+		// current visible RUT (either the read value or the override).
+	case rutMatchesRead && reading.RUTStatus == RUTStatusOK:
+		if err := s.Readings.ClearRUTOverride(ctx, reading.ID); err != nil {
+			return err
+		}
+	default:
+		if err := s.Readings.SetRUTOverride(ctx, reading.ID, req.RUT, now); err != nil {
+			return err
+		}
+	}
+
+	// Per question — clear when the submission matches what AMC read,
+	// upsert otherwise.
+	for _, edit := range req.Answers {
+		ans, ok := findAnswer(reading, edit.QuestionRef)
+		if !ok {
+			// Silently drop questions the reading does not know — the
+			// form was generated for a stale reading; the professor's
+			// next attempt will re-read the correct set.
+			continue
+		}
+		if matchesRead(ans, edit) {
+			if err := s.Readings.ClearAnswerOverride(ctx, reading.ID, edit.QuestionRef); err != nil {
+				return err
+			}
+			continue
+		}
+		override := AnswerOverride{
+			Marked:   edit.Marked,
+			Status:   edit.Status,
+			EditedAt: now,
+		}
+		if err := s.Readings.SetAnswerOverride(ctx, reading.ID, edit.QuestionRef, override); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SaveOverridesRequest carries the whole edit atomically.
+type SaveOverridesRequest struct {
+	ControlID  string
+	CopyNumber int
+	RUT        string
+	Answers    []AnswerEdit
+}
+
+// AnswerEdit is one question's new state.
+type AnswerEdit struct {
+	QuestionRef string
+	Marked      []int
+	Status      AnswerStatus
+}
+
+func findAnswer(r Reading, ref string) (Answer, bool) {
+	for _, a := range r.Answers {
+		if a.QuestionRef == ref {
+			return a, true
+		}
+	}
+	return Answer{}, false
+}
+
+// matchesRead reports whether an edit brings the answer back to what AMC
+// originally read (same marks in any order, same status).
+func matchesRead(a Answer, edit AnswerEdit) bool {
+	if a.Status != edit.Status {
+		return false
+	}
+	if len(a.Marked) != len(edit.Marked) {
+		return false
+	}
+	seen := make(map[int]int, len(a.Marked))
+	for _, m := range a.Marked {
+		seen[m]++
+	}
+	for _, m := range edit.Marked {
+		if seen[m] == 0 {
+			return false
+		}
+		seen[m]--
+	}
+	return true
+}
+
 // nextBatchNumber walks the uploads/ directory and picks the smallest
 // unused batch-N.pdf. Deterministic — a delete-then-upload puts the new
 // scan under a lower number than a fresh one would — which is what a

--- a/apps/server/internal/domain/controls/scans_internal_test.go
+++ b/apps/server/internal/domain/controls/scans_internal_test.go
@@ -1,0 +1,46 @@
+package controls
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The batch naming contract is stated in nextBatchNumber's docstring:
+// max+1 of existing batch-N.pdf, empty dir → 1, non-matching files
+// ignored. This pins it against surprise.
+func TestNextBatchNumberIsMaxPlusOne(t *testing.T) {
+	dir := t.TempDir()
+	if n, _ := nextBatchNumber(dir); n != 1 {
+		t.Errorf("empty dir → %d, want 1", n)
+	}
+
+	touch(t, dir, "batch-1.pdf", "batch-2.pdf")
+	if n, _ := nextBatchNumber(dir); n != 3 {
+		t.Errorf("{1,2} → %d, want 3", n)
+	}
+
+	// Deleting the highest brings the counter back — the uploads dir IS
+	// the persisted state.
+	if err := os.Remove(filepath.Join(dir, "batch-2.pdf")); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if n, _ := nextBatchNumber(dir); n != 2 {
+		t.Errorf("{1} after 2 deleted → %d, want 2", n)
+	}
+
+	// Non-matching filenames are ignored.
+	touch(t, dir, "notes.txt", "batch-abc.pdf", "batch-0.pdf")
+	if n, _ := nextBatchNumber(dir); n != 2 {
+		t.Errorf("with noise → %d, want 2", n)
+	}
+}
+
+func touch(t *testing.T, dir string, names ...string) {
+	t.Helper()
+	for _, n := range names {
+		if err := os.WriteFile(filepath.Join(dir, n), nil, 0o644); err != nil {
+			t.Fatalf("touch %s: %v", n, err)
+		}
+	}
+}

--- a/apps/server/internal/domain/controls/service.go
+++ b/apps/server/internal/domain/controls/service.go
@@ -59,9 +59,10 @@ type Service struct {
 	Store     Store
 	Generator Generator
 	// Analyzer and Readings power the WP-F pipeline: upload → analyse →
-	// persist a report → serve the review queue. Optional in the sense
-	// that Create/List/Get do not touch them; the scan methods panic
-	// when they are nil, and NewService wires that check.
+	// persist a report → serve the review queue. Required — NewService
+	// panics on either nil; no method here re-checks them, since a
+	// wiring mistake is a panic at boot rather than a nil dereference
+	// inside a request (backend-code-style.md §Errors).
 	Analyzer Analyzer
 	Readings ReadingStore
 	// WorkDir is what the SERVER sees as the root of the shared volume.

--- a/apps/server/internal/domain/controls/service.go
+++ b/apps/server/internal/domain/controls/service.go
@@ -58,6 +58,12 @@ type Service struct {
 	Bank      *bank.Bank
 	Store     Store
 	Generator Generator
+	// Analyzer and Readings power the WP-F pipeline: upload → analyse →
+	// persist a report → serve the review queue. Optional in the sense
+	// that Create/List/Get do not touch them; the scan methods panic
+	// when they are nil, and NewService wires that check.
+	Analyzer Analyzer
+	Readings ReadingStore
 	// WorkDir is what the SERVER sees as the root of the shared volume.
 	// In compose it is bind-mounted onto /work in the worker; in
 	// development it may be any path the operator chose (see
@@ -82,6 +88,10 @@ func NewService(deps Service) *Service {
 		panic("controls.NewService: no store")
 	case deps.Generator == nil:
 		panic("controls.NewService: no generator")
+	case deps.Analyzer == nil:
+		panic("controls.NewService: no analyzer")
+	case deps.Readings == nil:
+		panic("controls.NewService: no reading store")
 	case deps.WorkDir == "":
 		panic("controls.NewService: no work directory")
 	case deps.Now == nil:

--- a/apps/server/internal/domain/controls/service_test.go
+++ b/apps/server/internal/domain/controls/service_test.go
@@ -79,6 +79,33 @@ func (s *fakeStore) ControlPool(_ context.Context, id string) ([]controls.PoolEn
 	return s.pools[id], nil
 }
 
+// fakeReadingStore is the do-nothing double the pre-WP-F cases use. The
+// WP-F flows are exercised through Service.UploadScan in scans_test.go
+// with a real controlstore.
+type fakeReadingStore struct{}
+
+func (fakeReadingStore) UpsertReadingsFromReport(context.Context, string, controls.Report, time.Time) error {
+	return nil
+}
+func (fakeReadingStore) MarkMissingAsNotPresent(context.Context, string, time.Time) error { return nil }
+func (fakeReadingStore) ReadingsByControl(context.Context, string) ([]controls.Reading, error) {
+	return nil, nil
+}
+func (fakeReadingStore) ReadingByCopy(context.Context, string, int) (controls.Reading, error) {
+	return controls.Reading{}, controls.ErrReadingNotFound
+}
+func (fakeReadingStore) SetAnswerOverride(context.Context, int64, string, controls.AnswerOverride) error {
+	return nil
+}
+func (fakeReadingStore) ClearAnswerOverride(context.Context, int64, string) error { return nil }
+func (fakeReadingStore) SetRUTOverride(context.Context, int64, string, time.Time) error {
+	return nil
+}
+func (fakeReadingStore) ClearRUTOverride(context.Context, int64) error { return nil }
+func (fakeReadingStore) SetControlState(context.Context, string, controls.State) error {
+	return nil
+}
+
 // newService returns a Service against a fixture bank, a fake store, a
 // fake generator that succeeds (SujetSize > 0), and a work dir under t's
 // tempdir.
@@ -95,6 +122,8 @@ func newService(t *testing.T) (*controls.Service, *fakeStore, *amctest.Fake, str
 		Bank:      b,
 		Store:     store,
 		Generator: gen,
+		Analyzer:  gen,
+		Readings:  fakeReadingStore{},
 		WorkDir:   workDir,
 		Now:       func() time.Time { return time.Unix(1_755_446_400, 0).UTC() },
 		Seed:      1242,
@@ -272,8 +301,9 @@ func TestCreatePassesTheCorrectAbsoluteListingPathForCodeQuestions(t *testing.T)
 	gen := &amctest.Fake{WorkDir: workDir, SujetSize: 4}
 	store := newFakeStore()
 	svc := controls.NewService(controls.Service{
-		Bank: b, Store: store, Generator: gen, WorkDir: workDir,
-		Now: func() time.Time { return time.Now() }, Seed: 1,
+		Bank: b, Store: store, Generator: gen, Analyzer: gen, Readings: fakeReadingStore{},
+		WorkDir: workDir,
+		Now:     func() time.Time { return time.Now() }, Seed: 1,
 		Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
 	})
 

--- a/apps/server/internal/domain/course/bank/bank.go
+++ b/apps/server/internal/domain/course/bank/bank.go
@@ -32,10 +32,11 @@ type Bank struct {
 	Questions []Question
 
 	// Indices, built by Parse. Not exported: consumers reach them through
-	// Pool, FindDocument and DocumentSections, so a rename here does not
-	// leak into the callers.
-	docIndex     map[string]int
-	sectionIndex map[SectionRef]int
+	// Pool, FindDocument, FindQuestion and DocumentSections, so a rename
+	// here does not leak into the callers.
+	docIndex      map[string]int
+	sectionIndex  map[SectionRef]int
+	questionIndex map[string]int
 }
 
 // Document is one course document as the emitter published it: id, title, the
@@ -197,11 +198,12 @@ func Parse(r io.Reader) (*Bank, error) {
 	}
 
 	b := &Bank{
-		Version:      raw.Version,
-		Documents:    make([]Document, 0, len(raw.Documents)),
-		Questions:    make([]Question, 0, len(raw.Questions)),
-		docIndex:     make(map[string]int, len(raw.Documents)),
-		sectionIndex: make(map[SectionRef]int, len(raw.Documents)*4),
+		Version:       raw.Version,
+		Documents:     make([]Document, 0, len(raw.Documents)),
+		Questions:     make([]Question, 0, len(raw.Questions)),
+		docIndex:      make(map[string]int, len(raw.Documents)),
+		sectionIndex:  make(map[SectionRef]int, len(raw.Documents)*4),
+		questionIndex: make(map[string]int, len(raw.Questions)),
 	}
 	for i, d := range raw.Documents {
 		b.Documents = append(b.Documents, Document{
@@ -216,7 +218,7 @@ func Parse(r io.Reader) (*Bank, error) {
 		}
 	}
 	seenID := make(map[string]bool, len(raw.Questions))
-	for _, q := range raw.Questions {
+	for i, q := range raw.Questions {
 		if seenID[q.ID] {
 			return nil, fmt.Errorf("%w: %q", ErrDuplicateQuestionID, q.ID)
 		}
@@ -236,6 +238,7 @@ func Parse(r io.Reader) (*Bank, error) {
 			Alternatives: append([]string(nil), q.Alternatives...),
 			Correct:      append([]int(nil), q.Correct...),
 		})
+		b.questionIndex[q.ID] = i
 	}
 	return b, nil
 }
@@ -324,6 +327,17 @@ func (b *Bank) FindDocument(id string) (Document, bool) {
 func (b *Bank) HasSection(ref SectionRef) bool {
 	_, ok := b.sectionIndex[ref]
 	return ok
+}
+
+// FindQuestion returns the Question with id, and whether it exists.
+// WP-F's review page needs statement + alternatives together per rendered
+// question; the old code walked b.Questions twice per row.
+func (b *Bank) FindQuestion(id string) (Question, bool) {
+	i, ok := b.questionIndex[id]
+	if !ok {
+		return Question{}, false
+	}
+	return b.Questions[i], true
 }
 
 // --- JSON shape --------------------------------------------------------------

--- a/apps/server/internal/infra/amcworker/amctest/amctest.go
+++ b/apps/server/internal/infra/amcworker/amctest/amctest.go
@@ -45,6 +45,23 @@ type Fake struct {
 	// value writes that many bytes so the "PDF present" path can also be
 	// tested.
 	SujetSize int
+
+	// AnalyzeCalls records every Analyze call in order.
+	AnalyzeCalls []controls.AnalyzeRequest
+	// AnalyzeReports is popped left-to-right, one per Analyze call; the last
+	// one sticks (so a test with three uploads and one fixed report gets
+	// that report three times). An empty slice returns the zero Report.
+	AnalyzeReports []controls.Report
+	// AnalyzeErr, when set, is returned from Analyze instead of the success
+	// path.
+	AnalyzeErr error
+
+	// ReanalyzeCalls records every Reanalyze call in order.
+	ReanalyzeCalls []controls.ReanalyzeRequest
+	// ReanalyzeReports mirrors AnalyzeReports.
+	ReanalyzeReports []controls.Report
+	// ReanalyzeErr, when set, is returned from Reanalyze.
+	ReanalyzeErr error
 }
 
 // Generate satisfies controls.Generator. When Err is set, it returns that;

--- a/apps/server/internal/infra/amcworker/amctest/analyze.go
+++ b/apps/server/internal/infra/amcworker/amctest/analyze.go
@@ -1,0 +1,77 @@
+package amctest
+
+import (
+	"context"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+)
+
+// Analyze satisfies controls.Analyzer. Records the call and returns whatever
+// Report is at the head of AnalyzeReports (or an empty Report if the slice
+// is empty). AnalyzeErr wins over both.
+func (f *Fake) Analyze(_ context.Context, req controls.AnalyzeRequest) (controls.Report, error) {
+	f.mu.Lock()
+	f.AnalyzeCalls = append(f.AnalyzeCalls, req)
+	err := f.AnalyzeErr
+	var report controls.Report
+	if len(f.AnalyzeReports) > 0 {
+		report = f.AnalyzeReports[0]
+		if len(f.AnalyzeReports) > 1 {
+			f.AnalyzeReports = f.AnalyzeReports[1:]
+		}
+	}
+	f.mu.Unlock()
+
+	if err != nil {
+		return controls.Report{}, err
+	}
+	return report, nil
+}
+
+// Reanalyze satisfies controls.Analyzer. Same shape as Analyze: records the
+// call, pops from ReanalyzeReports, honours ReanalyzeErr.
+func (f *Fake) Reanalyze(_ context.Context, req controls.ReanalyzeRequest) (controls.Report, error) {
+	f.mu.Lock()
+	f.ReanalyzeCalls = append(f.ReanalyzeCalls, req)
+	err := f.ReanalyzeErr
+	var report controls.Report
+	if len(f.ReanalyzeReports) > 0 {
+		report = f.ReanalyzeReports[0]
+		if len(f.ReanalyzeReports) > 1 {
+			f.ReanalyzeReports = f.ReanalyzeReports[1:]
+		}
+	}
+	f.mu.Unlock()
+
+	if err != nil {
+		return controls.Report{}, err
+	}
+	return report, nil
+}
+
+// AnalyzeCallCount returns how many times Analyze was called.
+func (f *Fake) AnalyzeCallCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.AnalyzeCalls)
+}
+
+// LastAnalyzeCall returns the last Analyze request, if any.
+func (f *Fake) LastAnalyzeCall() (controls.AnalyzeRequest, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.AnalyzeCalls) == 0 {
+		return controls.AnalyzeRequest{}, false
+	}
+	return f.AnalyzeCalls[len(f.AnalyzeCalls)-1], true
+}
+
+// LastReanalyzeCall returns the last Reanalyze request, if any.
+func (f *Fake) LastReanalyzeCall() (controls.ReanalyzeRequest, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.ReanalyzeCalls) == 0 {
+		return controls.ReanalyzeRequest{}, false
+	}
+	return f.ReanalyzeCalls[len(f.ReanalyzeCalls)-1], true
+}

--- a/apps/server/internal/infra/amcworker/amctest/analyze_test.go
+++ b/apps/server/internal/infra/amcworker/amctest/analyze_test.go
@@ -1,0 +1,74 @@
+package amctest_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+	"github.com/so77id/nalanda/apps/server/internal/infra/amcworker/amctest"
+)
+
+func TestFakeAnalyzeRecordsCallsAndReturnsFixture(t *testing.T) {
+	report := controls.Report{
+		Pages:  controls.Pages{Captured: 4, Failed: 0},
+		Copies: map[string]controls.ReportCopy{"1": {RUT: "20123456", RUTStatus: controls.RUTStatusOK, Status: controls.CopyStatusOK}},
+	}
+	f := &amctest.Fake{AnalyzeReports: []controls.Report{report}}
+
+	got, err := f.Analyze(context.Background(), controls.AnalyzeRequest{
+		Project: "controls/abc", ScanPDF: "controls/abc/scans/1.pdf", Source: "controls/abc/inputs/source.tex",
+	})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if got.Copies["1"].RUT != "20123456" {
+		t.Errorf("returned report = %+v", got)
+	}
+	if f.AnalyzeCallCount() != 1 {
+		t.Errorf("AnalyzeCallCount = %d, want 1", f.AnalyzeCallCount())
+	}
+	last, ok := f.LastAnalyzeCall()
+	if !ok || last.Project != "controls/abc" {
+		t.Errorf("LastAnalyzeCall = %+v, ok=%v", last, ok)
+	}
+
+	// A second call with only one report queued still gets that report — it
+	// sticks so a two-upload test does not have to pre-load two fixtures
+	// when it only wants to observe the second call.
+	if _, err := f.Analyze(context.Background(), controls.AnalyzeRequest{
+		Project: "controls/abc", ScanPDF: "controls/abc/scans/2.pdf", Source: "controls/abc/inputs/source.tex",
+	}); err != nil {
+		t.Fatalf("Analyze (2): %v", err)
+	}
+	if f.AnalyzeCallCount() != 2 {
+		t.Errorf("AnalyzeCallCount after two = %d, want 2", f.AnalyzeCallCount())
+	}
+}
+
+func TestFakeAnalyzeReturnsErr(t *testing.T) {
+	boom := errors.New("boom")
+	f := &amctest.Fake{AnalyzeErr: boom}
+	if _, err := f.Analyze(context.Background(), controls.AnalyzeRequest{Project: "p"}); !errors.Is(err, boom) {
+		t.Errorf("Analyze: %v, want boom", err)
+	}
+}
+
+func TestFakeReanalyzeRecordsCallsAndReturnsFixture(t *testing.T) {
+	report := controls.Report{Scoring: controls.Scoring{Seuil: 0.30, Ticked: 0.25, Stale: true}}
+	f := &amctest.Fake{ReanalyzeReports: []controls.Report{report}}
+
+	got, err := f.Reanalyze(context.Background(), controls.ReanalyzeRequest{
+		Project: "controls/abc", Ticked: 0.25, Unsure: 0.1,
+	})
+	if err != nil {
+		t.Fatalf("Reanalyze: %v", err)
+	}
+	if !got.Scoring.Stale || got.Scoring.Ticked != 0.25 {
+		t.Errorf("returned report = %+v", got)
+	}
+	last, ok := f.LastReanalyzeCall()
+	if !ok || last.Ticked != 0.25 || last.Unsure != 0.1 {
+		t.Errorf("LastReanalyzeCall = %+v, ok=%v", last, ok)
+	}
+}

--- a/apps/server/internal/infra/amcworker/analyze.go
+++ b/apps/server/internal/infra/amcworker/analyze.go
@@ -1,0 +1,229 @@
+package amcworker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+)
+
+// Analyze runs POST /analyse against the worker. Serialised behind the same
+// mutex as Generate: AMC's state is sqlite in the project directory and two
+// runs against one project would race it, which is the whole reason this
+// wrapper exists (ADR-0030 §The worker is threaded; AMC is not re-entrant).
+//
+// Analyse is minutes-class — a 40-copy batch is under a minute measured, but
+// getimages + analyse + note + read_capture is orders of magnitude slower
+// than a synchronous generate. The caller's context is what bounds the wait.
+func (c *Client) Analyze(ctx context.Context, req controls.AnalyzeRequest) (controls.Report, error) {
+	if req.Project == "" {
+		return controls.Report{}, fmt.Errorf("%w: project path is required", controls.ErrAnalyzerRefused)
+	}
+	if req.ScanPDF == "" {
+		return controls.Report{}, fmt.Errorf("%w: scan pdf path is required", controls.ErrAnalyzerRefused)
+	}
+	if req.Source == "" {
+		return controls.Report{}, fmt.Errorf("%w: source path is required", controls.ErrAnalyzerRefused)
+	}
+
+	c.generateLock.Lock()
+	defer c.generateLock.Unlock()
+
+	body, err := json.Marshal(analyzeRequestBody{
+		Project: req.Project,
+		ScanPDF: req.ScanPDF,
+		Source:  req.Source,
+	})
+	if err != nil {
+		return controls.Report{}, fmt.Errorf("amcworker: encode analyse request: %w", err)
+	}
+	return c.postReport(ctx, "/analyse", body)
+}
+
+// Reanalyze runs POST /reanalyse against the worker. Same lock — the read
+// re-opens AMC's sqlite files.
+func (c *Client) Reanalyze(ctx context.Context, req controls.ReanalyzeRequest) (controls.Report, error) {
+	if req.Project == "" {
+		return controls.Report{}, fmt.Errorf("%w: project path is required", controls.ErrAnalyzerRefused)
+	}
+	if req.Ticked <= 0 || req.Ticked >= 1 {
+		return controls.Report{}, fmt.Errorf("%w: ticked must be in (0,1), got %v", controls.ErrAnalyzerRefused, req.Ticked)
+	}
+	if req.Unsure < 0 || req.Unsure >= req.Ticked {
+		return controls.Report{}, fmt.Errorf("%w: unsure must be in [0, ticked), got %v vs ticked %v", controls.ErrAnalyzerRefused, req.Unsure, req.Ticked)
+	}
+
+	c.generateLock.Lock()
+	defer c.generateLock.Unlock()
+
+	body, err := json.Marshal(reanalyzeRequestBody{
+		Project: req.Project,
+		Ticked:  req.Ticked,
+		Unsure:  req.Unsure,
+	})
+	if err != nil {
+		return controls.Report{}, fmt.Errorf("amcworker: encode reanalyse request: %w", err)
+	}
+	return c.postReport(ctx, "/reanalyse", body)
+}
+
+// postReport POSTs body to path and decodes the reading report. Shared by
+// Analyze and Reanalyze because their success and failure envelopes are the
+// same shape — only the request body differs.
+func (c *Client) postReport(ctx context.Context, path string, body []byte) (controls.Report, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.base+path, bytes.NewReader(body))
+	if err != nil {
+		return controls.Report{}, fmt.Errorf("amcworker: build request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(httpReq)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return controls.Report{}, fmt.Errorf("amcworker: %w", err)
+		}
+		return controls.Report{}, fmt.Errorf("%w: %v", controls.ErrAnalyzerUnavailable, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	// A reading report is roomier than a generate response — 40 copies × 4
+	// questions × doubtful entries plus metadata. 8 MiB is comfortably above
+	// what a real batch produces and well below anything that would be a
+	// runaway.
+	const maxRead = 8 << 20
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxRead))
+	if err != nil {
+		return controls.Report{}, fmt.Errorf("%w: read response: %v", controls.ErrAnalyzerUnavailable, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var payload workerError
+		if jerr := json.Unmarshal(respBody, &payload); jerr == nil && payload.Error != "" {
+			return controls.Report{}, fmt.Errorf("%w: worker answered %d: %s",
+				controls.ErrAnalyzerRefused, resp.StatusCode, payload.Error)
+		}
+		return controls.Report{}, fmt.Errorf("%w: worker answered %d: %s",
+			controls.ErrAnalyzerRefused, resp.StatusCode, truncateForLog(respBody))
+	}
+
+	var wire reportBody
+	if err := json.Unmarshal(respBody, &wire); err != nil {
+		return controls.Report{}, fmt.Errorf("%w: decode response: %v", controls.ErrAnalyzerRefused, err)
+	}
+	return wire.toDomain(), nil
+}
+
+// Assert the interface at compile time.
+var _ controls.Analyzer = (*Client)(nil)
+
+// --- wire shapes -------------------------------------------------------------
+
+type analyzeRequestBody struct {
+	Project string `json:"project"`
+	ScanPDF string `json:"scan_pdf"`
+	Source  string `json:"source"`
+}
+
+type reanalyzeRequestBody struct {
+	Project string  `json:"project"`
+	Ticked  float64 `json:"ticked"`
+	Unsure  float64 `json:"unsure"`
+}
+
+// reportBody mirrors read_capture.py's JSON shape.
+type reportBody struct {
+	Pages struct {
+		Captured int `json:"captured"`
+		Failed   int `json:"failed"`
+	} `json:"pages"`
+	Scoring struct {
+		Seuil  float64 `json:"seuil"`
+		Ticked float64 `json:"ticked"`
+		Stale  bool    `json:"stale"`
+	} `json:"scoring"`
+	Copies      map[string]copyBody `json:"copies"`
+	NeedsReview []string            `json:"needs_review"`
+}
+
+type copyBody struct {
+	RUT               string       `json:"rut"`
+	RUTStatus         string       `json:"rut_status"`
+	Answers           []answerBody `json:"answers"`
+	ExpectedQuestions int          `json:"expected_questions"`
+	SeenQuestions     int          `json:"seen_questions"`
+	MissingQuestions  []string     `json:"missing_questions"`
+	Status            string       `json:"status"`
+}
+
+type answerBody struct {
+	Question int            `json:"question"`
+	Name     string         `json:"name"`
+	Type     string         `json:"type"`
+	Marked   []int          `json:"marked"`
+	Doubtful []doubtfulBody `json:"doubtful"`
+	Status   string         `json:"status"`
+	Score    float64        `json:"score"`
+	Max      float64        `json:"max"`
+}
+
+type doubtfulBody struct {
+	Answer   int     `json:"answer"`
+	Darkness float64 `json:"darkness"`
+}
+
+func (b reportBody) toDomain() controls.Report {
+	out := controls.Report{
+		Pages: controls.Pages{
+			Captured: b.Pages.Captured,
+			Failed:   b.Pages.Failed,
+		},
+		Scoring: controls.Scoring{
+			Seuil:  b.Scoring.Seuil,
+			Ticked: b.Scoring.Ticked,
+			Stale:  b.Scoring.Stale,
+		},
+		Copies:      make(map[string]controls.ReportCopy, len(b.Copies)),
+		NeedsReview: append([]string(nil), b.NeedsReview...),
+	}
+	for k, v := range b.Copies {
+		out.Copies[k] = controls.ReportCopy{
+			RUT:               v.RUT,
+			RUTStatus:         controls.RUTStatus(v.RUTStatus),
+			Answers:           toAnswers(v.Answers),
+			ExpectedQuestions: v.ExpectedQuestions,
+			SeenQuestions:     v.SeenQuestions,
+			MissingQuestions:  append([]string(nil), v.MissingQuestions...),
+			Status:            controls.CopyStatus(v.Status),
+		}
+	}
+	return out
+}
+
+func toAnswers(in []answerBody) []controls.ReportAnswer {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]controls.ReportAnswer, len(in))
+	for i, a := range in {
+		doubtful := make([]controls.Doubtful, len(a.Doubtful))
+		for j, d := range a.Doubtful {
+			doubtful[j] = controls.Doubtful{Answer: d.Answer, Darkness: d.Darkness}
+		}
+		out[i] = controls.ReportAnswer{
+			Question: a.Question,
+			Name:     a.Name,
+			Type:     controls.QuestionType(a.Type),
+			Marked:   append([]int(nil), a.Marked...),
+			Doubtful: doubtful,
+			Status:   controls.AnswerStatus(a.Status),
+			Score:    a.Score,
+			Max:      a.Max,
+		}
+	}
+	return out
+}

--- a/apps/server/internal/infra/amcworker/analyze_test.go
+++ b/apps/server/internal/infra/amcworker/analyze_test.go
@@ -1,0 +1,185 @@
+package amcworker_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+	"github.com/so77id/nalanda/apps/server/internal/infra/amcworker"
+)
+
+// sampleReport is what a healthy /analyse response looks like — modelled on
+// read_capture.py's own docstring. Kept small (one copy) so an assertion on
+// the decoded shape stays legible.
+const sampleReport = `{
+  "pages": {"captured": 4, "failed": 0},
+  "scoring": {"seuil": 0.3, "ticked": 0.3, "stale": false},
+  "copies": {
+    "1": {
+      "rut": "20123456",
+      "rut_status": "ok",
+      "rut_columns": [{"column": 0, "digits": ["2"]}],
+      "answers": [
+        {"question": 9, "name": "q-if-1", "type": "simple",
+         "marked": [1], "doubtful": [], "status": "ok",
+         "score": 1.0, "max": 1.0},
+        {"question": 10, "name": "q-bucles-2", "type": "multiple",
+         "marked": [1, 3], "doubtful": [{"answer": 2, "darkness": 0.18}],
+         "status": "doubtful",
+         "score": 3.0, "max": 4.0}
+      ],
+      "expected_questions": 2,
+      "seen_questions": 2,
+      "missing_questions": [],
+      "status": "needs_review"
+    }
+  },
+  "needs_review": ["1"]
+}`
+
+func TestAnalyzeSendsProjectScanPDFAndSource(t *testing.T) {
+	var got analyzeSent
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/analyse" {
+			t.Errorf("worker got %s %s, want POST /analyse", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(sampleReport))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := amcworker.New(amcworker.Config{BaseURL: srv.URL})
+	report, err := client.Analyze(context.Background(), controls.AnalyzeRequest{
+		Project: "controls/abc",
+		ScanPDF: "controls/abc/scans/batch-1.pdf",
+		Source:  "controls/abc/inputs/source.tex",
+	})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if got.Project != "controls/abc" || got.ScanPDF != "controls/abc/scans/batch-1.pdf" ||
+		got.Source != "controls/abc/inputs/source.tex" {
+		t.Errorf("worker received %+v", got)
+	}
+	// The report round-trips into the domain shape.
+	if report.Pages.Captured != 4 || len(report.Copies) != 1 {
+		t.Errorf("Report = %+v", report)
+	}
+	copy1 := report.Copies["1"]
+	if copy1.RUTStatus != controls.RUTStatusOK || copy1.Status != controls.CopyStatusNeedsReview {
+		t.Errorf("Copy1 = %+v", copy1)
+	}
+	if len(copy1.Answers) != 2 || copy1.Answers[0].Type != controls.QuestionSimple ||
+		copy1.Answers[1].Type != controls.QuestionMultiple {
+		t.Errorf("answers = %+v", copy1.Answers)
+	}
+	if copy1.Answers[1].Doubtful[0].Darkness != 0.18 {
+		t.Errorf("doubtful darkness = %v", copy1.Answers[1].Doubtful[0].Darkness)
+	}
+}
+
+func TestAnalyzeRefusedOn4xxWrapsErrAnalyzerRefused(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"the batch was scored before it was fully captured","detail":"copy 6 question 'p2' has no score"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := amcworker.New(amcworker.Config{BaseURL: srv.URL})
+	_, err := client.Analyze(context.Background(), controls.AnalyzeRequest{
+		Project: "controls/x", ScanPDF: "controls/x/s.pdf", Source: "controls/x/s.tex",
+	})
+	if !errors.Is(err, controls.ErrAnalyzerRefused) {
+		t.Errorf("Analyze on 400: %v, want ErrAnalyzerRefused", err)
+	}
+	if !strings.Contains(err.Error(), "scored before it was fully captured") {
+		t.Errorf("error %q does not include worker's message", err.Error())
+	}
+}
+
+func TestAnalyzeRefusesInvalidRequestBeforeCallingTheWorker(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("Analyze reached the worker with an invalid request")
+	}))
+	t.Cleanup(srv.Close)
+	client := amcworker.New(amcworker.Config{BaseURL: srv.URL})
+
+	cases := []controls.AnalyzeRequest{
+		{Project: "", ScanPDF: "s", Source: "t"},
+		{Project: "p", ScanPDF: "", Source: "t"},
+		{Project: "p", ScanPDF: "s", Source: ""},
+	}
+	for _, req := range cases {
+		if _, err := client.Analyze(context.Background(), req); !errors.Is(err, controls.ErrAnalyzerRefused) {
+			t.Errorf("Analyze(%+v): %v, want ErrAnalyzerRefused", req, err)
+		}
+	}
+}
+
+func TestReanalyzeSendsProjectAndThresholds(t *testing.T) {
+	var got reanalyzeSent
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/reanalyse" {
+			t.Errorf("worker got %s %s, want POST /reanalyse", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(sampleReport))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := amcworker.New(amcworker.Config{BaseURL: srv.URL})
+	_, err := client.Reanalyze(context.Background(), controls.ReanalyzeRequest{
+		Project: "controls/abc", Ticked: 0.25, Unsure: 0.12,
+	})
+	if err != nil {
+		t.Fatalf("Reanalyze: %v", err)
+	}
+	if got.Project != "controls/abc" || got.Ticked != 0.25 || got.Unsure != 0.12 {
+		t.Errorf("worker received %+v", got)
+	}
+}
+
+func TestReanalyzeRefusesOutOfRangeThresholds(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("Reanalyze reached the worker with invalid thresholds")
+	}))
+	t.Cleanup(srv.Close)
+	client := amcworker.New(amcworker.Config{BaseURL: srv.URL})
+
+	cases := []controls.ReanalyzeRequest{
+		{Project: "p", Ticked: 0, Unsure: 0.1},
+		{Project: "p", Ticked: 1, Unsure: 0.1},
+		{Project: "p", Ticked: 0.3, Unsure: -0.1},
+		{Project: "p", Ticked: 0.3, Unsure: 0.4},
+		{Project: "", Ticked: 0.3, Unsure: 0.1},
+	}
+	for _, req := range cases {
+		if _, err := client.Reanalyze(context.Background(), req); !errors.Is(err, controls.ErrAnalyzerRefused) {
+			t.Errorf("Reanalyze(%+v): %v, want ErrAnalyzerRefused", req, err)
+		}
+	}
+}
+
+type analyzeSent struct {
+	Project string `json:"project"`
+	ScanPDF string `json:"scan_pdf"`
+	Source  string `json:"source"`
+}
+
+type reanalyzeSent struct {
+	Project string  `json:"project"`
+	Ticked  float64 `json:"ticked"`
+	Unsure  float64 `json:"unsure"`
+}

--- a/apps/server/internal/infra/config/config.go
+++ b/apps/server/internal/infra/config/config.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -59,6 +60,20 @@ const (
 	// the WORKER's side regardless of what this server names its own.
 	KeyWorkDir = "NALANDA_WORK_DIR"
 )
+
+// The entrance-controls WP-F block (#167). Optional variables that bound
+// what the scan upload will accept.
+const (
+	// KeyMaxScanMB is the largest scan PDF the upload handler will accept,
+	// in whole megabytes. Optional — defaults to 100. A single scan of a
+	// four-page control at 300 dpi is roughly 3-5 MB, so 100 is generous
+	// enough that a rare four-double-sided-sheet class fits and a runaway
+	// upload is refused before it enters the worker.
+	KeyMaxScanMB = "NALANDA_MAX_SCAN_MB"
+)
+
+// defaultMaxScanMB is what an unset KeyMaxScanMB resolves to.
+const defaultMaxScanMB = 100
 
 // ErrMissing is wrapped by every error caused by an absent or empty required
 // variable, so a caller can distinguish "the operator has not finished
@@ -127,6 +142,12 @@ type Config struct {
 	// The .tex the generator emits always uses /work absolute paths (from
 	// the worker's perspective, controls.WorkerWorkDir) whatever this is.
 	WorkDir string
+
+	// MaxScanBytes is what the upload handler will accept. Derived from
+	// KeyMaxScanMB (in whole megabytes) and expressed here as bytes so
+	// callers can pass it straight into http.MaxBytesReader without
+	// re-doing the multiplication.
+	MaxScanBytes int64
 }
 
 // Keys lists every variable this package reads, in the order an operator would
@@ -138,6 +159,7 @@ func Keys() []string {
 		KeyPublicURL, KeyGoogleClientID, KeyGoogleClientSecret,
 		KeySessionTTL, KeyBootstrapProfessorEmail,
 		KeyQuestionsJSONURL, KeyAmcWorkerURL, KeyWorkDir,
+		KeyMaxScanMB,
 	}
 }
 
@@ -224,7 +246,29 @@ func Load(lookup LookupFunc) (Config, error) {
 	}
 	cfg.SessionTTL = ttl
 
+	maxScanMB, err := parsePositiveInt(l.optional(KeyMaxScanMB, ""), defaultMaxScanMB)
+	if err != nil {
+		return Config{}, fmt.Errorf("%s: %w", KeyMaxScanMB, err)
+	}
+	cfg.MaxScanBytes = int64(maxScanMB) * (1 << 20)
+
 	return cfg, nil
+}
+
+// parsePositiveInt returns the value or the default (when raw is empty). A
+// non-empty non-integer or a non-positive value is refused.
+func parsePositiveInt(raw string, fallback int) (int, error) {
+	if raw == "" {
+		return fallback, nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("%q is not an integer", raw)
+	}
+	if n <= 0 {
+		return 0, fmt.Errorf("%d is not positive", n)
+	}
+	return n, nil
 }
 
 // SecureCookie reports whether the session cookie carries the Secure attribute.

--- a/apps/server/internal/infra/storage/controlstore/readings.go
+++ b/apps/server/internal/infra/storage/controlstore/readings.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
@@ -83,15 +84,13 @@ func (s *Store) UpsertReadingsFromReport(ctx context.Context, controlID string, 
 }
 
 func upsertReading(ctx context.Context, tx *sql.Tx, controlID string, copyNumber int, c controls.ReportCopy, now time.Time) (int64, error) {
-	var (
-		rutRead sql.NullString
-	)
-	if c.RUT != "" && c.RUTStatus == controls.RUTStatusOK {
-		rutRead = sql.NullString{String: c.RUT, Valid: true}
-	} else if c.RUT != "" {
-		// An unreadable RUT still carries the digits AMC could pin down;
-		// storing it verbatim lets the review page show what the reader
-		// saw beside the professor's typed correction.
+	var rutRead sql.NullString
+	// The wire report carries what AMC pinned down in either case: eight
+	// clean digits when RUTStatusOK, or the partial digits + `_` / `[…]`
+	// sentinels from read_capture when RUTStatusUnreadable. Both are
+	// stored verbatim — the review page shows what AMC saw beside the
+	// professor's typed correction (§Reading with different thresholds).
+	if c.RUT != "" {
 		rutRead = sql.NullString{String: c.RUT, Valid: true}
 	}
 	if _, err := tx.ExecContext(ctx,
@@ -401,8 +400,8 @@ func scanReading(row interface{ Scan(...any) error }) (controls.Reading, error) 
 }
 
 func parseCopyNumber(key string) (int, error) {
-	var n int
-	if _, err := fmt.Sscanf(key, "%d", &n); err != nil {
+	n, err := strconv.Atoi(key)
+	if err != nil {
 		return 0, fmt.Errorf("copy key %q is not a number: %w", key, err)
 	}
 	if n < 1 {

--- a/apps/server/internal/infra/storage/controlstore/readings.go
+++ b/apps/server/internal/infra/storage/controlstore/readings.go
@@ -1,0 +1,412 @@
+package controlstore
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+)
+
+// Compile-time proof: the Store here also satisfies ReadingStore.
+var _ controls.ReadingStore = (*Store)(nil)
+
+// UpsertReadingsFromReport writes/updates the report against controlID.
+// Overrides are left intact so a re-read at a different sensitivity does
+// not wipe manual decisions (issue #167 §Reading with different thresholds).
+func (s *Store) UpsertReadingsFromReport(ctx context.Context, controlID string, report controls.Report, now time.Time) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("controlstore.UpsertReadingsFromReport: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Sort the copy keys so the write order is deterministic. It is not
+	// load-bearing today, but it removes a source of flake from tests
+	// that assert the row-ordered result of a stream.
+	keys := make([]string, 0, len(report.Copies))
+	for k := range report.Copies {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		copyNumber, err := parseCopyNumber(key)
+		if err != nil {
+			return fmt.Errorf("controlstore.UpsertReadingsFromReport: %w", err)
+		}
+		reportCopy := report.Copies[key]
+
+		readingID, err := upsertReading(ctx, tx, controlID, copyNumber, reportCopy, now)
+		if err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx,
+			`DELETE FROM answer WHERE reading_id = ?`, readingID); err != nil {
+			return fmt.Errorf("controlstore.UpsertReadingsFromReport: delete answers for reading %d: %w", readingID, err)
+		}
+		for _, ans := range reportCopy.Answers {
+			markedJSON, err := json.Marshal(ans.Marked)
+			if err != nil {
+				return fmt.Errorf("controlstore.UpsertReadingsFromReport: encode marked: %w", err)
+			}
+			doubtfulJSON, err := json.Marshal(ans.Doubtful)
+			if err != nil {
+				return fmt.Errorf("controlstore.UpsertReadingsFromReport: encode doubtful: %w", err)
+			}
+			if ans.Name == "" {
+				return fmt.Errorf("controlstore.UpsertReadingsFromReport: copy %d question %d has empty layout name — the wrapper cannot resolve it against the pool",
+					copyNumber, ans.Question)
+			}
+			if _, err := tx.ExecContext(ctx,
+				`INSERT INTO answer
+                    (reading_id, question_ref, question_type, marked_json, doubtful_json, status, score, max)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+				readingID, ans.Name, string(ans.Type),
+				string(markedJSON), string(doubtfulJSON),
+				string(ans.Status), ans.Score, ans.Max,
+			); err != nil {
+				return fmt.Errorf("controlstore.UpsertReadingsFromReport: insert answer copy %d %s: %w",
+					copyNumber, ans.Name, err)
+			}
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("controlstore.UpsertReadingsFromReport: commit: %w", err)
+	}
+	return nil
+}
+
+func upsertReading(ctx context.Context, tx *sql.Tx, controlID string, copyNumber int, c controls.ReportCopy, now time.Time) (int64, error) {
+	var (
+		rutRead sql.NullString
+	)
+	if c.RUT != "" && c.RUTStatus == controls.RUTStatusOK {
+		rutRead = sql.NullString{String: c.RUT, Valid: true}
+	} else if c.RUT != "" {
+		// An unreadable RUT still carries the digits AMC could pin down;
+		// storing it verbatim lets the review page show what the reader
+		// saw beside the professor's typed correction.
+		rutRead = sql.NullString{String: c.RUT, Valid: true}
+	}
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO reading (control_id, copy_number, rut_read, rut_status, copy_status, read_at)
+         VALUES (?, ?, ?, ?, ?, ?)
+         ON CONFLICT (control_id, copy_number) DO UPDATE SET
+             rut_read = excluded.rut_read,
+             rut_status = excluded.rut_status,
+             copy_status = excluded.copy_status,
+             read_at = excluded.read_at`,
+		controlID, copyNumber, rutRead, string(c.RUTStatus), string(c.Status), now.Unix(),
+	); err != nil {
+		return 0, fmt.Errorf("controlstore.upsertReading: %s/%d: %w", controlID, copyNumber, err)
+	}
+	var id int64
+	if err := tx.QueryRowContext(ctx,
+		`SELECT id FROM reading WHERE control_id = ? AND copy_number = ?`,
+		controlID, copyNumber).Scan(&id); err != nil {
+		return 0, fmt.Errorf("controlstore.upsertReading: lookup id %s/%d: %w", controlID, copyNumber, err)
+	}
+	return id, nil
+}
+
+// MarkMissingAsNotPresent inserts a not_present reading for every printed
+// copia that has no reading yet. Idempotent.
+func (s *Store) MarkMissingAsNotPresent(ctx context.Context, controlID string, now time.Time) error {
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO reading (control_id, copy_number, rut_read, rut_status, copy_status, read_at)
+         SELECT c.control_id, c.numero, NULL, 'not_present', 'not_present', ?
+         FROM copia c
+         WHERE c.control_id = ?
+           AND NOT EXISTS (
+             SELECT 1 FROM reading r
+             WHERE r.control_id = c.control_id AND r.copy_number = c.numero
+           )`,
+		now.Unix(), controlID); err != nil {
+		return fmt.Errorf("controlstore.MarkMissingAsNotPresent: %w", err)
+	}
+	return nil
+}
+
+// ReadingsByControl returns every reading for a control, ordered by
+// copy_number ascending, with overrides eagerly attached.
+func (s *Store) ReadingsByControl(ctx context.Context, controlID string) ([]controls.Reading, error) {
+	rows, err := s.db.QueryContext(ctx, `
+        SELECT id, control_id, copy_number, rut_read, rut_status, copy_status, read_at, last_edited_at
+        FROM reading
+        WHERE control_id = ?
+        ORDER BY copy_number ASC`, controlID)
+	if err != nil {
+		return nil, fmt.Errorf("controlstore.ReadingsByControl: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var readings []controls.Reading
+	for rows.Next() {
+		r, err := scanReading(rows)
+		if err != nil {
+			return nil, fmt.Errorf("controlstore.ReadingsByControl: scan: %w", err)
+		}
+		readings = append(readings, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("controlstore.ReadingsByControl: iterate: %w", err)
+	}
+	if err := s.attachAnswersAndOverrides(ctx, readings); err != nil {
+		return nil, err
+	}
+	return readings, nil
+}
+
+// ReadingByCopy returns one reading (with overrides), or
+// ErrReadingNotFound.
+func (s *Store) ReadingByCopy(ctx context.Context, controlID string, copyNumber int) (controls.Reading, error) {
+	row := s.db.QueryRowContext(ctx, `
+        SELECT id, control_id, copy_number, rut_read, rut_status, copy_status, read_at, last_edited_at
+        FROM reading
+        WHERE control_id = ? AND copy_number = ?`, controlID, copyNumber)
+	r, err := scanReading(row)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return controls.Reading{}, controls.ErrReadingNotFound
+		}
+		return controls.Reading{}, fmt.Errorf("controlstore.ReadingByCopy: %w", err)
+	}
+	readings := []controls.Reading{r}
+	if err := s.attachAnswersAndOverrides(ctx, readings); err != nil {
+		return controls.Reading{}, err
+	}
+	return readings[0], nil
+}
+
+func (s *Store) attachAnswersAndOverrides(ctx context.Context, readings []controls.Reading) error {
+	if len(readings) == 0 {
+		return nil
+	}
+	// One pass per reading — simpler than one big IN () join, and the
+	// reading count is bounded by the copy count, which is bounded by
+	// maxCopies (300 today). If that ever becomes a problem the read
+	// shape here changes without moving the interface.
+	for i := range readings {
+		if err := s.loadAnswers(ctx, &readings[i]); err != nil {
+			return err
+		}
+		if err := s.loadRUTOverride(ctx, &readings[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Store) loadAnswers(ctx context.Context, r *controls.Reading) error {
+	rows, err := s.db.QueryContext(ctx, `
+        SELECT a.question_ref, a.question_type, a.marked_json, a.doubtful_json, a.status, a.score, a.max,
+               o.marked_json, o.status, o.edited_at
+        FROM answer a
+        LEFT JOIN answer_override o ON o.reading_id = a.reading_id AND o.question_ref = a.question_ref
+        WHERE a.reading_id = ?
+        ORDER BY a.question_ref ASC`, r.ID)
+	if err != nil {
+		return fmt.Errorf("controlstore.loadAnswers: reading %d: %w", r.ID, err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	r.Answers = nil
+	for rows.Next() {
+		var (
+			a             controls.Answer
+			qtype         string
+			markedJSON    string
+			doubtfulJSON  string
+			status        string
+			ovMarkedJSON  sql.NullString
+			ovStatus      sql.NullString
+			ovEditedAtRaw sql.NullInt64
+		)
+		if err := rows.Scan(
+			&a.QuestionRef, &qtype, &markedJSON, &doubtfulJSON, &status, &a.Score, &a.Max,
+			&ovMarkedJSON, &ovStatus, &ovEditedAtRaw,
+		); err != nil {
+			return fmt.Errorf("controlstore.loadAnswers: scan: %w", err)
+		}
+		a.QuestionType = controls.QuestionType(qtype)
+		a.Status = controls.AnswerStatus(status)
+		if err := json.Unmarshal([]byte(markedJSON), &a.Marked); err != nil {
+			return fmt.Errorf("controlstore.loadAnswers: decode marked: %w", err)
+		}
+		if err := json.Unmarshal([]byte(doubtfulJSON), &a.Doubtful); err != nil {
+			return fmt.Errorf("controlstore.loadAnswers: decode doubtful: %w", err)
+		}
+		if ovMarkedJSON.Valid {
+			ov := controls.AnswerOverride{
+				Status:   controls.AnswerStatus(ovStatus.String),
+				EditedAt: time.Unix(ovEditedAtRaw.Int64, 0).UTC(),
+			}
+			if err := json.Unmarshal([]byte(ovMarkedJSON.String), &ov.Marked); err != nil {
+				return fmt.Errorf("controlstore.loadAnswers: decode override marked: %w", err)
+			}
+			a.Override = &ov
+		}
+		r.Answers = append(r.Answers, a)
+	}
+	return rows.Err()
+}
+
+func (s *Store) loadRUTOverride(ctx context.Context, r *controls.Reading) error {
+	var (
+		rut         string
+		editedAt    int64
+		hasOverride bool
+	)
+	row := s.db.QueryRowContext(ctx,
+		`SELECT rut, edited_at FROM rut_override WHERE reading_id = ?`, r.ID)
+	switch err := row.Scan(&rut, &editedAt); err {
+	case nil:
+		hasOverride = true
+	case sql.ErrNoRows:
+	default:
+		return fmt.Errorf("controlstore.loadRUTOverride: reading %d: %w", r.ID, err)
+	}
+	if hasOverride {
+		r.RUTOverride = &controls.RUTOverride{
+			RUT:      rut,
+			EditedAt: time.Unix(editedAt, 0).UTC(),
+		}
+	}
+	return nil
+}
+
+// SetAnswerOverride upserts an override for one (reading_id,
+// question_ref) and stamps the reading's last_edited_at.
+func (s *Store) SetAnswerOverride(ctx context.Context, readingID int64, questionRef string, override controls.AnswerOverride) error {
+	markedJSON, err := json.Marshal(override.Marked)
+	if err != nil {
+		return fmt.Errorf("controlstore.SetAnswerOverride: encode marked: %w", err)
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("controlstore.SetAnswerOverride: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO answer_override (reading_id, question_ref, marked_json, status, edited_at)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT (reading_id, question_ref) DO UPDATE SET
+             marked_json = excluded.marked_json,
+             status      = excluded.status,
+             edited_at   = excluded.edited_at`,
+		readingID, questionRef, string(markedJSON), string(override.Status), override.EditedAt.Unix(),
+	); err != nil {
+		return fmt.Errorf("controlstore.SetAnswerOverride: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE reading SET last_edited_at = ? WHERE id = ?`,
+		override.EditedAt.Unix(), readingID); err != nil {
+		return fmt.Errorf("controlstore.SetAnswerOverride: stamp: %w", err)
+	}
+	return tx.Commit()
+}
+
+// ClearAnswerOverride deletes the override for (reading_id, question_ref).
+func (s *Store) ClearAnswerOverride(ctx context.Context, readingID int64, questionRef string) error {
+	if _, err := s.db.ExecContext(ctx,
+		`DELETE FROM answer_override WHERE reading_id = ? AND question_ref = ?`,
+		readingID, questionRef); err != nil {
+		return fmt.Errorf("controlstore.ClearAnswerOverride: %w", err)
+	}
+	return nil
+}
+
+// SetRUTOverride upserts the RUT override.
+func (s *Store) SetRUTOverride(ctx context.Context, readingID int64, rut string, editedAt time.Time) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("controlstore.SetRUTOverride: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	if _, err := tx.ExecContext(ctx,
+		`INSERT INTO rut_override (reading_id, rut, edited_at)
+         VALUES (?, ?, ?)
+         ON CONFLICT (reading_id) DO UPDATE SET
+             rut = excluded.rut,
+             edited_at = excluded.edited_at`,
+		readingID, rut, editedAt.Unix()); err != nil {
+		return fmt.Errorf("controlstore.SetRUTOverride: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx,
+		`UPDATE reading SET last_edited_at = ? WHERE id = ?`,
+		editedAt.Unix(), readingID); err != nil {
+		return fmt.Errorf("controlstore.SetRUTOverride: stamp: %w", err)
+	}
+	return tx.Commit()
+}
+
+// ClearRUTOverride deletes the RUT override.
+func (s *Store) ClearRUTOverride(ctx context.Context, readingID int64) error {
+	if _, err := s.db.ExecContext(ctx,
+		`DELETE FROM rut_override WHERE reading_id = ?`, readingID); err != nil {
+		return fmt.Errorf("controlstore.ClearRUTOverride: %w", err)
+	}
+	return nil
+}
+
+// SetControlState updates control.state.
+func (s *Store) SetControlState(ctx context.Context, controlID string, state controls.State) error {
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE control SET state = ? WHERE id = ?`, string(state), controlID)
+	if err != nil {
+		return fmt.Errorf("controlstore.SetControlState: %w", err)
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("controlstore.SetControlState: rows affected: %w", err)
+	}
+	if n == 0 {
+		return fmt.Errorf("controlstore.SetControlState: %s: %w", controlID, controls.ErrControlNotFound)
+	}
+	return nil
+}
+
+func scanReading(row interface{ Scan(...any) error }) (controls.Reading, error) {
+	var (
+		r               controls.Reading
+		rutRead         sql.NullString
+		rutStatus       string
+		copyStatus      string
+		readAt          int64
+		lastEditedAtRaw sql.NullInt64
+	)
+	if err := row.Scan(&r.ID, &r.ControlID, &r.CopyNumber, &rutRead, &rutStatus, &copyStatus, &readAt, &lastEditedAtRaw); err != nil {
+		return controls.Reading{}, err
+	}
+	r.RUTStatus = controls.RUTStatus(rutStatus)
+	r.CopyStatus = controls.CopyStatus(copyStatus)
+	r.ReadAt = time.Unix(readAt, 0).UTC()
+	if rutRead.Valid {
+		s := rutRead.String
+		r.RUTRead = &s
+	}
+	if lastEditedAtRaw.Valid {
+		t := time.Unix(lastEditedAtRaw.Int64, 0).UTC()
+		r.LastEditedAt = &t
+	}
+	return r, nil
+}
+
+func parseCopyNumber(key string) (int, error) {
+	var n int
+	if _, err := fmt.Sscanf(key, "%d", &n); err != nil {
+		return 0, fmt.Errorf("copy key %q is not a number: %w", key, err)
+	}
+	if n < 1 {
+		return 0, fmt.Errorf("copy key %q must be positive", key)
+	}
+	return n, nil
+}

--- a/apps/server/internal/infra/storage/controlstore/readings_test.go
+++ b/apps/server/internal/infra/storage/controlstore/readings_test.go
@@ -1,0 +1,335 @@
+package controlstore_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+	"github.com/so77id/nalanda/apps/server/internal/infra/storage/controlstore"
+)
+
+// seedControl creates one control with N copies so a reading test has a
+// pool to persist into.
+func seedControl(t *testing.T, ctx context.Context, db *sql.DB, id string, copies int) {
+	t.Helper()
+	userID := insertProfessor(t, ctx, db, "reader-"+id+"@example.com")
+	store := controlstore.New(db)
+	c := newControl(id, userID, nil)
+	c.Copies = copies
+	if err := store.CreateControl(ctx, c, []controls.PoolEntry{
+		{Ref: "q-if-1", Order: 0},
+		{Ref: "q-bucles-1", Order: 1},
+	}); err != nil {
+		t.Fatalf("CreateControl: %v", err)
+	}
+}
+
+// sampleCopy returns a ReportCopy with two answers for testing.
+func sampleCopy(rut string, status controls.CopyStatus, rutStatus controls.RUTStatus) controls.ReportCopy {
+	return controls.ReportCopy{
+		RUT:               rut,
+		RUTStatus:         rutStatus,
+		ExpectedQuestions: 2, SeenQuestions: 2,
+		Status: status,
+		Answers: []controls.ReportAnswer{
+			{Question: 9, Name: "q-if-1", Type: controls.QuestionSimple,
+				Marked: []int{1}, Doubtful: nil, Status: controls.AnswerStatusOK,
+				Score: 1.0, Max: 1.0},
+			{Question: 10, Name: "q-bucles-1", Type: controls.QuestionMultiple,
+				Marked:   []int{1, 3},
+				Doubtful: []controls.Doubtful{{Answer: 2, Darkness: 0.18}},
+				Status:   controls.AnswerStatusDoubtful,
+				Score:    3.0, Max: 4.0},
+		},
+	}
+}
+
+func TestUpsertReadingsFromReportInsertsThenUpdatesOnASecondCall(t *testing.T) {
+	ctx, db := migrated(t)
+	seedControl(t, ctx, db, "CTRL0100READING0000000AAAA", 3)
+	store := controlstore.New(db)
+
+	now := time.Unix(1_755_600_000, 0).UTC()
+	report := controls.Report{
+		Copies: map[string]controls.ReportCopy{
+			"1": sampleCopy("20123456", controls.CopyStatusNeedsReview, controls.RUTStatusOK),
+			"2": sampleCopy("", controls.CopyStatusIncomplete, controls.RUTStatusUnreadable),
+		},
+	}
+	if err := store.UpsertReadingsFromReport(ctx, "CTRL0100READING0000000AAAA", report, now); err != nil {
+		t.Fatalf("Upsert first: %v", err)
+	}
+
+	// Copy 1 is present with two answers, RUT ok.
+	r, err := store.ReadingByCopy(ctx, "CTRL0100READING0000000AAAA", 1)
+	if err != nil {
+		t.Fatalf("ReadingByCopy(1): %v", err)
+	}
+	if r.RUTStatus != controls.RUTStatusOK || r.RUTRead == nil || *r.RUTRead != "20123456" {
+		t.Errorf("Reading(1) RUT = %+v (%v)", r.RUTRead, r.RUTStatus)
+	}
+	if len(r.Answers) != 2 || r.Answers[0].QuestionRef != "q-bucles-1" || r.Answers[1].QuestionRef != "q-if-1" {
+		// ORDER BY question_ref ASC — bucles < if lexicographically.
+		t.Errorf("Reading(1) answers = %+v", r.Answers)
+	}
+	multi := r.Answers[0]
+	if multi.QuestionType != controls.QuestionMultiple || len(multi.Marked) != 2 ||
+		len(multi.Doubtful) != 1 || multi.Doubtful[0].Darkness != 0.18 {
+		t.Errorf("Reading(1) multiple = %+v", multi)
+	}
+
+	// A second upsert with a repaired report replaces the answers and
+	// updates the status. Overrides — none set yet — stay absent, but
+	// this is what the "overrides survive" contract will be built on.
+	later := now.Add(time.Hour)
+	report2 := controls.Report{
+		Copies: map[string]controls.ReportCopy{
+			"1": {
+				RUT: "20123456", RUTStatus: controls.RUTStatusOK,
+				ExpectedQuestions: 2, SeenQuestions: 2, Status: controls.CopyStatusOK,
+				Answers: []controls.ReportAnswer{
+					{Question: 9, Name: "q-if-1", Type: controls.QuestionSimple,
+						Marked: []int{1}, Status: controls.AnswerStatusOK, Score: 1.0, Max: 1.0},
+				},
+			},
+		},
+	}
+	if err := store.UpsertReadingsFromReport(ctx, "CTRL0100READING0000000AAAA", report2, later); err != nil {
+		t.Fatalf("Upsert second: %v", err)
+	}
+	r, err = store.ReadingByCopy(ctx, "CTRL0100READING0000000AAAA", 1)
+	if err != nil {
+		t.Fatalf("ReadingByCopy(1) after upsert: %v", err)
+	}
+	if r.CopyStatus != controls.CopyStatusOK {
+		t.Errorf("Reading(1).CopyStatus = %s, want ok", r.CopyStatus)
+	}
+	if len(r.Answers) != 1 {
+		t.Errorf("Reading(1) answers after re-upsert = %d, want 1", len(r.Answers))
+	}
+	if !r.ReadAt.Equal(later) {
+		t.Errorf("Reading(1).ReadAt = %v, want %v", r.ReadAt, later)
+	}
+}
+
+func TestUpsertReadingsFromReportRefusesAnswerWithoutName(t *testing.T) {
+	ctx, db := migrated(t)
+	seedControl(t, ctx, db, "CTRL0110NONAME0000000000AA", 1)
+	store := controlstore.New(db)
+
+	report := controls.Report{
+		Copies: map[string]controls.ReportCopy{
+			"1": {
+				RUTStatus: controls.RUTStatusUnreadable, Status: controls.CopyStatusNeedsReview,
+				Answers: []controls.ReportAnswer{
+					{Question: 9, Name: "", Type: controls.QuestionSimple,
+						Marked: []int{1}, Status: controls.AnswerStatusOK, Score: 1.0, Max: 1.0},
+				},
+			},
+		},
+	}
+	if err := store.UpsertReadingsFromReport(ctx, "CTRL0110NONAME0000000000AA", report, time.Now()); err == nil {
+		t.Fatal("Upsert accepted an answer without a layout name, want a refusal")
+	}
+	// Nothing should be committed.
+	rs, err := store.ReadingsByControl(ctx, "CTRL0110NONAME0000000000AA")
+	if err != nil {
+		t.Fatalf("ReadingsByControl: %v", err)
+	}
+	if len(rs) != 0 {
+		t.Errorf("readings = %d, want 0 (refusal must roll back)", len(rs))
+	}
+}
+
+func TestMarkMissingAsNotPresentAddsAReadingPerMissingCopy(t *testing.T) {
+	ctx, db := migrated(t)
+	seedControl(t, ctx, db, "CTRL0120MISSING0000000000A", 4)
+	store := controlstore.New(db)
+
+	// Upload only two of the four copies.
+	now := time.Unix(1_755_600_000, 0).UTC()
+	report := controls.Report{
+		Copies: map[string]controls.ReportCopy{
+			"1": sampleCopy("20123456", controls.CopyStatusOK, controls.RUTStatusOK),
+			"3": sampleCopy("20234567", controls.CopyStatusOK, controls.RUTStatusOK),
+		},
+	}
+	if err := store.UpsertReadingsFromReport(ctx, "CTRL0120MISSING0000000000A", report, now); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	if err := store.MarkMissingAsNotPresent(ctx, "CTRL0120MISSING0000000000A", now); err != nil {
+		t.Fatalf("MarkMissingAsNotPresent: %v", err)
+	}
+	// Idempotent: a second call must not double up.
+	if err := store.MarkMissingAsNotPresent(ctx, "CTRL0120MISSING0000000000A", now); err != nil {
+		t.Fatalf("MarkMissingAsNotPresent (2nd): %v", err)
+	}
+
+	readings, err := store.ReadingsByControl(ctx, "CTRL0120MISSING0000000000A")
+	if err != nil {
+		t.Fatalf("ReadingsByControl: %v", err)
+	}
+	if len(readings) != 4 {
+		t.Fatalf("readings = %d, want 4 (one per printed copy)", len(readings))
+	}
+	// Copy 2 and 4 are not_present; copies 1 and 3 are unchanged.
+	for _, r := range readings {
+		switch r.CopyNumber {
+		case 1, 3:
+			if r.CopyStatus != controls.CopyStatusOK {
+				t.Errorf("copy %d status = %s, want ok", r.CopyNumber, r.CopyStatus)
+			}
+		case 2, 4:
+			if r.CopyStatus != controls.CopyStatusNotPresent || r.RUTStatus != controls.RUTStatusNotPresent || r.RUTRead != nil {
+				t.Errorf("copy %d = %+v, want not_present", r.CopyNumber, r)
+			}
+		default:
+			t.Errorf("unexpected copy_number %d", r.CopyNumber)
+		}
+	}
+}
+
+func TestReadingByCopyReturnsErrReadingNotFoundForAMissingCopy(t *testing.T) {
+	ctx, db := migrated(t)
+	store := controlstore.New(db)
+	if _, err := store.ReadingByCopy(ctx, "does-not-exist", 1); !errors.Is(err, controls.ErrReadingNotFound) {
+		t.Errorf("ReadingByCopy(missing): %v, want ErrReadingNotFound", err)
+	}
+}
+
+func TestSetAndClearAnswerOverrideStampsLastEditedAtAndSurvivesReupsert(t *testing.T) {
+	ctx, db := migrated(t)
+	seedControl(t, ctx, db, "CTRL0130OVERRIDE0000000AAA", 1)
+	store := controlstore.New(db)
+
+	now := time.Unix(1_755_600_000, 0).UTC()
+	report := controls.Report{
+		Copies: map[string]controls.ReportCopy{
+			"1": sampleCopy("20123456", controls.CopyStatusNeedsReview, controls.RUTStatusOK),
+		},
+	}
+	if err := store.UpsertReadingsFromReport(ctx, "CTRL0130OVERRIDE0000000AAA", report, now); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	r, _ := store.ReadingByCopy(ctx, "CTRL0130OVERRIDE0000000AAA", 1)
+
+	editedAt := now.Add(2 * time.Hour)
+	override := controls.AnswerOverride{
+		Marked: []int{2}, Status: controls.AnswerStatusOK, EditedAt: editedAt,
+	}
+	if err := store.SetAnswerOverride(ctx, r.ID, "q-if-1", override); err != nil {
+		t.Fatalf("SetAnswerOverride: %v", err)
+	}
+	r, err := store.ReadingByCopy(ctx, "CTRL0130OVERRIDE0000000AAA", 1)
+	if err != nil {
+		t.Fatalf("ReadingByCopy: %v", err)
+	}
+	if r.LastEditedAt == nil || !r.LastEditedAt.Equal(editedAt) {
+		t.Errorf("LastEditedAt = %v, want %v", r.LastEditedAt, editedAt)
+	}
+	// Find the answer we overrode.
+	var found *controls.Answer
+	for i := range r.Answers {
+		if r.Answers[i].QuestionRef == "q-if-1" {
+			found = &r.Answers[i]
+		}
+	}
+	if found == nil || found.Override == nil {
+		t.Fatalf("q-if-1 override = %+v", found)
+	}
+	if found.Override.Marked[0] != 2 || found.Override.Status != controls.AnswerStatusOK {
+		t.Errorf("override = %+v", found.Override)
+	}
+
+	// A re-upsert with a different report must NOT wipe the override.
+	report2 := controls.Report{
+		Copies: map[string]controls.ReportCopy{
+			"1": sampleCopy("20123456", controls.CopyStatusOK, controls.RUTStatusOK),
+		},
+	}
+	if err := store.UpsertReadingsFromReport(ctx, "CTRL0130OVERRIDE0000000AAA", report2, now.Add(time.Hour)); err != nil {
+		t.Fatalf("Upsert 2: %v", err)
+	}
+	r, _ = store.ReadingByCopy(ctx, "CTRL0130OVERRIDE0000000AAA", 1)
+	for i := range r.Answers {
+		if r.Answers[i].QuestionRef == "q-if-1" {
+			if r.Answers[i].Override == nil || r.Answers[i].Override.Marked[0] != 2 {
+				t.Errorf("q-if-1 override lost across re-upsert: %+v", r.Answers[i].Override)
+			}
+		}
+	}
+
+	// Clear removes the override.
+	if err := store.ClearAnswerOverride(ctx, r.ID, "q-if-1"); err != nil {
+		t.Fatalf("ClearAnswerOverride: %v", err)
+	}
+	r, _ = store.ReadingByCopy(ctx, "CTRL0130OVERRIDE0000000AAA", 1)
+	for i := range r.Answers {
+		if r.Answers[i].QuestionRef == "q-if-1" && r.Answers[i].Override != nil {
+			t.Errorf("q-if-1 override still present after Clear: %+v", r.Answers[i].Override)
+		}
+	}
+}
+
+func TestSetAndClearRUTOverride(t *testing.T) {
+	ctx, db := migrated(t)
+	seedControl(t, ctx, db, "CTRL0140RUTOVER0000000000A", 1)
+	store := controlstore.New(db)
+
+	now := time.Unix(1_755_600_000, 0).UTC()
+	report := controls.Report{
+		Copies: map[string]controls.ReportCopy{
+			"1": sampleCopy("", controls.CopyStatusNeedsReview, controls.RUTStatusUnreadable),
+		},
+	}
+	if err := store.UpsertReadingsFromReport(ctx, "CTRL0140RUTOVER0000000000A", report, now); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	r, _ := store.ReadingByCopy(ctx, "CTRL0140RUTOVER0000000000A", 1)
+
+	editedAt := now.Add(time.Hour)
+	if err := store.SetRUTOverride(ctx, r.ID, "20999888", editedAt); err != nil {
+		t.Fatalf("SetRUTOverride: %v", err)
+	}
+	r, _ = store.ReadingByCopy(ctx, "CTRL0140RUTOVER0000000000A", 1)
+	if r.RUTOverride == nil || r.RUTOverride.RUT != "20999888" {
+		t.Errorf("RUTOverride = %+v", r.RUTOverride)
+	}
+	if r.LastEditedAt == nil || !r.LastEditedAt.Equal(editedAt) {
+		t.Errorf("LastEditedAt = %v, want %v", r.LastEditedAt, editedAt)
+	}
+	if err := store.ClearRUTOverride(ctx, r.ID); err != nil {
+		t.Fatalf("ClearRUTOverride: %v", err)
+	}
+	r, _ = store.ReadingByCopy(ctx, "CTRL0140RUTOVER0000000000A", 1)
+	if r.RUTOverride != nil {
+		t.Errorf("RUTOverride still present after Clear: %+v", r.RUTOverride)
+	}
+}
+
+func TestSetControlStateUpdatesTheRow(t *testing.T) {
+	ctx, db := migrated(t)
+	seedControl(t, ctx, db, "CTRL0150STATE00000000000AA", 1)
+	store := controlstore.New(db)
+
+	if err := store.SetControlState(ctx, "CTRL0150STATE00000000000AA", controls.InReview); err != nil {
+		t.Fatalf("SetControlState in_review: %v", err)
+	}
+	c, _ := store.ControlByID(ctx, "CTRL0150STATE00000000000AA")
+	if c.State != controls.InReview {
+		t.Errorf("State = %s, want in_review", c.State)
+	}
+	if err := store.SetControlState(ctx, "CTRL0150STATE00000000000AA", controls.Graded); err != nil {
+		t.Fatalf("SetControlState graded: %v", err)
+	}
+	c, _ = store.ControlByID(ctx, "CTRL0150STATE00000000000AA")
+	if c.State != controls.Graded {
+		t.Errorf("State = %s, want graded", c.State)
+	}
+	if err := store.SetControlState(ctx, "does-not-exist", controls.Graded); !errors.Is(err, controls.ErrControlNotFound) {
+		t.Errorf("SetControlState(missing): %v, want ErrControlNotFound", err)
+	}
+}

--- a/apps/server/migrations/00005_readings.sql
+++ b/apps/server/migrations/00005_readings.sql
@@ -1,0 +1,96 @@
+-- The reading half of the entrance-controls subsystem (issue #167, WP-F).
+-- Four tables:
+--
+--   reading          one row per copy READ (or explicitly not_present)
+--   answer           one row per question of a reading, in the pool's order
+--   answer_override  the professor's edit for one (reading, question_ref)
+--   rut_override     the professor's typed RUT for one reading
+--
+-- The two override tables are kept apart from their base rows so an
+-- INSERT is what a save is (never UPDATE OR INSERT), and the pre-override
+-- state is what the answer row still holds. A future audit reads what AMC
+-- read AND what the professor decided from the same query
+-- (docs/design/2026-08-controles.md §The domain, note on Override).
+--
+-- The report's rut_status carries two values on the wire ('ok' | 'unreadable'),
+-- ADR-0031. A third value 'not_present' is used HERE on reading rows for
+-- copias that were printed but never captured — the results table renders
+-- them as "no rendida" without them counting toward "requieren revisión".
+
+-- +goose Up
+
+CREATE TABLE reading (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    control_id     TEXT    NOT NULL REFERENCES control(id) ON DELETE CASCADE,
+    -- 1-based, matches copia.numero and AMC's printed \onecopy index.
+    copy_number    INTEGER NOT NULL CHECK (copy_number > 0),
+    -- Nullable: the RUT boxes may be unreadable, or the copy may be
+    -- not_present at all.
+    rut_read       TEXT,
+    rut_status     TEXT    NOT NULL CHECK (rut_status IN ('ok', 'unreadable', 'not_present')),
+    copy_status    TEXT    NOT NULL CHECK (copy_status IN ('ok', 'needs_review', 'incomplete', 'not_present')),
+    -- unix seconds. read_at is when this row's answers were last updated
+    -- from a report (analyse or reanalyse); last_edited_at is set when
+    -- any override lands, and is what tells the UI a copy was touched by
+    -- a human.
+    read_at        INTEGER NOT NULL,
+    last_edited_at INTEGER,
+    -- One reading per copia. The UNIQUE is what UPSERT keys on when a
+    -- second /analyse arrives for the same batch and adds pages.
+    UNIQUE (control_id, copy_number)
+);
+CREATE INDEX idx_reading_by_control ON reading (control_id, copy_number);
+
+CREATE TABLE answer (
+    reading_id    INTEGER NOT NULL REFERENCES reading(id) ON DELETE CASCADE,
+    -- The bank id (control_pregunta.pregunta_ref). Comes from AMC's
+    -- layout_question.name at read time; the wrapper resolves it against
+    -- the pool.
+    question_ref  TEXT    NOT NULL,
+    -- The engine's own scoring type. Load-bearing because AMC weighs a
+    -- simple question 1 and a multiple one-point-per-alternative, and
+    -- the caller normalises differently between the two (ADR-0031 §Every
+    -- question weighs one point).
+    question_type TEXT    NOT NULL CHECK (question_type IN ('simple', 'multiple')),
+    -- JSON arrays. Two columns kept as text because sqlite has no array
+    -- type, and the natural read shape is "here is the whole list at
+    -- once"; a normalised child table would answer that read with a
+    -- second query for every question.
+    marked_json   TEXT    NOT NULL,
+    doubtful_json TEXT    NOT NULL,
+    status        TEXT    NOT NULL CHECK (status IN ('ok', 'blank', 'ambiguous', 'doubtful')),
+    -- Score/max are what the engine returned. The relative and the grade
+    -- are computed on the fly in Go — computing them here would freeze
+    -- the arithmetic in the schema.
+    score         REAL    NOT NULL,
+    max           REAL    NOT NULL,
+    PRIMARY KEY (reading_id, question_ref)
+);
+
+CREATE TABLE answer_override (
+    reading_id    INTEGER NOT NULL,
+    question_ref  TEXT    NOT NULL,
+    marked_json   TEXT    NOT NULL,
+    status        TEXT    NOT NULL CHECK (status IN ('ok', 'blank', 'ambiguous', 'doubtful')),
+    edited_at     INTEGER NOT NULL,
+    PRIMARY KEY (reading_id, question_ref),
+    -- No FK to answer(reading_id, question_ref): a re-read replaces the
+    -- answer rows, and if the FK cascaded the override would go with
+    -- them. The reading FK is what survives incremental captures.
+    FOREIGN KEY (reading_id) REFERENCES reading(id) ON DELETE CASCADE
+);
+
+CREATE TABLE rut_override (
+    reading_id INTEGER NOT NULL,
+    rut        TEXT    NOT NULL,
+    edited_at  INTEGER NOT NULL,
+    PRIMARY KEY (reading_id),
+    FOREIGN KEY (reading_id) REFERENCES reading(id) ON DELETE CASCADE
+);
+
+-- +goose Down
+
+DROP TABLE rut_override;
+DROP TABLE answer_override;
+DROP TABLE answer;
+DROP TABLE reading;

--- a/docs/decisions/0037-the-scan-page-image-path-is-part-of-the-worker-contract.md
+++ b/docs/decisions/0037-the-scan-page-image-path-is-part-of-the-worker-contract.md
@@ -1,0 +1,102 @@
+# ADR-0037: The scan-page image path is part of the worker's contract
+
+**Status:** Accepted
+**Date:** 2026-08-17
+**Decision-makers:** Miguel Rodriguez
+**Source:** #167 review (Round B, ADR-hunter finding)
+
+## Context
+
+WP-F's review page (`/controls/{id}/copies/{copy}/review`) needs the scanned
+image of the copy on its left. The sibling endpoint `GET
+/controls/{id}/copies/{copy}/page/{n}` serves the image, and today
+`apps/server` reads it directly from the shared volume at
+
+```
+<work_dir>/controls/<id>/scans/copy-<copy>-page-<n>.png
+```
+
+That path is a NAMING MODEL of what `apps/amc-worker`'s `getimages`
+subcommand writes into the AMC project's `scans/` subdirectory. Reading it
+from the server means the server now knows a fact about AMC's on-disk
+layout — and ADR-0031 §Consequences says the opposite:
+
+> We depend on the engine's private storage, not only its CLI. The current
+> reader opens AMC's `layout.sqlite`, `capture.sqlite` and `scoring.sqlite`
+> directly and knows facts like `capture_zone.type = 4` and
+> `scoring_question.type = 2` for a multiple-answer question. That coupling
+> is deliberately confined to `read_capture.py` inside the worker image,
+> which is what keeps an engine swap a container swap.
+
+WP-F's review of its own diff (Round B) surfaced this as an ADR-worthy move:
+the confinement clause is what makes reversing ADR-0030 (the engine choice)
+a container swap. If a second site now models AMC's on-disk layout,
+reversing the engine becomes a container swap **plus** an `apps/server`
+change to a naming convention that only made sense for AMC.
+
+## Decision
+
+**The scan-page image path is part of the worker contract — same class of
+promise as `/generate`'s response paths.** The worker is what produces those
+files and the worker is what names them; `apps/server` opens whatever the
+worker's naming convention says.
+
+Concretely:
+
+- `apps/amc-worker/README.md` §How it is driven (or its route table) states
+  the path shape:
+  `<project>/scans/copy-<copy_number>-page-<page_number>.png`.
+  A fallback engine (OMRChecker or any other, ADR-0030 §Not yet proven) has
+  to produce files under the same names — same rule as `sujet.pdf`,
+  `corrige.pdf`, `calage.xy` for `/generate`.
+- `apps/server` opens that path via `Service.ProjectDir(id) + "/scans/copy-N-page-M.png"`
+  — the same shape both containers see because both mount the same volume.
+- ADR-0031's confinement clause is amended, not reversed: `read_capture.py`
+  is still the only site that knows AMC's sqlite schema
+  (`capture_zone.type`, `scoring_question.type`, etc.). Filenames that live
+  under `<project>/` on the shared volume are worker-produced but
+  server-consumed, and the contract exists for exactly that seam.
+
+## Alternatives considered
+
+- **Route the image through a worker HTTP endpoint (e.g. `GET
+  /scans/page`).** Cleaner theoretically: the server never touches AMC's
+  on-disk paths, and ADR-0031's confinement clause survives verbatim.
+  Rejected for V1: the image is on the same shared volume the server
+  already reads (`sujet.pdf`, `corrige.pdf`), so the round trip buys no
+  isolation while adding a request to the professor's page render. The
+  moment there is a real reason for the worker to see the request (say,
+  redacting the RUT strip before serving, or per-request auth), this ADR
+  reopens.
+- **Keep the coupling implicit** — no README section, no ADR. Rejected:
+  ADR-0031's confinement clause is exactly the kind of decision that has to
+  say what falls INSIDE and what falls OUTSIDE, and adding a second site
+  without saying so is how the confinement clause quietly stops being true.
+
+## Consequences
+
+- **`apps/amc-worker/README.md` gains a `<project>/scans/` naming section**
+  covering `copy-N-page-M.png`. Any change to the naming is a coordinated
+  change across both apps — the same rule that governs `/generate`'s
+  response paths.
+- **The paper check is what pins the naming** (ADR-0030 §Not yet proven).
+  Until then this ADR is provisional in one specific sense: if AMC's
+  `getimages` produces a different filename shape than the code assumes,
+  either this ADR's shape or the code's `Sprintf` has to move — and the
+  move is one file.
+- **Engine swap remains "a container swap + one contract to satisfy",**
+  same as `/generate`. It stops being "a container swap plus a hunt for
+  every place `apps/server` guessed at AMC's private naming" — which is
+  what the confinement clause was there to prevent.
+
+## References
+
+- ADR-0030 — the engine and the container boundary.
+- ADR-0031 — the reading report is the contract; its §Consequences carries
+  the confinement clause this ADR extends.
+- ADR-0034 — the backend is born with the controls; the `amc-work` volume
+  seeding order.
+- `apps/server/internal/app/web/handler/review.go` — the `PageImage`
+  handler that consumes this contract.
+- `apps/amc-worker/worker.py` — the `/analyse` handler that produces the
+  files via AMC's `getimages`.

--- a/docs/design/2026-08-controles.md
+++ b/docs/design/2026-08-controles.md
@@ -141,7 +141,7 @@ touched.
 | C3 ✅ | [#151](https://github.com/so77id/nalanda/issues/151) | **Backoffice** — server-rendered layout and the professor CRUD | C2 |
 | D | not refined | **Course and roster** — tables and CSV import. Canvas import noted, not assumed | C1 |
 | E ✅ | [#166](https://github.com/so77id/nalanda/issues/166) | **Create a control, generate the PDF** — bank reader, AMC worker client, controls domain (Service + Store + tex generator), the three screens (list, form, detail), the two PDF downloads. `/` now redirects to `/controls` (was `/professors`). | A, B, C1–C3, **+ the paper check** |
-| F | not refined | **Read scans, manual review queue** | E |
+| F ✅ | [#167](https://github.com/so77id/nalanda/issues/167) | **Read scans, manual review queue** — the Escaneos box turns live, `/analyse` runs from a PDF upload, readings/answers/overrides persist through `controls.ReadingStore`, the results table + side-by-side review page ship, and *Cerrar corrección* moves the control to `graded`. Rider on the paper check (§Not yet proven) — the reader is not confirmed. | E, **+ paper check** |
 | G | not refined | **Publish grades** — spreadsheet, email, Canvas | F |
 
 WPs D–G are deliberately unrefined. A spec written against an engine the spike

--- a/docs/standards/guides/add-a-backend-endpoint.md
+++ b/docs/standards/guides/add-a-backend-endpoint.md
@@ -246,9 +246,12 @@ this student's sheet" — reads both from the same query.
 
 The paired resource for the image on the left is a **sibling
 endpoint**, not a data URL in the page: `GET .../page/{n}` streams
-the scanned image (`Content-Type` set from the path suffix, not
-inferred). Bounds the path segment with a caller-side check
-(page > 0, copy in the control's range) before it touches the disk.
+the scanned image (`Content-Type` set explicitly rather than sniffed
+from the body). Bound the path segments with caller-side checks
+(page in an absolute cap, copy within the create-form's ceiling)
+before touching the disk — a per-row check that copy belongs to
+this control is preferable when the row is already loaded; the fixed
+cap is the fallback when it isn't.
 
 ## Checklist
 

--- a/docs/standards/guides/add-a-backend-endpoint.md
+++ b/docs/standards/guides/add-a-backend-endpoint.md
@@ -218,6 +218,38 @@ the rule, and name the test and line in the commit message. Reviewing a test by
 reading it is how a test that cannot fail gets written — #150 found four of its
 own that way, including two that asserted a redirect the handler produced anyway.
 
+## A pattern the review flow adds — the split-view page
+
+WP-F (#167) introduced a shape worth naming for the next endpoint that
+carries editable per-row detail: a **review page**. The reader is the
+professor sitting in front of one row's worth of context (the scanned
+image on the left, the editable form on the right); the endpoint is
+therefore **two URLs**, not one:
+
+- `GET .../review` — renders the page. Loads the whole row (with any
+  prior overrides eagerly attached — the store's shape is
+  `SELECT … LEFT JOIN override`, so the "was this edited by a human"
+  bit travels with the row) and hands the template pre-filled inputs.
+- `POST .../review` — saves. The handler **enumerates the row's own
+  fields** rather than trusting the client with the field set: a stale
+  form that names a field the row no longer has silently drops that
+  field. Values that MATCH what the machine read for that field **clear
+  any override** rather than upserting a redundant one — so a professor
+  can undo their own edit by putting the value back.
+
+Where the "undo" bit lives in the schema is why the WP-F migration
+holds `answer_override` alongside `answer` (both keyed by
+`(reading_id, question_ref)`) rather than mutating `answer` in place:
+an INSERT is what a save is, the pre-override state is what the
+base row still holds, and a future audit — or "what did I change on
+this student's sheet" — reads both from the same query.
+
+The paired resource for the image on the left is a **sibling
+endpoint**, not a data URL in the page: `GET .../page/{n}` streams
+the scanned image (`Content-Type` set from the path suffix, not
+inferred). Bounds the path segment with a caller-side check
+(page > 0, copy in the control's range) before it touches the disk.
+
 ## Checklist
 
 - [ ] The endpoint is on the right surface, and neither surface imports the other.

--- a/infra/local/docker-compose.yml
+++ b/infra/local/docker-compose.yml
@@ -56,6 +56,10 @@ services:
       # (ADR-0034 §Consequences). The .tex the generator emits writes /work
       # absolute paths regardless — this only decides where the server writes.
       NALANDA_WORK_DIR: "/work"
+      # --- WP-F (issue #167): scans ---
+      # The largest scan PDF the upload handler will accept, in whole MB.
+      # Optional — defaults to 100 in the loader.
+      NALANDA_MAX_SCAN_MB: "${NALANDA_MAX_SCAN_MB:-100}"
     volumes:
       - server-data:/data
       # Shared with the amc-worker service below. The server writes a


### PR DESCRIPTION
Closes #167.

## Summary

WP-F turns the Escaneos placeholder from WP-E into a working scanner pipeline: a professor uploads a scanned PDF from `/controls/:id`, sees a per-copy results table, opens a side-by-side review page for anything AMC couldn't read cleanly, and closes the correction. The reading report is persisted through a new `controls.ReadingStore`; overrides live beside AMC's numbers rather than replacing them, so a re-read at a different sensitivity does not wipe manual decisions.

- **`apps/server`** gains the `Analyzer` interface, four database tables (`reading`, `answer`, `answer_override`, `rut_override` — migration `00005`), the upload endpoint (`POST /controls/:id/scans`), the results table + `Cerrar corrección` gate on `/controls/:id`, the review page (`GET/POST /controls/:id/copies/:copy/review`), the scanned-page-image endpoint (`GET /controls/:id/copies/:copy/page/:n`), and `POST /controls/:id/reanalyze` for re-reading at new thresholds. `NALANDA_MAX_SCAN_MB` (default 100) bounds the upload; new config landed in the four homes the gate walks.
- **`apps/amc-worker`** gains `POST /reanalyse` (re-read stored captures at new thresholds) and its README §How it is driven grows a "Named files under `<project>/`" block covering `copy-N-page-M.png`.
- **New ADR 0037** formalises that image-file naming as part of the worker contract — the same class of promise as `/generate`'s response paths.

## Slices

Every slice is a commit; the per-commit protocol was green before each. See `apps/server/CLAUDE.md` for the two-protocol rule.

- [x] S1 — `internal/infra/amcworker` grows `Analyze` and `Reanalyze` through an `Analyzer` interface declared by `controls`; `amctest.Fake` records calls and returns fixtures (`a8c06ad`).
- [x] S2 — Persist a report — `readings`, `answers`, `answer_overrides`, `rut_overrides` — migration `00005` (`5b6369d`).
- [x] S3 — The upload endpoint (`POST /controls/:id/scans`) with all failure modes red, incremental-capture behaviour asserted (`4ff740f`).
- [x] S4 — Results table on `/controls/:id`, including `not_present` rows and the estado collapse rules (`c5f812b`).
- [x] S5 — `GET /controls/:id/copies/:copy/review` and `GET .../page/:n` — split view with the scanned image (`8661143`).
- [x] S6 — `POST .../review` saves overrides through `answer_overrides` / `rut_overrides`; grade recomputes on read (`6213faf`).
- [x] S7 — *"Re-leer con otra sensibilidad"* — `Reanalyze` with new thresholds, overrides preserved (`6d8144d`).
- [x] S8 — *"Cerrar corrección"* — the gate rules, the `graded` warning on subsequent edits (`6d8144d`, folded into S7's commit).
- [x] S9 — Docs — `add-a-backend-endpoint.md` updated with the review pattern; `apps/server/README.md` §"What is not here yet" updated; `2026-08-controles.md` §Roadmap marks F as shipped (`47cc1b9`).

Two more commits from the pipeline: `ddd30be` (Panel A fixes) and `9ed9775` (Panel B fixes, including moving grade math to the domain and shipping ADR-0037).

## Acceptance criteria & evidence

1. **Upload → results table** — `apps/server/internal/app/web/handler/scans.go` `UploadScan` → `controls.Service.UploadScan` (`internal/domain/controls/scans.go:68`) → `Analyzer.Analyze` → `UpsertReadingsFromReport` → `MarkMissingAsNotPresent` → state to `in_review`. Handler test: `handler/scans_test.go:TestUploadScanCallsAnalyzerAndFlashesSuccess`.
2. **Every printed copy shows** — including `not_present`. `handler/results_test.go:TestResultsTableRendersNotPresentRow`.
3. **`[revisar]` opens the split view; saving recomputes the grade** — `handler/review_test.go:TestReviewPageRendersEditableFormForACopy` + `handler/save_review_test.go:TestSaveReviewOverridesLandAndFlashConfirms`.
4. **Every answer type is editable** — radios (simple), checkboxes (multiple), per-question `[En blanco]`. Template: `apps/server/internal/app/web/view/templates/pages/review.html`. RUT edit persisted through `rut_override`; server-side validation added in review fixes (SEC-1).
5. **Incremental uploads add captures; overrides survive** — `controlstore.SetAnswerOverride` keys on `(reading_id, question_ref)` and `UpsertReadingsFromReport` replaces answers but not overrides. `controlstore/readings_test.go:TestSetAndClearAnswerOverrideStampsLastEditedAtAndSurvivesReupsert`.
6. **Re-leer con otra sensibilidad** — `controls.Service.Reanalyze` → `Analyzer.Reanalyze` (worker route added to `apps/amc-worker/worker.py`). Overrides preserved by the same re-upsert path. Revert-to-defaults is a follow-up (see Notes).
7. **Cerrar corrección** enabled only when all failure kinds resolved — `handler/controls.go:closeGate` + `controls.Service.CloseCorrection`. `internal/domain/controls/grade_test.go` and the boundary lists in service tests pin the gate rules.
8. **Graded still permits edits with a visible warning** — `pages/review.html` `{{ if .Graded }}` block; the same aviso is rendered on `/controls/:id` post-close.
9. **Every state-changing form carries a CSRF token** — router table gates POSTs by default; `TestEveryStateChangingRouteVerifiesCSRF` in `router_test.go` walks the table.
10. **Everything a professor reads is Spanish** — grep of `templates/pages/*.html`, flash strings; identifiers/tests stay English.
11. **Both themes verified at ≥1440 px in a real browser** — pending human capture (see Notes below).
12. **Full pre-PR protocol green** — including `govulncheck` and `docker compose up --wait server` + `curl /health` (both surfaces). Rerun after Round B fixes.
13. **Annotated PDF never regenerated after manual edit** — deliberate; `apps/server/README.md` §"What is not here yet" records the follow-up.

## Tests

**Per-commit protocol** (`gofmt -l . / go vet / go build / go test`) green before every commit. **Pre-PR protocol** run end-to-end after the last commit:

```
gofmt -l . → empty
go vet ./... → clean
go test -race -count=1 ./... → 26 packages ok
go build ./... → clean
govulncheck ./... → No vulnerabilities found
docker build → ok
compose up --wait server → Healthy
curl /health → {"process":"up","database":"up"}
curl /api/health → {"process":"up","database":"up"}
```

New tests colocated with the code they cover:

- `internal/domain/controls/grade_test.go` — §C7 grade math at 0/50/100 %, negative and >100 % clamps, override full-point contract.
- `internal/domain/controls/scans_internal_test.go` — `nextBatchNumber` semantics (max+1, gap after delete reuses).
- `internal/infra/amcworker/analyze_test.go` — Analyzer wire, 4xx wrap, threshold refusal.
- `internal/infra/amcworker/amctest/analyze_test.go` — Fake records + returns fixtures.
- `internal/infra/storage/controlstore/readings_test.go` — upsert-then-update, not_present marker, override survives re-upsert, RUT override, `SetControlState`.
- `internal/app/web/handler/scans_test.go` — happy upload, non-PDF refused, 404 for unknown control.
- `internal/app/web/handler/results_test.go` — every estado collapse (ok, RUT ilegible, marca dudosa, página faltante, no rendida) + summary line.
- `internal/app/web/handler/review_test.go` — split-view render, missing-copy 404, page image served + 404.
- `internal/app/web/handler/save_review_test.go` — save overrides + `[En blanco]`.

## Reviews run

Two rounds of the multi-agent pipeline over `main...HEAD`, both with worktree-isolated lenses:

- **Round A** (code): `lens-correctness-tests`, `lens-arch-simplicity`, `lens-security`. 24 raw → 21 unique after dedup. Every important/critical was addressed inline (commit `ddd30be`); dismissed / deferred items are annotated in the same commit body.
- **Round B** (docs): `lens-docs-completeness`, `lens-docs-accuracy`, `lens-adr-hunter`, `lens-agent-readability`. 9 findings; 1 critical + 1 important addressed structurally (commit `9ed9775` — grade math moved to the domain, ADR-0037 shipped).

`lens-performance` intentionally skipped — no hot paths in the diff.

## Manual verification (yours)

The screenshots the WP-F issue's AC-11 asks for still need a human — the app is easiest to run through `infra/local/docker-compose.yml`. From `apps/server/`:

```
docker build -t nalanda/server:dev .
cd ../../infra/local && docker compose up -d --build --wait server
open http://127.0.0.1:8081
```

Login is Google-gated locally (placeholder OAuth values in `.env`); a real check is `GOOGLE-CHECK.md`. What to look at once inside:

1. `/controls/:id` — the Escaneos box with the upload form (both themes, ≥ 1440 px).
2. Same page after a successful upload — the Resultados table, the *Cerrar corrección* button (enabled/disabled with the "Faltan N revisiones" hint), the "Re-leer con otra sensibilidad" details, both themes.
3. `/controls/:id/copies/1/review` — the split view (scan image on the left, form on the right), both themes, ≥ 1440 px.

I couldn't run the paper check — Miguel's second-tanda-with-pencil is what confirms the reader (ADR-0030 §Not yet proven remains open on this).

## Notes

- **ADR-0037** landed with this PR: the scan-page image path (`<project>/scans/copy-N-page-M.png`) is now part of the worker contract, same class of promise as `/generate`'s response paths.
- **Grade arithmetic moved from `internal/app/web/handler` into `internal/domain/controls`** in the review pipeline — WP-G (grade export) can call `controls.TotalAndGrade` from either surface without importing the web handler.
- **`SEC-3` (per-control isolation)** deliberately not built — `#167 §Non-goals` records it as V2/#163.
- **`SEC-4` (per-control upload quota)** captured as follow-up in `apps/server/README.md` §What is not here yet.
- **Revert-to-previous-thresholds** button after reanalyze not built — the current defaults (0.30 / 0.10) are what the form pre-fills, so a manual revert is one form submit away. A UI improvement whose value shows up once a professor has changed thresholds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016djeSS2nkuJrujvNq5NqfF
