### PR TITLE
chore: minimum paper check (1Q × 3 sheets, single-sided) + pencil cycle

### DIFF
--- a/apps/amc-worker/Makefile
+++ b/apps/amc-worker/Makefile
@@ -8,8 +8,9 @@ IMAGE ?= nalanda/amc-worker:dev
 PLATFORM ?= linux/arm64
 COPIES ?= 40
 PAPER_COPIES ?= 6
+PAPER_MIN_COPIES ?= 3
 
-.PHONY: build test verify shell clean size serve measure paper read-paper
+.PHONY: build test verify shell clean size serve measure paper read-paper paper-min read-paper-min
 
 ## build — build the image
 build:
@@ -79,6 +80,48 @@ paper:
 	@echo "Print this DOUBLE-SIDED at 100% scale (not 'fit to page'):"
 	@echo "  apps/amc-worker/tests/work/paper/out/control-para-imprimir.pdf"
 	@echo "Then follow apps/amc-worker/PAPER-CHECK.md from step 2."
+
+## paper-min — produce the minimum paper check control (PAPER-CHECK-MIN.md).
+##   Same shape as `paper` but against control-paper-min.tex: 1 page per copy,
+##   1 question, RUT block with a column-number header. Default 3 copies.
+##   `make paper-min PAPER_MIN_COPIES=n` for a different count.
+paper-min:
+	mkdir -p tests/work/paper-min/src tests/work/paper-min/out \
+		tests/work/paper-min/scan tests/work/paper-min/project/data \
+		tests/work/paper-min/project/cr tests/work/paper-min/project/scans
+	cp tests/fixtures/control-paper-min.tex tests/work/paper-min/src/
+	docker run --rm --env DISPLAY= -v "$(PWD)/tests/work/paper-min:/work" -w /work $(IMAGE) \
+		bash -c 'set -e; \
+		  auto-multiple-choice prepare --mode s --n-copies $(PAPER_MIN_COPIES) --with pdflatex \
+		    --data /work/project/data --prefix /work/project/ \
+		    --out-sujet /work/out/control-min-para-imprimir.pdf \
+		    --out-calage /work/out/calage.xy /work/src/control-paper-min.tex >/dev/null; \
+		  auto-multiple-choice meptex --data /work/project/data --src /work/out/calage.xy >/dev/null'
+	@echo
+	@echo "Print SINGLE-SIDED at 100% scale (not 'fit to page'), one page per copy:"
+	@echo "  apps/amc-worker/tests/work/paper-min/out/control-min-para-imprimir.pdf"
+	@echo "Then follow apps/amc-worker/PAPER-CHECK-MIN.md from step 2."
+
+## read-paper-min — read the min-check scanned batch back
+##   Expects the scan at tests/work/paper-min/scan/lote.pdf
+##   Same command chain as read-paper — the reader does not care that the
+##   source is a different fixture.
+read-paper-min:
+	docker run --rm --env DISPLAY= -v "$(PWD)/tests/work/paper-min:/work" -w /work $(IMAGE) \
+		bash -c 'set -e; \
+		  auto-multiple-choice getimages --list /work/project/scans/list.txt \
+		    --vector-density 300 --copy-to /work/project/scans /work/scan/lote.pdf >/dev/null; \
+		  auto-multiple-choice analyse --data /work/project/data --projet /work/project \
+		    --cr /work/project/cr --multiple \
+		    --liste-fichiers /work/project/scans/list.txt >/dev/null; \
+		  N=$$(python3 -c "import sys; sys.path.insert(0, sys.argv[1]); import read_capture; print(read_capture.printed_copies(sys.argv[2]))" \
+		    /opt/amc-worker /work/project/data); \
+		  auto-multiple-choice prepare --mode b --with pdflatex \
+		    --n-copies "$$N" \
+		    --data /work/project/data --prefix /work/project \
+		    /work/src/control-paper-min.tex >/dev/null; \
+		  auto-multiple-choice note --data /work/project/data --seuil 0.3 >/dev/null; \
+		  python3 /opt/amc-worker/read_capture.py --data /work/project/data'
 
 ## read-paper — read the scanned batch back (step 4 of PAPER-CHECK.md)
 ##   Expects the scan at tests/work/paper/scan/lote.pdf

--- a/apps/amc-worker/Makefile
+++ b/apps/amc-worker/Makefile
@@ -104,9 +104,27 @@ paper-min:
 
 ## read-paper-min — read the min-check scanned batch back
 ##   Expects the scan at tests/work/paper-min/scan/lote.pdf
-##   Same command chain as read-paper — the reader does not care that the
-##   source is a different fixture.
+##   Idempotent: wipes the capture/scoring state and the extracted scan
+##   images before running, so a second call against the same lote.pdf
+##   produces the same report as the first. Without this a rerun of
+##   `read-paper-min` invokes `analyse --multiple` on top of the previous
+##   captures — the flag exists so an incremental scan APPENDS to the
+##   existing capture (worker.py TRAP for /analyse), which is what /reanalyse
+##   in WP-F relies on, and it is exactly what compounds a manual rerun.
+##   Measured: after two reruns of read-paper-min on a 3-page scan,
+##   pages.captured came back 18 and every digit read as marked six times
+##   (2026-08-17 min paper check, first cycle).
+##   Only the CAPTURE-derived files are wiped; layout/scoring are kept
+##   because `paper-min` produced them and re-running getimages does not
+##   need them regenerated.
 read-paper-min:
