### PR TITLE
fix(infra): drop amc-worker host port on the Jetson

### DIFF
--- a/infra/deploy/jetson/docker-compose.jetson.yml
+++ b/infra/deploy/jetson/docker-compose.jetson.yml
@@ -49,6 +49,13 @@ services:
   amc-worker:
     image: ghcr.io/so77id/nalanda-amc-worker:latest
     pull_policy: always
+    # No host port on this box: DocumentBuddy's bot already owns 8080 on the
+    # Nano, and the worker is reachable by `apps/server` over the compose
+    # network anyway (`http://amc-worker:8080`). The base file's loopback
+    # publish is a dev convenience; production drops it. Compose merges lists
+    # by appending — `!reset null` clears the field entirely (requires compose
+    # 2.24+; the Jetson runs 2.29.2).
+    ports: !reset null
     labels:
       com.centurylinklabs.watchtower.enable: "true"
 


### PR DESCRIPTION
Hotfix del bring-up post-#175.

## Problem

`docker compose up -d amc-worker` en la Jetson falla:

```
Error starting userland proxy: listen tcp4 127.0.0.1:8080: bind: address already in use
```

Puerto 8080 en la Jetson lo ocupa `docbuddy-bot` (0.0.0.0:8080). El
base compose de Nalanda publica el worker en `127.0.0.1:8080:8080` como
dev convenience — en producción no lo necesita, porque `apps/server`
alcanza al worker por la compose network en `http://amc-worker:8080`.

## Fix

`ports: !reset null` en el overlay del Jetson. Compose 2.24+ resuelve la
etiqueta y elimina el field enteramente; la Jetson corre 2.29.2 así que
funciona ahí. Verificado por SSH:

    $ ssh jetson-ts 'COMPOSE_FILE=... docker compose config' | grep -A2 "amc-worker"
    amc-worker:
      build: ...
      depends_on: ...
      # (no ports: key)

El worker sigue accesible por el server via compose DNS
(`NALANDA_AMC_WORKER_URL: http://amc-worker:8080` en el base).

## Test plan

- [x] `docker compose config` en la Jetson no muestra `ports:` bajo amc-worker
- [ ] Post-merge: `git pull` + `docker compose up -d amc-worker` en la Jetson (el bring-up de S3/S4 de #175, que quedó bloqueado por esto)