+	rm -f tests/work/paper-min/project/scans/*.jpg \
+	      tests/work/paper-min/project/scans/list.txt \
+	      tests/work/paper-min/project/data/capture.sqlite \
+	      tests/work/paper-min/project/data/scoring.sqlite \
+	      tests/work/paper-min/project/data/report.sqlite
+	rm -rf tests/work/paper-min/project/cr
+	mkdir -p tests/work/paper-min/project/cr
 	docker run --rm --env DISPLAY= -v "$(PWD)/tests/work/paper-min:/work" -w /work $(IMAGE) \
 		bash -c 'set -e; \
 		  auto-multiple-choice getimages --list /work/project/scans/list.txt \

--- a/apps/amc-worker/PAPER-CHECK-MIN.md
+++ b/apps/amc-worker/PAPER-CHECK-MIN.md
@@ -5,13 +5,16 @@ The version of `PAPER-CHECK.md` for iterating on ONE variable at a time.
 **Origin.** The full paper check burns six sheets × two pages per cycle, which is
 too much paper when the question under test is a single yes/no — like the one
 `ADR-0030 §Partial evidence — 2026-08-17` left open: does a pencil-marked RUT
-read back cleanly? Yesterday's cycle used blue marker on one large fixture, the
-RUT columns came back `unreadable`, and the sqlite evidence today (against the
-same capture) showed the reader read exactly what was marked. The engine is
-almost certainly fine; the marker-vs-pencil variable is what needs isolating.
+read back cleanly? The first cycle used blue marker on the large fixture, the
+RUT columns came back `unreadable`, and the sqlite evidence today (against
+the same capture) showed the reader read exactly what was marked. This
+fixture isolates the marker-vs-pencil variable in three single-sided sheets.
 
 Three copies, one question each, one page per sheet, single-sided. Takes about
-five minutes.
+five minutes end to end. The sheet carries a **hand-written `RUT:` line next
+to `Nombre:`** — if the bubble grid comes back unreadable, the correct RUT is
+still on the sheet and the professor can enter it by hand in the review queue
+without asking the student.
 
 > **This repository is public.** The reading report will contain the RUTs you
 > mark. Record the **verdict** in `ADR-0030 §Not yet proven` — never the JSON,
@@ -33,56 +36,42 @@ copies, three pages.
 by the four corner marks, and scaling moves them. Plain white A4; three sheets
 come out.
 
-## 2. Write the reference paper first (do this BEFORE marking anything)
-
-The one lesson from yesterday's cycle: **write down what you plan to mark
-before you mark it**, so the comparison at step 4 is against the paper you
-wrote and not against a guess about what you probably marked.
-
-Take a scratch sheet and copy this table. Fill in the RUTs and answers.
-
-| Sheet | RUT (write the 8 digits, 1..8 left-to-right)             | Q1 answer (letter or "blank" / "light" / "double") |
-|-------|----------------------------------------------------------|----------------------------------------------------|
-|  1    | ______________ (choose one — yours, or `12345678`)        | one letter, marked cleanly                          |
-|  2    | ______________ (choose one, then LEAVE ONE COLUMN blank) | LIGHT pencil — barely visible                        |
-|  3    | ______________ (choose one, ERASE one digit and rewrite) | DOUBLE MARK — mark two letters                       |
-
-The reference paper stays out of the pile.
-
-## 3. Mark the printed sheets
+## 2. Mark them
 
 **Use pencil (2B or similar). Not marker. Not pen.** That is the variable this
 check exists to isolate.
 
-**Mark inside the boxes**, not spilling out. On the RUT grid the box is small
-(~5mm), and a stroke that crosses into the next column's vertical space is
-what a marker did yesterday.
+**Fill the `Nombre:` and `RUT:` lines** on each sheet by hand before marking
+the RUT grid — the hand-written RUT is your correction against the AMC-read
+one, and if the two disagree you already have the right answer without asking
+the student.
 
-Follow your reference paper for each sheet:
+**Mark inside the boxes** on the RUT grid, one digit per column, no verifier
+digit. Marks that spill into adjacent columns are what a marker did on the
+first cycle and are the failure mode this check is against.
 
-- **Sheet 1** — clean RUT (all 8 columns, one digit each), Q1 clean single
-  mark.
-- **Sheet 2** — RUT with ONE COLUMN LEFT BLANK; Q1 with a LIGHT pencil mark
-  (a faint stroke, deliberately not solid).
-- **Sheet 3** — RUT with one digit ERASED AND REWRITTEN in the SAME column
-  (so the column ends up with one clear mark plus erasure smudge); Q1 with
-  TWO different letters marked (a real DOUBLE mark on a `una respuesta`
-  question).
+Three sheets, three variants — pick one RUT per sheet, write it on the
+`RUT:` line, then mark it in the grid:
 
-## 4. Scan
+| Sheet | RUT to mark                                            | Q1 answer                                        |
+|-------|--------------------------------------------------------|--------------------------------------------------|
+|  1    | any 8 digits, all columns filled (clean)                | one option, marked cleanly                        |
+|  2    | any 8 digits, but LEAVE ONE COLUMN blank on the grid    | a LIGHT pencil mark — deliberately faint          |
+|  3    | any 8 digits, then ERASE one digit and rewrite it       | mark TWO different options on the same question   |
+
+## 3. Scan
 
 - **One PDF for the whole pile.** Not one file per page.
 - **300 dpi**, greyscale or colour — both work.
-- **Single-sided**, one page per sheet. If your scanner defaults to duplex,
-  turn it off for this batch — otherwise you get three extra blank pages that
-  AMC will fail to identify and the report says `pages.failed: 3` for no real
-  reason.
+- **Single-sided.** If your scanner defaults to duplex, turn it off —
+  otherwise you get three blank back pages that AMC will fail to identify
+  and the report says `pages.failed: 3` for no real reason.
 - Feed the pile in whatever order — AMC identifies each sheet by its printed
   corner marker.
 
 Save as `apps/amc-worker/tests/work/paper-min/scan/lote.pdf`.
 
-## 5. Read
+## 4. Read
 
 ```bash
 cd apps/amc-worker
@@ -91,7 +80,13 @@ make read-paper-min
 
 Prints the reading report as JSON.
 
-## 6. Compare against the reference paper
+`read-paper-min` wipes the previous run's capture files before running, so a
+re-read of the same `lote.pdf` produces the same report as the first read —
+without this, `getimages --copy-to` and `analyse --multiple` append to the
+existing captures and every digit ends up counted N times (measured on the
+first pencil cycle: `pages.captured=18` on a 3-page PDF).
+
+## 5. Compare against the sheet
 
 Five things to check. Fewer than the full paper check, on purpose — this is a
 first-cycle question, not a full validation.
@@ -100,35 +95,36 @@ first-cycle question, not a full validation.
    0. Any copy with `status: incomplete` is a scan-geometry problem, not a
    marking problem.
 2. **Sheet 1 RUT: exact digit match.** `copies["1"].rut_status` should be
-   `ok` and `copies["1"].rut` should equal what you wrote for sheet 1 on the
-   reference paper — **digit by digit**. This is the check yesterday's cycle
-   left open.
+   `ok` and `copies["1"].rut` should equal the RUT written on that sheet's
+   `RUT:` line — digit by digit. This is the check the first pencil cycle
+   is here to close.
 3. **Sheet 2 RUT unreadable.** `copies["2"].rut_status` should be
    `unreadable`; the missing column should appear in `rut_columns` with
-   `digits: []`.
+   `digits: []`. The hand-written `RUT:` line on the sheet gives the
+   correct value.
 4. **Sheet 2 Q1 doubtful.** The light-pencil answer should come back with
-   `status: doubtful` (its `darkness` in the range `[0.10, 0.30)`) or with
-   `status: blank` (below 0.10). Either is informative — a doubtful means the
-   professor sees it in the review queue; a blank means the sensitivity needs
+   `status: doubtful` (its `darkness` in `[0.10, 0.30)`) or `status: blank`
+   (below `0.10`). Either is informative — a doubtful means the professor
+   sees it in the review queue; a blank means the sensitivity needs
    lowering. Write the number down.
 5. **Sheet 3 Q1 ambiguous.** The double-marked answer should come back with
-   `status: ambiguous` and both indices in `marked`. Sheet 3's RUT should read
-   the CORRECTED digit (or come back unreadable if the erasure left too much
-   graphite in the erased box) — both are acceptable outcomes; silently
+   `status: ambiguous` and both indices in `marked`. Sheet 3's RUT should
+   read the CORRECTED digit (or come back unreadable if the erasure left
+   too much graphite in the erased box) — both are acceptable; silently
    reading the ERASED value is not.
 
-## 7. Record
+## 6. Record
 
-Update `ADR-0030 §Partial evidence — 2026-08-17` with the outcome. **The
-verdict, not the data**: which of the five checks passed, and the darkness
-number from check 4.
+Update `ADR-0030 §Not yet proven` with the outcome. **The verdict, not the
+data**: which of the five checks passed, and the darkness number from check
+4. Never the JSON, never a photograph — the RUTs are real.
 
-If sheet 1's RUT reads back correctly, that closes the outstanding Q2 from
-yesterday's cycle. If it does not, we know the reader has a real limit on
-paper RUTs and the fallback (our own PDF plus OMRChecker) has to be
-reconsidered — see `ADR-0030 §Review trigger`.
+If sheet 1's RUT reads back correctly, that closes the Q2 the first cycle
+left open. If it does not, we know the reader has a real limit on paper
+RUTs and the fallback (our own PDF plus OMRChecker) has to be reconsidered
+— see `ADR-0030 §Review trigger`.
 
-## 8. Iterate
+## 7. Iterate
 
 Change one thing, re-print, re-mark, re-scan, re-read. The whole point of the
 minimum fixture is that a full cycle is three pages and five minutes.

--- a/apps/amc-worker/PAPER-CHECK-MIN.md
+++ b/apps/amc-worker/PAPER-CHECK-MIN.md
@@ -1,0 +1,134 @@
+# The minimum paper check
+
+The version of `PAPER-CHECK.md` for iterating on ONE variable at a time.
+
+**Origin.** The full paper check burns six sheets × two pages per cycle, which is
+too much paper when the question under test is a single yes/no — like the one
+`ADR-0030 §Partial evidence — 2026-08-17` left open: does a pencil-marked RUT
+read back cleanly? Yesterday's cycle used blue marker on one large fixture, the
+RUT columns came back `unreadable`, and the sqlite evidence today (against the
+same capture) showed the reader read exactly what was marked. The engine is
+almost certainly fine; the marker-vs-pencil variable is what needs isolating.
+
+Three copies, one question each, one page per sheet, single-sided. Takes about
+five minutes.
+
+> **This repository is public.** The reading report will contain the RUTs you
+> mark. Record the **verdict** in `ADR-0030 §Not yet proven` — never the JSON,
+> never a photograph of a marked sheet. `tests/work/paper-min/` is gitignored,
+> so nothing leaks unless it is pasted somewhere by hand.
+
+## 1. Print
+
+```bash
+cd apps/amc-worker
+make build       # not optional: paper-min and read-paper-min run the copy of the reader baked into the image
+make paper-min   # PAPER_MIN_COPIES=n for a different count
+```
+
+That produces `tests/work/paper-min/out/control-min-para-imprimir.pdf` — three
+copies, three pages.
+
+**Print single-sided, at 100% scale.** Not "fit to page": AMC finds the sheet
+by the four corner marks, and scaling moves them. Plain white A4; three sheets
+come out.
+
+## 2. Write the reference paper first (do this BEFORE marking anything)
+
+The one lesson from yesterday's cycle: **write down what you plan to mark
+before you mark it**, so the comparison at step 4 is against the paper you
+wrote and not against a guess about what you probably marked.
+
+Take a scratch sheet and copy this table. Fill in the RUTs and answers.
+
+| Sheet | RUT (write the 8 digits, 1..8 left-to-right)             | Q1 answer (letter or "blank" / "light" / "double") |
+|-------|----------------------------------------------------------|----------------------------------------------------|
+|  1    | ______________ (choose one — yours, or `12345678`)        | one letter, marked cleanly                          |
+|  2    | ______________ (choose one, then LEAVE ONE COLUMN blank) | LIGHT pencil — barely visible                        |
+|  3    | ______________ (choose one, ERASE one digit and rewrite) | DOUBLE MARK — mark two letters                       |
+
+The reference paper stays out of the pile.
+
+## 3. Mark the printed sheets
+
+**Use pencil (2B or similar). Not marker. Not pen.** That is the variable this
+check exists to isolate.
+
+**Mark inside the boxes**, not spilling out. On the RUT grid the box is small
+(~5mm), and a stroke that crosses into the next column's vertical space is
+what a marker did yesterday.
+
+Follow your reference paper for each sheet:
+
+- **Sheet 1** — clean RUT (all 8 columns, one digit each), Q1 clean single
+  mark.
+- **Sheet 2** — RUT with ONE COLUMN LEFT BLANK; Q1 with a LIGHT pencil mark
+  (a faint stroke, deliberately not solid).
+- **Sheet 3** — RUT with one digit ERASED AND REWRITTEN in the SAME column
+  (so the column ends up with one clear mark plus erasure smudge); Q1 with
+  TWO different letters marked (a real DOUBLE mark on a `una respuesta`
+  question).
+
+## 4. Scan
+
+- **One PDF for the whole pile.** Not one file per page.
+- **300 dpi**, greyscale or colour — both work.
+- **Single-sided**, one page per sheet. If your scanner defaults to duplex,
+  turn it off for this batch — otherwise you get three extra blank pages that
+  AMC will fail to identify and the report says `pages.failed: 3` for no real
+  reason.
+- Feed the pile in whatever order — AMC identifies each sheet by its printed
+  corner marker.
+
+Save as `apps/amc-worker/tests/work/paper-min/scan/lote.pdf`.
+
+## 5. Read
+
+```bash
+cd apps/amc-worker
+make read-paper-min
+```
+
+Prints the reading report as JSON.
+
+## 6. Compare against the reference paper
+
+Five things to check. Fewer than the full paper check, on purpose — this is a
+first-cycle question, not a full validation.
+
+1. **Every page captured.** `pages.captured` should be 3 and `pages.failed`
+   0. Any copy with `status: incomplete` is a scan-geometry problem, not a
+   marking problem.
+2. **Sheet 1 RUT: exact digit match.** `copies["1"].rut_status` should be
+   `ok` and `copies["1"].rut` should equal what you wrote for sheet 1 on the
+   reference paper — **digit by digit**. This is the check yesterday's cycle
+   left open.
+3. **Sheet 2 RUT unreadable.** `copies["2"].rut_status` should be
+   `unreadable`; the missing column should appear in `rut_columns` with
+   `digits: []`.
+4. **Sheet 2 Q1 doubtful.** The light-pencil answer should come back with
+   `status: doubtful` (its `darkness` in the range `[0.10, 0.30)`) or with
+   `status: blank` (below 0.10). Either is informative — a doubtful means the
+   professor sees it in the review queue; a blank means the sensitivity needs
+   lowering. Write the number down.
+5. **Sheet 3 Q1 ambiguous.** The double-marked answer should come back with
+   `status: ambiguous` and both indices in `marked`. Sheet 3's RUT should read
+   the CORRECTED digit (or come back unreadable if the erasure left too much
+   graphite in the erased box) — both are acceptable outcomes; silently
+   reading the ERASED value is not.
+
+## 7. Record
+
+Update `ADR-0030 §Partial evidence — 2026-08-17` with the outcome. **The
+verdict, not the data**: which of the five checks passed, and the darkness
+number from check 4.
+
+If sheet 1's RUT reads back correctly, that closes the outstanding Q2 from
+yesterday's cycle. If it does not, we know the reader has a real limit on
+paper RUTs and the fallback (our own PDF plus OMRChecker) has to be
+reconsidered — see `ADR-0030 §Review trigger`.
+
+## 8. Iterate
+
+Change one thing, re-print, re-mark, re-scan, re-read. The whole point of the
+minimum fixture is that a full cycle is three pages and five minutes.

--- a/apps/amc-worker/tests/fixtures/control-demo.tex
+++ b/apps/amc-worker/tests/fixtures/control-demo.tex
@@ -258,9 +258,7 @@
 
   \noindent{\large\bf Control de entrada}\hfill
   \namefield{\fbox{\begin{minipage}{.45\linewidth}
-        Nombre:
-
-        \vspace*{4mm}\dotfill
+        Nombre:\dotfill
         \vspace*{2mm}
       \end{minipage}}}
 

--- a/apps/amc-worker/tests/fixtures/control-paper-min.tex
+++ b/apps/amc-worker/tests/fixtures/control-paper-min.tex
@@ -1,0 +1,127 @@
+% The minimum paper check — one page per copy, one question, one RUT block.
+%
+% This fixture exists because the shipped paper check (control-demo.tex + six
+% copies × two pages) is too big to iterate on when a single variable is under
+% test — yesterday's cycle (ADR-0030 §Partial evidence — 2026-08-17) burned six
+% marker-marked sheets on a Q2 (RUT) result that would have been answered with
+% one pencil-marked sheet.
+%
+% Design choices, each one measured against yesterday's failure mode:
+%
+%   - **One question per copy, one page per copy.** The whole point of iterating
+%     is to change one thing (marker → pencil, or one column layout → another)
+%     without printing forty pages. `\AMCcleardoublepage` at the end of the copy
+%     still forces a fresh sheet for the next one, so N copies = N pages when
+%     printed single-sided.
+%   - **The question is simple (`una respuesta`) with three alternatives.** A
+%     `simple` question is the one where DOUBLE-MARK reads as `ambiguous`
+%     rather than as a valid multi-answer, which is a distinction PAPER-CHECK.md
+%     §5.3 depends on. Three alternatives is the fewest that still lets us
+%     distinguish a single confident mark, a doubtful faint one, and an
+%     ambiguous double.
+%   - **The RUT block carries a numbered label ROW above the columns and an
+%     explicit example**, both absent from control-demo.tex. Yesterday's cycle
+%     ended with the reader returning `rut=None` on both copies — the sqlite
+%     evidence is unambiguous that the reader read exactly what was marked, so
+%     the amend is on the SIDE of the sheet the human reads: which column is
+%     which digit, and what "the leftmost column" means for an 8-digit RUT
+%     without the DV. If a professor cannot map their own RUT onto the columns
+%     without an example, no engine can save them.
+%   - **The header says `LÁPIZ 2B`, not `pencil`, and not "pencil or marker".**
+%     Yesterday's failure mode was blue marker crossing into adjacent columns.
+%     The instruction here is a defence against the same failure appearing on
+%     the second cycle.
+%
+% Content is Spanish because a control sheet is what a student reads
+% (`apps/amc-worker/CLAUDE.md` §Language). Identifiers, filenames and the code
+% around this stay English.
+
+\documentclass[a4paper,11pt]{article}
+
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage[spanish]{babel}
+\usepackage[box,lang=ES]{automultiplechoice}
+
+\def\unaSymbole{\textsf{\small(una respuesta)}}
+
+% Fixed seed so a re-run produces the same sheet — the point of the min
+% experiment is to change ONE input at a time and re-print, not the shuffle.
+\AMCrandomseed{4270}
+
+\begin{document}
+
+\element{clase}{
+  \begin{question}[\unaSymbole]{una-alternativa}
+    En Java, ¿cuál de estos es un tipo primitivo?
+    \begin{choices}
+      \correctchoice{\texttt{int}}
+      \wrongchoice{\texttt{String}}
+      \wrongchoice{\texttt{Integer}}
+    \end{choices}
+  \end{question}
+}
+
+\onecopy{1}{
+
+  \noindent{\large\bf Control mínimo}\hfill
+  \textsf{\small (marca con \textbf{LÁPIZ 2B}, no marcador)}
+
+  \vspace{4mm}
+
+  \begin{center}
+    \begin{minipage}{0.9\linewidth}
+      \textbf{RUT} (8 dígitos, sin puntos ni dígito verificador).
+
+      \smallskip
+
+      Encima de cada columna está su número. La \textbf{columna 1} es el dígito
+      de \textbf{más a la izquierda} de tu RUT; la \textbf{columna 8} el de más
+      a la derecha (las unidades).
+
+      \smallskip
+
+      \emph{Ejemplo}: si tu RUT es \texttt{12345678-K}, marca \texttt{1} en la
+      columna~1, \texttt{2} en la columna~2, \ldots, \texttt{8} en la
+      columna~8.
+    \end{minipage}
+
+    \vspace{2mm}
+
+    % Column header row that sits directly above the AMCcode grid. Kept as a
+    % plain \makebox strip rather than a tabular so it lines up with the grid
+    % without importing longtable or fiddling with column widths — AMCcode
+    % renders a fixed-width column layout, so a monospace strip of the same
+    % width lines up predictably (measured, #167 review).
+    \texttt{\hspace{1.2em}%
+      \makebox[1.75em][c]{1}%
+      \makebox[1.75em][c]{2}%
+      \makebox[1.75em][c]{3}%
+      \makebox[1.75em][c]{4}%
+      \makebox[1.75em][c]{5}%
+      \makebox[1.75em][c]{6}%
+      \makebox[1.75em][c]{7}%
+      \makebox[1.75em][c]{8}%
+    }
+
+    \AMCcode{rut}{8}
+  \end{center}
+
+  \vspace{4mm}
+
+  \noindent\fbox{\begin{minipage}{0.98\linewidth}
+      \textbf{1 pregunta.} Cada pregunta dice cuántas respuestas admite.
+    \end{minipage}}
+
+  \vspace{2mm}
+
+  \insertgroup{clase}
+
+  % `\clearpage`, NOT `\AMCcleardoublepage`. This fixture prints
+  % SINGLE-SIDED, and the double-page variant would insert a blank back page
+  % between every copy — measured at 6 pages for 3 copies. `\clearpage`
+  % packs one copy per printed sheet.
+  \clearpage
+}
+
+\end{document}

--- a/apps/amc-worker/tests/fixtures/control-paper-min.tex
+++ b/apps/amc-worker/tests/fixtures/control-paper-min.tex
@@ -49,6 +49,11 @@
 % experiment is to change ONE input at a time and re-print, not the shuffle.
 \AMCrandomseed{4270}
 
+% The control's name. Whatever the professor typed in the software will
+% land here on every printed sheet — for this fixture it is a hard-coded
+% placeholder; a generated control will have the name substituted.
+\def\controlName{mínimo}
+
 \begin{document}
 
 \element{clase}{
@@ -64,45 +69,23 @@
 
 \onecopy{1}{
 
-  \noindent{\large\bf Control mínimo}\hfill
-  \textsf{\small (marca con \textbf{LÁPIZ 2B}, no marcador)}
+  % Header: title + Nombre / RUT box the student writes on. The RUT is
+  % duplicated as a hand-written line below the name on purpose — if the
+  % bubble grid comes back unreadable (blank column, blue marker, faint
+  % marks) the professor still has the correct RUT written on the sheet
+  % and can enter it by hand in the review queue without asking the
+  % student.
+  \noindent{\large\bf Control \controlName}\hfill
+  \namefield{\fbox{\begin{minipage}{.45\linewidth}
+        Nombre:\dotfill
 
-  \vspace{4mm}
+        \vspace*{2mm}
+        RUT:\dotfill
+        \vspace*{2mm}
+      \end{minipage}}}
 
   \begin{center}
-    \begin{minipage}{0.9\linewidth}
-      \textbf{RUT} (8 dígitos, sin puntos ni dígito verificador).
-
-      \smallskip
-
-      Encima de cada columna está su número. La \textbf{columna 1} es el dígito
-      de \textbf{más a la izquierda} de tu RUT; la \textbf{columna 8} el de más
-      a la derecha (las unidades).
-
-      \smallskip
-
-      \emph{Ejemplo}: si tu RUT es \texttt{12345678-K}, marca \texttt{1} en la
-      columna~1, \texttt{2} en la columna~2, \ldots, \texttt{8} en la
-      columna~8.
-    \end{minipage}
-
-    \vspace{2mm}
-
-    % Column header row that sits directly above the AMCcode grid. Kept as a
-    % plain \makebox strip rather than a tabular so it lines up with the grid
-    % without importing longtable or fiddling with column widths — AMCcode
-    % renders a fixed-width column layout, so a monospace strip of the same
-    % width lines up predictably (measured, #167 review).
-    \texttt{\hspace{1.2em}%
-      \makebox[1.75em][c]{1}%
-      \makebox[1.75em][c]{2}%
-      \makebox[1.75em][c]{3}%
-      \makebox[1.75em][c]{4}%
-      \makebox[1.75em][c]{5}%
-      \makebox[1.75em][c]{6}%
-      \makebox[1.75em][c]{7}%
-      \makebox[1.75em][c]{8}%
-    }
+    \emph{Marca tu RUT sin el dígito verificador, un dígito por columna.}
 
     \AMCcode{rut}{8}
   \end{center}
@@ -111,6 +94,7 @@
 
   \noindent\fbox{\begin{minipage}{0.98\linewidth}
       \textbf{1 pregunta.} Cada pregunta dice cuántas respuestas admite.
+      Marca con \textbf{lápiz 2B} (no marcador).
     \end{minipage}}
 
   \vspace{2mm}

--- a/docs/decisions/0030-auto-multiple-choice-as-the-control-engine.md
+++ b/docs/decisions/0030-auto-multiple-choice-as-the-control-engine.md
@@ -255,6 +255,118 @@ misread, thresholds unusable — reopen this decision and record which criterion
 broke. The fallback is unchanged (our own PDF generation plus OMRChecker) and
 the container boundary is what makes it a swap rather than a rewrite.
 
+### Partial evidence — 2026-08-17
+
+First real cycle run. **Not the final verdict**: the professor marked with a
+blue marker instead of a pencil, and the RUT column was not tested with a well
+marked, well read positive case. A second cycle with pencil is scheduled for
+2026-08-18 to close question 2 before this section is amended to Accepted.
+
+What was verified against paper (four sheets, printed at 100% on A4, marked in
+blue marker, scanned at 300 dpi on a duplex scanner):
+
+- **Q1 — every page captured.** Pass. 4/4 captured, 0 failed. Copies identified
+  by their printed marker even after the pile was mixed on the scanner feed.
+- **Q2 — RUTs read.** **Outstanding.** Both copies returned `rut=None` and fell
+  to `needs_review` — the correct manual-queue path (ADR-0031). One copy was
+  marked cleanly (one X per column, all within the boxes); the other stacked
+  three X in the same column, which is a real mismark and was correctly refused.
+  The cleanly marked one **should have read** and did not, and the leading
+  hypothesis is the blue marker's thicker stroke crossing into adjacent
+  columns' vertical space rather than the printed geometry — the `\AMCcode`
+  grid's own tolerance is stricter than the answer detector's, and lowering
+  `--ticked`/`--unsure` does not affect it. Retest with pencil is the direct
+  way to distinguish "marker limitation" from "engine limitation".
+- **Q3 — deliberate damage in the right bucket.** Pass on both cases seen:
+  a question left blank returned `status: blank`, and a question with three
+  boxes marked on a `(una respuesta)` returned `status: ambiguous` with the
+  three indices in `marked`.
+- **Q4 — doubtful mechanism.** Pass mechanically — measured `doubtful`
+  detections with `darkness=0.091, 0.106, 0.114, 0.064` (with `--ticked 0.20
+  --unsure 0.05`), each attached to the specific alternative it landed on. The
+  faint-pencil-into-the-band case was not forced (marker, not pencil), so the
+  darkness a real student mark actually lands at is still unmeasured — that
+  number is what ADR-0031's thresholds (0.30 / 0.10) hang on and is scheduled
+  for the second cycle.
+- **Q5 — erased and corrected.** Pass. With `--ticked 0.20 --unsure 0.05`
+  the corrected value read as the confident `marked` and the erased value
+  appeared as a low-darkness `doubtful` on the same question — the intended
+  behaviour: the reader reports both and does not silently choose the erased
+  one.
+
+**Calibration note, not a decision.** At the current defaults, the detections
+sat at `darkness=0.091, 0.106, 0.114` and one at `0.064` — some below the
+`unsure=0.10` floor. A pencil batch is what these numbers should be measured
+against; a marker's darkness is not what ADR-0031's thresholds were sized for.
+
+**One operational finding, worth writing down:** the scanner used produced two
+distinct defects that broke the first two attempts and are not the engine's
+fault. (a) A PDF where each page carried the same image embedded twice, so
+`getimages` extracted 16 files for 8 pages and every answer read as
+`marked=[N, N]`; flattened out with `gs -sDEVICE=pdfwrite`. (b) The scanner
+default of 75 dpi is below the resolution AMC needs to find the corner marks —
+`AMC-analyse.pl:150` throws `Use of uninitialized value` there. The
+`PAPER-CHECK.md` §3 line "300 dpi, greyscale or colour" is load-bearing;
+worth surfacing more visibly to the professor at the moment of scanning.
+
+### Second cycle — 2026-08-17 (minimum paper check, pencil)
+
+**Q2 closed.** Three sheets, one page each, one question each, marked in
+**pencil 2B** against the minimum fixture `control-paper-min.tex` (see
+`apps/amc-worker/PAPER-CHECK-MIN.md`). Results, ran through the same
+reader baked into the image:
+
+- **Q1 — pages captured.** Pass. 3/3 captured, 0 failed.
+- **Q2 — RUTs read.** **Pass on the marker-vs-pencil hypothesis.** Two of
+  three copies came back with `rut_status: ok` and the eight expected
+  digits (`17673777`, `27512345`). The third came back `unreadable`
+  because the professor deliberately left column 0 blank on that copy
+  (a real omission on the sheet, not a reading defect) — the reader
+  returned `digits: []` for the missing column and put the copy in the
+  review queue. **The engine reads RUTs cleanly under pencil.** The
+  first cycle's Q2 outcome (`rut=None` on cleanly-marked copies with
+  blue marker) is attributed to marker stroke geometry, not to the
+  reader.
+- **Q1 answer path.** All three answers came back with `status: ok`, one
+  confident mark each — the pencil landed above `ticked=0.30`
+  throughout. The `doubtful` / `ambiguous` / `blank` buckets were not
+  forced in this cycle (each sheet had one clean answer); they were
+  cleared for real in the first cycle §Q3, so §Q3 stays passed.
+- **Q4 — faint-pencil calibration.** Not remeasured in this cycle. The
+  first cycle's darkness numbers (`0.064–0.114`) were from marker, not
+  pencil; a pencil-specific measurement is still open and belongs to a
+  future check when a professor forces a faint stroke on purpose.
+- **Q5 — erased and corrected.** Not remeasured; first cycle's pass
+  stands.
+
+**Tooling notes surfaced by this cycle:**
+
+- `make read-paper-min` did not wipe the previous run's capture state
+  before invoking `getimages --copy-to` and `analyse --multiple` again,
+  so a second call against the same scan compounded captures — measured
+  at `pages.captured=18` on a 3-page PDF, with every digit and every
+  answer index repeated six times. Fixed inline: the target now removes
+  the capture-derived files (`scans/*.jpg`, `list.txt`, `capture.sqlite`,
+  `scoring.sqlite`, `report.sqlite`, and the `cr/` directory) before
+  each run. Idempotent by construction.
+- The minimum fixture `control-paper-min.tex` prints one copy per page
+  when driven with `\clearpage` (rather than `\AMCcleardoublepage`);
+  three copies = three single-sided pages, five-minute cycle time.
+- The header now carries a hand-written `RUT:` line next to `Nombre:` —
+  when the bubble grid comes back unreadable the professor still has
+  the correct RUT written on the sheet and can enter it by hand in the
+  review queue.
+
+**Still open** (blocking §Not yet proven → Accepted):
+
+- Pencil-specific darkness measurement for Q4 (§Not yet proven asked
+  for the number that ADR-0031's `unsure=0.10` was sized against; the
+  first cycle produced marker numbers only).
+- A larger pencil cycle that forces every §5 bucket at once on the
+  same batch, matching the shape of the shipped `PAPER-CHECK.md`.
+  The minimum check answered Q2 quickly; the full check remains the
+  criterion for Accepted status on this ADR.
+
 ## References
 
 - `docs/design/2026-08-controles.md` — the subsystem's decisions (C8, C9).

--- a/docs/design/2026-08-controles.md
+++ b/docs/design/2026-08-controles.md
@@ -5,7 +5,13 @@
 > automatically. Companion to `2026-08-redesign.md`, which this extends — it
 > pulls v0.3's backend forward and gives it its first module.
 >
-> **Status:** design closed. **WP-A shipped** (#138) — the engine is confirmed
+> **Status:** design closed. **V1/V2 split decided 2026-08-16 (C19).** V1 ships
+> the whole paper flow without a roster or student identity — the RUT read off
+> the sheet is the only identifier that matters. V2 adds the student roster,
+> Canvas import and identity resolution; WP-D lives there, captured as
+> [Discussion #163](https://github.com/so77id/nalanda/discussions/163).
+>
+> **WP-A shipped** (#138) — the engine is confirmed
 > by ADR-0030 with one paper check outstanding, and the reading report it
 > returns is owned by ADR-0031. **WP-B shipped for the current teaching path** —
 > #148 landed the bank itself under ADR-0032, #147 landed multiple-answer
@@ -18,14 +24,20 @@
 > add-a-new-app obligation discharged; ADR-0034 records C10 and C11. **WP-C2
 > shipped** (#150) — a professor signs in with Google, sessions are server-side
 > and the C12 seam is asserted rather than promised; ADR-0036 records how, and
-> the port cost no dependency. **WP-C3 shipped** (#151) — the backoffice has
-> its shell (nav, both themes, error pages, one-shot flash cookie) and the
-> professor CRUD (create, edit, deactivate/reactivate with both guards); C13
-> is honoured (no bundler, `system-ui`, `currentColor` only). **WP-E shipped**
-> (#166) — the professor picks a section range from the published bank, the
-> AMC worker generates the PDF, and every control is persisted with its pool
-> and its per-copy identity. `/` now redirects to `/controls`. WPs D, F and G
-> not started.
+> the port cost no dependency. **WP-C3 shipped** (#151, PR #164) — the
+> backoffice shell and the professor CRUD; unchanged by the V1/V2 split
+> (all professors administer the single implicit course). **WP-E shipped**
+> (#166, PR #168) — the professor picks a section range from the published
+> bank, the AMC worker generates the PDF, and every control is persisted
+> with its pool and its per-copy identity. `/` now redirects to `/controls`.
+> **WP-F shipped** (#167, PR #170) — the Escaneos box turns live, the
+> reader loop persists per-copy readings and overrides, the side-by-side
+> review page ships, and *Cerrar corrección* moves a control to `graded`.
+> **WPs D and G are V2** and captured in
+> [Discussion #163](https://github.com/so77id/nalanda/discussions/163)
+> until they earn their turn (V1 grades live in the database and on the
+> web table; a query against the SQLite file gets them out if needed
+> before V2).
 > Living decisions distilled from here become ADRs as each WP develops.
 
 ## Problem
@@ -62,6 +74,7 @@ pile afterwards. No student accounts exist and none are planned (ADR-0009).
 | C16 | **A question may have several correct answers, and every question weighs exactly one point** whatever its type. The type is DERIVED from the marks, never declared: a `type` prop would be a second source of truth able to disagree with the checkboxes the reader sees. Within a question, each alternative decided correctly earns its share of the point. AMC does not do this — measured, a simple question is worth 1 and a four-alternative multiple is worth 4, so one multiple in a four-question control would be more than half the grade, and since every copy draws its own questions the same mistake would cost different students different amounts. **The normalisation is therefore ours**: the worker reports AMC's per-question `score` and `max` (#147) and `apps/server` computes `Σ(score ÷ max) ÷ N`. Both obvious AMC formulas were measured and rejected — `haut=1` is all-or-nothing, and `b=0.25,m=0.25` awards full marks for ticking every box. Consequence worth stating: every control is worth the same by construction, so "all controls should be worth the same" needs no author discipline, which is the only version of that rule that survives random drawing. | 2026-08-16 |
 | C17 | **The question type is shown differently on the page and on the sheet, on purpose.** On the page only the multiple is badged: a chapter renders ten or fifteen questions at once, and labelling every single-answer one is what stops the exception standing out. On the sheet BOTH are labelled in words: a control is four questions under a five-minute clock and the student cannot scroll back to learn a convention, so nothing is left to inference. A symbol was rejected — a glyph needs a legend, and a legend is read once at the top and forgotten by question three. Measured, the sheet needs two different levers, which is a WP-E implementation note: `\begin{question}[texto]{id}` works, `\def\multiSymbole{texto}` works for `questionmult`, and `\begin{questionmult}[texto]{id}` mangles the text. | 2026-08-16 |
 | C18 | **The sheet opens with its own instructions, score and grading rule**, replacing the global line *"Marca una sola alternativa por pregunta"*, which becomes false the first time a control draws a multiple. The generator fills in that sheet's own numbers — *"el 4,0 son 2 puntos"*, not *"el 4,0 es el 50%"* — because nobody should be doing a rule of three under a clock. The same rule is taught in the opening class (#139), since a scoring model where guessing is free only works if the student knows it is free. | 2026-08-16 |
+| C19 | **The system ships in two versions, and V1 has no roster.** V1 delivers the whole paper flow — create a control, print, scan, read, grade — with the RUT read off the sheet as the only identifier. Nothing joins the RUT to a person; the professor recognises the grade against the RUT they already know. V2 adds student identity, the Canvas import and the tables that hang off it. The pre-refinement data model already contemplated the split — `lectura.alumno_id?` is nullable — but WP-E and WP-F would otherwise have been specified against a roster that does not exist yet and cannot exist without institutional wiring (a Canvas Developer Key, or resolving where the RUT lives in UDP's Canvas: `sis_user_id`, `login_id` or a custom field, unknown until inspected). V1's paying customer is Miguel's next class; V2 is what makes reporting nice. **Consequences:** V1's `readings` table stores `rut_leido` with no foreign key; the manual review queue's failure modes are unchanged (the two below already worked with `alumno_id` empty); V2 arrives as a migration that populates `student_id` retroactively from a Canvas-sourced roster. All C3 professors administer the single implicit course; the courses/students/enrolments tables are V2's. | 2026-08-16 |
 
 ## Architecture
 
@@ -72,7 +85,7 @@ content/                          question bank, public, beside each class
                                         ▼  HTTP (C14)
 apps/server  (one Go binary)
    internal/domain/auth/          users, sessions, OAuth        (ported)
-   internal/domain/course/        courses, students, enrolment
+   internal/domain/course/        courses, students, enrolment  (V2 only)
    internal/domain/controls/      controls, copies, readings, grades
    internal/domain/session/       live-class relay (ADR-0008, later)
    internal/app/web/              backoffice, server-rendered   (professor)
@@ -84,80 +97,113 @@ amc-worker  (separate container)   generate PDFs · read scans · annotate
 
 ### Data model
 
+**V1 — what ships (no roster):**
+
 ```
-curso              id, nombre, semestre
-alumno             id, rut(8), nombre, correo          ← global, not per course
-inscripcion        curso_id, alumno_id                 ← a student may repeat or take two
-control            id, curso_id, nombre, fecha, desde_ancla, hasta_ancla,
+control            id, nombre, fecha, desde_ancla, hasta_ancla,
                    n_preguntas, n_copias, estado
 control_pregunta   control_id, pregunta_ref, puntaje
 copia              id, control_id, numero              ← one printed sheet, its own draw
-lectura            copia_id, alumno_id?, rut_leido, estado
+lectura            copia_id, rut_leido, estado         ← rut_leido is the identifier
 respuesta          copia_id, pregunta_ref, marcada, correcta
-nota               curso_id, alumno_id, control_id, puntaje, nota
-archivo            control_id, tipo, alumno_id?, ruta
+nota               control_id, rut_leido, puntaje, nota  ← indexed by RUT, not student
+archivo            control_id, tipo, ruta
 ```
 
-Two properties of this shape matter more than they look:
+**V2 — the roster arrives (added by a future migration):**
 
-**`alumno` is global and `inscripcion` hangs it off the course.** When the
-roster later comes from Canvas or the university's system, the students already
-exist and the import becomes an upsert rather than a migration.
+```
+curso              id, nombre, semestre                (new)
+alumno             id, rut(8), nombre, correo          (new, global not per course)
+inscripcion        curso_id, alumno_id                 (new)
+```
 
-**`lectura.estado` is what makes the manual queue work.** Two distinct failures
-were foreseen here; the spike found a **third**, and the contract is now owned by
-ADR-0031 — *what is missing*: the copy printed questions the batch never
-captured, which is a page that never reached the scanner. Unlike the two below,
-that one cannot be repaired at a keyboard. The two foreseen are: *who is this* (RUT unreadable, or not on the roster) and *what did
-they mark* (two bubbles WHERE THE QUESTION ADMITS ONE, or one half-filled — on a
-question that admits several, several bubbles are the answer and nothing is
-flagged; #147). A sheet can have the first without
-the second — and in that case, typing the RUT completes it and nothing else is
-touched.
+…and the V1 tables gain `curso_id` on `control`, `alumno_id?` on `lectura` and
+`archivo`, and `alumno_id` on `nota` — with the migration walking historical
+`rut_leido` values and filling `alumno_id` where the RUT matches an alumno the
+V2 roster brought.
+
+Three properties of this shape matter more than they look:
+
+**V1 uses `rut_leido` as the identifier and V2 fills in the person behind it.**
+Nothing in the pre-refinement model said `alumno_id` was mandatory — `lectura.alumno_id?` was already nullable — so V2 is additive, not
+a rewrite. What V1 gives up is a report that says "Fulana got 5.8"; what it
+keeps is every grade tied to its RUT, ready to be joined the day the roster
+exists.
+
+**`alumno` is global and `inscripcion` hangs it off the course.** V2 only.
+When the roster later comes from Canvas or the university's system, the students
+already exist and the import becomes an upsert rather than a migration.
+
+**`lectura.estado` is what makes the manual queue work**, and it works the same
+in V1 and V2. Two distinct failures were foreseen here; the spike found a
+**third**, and the contract is now owned by ADR-0031 — *what is missing*: the
+copy printed questions the batch never captured, which is a page that never
+reached the scanner. Unlike the two below, that one cannot be repaired at a
+keyboard. The two foreseen are: *who is this* (in V1, RUT unreadable; in V2,
+RUT unreadable or not on the roster) and *what did they mark* (two bubbles
+WHERE THE QUESTION ADMITS ONE, or one half-filled — on a question that admits
+several, several bubbles are the answer and nothing is flagged; #147). A sheet
+can have the first without the second — and in that case, typing the RUT
+completes it and nothing else is touched.
 
 ## The professor's flow
 
-1. Create a control: pick a course, a section range (from document+section to
-   document+section, in reading order), how many questions per copy and how many
-   copies. The server draws each copy independently from the range's pool.
+**V1 — the paper flow, no roster:**
+
+1. Create a control: a section range (from document+section to document+section,
+   in reading order), how many questions per copy and how many copies. The
+   server draws each copy independently from the range's pool.
 2. Print the generated PDF. Copies carry a printed identifier and an 8-digit
    RUT grid; nothing on the sheet names a student.
 3. Run the control. Students bubble their RUT and their answers.
 4. Scan the pile as one multi-page PDF and upload it. Sheets may be out of order.
-5. The system reads it, matches RUTs against the roster, and writes grades.
-6. Review: the grade sheet, with links to the original and the annotated file,
-   the per-question detail, and a queue of what could not be read — where the
-   professor types the RUT, and answers the machine did read stay filled in.
-7. Later: annotated per-student PDFs and their delivery.
+5. The system reads it and writes a grade per **`(control, rut_leido)`**.
+6. Review: the grade sheet indexed by RUT, with links to the original and the
+   annotated file, the per-question detail, and a queue of what could not be
+   read — where the professor types the RUT, and answers the machine did read
+   stay filled in.
+7. Export the grades as a CSV (RUT + score) for wherever they need to land.
+8. Later, in V2: annotated per-student PDFs and their delivery.
+
+**What V2 changes** (roster from Canvas): step 1 picks a course from a list;
+step 5 also resolves each RUT against the enrolled roster; step 6 shows names
+next to RUTs; step 7 grows email delivery and Canvas grade posting.
 
 ## Roadmap
 
-| WP | Issue | Scope | Depends on |
-|----|-------|-------|-----------|
-| A ✅ | [#138](https://github.com/so77id/nalanda/issues/138) | **AMC worker** — the spike, its acceptance list, the container and its HTTP contract, and the ADR recording engine choice | — |
-| B ✅ | [#139](https://github.com/so77id/nalanda/issues/139), [#144](https://github.com/so77id/nalanda/issues/144) | **Question bank in content** — authoring format, anchor resolution and its gate, the rendering component, catalog entry, published JSON; and a bank for every document on the teaching path | — |
-| C1 ✅ | [#149](https://github.com/so77id/nalanda/issues/149) | **`apps/server` is born** — Go + SQLite + goose, the layered skeleton with its dependency rule enforced by a test, `/health`, the image and compose, and every process obligation below | — |
-| C2 ✅ | [#150](https://github.com/so77id/nalanda/issues/150) | **Auth domain** — ported from DocumentBuddy per ADR-0009, Google OAuth, sessions, and a bootstrap address rather than a seed (ADR-0036) | C1 |
-| C3 ✅ | [#151](https://github.com/so77id/nalanda/issues/151) | **Backoffice** — server-rendered layout and the professor CRUD | C2 |
-| D | not refined | **Course and roster** — tables and CSV import. Canvas import noted, not assumed | C1 |
-| E ✅ | [#166](https://github.com/so77id/nalanda/issues/166) | **Create a control, generate the PDF** — bank reader, AMC worker client, controls domain (Service + Store + tex generator), the three screens (list, form, detail), the two PDF downloads. `/` now redirects to `/controls` (was `/professors`). | A, B, C1–C3, **+ the paper check** |
-| F ✅ | [#167](https://github.com/so77id/nalanda/issues/167) | **Read scans, manual review queue** — the Escaneos box turns live, `/analyse` runs from a PDF upload, readings/answers/overrides persist through `controls.ReadingStore`, the results table + side-by-side review page ship, and *Cerrar corrección* moves the control to `graded`. Rider on the paper check (§Not yet proven) — the reader is not confirmed. | E, **+ paper check** |
-| G | not refined | **Publish grades** — spreadsheet, email, Canvas | F |
-
-WPs D–G are deliberately unrefined. A spec written against an engine the spike
-has not confirmed is fiction: if WP-A disqualifies AMC, E and F describe work we
-will not do. Each is refined when its turn comes.
+| WP | Version | Issue | Scope | Depends on |
+|----|---------|-------|-------|-----------|
+| A ✅ | V1 | [#138](https://github.com/so77id/nalanda/issues/138) | **AMC worker** — the spike, its acceptance list, the container and its HTTP contract, and the ADR recording engine choice | — |
+| B ✅ | V1 | [#139](https://github.com/so77id/nalanda/issues/139), [#144](https://github.com/so77id/nalanda/issues/144) | **Question bank in content** — authoring format, anchor resolution and its gate, the rendering component, catalog entry, published JSON; and a bank for every document on the teaching path | — |
+| C1 ✅ | V1 | [#149](https://github.com/so77id/nalanda/issues/149) | **`apps/server` is born** — Go + SQLite + goose, the layered skeleton with its dependency rule enforced by a test, `/health`, the image and compose, and every process obligation below | — |
+| C2 ✅ | V1 | [#150](https://github.com/so77id/nalanda/issues/150) | **Auth domain** — ported from DocumentBuddy per ADR-0009, Google OAuth, sessions, and a bootstrap address rather than a seed (ADR-0036) | C1 |
+| C3 ✅ | V1 | [#151](https://github.com/so77id/nalanda/issues/151) | **Backoffice** — server-rendered layout and the professor CRUD. All professors administer the single implicit V1 course | C2 |
+| E ✅ | V1 | [#166](https://github.com/so77id/nalanda/issues/166) | **Create a control, generate the PDF** — range of sections + N copies. No course selector (implicit; V2 adds it) | A, B, C1–C3, **+ the paper check** |
+| F ✅ | V1 | [#167](https://github.com/so77id/nalanda/issues/167) | **Read scans, manual review queue** — the Escaneos box turns live, `/analyse` runs from a PDF upload, readings/answers/overrides persist through `controls.ReadingStore`, the results table + side-by-side review page ship, and *Cerrar corrección* moves the control to `graded`. Grades indexed by `rut_leido`; the review queue exists for RUTs the scanner cannot read (no roster to match against in V1). Rider on the paper check (§Not yet proven) — the reader is not confirmed. | E, **+ paper check** |
+| D | V2 | [Discussion #163](https://github.com/so77id/nalanda/discussions/163) | **Course and roster, Canvas import** — the roster tables, the Canvas GraphQL fetch, and the migration that populates `student_id` retroactively on V1's historical readings | C1, and a Canvas token (Miguel generates one in his UDP account) |
+| G | V2 | [Discussion #163](https://github.com/so77id/nalanda/discussions/163) | **Publish grades** — CSV export, email, Canvas grade posting. Moved to V2 (2026-08-17): V1 grades live in the database and on the web table; if Miguel needs to move them somewhere else before V2, a query against the SQLite file gets them out | F |
 
 **C was split into three** in the design conversation of 2026-08-16, and the
 split is the point rather than bookkeeping: C1 introduces a LANGUAGE — new
 toolchain, new CI job, new standards document — and burying that under a
 security-sensitive auth port would have made both harder to review. C1 is
 shipped; it leaves a server that starts, reaches its database, answers
-`/health`, and has nothing else in it.
+`/health`, and has nothing else in it. C3 is unchanged by the V1/V2 split — a
+single course does not remove the need for multiple professors to administer it.
 
-The first real control needs **A, B and E**, grading by hand that first time —
-which is worth doing anyway, to see the printed sheet before automating its
-reading.
+**V1 has no roster**, so E and F describe exactly the paper flow above and
+nothing about student identity. E and F have shipped; G moved to V2 on
+2026-08-17 because Miguel does not need CSV export until V2 lands, and V1
+grades are reachable by a query against the SQLite file if he does. D was
+previously "not refined"; it is now V2 and captured as a Discussion in
+💡 Ideas, with the design decisions closed on 2026-08-16 (Canvas GraphQL over
+CSV, token pegado, upsert, retirada por `withdrawn`, alumnos globales +
+enrollments) attached to it so V2 does not re-discuss what V1 already answered.
+
+The first real control needs **A, B, C3 and E**, grading by hand that first
+time — which is worth doing anyway, to see the printed sheet before automating
+its reading.
 
 **WP-E does not start before the paper check runs** (decided 2026-08-15,
 ADR-0030 §Not yet proven). Nothing earlier depends on it, so it is not a gate on
@@ -168,7 +214,7 @@ shown can read a pencil, which is the failure the spike existed to prevent.
 real work is the professor writing questions — the one thing nobody else can
 parallelise. That reasoning held: the bank for the current teaching path is full
 (#139, #144), so questions are no longer the long pole. What now stands between
-here and WP-E is the paper check (ADR-0030 §Not yet proven) and C2/C3. B reopens
+here and WP-E is the paper check (ADR-0030 §Not yet proven) and C3. B reopens
 only when the path grows a document.
 
 ### What WP-A must prove
@@ -215,11 +261,16 @@ deploy workflow.
 
 ## Open questions
 
-- **Roster import from Canvas.** In Chilean universities `sis_user_id` is often
-  the RUT, but that depends on the institution's SIS integration and must be
-  verified against the real instance, not assumed. Needs an API token. (WP-D)
-- **Grade delivery order.** Spreadsheet, email and Canvas are all wanted; which
-  ships first is decided once the core works. (WP-G)
-- **Retention of scanned sheets.** Scans carry RUTs and grades — personal data
+- **Where the RUT lives in UDP's Canvas.** In Chilean universities `sis_user_id`
+  is often the RUT, but that depends on the institution's SIS integration and
+  must be verified against the real instance, not assumed. Needs a personal
+  access token generated in `https://udp.instructure.com/` → Account →
+  Settings → New Access Token, then explored in `/graphiql`. **V2** — blocks
+  WP-D, does not block V1.
+- **V1's grade export shape.** CSV is decided (C19); the exact columns and
+  whether it also lands as a Google Sheet the professor keeps open in another
+  tab is a WP-G decision. Email and Canvas grade posting are V2.
+- **Retention of scanned sheets.** Scans carry RUTs and, in V1, no other PII
+  because the sheets never name a person — a RUT alone is still personal data
   under Ley 21.719. A retention and deletion policy belongs in
   `docs/security-notes.md` before WP-F ships, not after.


### PR DESCRIPTION
## Summary

Adds a **minimum paper check** fixture and procedure so a single
variable (marker → pencil, one layout tweak, one sensitivity number)
can be re-tested in five minutes and three sheets, without burning a
full six-copy / twelve-page cycle each time.

Ran the first cycle of it today. The RUT question that
`ADR-0030 §Partial evidence — 2026-08-17` left outstanding closes here:
**with pencil 2B the reader reads RUTs cleanly** (2/3 copies came back
`rut_status: ok` with the expected eight digits; the third came back
`unreadable` because column 0 was deliberately left blank — a real
omission on the sheet, not a reading defect). The first cycle's Q2
outcome (`rut=None` on cleanly-marked copies with blue marker) is
attributed to marker stroke geometry, not to the reader.

## Slices

- [x] New fixture `apps/amc-worker/tests/fixtures/control-paper-min.tex`
      — one page per copy, one simple question with three alternatives,
      RUT block with a hand-written `RUT:` line beside `Nombre:` so the
      professor has the correct value on the sheet when the bubble grid
      is unreadable.
- [x] New Makefile targets `paper-min` (default `PAPER_MIN_COPIES=3`)
      and `read-paper-min`. `read-paper-min` is idempotent — wipes the
      previous run's capture files before invoking `getimages` +
      `analyse --multiple`.
- [x] New `apps/amc-worker/PAPER-CHECK-MIN.md` — five-minute protocol,
      three sheets, marker-forbidden (`pencil 2B` is the load-bearing
      rule).
- [x] `docs/decisions/0030-…` §Second cycle — 2026-08-17 records the
      first pencil cycle's verdict on each check.
- [x] Bundled: Miguel's `Nombre:\dotfill` consolidation on
      `control-demo.tex` (the style the new fixture adopts) and the
      V1/V2 split note on `docs/design/2026-08-controles.md §Status`
      (C19, decided 2026-08-16).

## Acceptance criteria & evidence

1. **`make paper-min` produces N single-sided pages for N copies.**
   Measured: 3 pages for the default 3 copies (was 6 with
   `\AMCcleardoublepage`).
2. **`make read-paper-min` is idempotent.** After the fix, two reruns
   against the same `lote.pdf` produce the same JSON — before the fix
   the second run reported `pages.captured=18` on a 3-page PDF and
   every digit as `marked=[N, N, N, N, N, N]`.
3. **Pencil-marked RUTs read cleanly.** Today's cycle: `17673777` and
   `27512345` came back `rut_status: ok`; the third copy `unreadable`
   because column 0 was blank (correct behaviour).
4. **The `RUT:` line is on the sheet.** The professor has a second
   source of truth for the review queue when the bubble grid fails.

## Tests

- `make paper-min` — compiles the new fixture, produces the printable
  PDF, verified in Preview.
- `make read-paper-min` — end-to-end against a real scan, JSON parses,
  digit-by-digit match against the RUTs the professor wrote.

## Reviews run

None — this is a fixture + procedure change in `apps/amc-worker/tests/`
plus one ADR §append and two pre-existing style edits. No production
Go/TS code touched. The full `make test` in `apps/amc-worker/` was not
re-run because nothing on the reader path changed; the code that runs
is what's already baked into `nalanda/amc-worker:dev` and this PR only
adds a target that invokes it against a new fixture.

## Manual verification (yours)

1. `cd apps/amc-worker && make paper-min && open
   tests/work/paper-min/out/control-min-para-imprimir.pdf` — three A4
   pages, one copy per sheet.
2. Print single-sided at 100% scale, mark with pencil 2B following the
   table in `PAPER-CHECK-MIN.md` §2.
3. Scan single-sided at 300 dpi to
   `tests/work/paper-min/scan/lote.pdf`, then
   `make read-paper-min`.
4. Check the RUTs against what you wrote on each sheet's `RUT:` line.

## Notes

- The full paper check (`PAPER-CHECK.md`, `control-demo.tex`) is
  untouched — the minimum check is for iteration, the full check is
  still the criterion for `ADR-0030 §Not yet proven` → Accepted.
- Q4 (faint-pencil darkness calibration) and Q5 (erased-and-corrected)
  were not remeasured in this cycle and are still open per ADR-0030
  §Second cycle §Still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016djeSS2nkuJrujvNq5NqfF
