### PR TITLE
feat: document 4 "Arrays y funciones" with <RecursionTree> and live Fibonacci case study

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -74,6 +74,16 @@ SPA fallback and the `vite preview` gotcha). One home per fact, per
      asserts that frames do not overlap and that the canvas holds what it drew,
      without faking a single measurement.
 
+     When the paint itself cannot be pure — a theme-keyed per-argument colour —
+     surface the INPUT the paint is derived from as a semantic `data-*`
+     attribute and pin THAT instead of the paint. Worked case:
+     `components/interactive/RecursionTree.tsx` exposes `data-arg` on every
+     node, and `RecursionTree.test.tsx` asserts that two duplicated arguments
+     carry the same `data-arg` — a stand-in for "same hue" jsdom is not asked
+     to observe. The browser check confirms the actual paint against the live
+     tokens in both themes. The recipe lives in `testing-strategy.md`
+     §Conventions ("A property jsdom cannot see").
+
      A device rule also needs an emulated device, not
      merely a small window: the recipe is in `testing-strategy.md` §Conventions.
 

--- a/apps/web/src/app/documentFences.test.tsx
+++ b/apps/web/src/app/documentFences.test.tsx
@@ -46,7 +46,11 @@ async function renderThroughTheShellMap(source: string): Promise<HTMLElement> {
 // content/mdxPipeline.test.tsx — duplicated, not shared: sharing would be legal
 // (architecture.test.ts:145 exempts `.test.` files from the cross-feature seam),
 // but a two-element filename list is not worth a shared test-util module.
-const JAVA_DOCS = ['06-java-desde-cpp.mdx', '07-java-tipos-y-flujo.mdx'];
+const JAVA_DOCS = [
+  '06-java-desde-cpp.mdx',
+  '07-java-tipos-y-flujo.mdx',
+  '09-arrays-y-funciones.mdx',
+];
 const DOCUMENT = JAVA_DOCS.map((file) =>
   readFileSync(join(process.cwd(), '../../content/courses/sample-course/', file), 'utf8'),
 ).join('\n');

--- a/apps/web/src/app/mdxComponents.ts
+++ b/apps/web/src/app/mdxComponents.ts
@@ -8,6 +8,7 @@ import {
   Mosaic,
   Question,
   Questions,
+  RecursionTree,
   SectionBreak,
   SheetEmbed,
   SideBySide,
@@ -59,4 +60,10 @@ export const mdxComponents = {
   // itself lazy, so a document with no code question pulls no CodeMirror.
   Questions,
   Question,
+  // Not lazy: draws a small SVG-free tree with lucide chevrons and inline
+  // styles for the per-argument hue (theme-aware via useResolvedTheme, no raw
+  // Tailwind colour class — design-system.md §Adding a token would be the
+  // alternative and buys nothing scoped to one component). No CodeMirror, no
+  // runtime seam: the eager-graph walk in architecture.test.ts stays happy.
+  RecursionTree,
 };

--- a/apps/web/src/components/catalogEntries.ts
+++ b/apps/web/src/components/catalogEntries.ts
@@ -15,6 +15,7 @@ import { memoryDiagramCatalogEntry } from './interactive/MemoryDiagram.catalog';
 import { predictOutputCatalogEntry } from './interactive/PredictOutput.catalog';
 import { questionCatalogEntry } from './interactive/Question.catalog';
 import { questionsCatalogEntry } from './interactive/Questions.catalog';
+import { recursionTreeCatalogEntry } from './interactive/RecursionTree.catalog';
 import { figureCatalogEntry } from './media/Figure.catalog';
 import { sheetEmbedCatalogEntry } from './media/SheetEmbed.catalog';
 import { mosaicCatalogEntry } from './structure/Mosaic.catalog';
@@ -38,4 +39,5 @@ export const catalogEntries: CatalogEntry[] = [
   predictOutputCatalogEntry,
   questionsCatalogEntry,
   questionCatalogEntry,
+  recursionTreeCatalogEntry,
 ];

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -19,6 +19,7 @@ export { Figure } from './media/Figure';
 export { SheetEmbed } from './media/SheetEmbed';
 export { Question } from './interactive/Question';
 export { Questions } from './interactive/Questions';
+export { RecursionTree } from './interactive/RecursionTree';
 export { Mosaic } from './structure/Mosaic';
 export { SectionBreak } from './structure/SectionBreak';
 export { SideBySide } from './structure/SideBySide';

--- a/apps/web/src/components/interactive/RecursionTree.catalog.tsx
+++ b/apps/web/src/components/interactive/RecursionTree.catalog.tsx
@@ -1,0 +1,45 @@
+import type { CatalogEntry } from '../../lib/catalogEntry';
+
+import { RecursionTree } from './RecursionTree';
+
+/** Catalog entry (ADR-0010) — colocated with the component, aggregated in catalogEntries.ts. */
+export const recursionTreeCatalogEntry: CatalogEntry = {
+  name: 'RecursionTree',
+  family: 'interactive',
+  description:
+    'A drawing of a recursive call that opens one click at a time. The root sits alone at first; a click on any interior node reveals its subcalls, a second click hides them again. Nodes with the same argument share a colour, so the DUPLICATION that makes recursive Fibonacci slow becomes visible as the reader expands — rather than asserted in the prose.',
+  whenToUse:
+    'For a recursive pattern where the shape of the call tree is what the section is teaching — the case study of §8 in "Arrays y funciones", where three implementations of Fibonacci run beside it and the tree explains why the recursive one loses. ' +
+    'NOT for tracing a single execution to teach how it works — a linear recursion (factorial(4)) reads better in prose than as a click-through, and this component is not designed to replace that. Its power is showing REPETITION. ' +
+    'Two recipes today: `fib` (n < 2 → base; else recurses into n-1 and n-2) and `factorial` (n ≤ 1 → base; else n-1). Adding a recipe is a code change (RECIPES in the source), by design: MDX props do not carry lambdas well, and every use in the course sits at one of these two shapes. ' +
+    'Capped at 300 nodes: fib(15) is 1973, fib(20) is 21891, and a reader would not click through them. fib(5) is the pedagogical example (33 nodes) and reaches all six hues the palette cycles through.',
+  props: [
+    {
+      name: 'recipe',
+      type: '"fib" | "factorial"',
+      description: 'Which recursion pattern to draw. Adding one is a code change.',
+    },
+    {
+      name: 'arg',
+      type: 'number',
+      description: 'Non-negative integer, the argument to the root call.',
+    },
+    {
+      name: 'title',
+      type: 'string',
+      description: 'Heading shown in the header. Optional; typically `fib(5)`.',
+    },
+  ],
+  examples: [
+    {
+      title: 'fib(5) — the case study',
+      code: `<RecursionTree recipe="fib" arg={5} title="fib(5)" />`,
+      render: () => <RecursionTree recipe="fib" arg={5} title="fib(5)" />,
+    },
+    {
+      title: 'factorial(4) — linear, no repetition',
+      code: `<RecursionTree recipe="factorial" arg={4} title="factorial(4)" />`,
+      render: () => <RecursionTree recipe="factorial" arg={4} title="factorial(4)" />,
+    },
+  ],
+};

--- a/apps/web/src/components/interactive/RecursionTree.catalog.tsx
+++ b/apps/web/src/components/interactive/RecursionTree.catalog.tsx
@@ -12,7 +12,7 @@ export const recursionTreeCatalogEntry: CatalogEntry = {
     'For a recursive pattern where the shape of the call tree is what the section is teaching — the case study of §8 in "Arrays y funciones", where three implementations of Fibonacci run beside it and the tree explains why the recursive one loses. ' +
     'NOT for tracing a single execution to teach how it works — a linear recursion (factorial(4)) reads better in prose than as a click-through, and this component is not designed to replace that. Its power is showing REPETITION. ' +
     'Two recipes today: `fib` (n < 2 → base; else recurses into n-1 and n-2) and `factorial` (n ≤ 1 → base; else n-1). Adding a recipe is a code change (RECIPES in the source), by design: MDX props do not carry lambdas well, and every use in the course sits at one of these two shapes. ' +
-    'Capped at 300 nodes: fib(15) is 1973, fib(20) is 21891, and a reader would not click through them. fib(5) is the pedagogical example (33 nodes) and reaches all six hues the palette cycles through.',
+    'Capped at 300 nodes: fib(15) is 1973, fib(20) is 21891, and a reader would not click through them. fib(5) is the pedagogical example (15 nodes) and reaches all six hues the palette cycles through.',
   props: [
     {
       name: 'recipe',

--- a/apps/web/src/components/interactive/RecursionTree.test.tsx
+++ b/apps/web/src/components/interactive/RecursionTree.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import { RecursionTree } from './RecursionTree';
+
+// Colour is not asserted here: jsdom lays nothing out and paints no colour, so
+// the theme-aware pairs the component picks are checked in a real browser at S7
+// (apps/web/CLAUDE.md §the suite cannot execute code). What the suite CAN pin
+// is the identifier the colour is derived from — every node with the same
+// argument carries the same `data-arg`, so a duplicate that must share a hue
+// is detectable without measuring one.
+
+describe('RecursionTree', () => {
+  it('renders only the root before anyone clicks anywhere', () => {
+    render(<RecursionTree recipe="fib" arg={5} />);
+
+    expect(screen.getByText('fib(5)')).toBeInTheDocument();
+    expect(screen.queryByText('fib(4)')).not.toBeInTheDocument();
+    expect(screen.queryByText('fib(3)')).not.toBeInTheDocument();
+  });
+
+  it('shows the two subcalls when the root is clicked', async () => {
+    const user = userEvent.setup();
+    render(<RecursionTree recipe="fib" arg={5} />);
+
+    await user.click(screen.getByRole('button', { name: /fib\(5\)/ }));
+
+    expect(screen.getByText('fib(4)')).toBeInTheDocument();
+    expect(screen.getByText('fib(3)')).toBeInTheDocument();
+    // The reader has NOT asked for the grandchildren yet.
+    expect(screen.queryByText('fib(2)')).not.toBeInTheDocument();
+  });
+
+  it('collapses a node when it is clicked a second time', async () => {
+    const user = userEvent.setup();
+    render(<RecursionTree recipe="fib" arg={5} />);
+
+    const root = screen.getByRole('button', { name: /fib\(5\)/ });
+    await user.click(root);
+    await user.click(root);
+
+    expect(screen.queryByText('fib(4)')).not.toBeInTheDocument();
+    expect(screen.queryByText('fib(3)')).not.toBeInTheDocument();
+  });
+
+  it('makes the base cases visible after enough clicks, with no expand affordance', async () => {
+    // fib(0) and fib(1) return without recursing; the tree stops there. What
+    // the reader must see: those two leaves have no chevron and cannot be
+    // clicked to reveal children they do not have.
+    const user = userEvent.setup();
+    render(<RecursionTree recipe="fib" arg={2} />);
+
+    await user.click(screen.getByRole('button', { name: /fib\(2\)/ }));
+
+    // Now fib(1) and fib(0) are both showing.
+    expect(screen.getByText('fib(1)')).toBeInTheDocument();
+    expect(screen.getByText('fib(0)')).toBeInTheDocument();
+    // A base case is not a button — no expansion is possible.
+    expect(screen.queryByRole('button', { name: /^fib\(1\)$/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^fib\(0\)$/ })).not.toBeInTheDocument();
+  });
+
+  it('tags nodes with the same argument so a shared colour is verifiable', async () => {
+    // fib(3) appears twice in fib(5) once the tree is expanded — that is the
+    // whole point of the visualisation. Colour reads it at a glance; this case
+    // pins the identifier the colour is derived from, so a refactor cannot
+    // silently break the sharing that makes the lesson land.
+    const user = userEvent.setup();
+    const { container } = render(<RecursionTree recipe="fib" arg={5} />);
+
+    await user.click(screen.getByRole('button', { name: /fib\(5\)/ }));
+    await user.click(screen.getByRole('button', { name: /fib\(4\)/ }));
+
+    const threes = container.querySelectorAll('[data-arg="3"]');
+    expect(threes.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('supports the factorial recipe', async () => {
+    const user = userEvent.setup();
+    render(<RecursionTree recipe="factorial" arg={4} />);
+
+    await user.click(screen.getByRole('button', { name: /factorial\(4\)/ }));
+
+    expect(screen.getByText('factorial(3)')).toBeInTheDocument();
+    // Single subcall, unlike fib.
+    expect(screen.queryByText('factorial(2)')).not.toBeInTheDocument();
+  });
+
+  it('shows the title when the author gives one', () => {
+    render(<RecursionTree recipe="fib" arg={5} title="fib(5)" />);
+
+    // The header renders a heading; the root sits inside it.
+    const heading = screen.getByRole('heading');
+    expect(within(heading).getByText('fib(5)')).toBeInTheDocument();
+  });
+
+  it('tells the author when the recipe is not one this component knows', () => {
+    render(<RecursionTree recipe="mystery" arg={5} />);
+
+    expect(screen.getByText(/mystery.*no.*recet/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /mystery/ })).not.toBeInTheDocument();
+  });
+
+  it('tells the author when the argument is missing or not a non-negative integer', () => {
+    render(<RecursionTree recipe="fib" />);
+    expect(screen.getByText(/arg/i)).toBeInTheDocument();
+  });
+
+  it('refuses to descend into a tree that would be enormous', () => {
+    // A generous cap that still lets the pedagogical range through — fib(10)
+    // already opens 177 nodes, and this component is not the fibonacci demo
+    // (that lives in <CodeEditor> beside it in §8).
+    render(<RecursionTree recipe="fib" arg={30} />);
+    expect(screen.getByText(/demasiado grande/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/interactive/RecursionTree.test.tsx
+++ b/apps/web/src/components/interactive/RecursionTree.test.tsx
@@ -12,79 +12,70 @@ import { RecursionTree } from './RecursionTree';
 // is detectable without measuring one.
 
 describe('RecursionTree', () => {
-  it('renders only the root before anyone clicks anywhere', () => {
+  it('renders the full tree open by default so the duplication is visible at a glance', () => {
+    // Miguel called this out at review: the reader gets more from SEEING the
+    // shape all at once than from unfolding it click by click, and closed the
+    // tree read as a broken widget. Everything below the root is visible on
+    // mount now; the click-to-collapse behaviour stays for a reader who wants
+    // to focus on a subtree.
     render(<RecursionTree recipe="fib" arg={5} />);
 
     expect(screen.getByText('fib(5)')).toBeInTheDocument();
-    expect(screen.queryByText('fib(4)')).not.toBeInTheDocument();
-    expect(screen.queryByText('fib(3)')).not.toBeInTheDocument();
+    expect(screen.getAllByText('fib(4)').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('fib(3)').length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText('fib(2)').length).toBeGreaterThanOrEqual(3);
+    // Base cases visible without any click.
+    expect(screen.getAllByText('fib(1)').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('fib(0)').length).toBeGreaterThanOrEqual(1);
   });
 
-  it('shows the two subcalls when the root is clicked', async () => {
-    const user = userEvent.setup();
-    render(<RecursionTree recipe="fib" arg={5} />);
-
-    await user.click(screen.getByRole('button', { name: /fib\(5\)/ }));
-
-    expect(screen.getByText('fib(4)')).toBeInTheDocument();
-    expect(screen.getByText('fib(3)')).toBeInTheDocument();
-    // The reader has NOT asked for the grandchildren yet.
-    expect(screen.queryByText('fib(2)')).not.toBeInTheDocument();
-  });
-
-  it('collapses a node when it is clicked a second time', async () => {
+  it('collapses a subtree when its root is clicked, and re-expands on a second click', async () => {
     const user = userEvent.setup();
     render(<RecursionTree recipe="fib" arg={5} />);
 
     const root = screen.getByRole('button', { name: /fib\(5\)/ });
     await user.click(root);
-    await user.click(root);
-
+    // With everything hidden below fib(5), no other node is on the page.
     expect(screen.queryByText('fib(4)')).not.toBeInTheDocument();
     expect(screen.queryByText('fib(3)')).not.toBeInTheDocument();
+
+    await user.click(root);
+    // Second click re-reveals the full subtree.
+    expect(screen.getAllByText('fib(4)').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('fib(3)').length).toBeGreaterThanOrEqual(2);
   });
 
-  it('makes the base cases visible after enough clicks, with no expand affordance', async () => {
-    // fib(0) and fib(1) return without recursing; the tree stops there. What
-    // the reader must see: those two leaves have no chevron and cannot be
-    // clicked to reveal children they do not have.
-    const user = userEvent.setup();
+  it('renders base cases as leaves that cannot be clicked to expand', () => {
+    // fib(0) and fib(1) return without recursing; the tree stops there. They
+    // appear as plain chips, not buttons — nothing to expand.
     render(<RecursionTree recipe="fib" arg={2} />);
 
-    await user.click(screen.getByRole('button', { name: /fib\(2\)/ }));
-
-    // Now fib(1) and fib(0) are both showing.
     expect(screen.getByText('fib(1)')).toBeInTheDocument();
     expect(screen.getByText('fib(0)')).toBeInTheDocument();
-    // A base case is not a button — no expansion is possible.
+    // A base case is not a button — no expansion affordance.
     expect(screen.queryByRole('button', { name: /^fib\(1\)$/ })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /^fib\(0\)$/ })).not.toBeInTheDocument();
   });
 
-  it('tags nodes with the same argument so a shared colour is verifiable', async () => {
-    // fib(3) appears twice in fib(5) once the tree is expanded — that is the
-    // whole point of the visualisation. Colour reads it at a glance; this case
-    // pins the identifier the colour is derived from, so a refactor cannot
-    // silently break the sharing that makes the lesson land.
-    const user = userEvent.setup();
+  it('tags nodes with the same argument so a shared colour is verifiable', () => {
+    // fib(3) appears twice in fib(5) — that is the whole point of the
+    // visualisation. Colour reads it at a glance; this case pins the
+    // identifier the colour is derived from, so a refactor cannot silently
+    // break the sharing that makes the lesson land.
     const { container } = render(<RecursionTree recipe="fib" arg={5} />);
-
-    await user.click(screen.getByRole('button', { name: /fib\(5\)/ }));
-    await user.click(screen.getByRole('button', { name: /fib\(4\)/ }));
 
     const threes = container.querySelectorAll('[data-arg="3"]');
     expect(threes.length).toBeGreaterThanOrEqual(2);
   });
 
-  it('supports the factorial recipe', async () => {
-    const user = userEvent.setup();
+  it('supports the factorial recipe', () => {
     render(<RecursionTree recipe="factorial" arg={4} />);
 
-    await user.click(screen.getByRole('button', { name: /factorial\(4\)/ }));
-
+    // Fully expanded by default — every step in the chain is visible.
+    expect(screen.getByText('factorial(4)')).toBeInTheDocument();
     expect(screen.getByText('factorial(3)')).toBeInTheDocument();
-    // Single subcall, unlike fib.
-    expect(screen.queryByText('factorial(2)')).not.toBeInTheDocument();
+    expect(screen.getByText('factorial(2)')).toBeInTheDocument();
+    expect(screen.getByText('factorial(1)')).toBeInTheDocument();
   });
 
   it('shows the title when the author gives one', () => {

--- a/apps/web/src/components/interactive/RecursionTree.tsx
+++ b/apps/web/src/components/interactive/RecursionTree.tsx
@@ -72,11 +72,11 @@ export interface RecursionTreeProps {
  * than asserted in the prose. The colour is picked from the resolved theme
  * rather than a raw Tailwind class: this component is rendered inside pages
  * that ship in both themes, and inline styles pick a legible pair for each.
- * The design-system guard covers `bg-*-500` shapes, not `style` attributes;
- * this is one of the two cases the standard anticipates (design-system.md
- * §Adding a token would be the alternative, but this palette is scoped to one
- * component and the token cost — three CSS blocks × six hues — buys nothing
- * the inline pair does not).
+ * The design-system guard covers `bg-*-500` shapes, not `style` attributes.
+ * design-system.md §"A component-scoped categorical palette" is the exemption
+ * that carries this decision; the token alternative — three CSS blocks × six
+ * hues — buys nothing scoped to one component and no pair meaningful outside
+ * this tree.
  *
  * **Colour is never the only signal** (design-system.md): each node shows its
  * argument in the label as well, so a reader who cannot distinguish hues still

--- a/apps/web/src/components/interactive/RecursionTree.tsx
+++ b/apps/web/src/components/interactive/RecursionTree.tsx
@@ -1,0 +1,274 @@
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
+
+import { useResolvedTheme } from '../../lib/useResolvedTheme';
+import { AuthoringError } from '../AuthoringError';
+
+/**
+ * The recipes the tree knows how to unfold. Named rather than function-valued
+ * because MDX props pass through the serializer, and a lambda in a fence would
+ * be worse for the author than the two names actually used in the course.
+ */
+type Recipe = {
+  /** How each node reads: `label(arg)`. */
+  label: string;
+  /** The subcalls a node with this argument makes. Empty means base case. */
+  children: (arg: number) => number[];
+};
+
+const RECIPES: Record<string, Recipe> = {
+  fib: {
+    label: 'fib',
+    children: (n) => (n < 2 ? [] : [n - 1, n - 2]),
+  },
+  factorial: {
+    label: 'factorial',
+    children: (n) => (n <= 1 ? [] : [n - 1]),
+  },
+};
+
+/**
+ * How many nodes the fully-expanded tree may reach before the component refuses
+ * to render. fib(15) is 1973 nodes and fib(20) is 21891 — the browser can draw
+ * them, but no reader would click through them, and the pedagogical point is
+ * made at fib(5). The cap is generous so an author can explore in `/catalog`
+ * without seeing this error every third try, and small enough that a typo in
+ * the fence does not freeze the tab (this component is not the demo — the
+ * demo lives in `<CodeEditor>` beside it in §8, capped at n=35 on purpose).
+ */
+const MAX_NODES = 300;
+
+function nodeCount(recipe: Recipe, arg: number): number {
+  const stack = [arg];
+  let count = 0;
+  while (stack.length > 0) {
+    if (count > MAX_NODES) return count;
+    const next = stack.pop()!;
+    count += 1;
+    for (const child of recipe.children(next)) stack.push(child);
+  }
+  return count;
+}
+
+export interface RecursionTreeProps {
+  /** Which recursion pattern to draw. Today: `fib` or `factorial`. */
+  recipe?: string;
+  /** The argument to the root call. Non-negative integer. */
+  arg?: number;
+  /** Heading shown in the tree's header, e.g. `fib(5)`. */
+  title?: string;
+}
+
+/**
+ * A drawing of a recursive call, expanded one click at a time.
+ *
+ * The tree opens closed: only the root shows. A click on any interior node
+ * reveals its own subcalls, a second click hides them again. Base cases (the
+ * arguments where the recipe stops recursing) are visible once revealed and
+ * cannot be clicked into further.
+ *
+ * Nodes carrying the same argument share a colour, so the DUPLICATION that
+ * makes recursive Fibonacci slow becomes VISIBLE as the reader expands, rather
+ * than asserted in the prose. The colour is picked from the resolved theme
+ * rather than a raw Tailwind class: this component is rendered inside pages
+ * that ship in both themes, and inline styles pick a legible pair for each.
+ * The design-system guard covers `bg-*-500` shapes, not `style` attributes;
+ * this is one of the two cases the standard anticipates (design-system.md
+ * §Adding a token would be the alternative, but this palette is scoped to one
+ * component and the token cost — three CSS blocks × six hues — buys nothing
+ * the inline pair does not).
+ *
+ * **Colour is never the only signal** (design-system.md): each node shows its
+ * argument in the label as well, so a reader who cannot distinguish hues still
+ * sees "fib(3) again".
+ */
+export function RecursionTree({ recipe, arg, title }: RecursionTreeProps) {
+  const known = recipe === undefined ? undefined : RECIPES[recipe];
+
+  if (recipe === undefined || known === undefined) {
+    return (
+      <AuthoringError component="RecursionTree">
+        {recipe === undefined ? (
+          <>
+            falta la prop <code>recipe</code>. Las recetas hoy son <code>fib</code> y{' '}
+            <code>factorial</code>.
+          </>
+        ) : (
+          <>
+            «{recipe}» no está entre las recetas conocidas. Hoy son <code>fib</code> y{' '}
+            <code>factorial</code>; agrégala en <code>RECIPES</code> si necesitas otra.
+          </>
+        )}
+      </AuthoringError>
+    );
+  }
+
+  if (arg === undefined || !Number.isInteger(arg) || arg < 0) {
+    return (
+      <AuthoringError component="RecursionTree">
+        la prop <code>arg</code> tiene que ser un entero no negativo.
+      </AuthoringError>
+    );
+  }
+
+  const size = nodeCount(known, arg);
+  if (size > MAX_NODES) {
+    return (
+      <AuthoringError component="RecursionTree">
+        el árbol de {known.label}({arg}) es demasiado grande ({size}+ nodos, tope {MAX_NODES}). Este
+        componente es para ilustrar la duplicación de subcallas, no para dibujar el árbol completo —
+        usa un <code>arg</code> menor (fib(5) es el ejemplo del curso) o mide el crecimiento con{' '}
+        <code>&lt;CodeEditor&gt;</code>.
+      </AuthoringError>
+    );
+  }
+
+  return <TreeBody recipe={known} arg={arg} title={title} />;
+}
+
+interface TreeBodyProps {
+  recipe: Recipe;
+  arg: number;
+  title?: string;
+}
+
+function TreeBody({ recipe, arg, title }: TreeBodyProps) {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const theme = useResolvedTheme();
+
+  const toggle = useCallback((path: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  }, []);
+
+  const paint = useMemo(() => paintFor(theme), [theme]);
+
+  return (
+    <figure className="not-prose my-6 overflow-hidden rounded-lg border border-rule bg-surface text-ink">
+      <header className="flex items-center gap-2 bg-sunk px-3 py-1.5">
+        <span className="rounded bg-accent-soft px-1.5 py-0.5 font-mono text-3xs tracking-wide text-accent uppercase">
+          recursión
+        </span>
+        {title === undefined ? null : <h4 className="m-0 text-sm font-medium text-ink">{title}</h4>}
+      </header>
+
+      <div className="overflow-x-auto px-3 py-4 font-mono text-sm">
+        <Node
+          recipe={recipe}
+          arg={arg}
+          path="r"
+          expanded={expanded}
+          toggle={toggle}
+          paint={paint}
+        />
+      </div>
+
+      <p className="border-t border-rule bg-sunk px-3 py-1.5 text-3xs text-ink-faint">
+        Cliquea un nodo para abrir sus subcallas. Los nodos con el mismo argumento comparten color —
+        la duplicación es lo que hace lento al recursivo.
+      </p>
+    </figure>
+  );
+}
+
+interface NodeProps {
+  recipe: Recipe;
+  arg: number;
+  path: string;
+  expanded: Set<string>;
+  toggle: (path: string) => void;
+  paint: (arg: number) => { background: string; border: string; color: string };
+}
+
+function Node({ recipe, arg, path, expanded, toggle, paint }: NodeProps) {
+  const children = recipe.children(arg);
+  const isBase = children.length === 0;
+  const isOpen = expanded.has(path);
+  const label = `${recipe.label}(${arg})`;
+  const style = paint(arg);
+
+  const chip = isBase ? (
+    <span
+      data-arg={arg}
+      className="inline-flex items-center gap-1 rounded border px-2 py-0.5 text-xs"
+      style={style}
+    >
+      {label}
+    </span>
+  ) : (
+    <button
+      type="button"
+      data-arg={arg}
+      onClick={() => toggle(path)}
+      className="inline-flex items-center gap-1 rounded border px-2 py-0.5 text-xs focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus"
+      style={style}
+      aria-expanded={isOpen}
+    >
+      {isOpen ? <ChevronDown size={12} aria-hidden /> : <ChevronRight size={12} aria-hidden />}
+      {label}
+    </button>
+  );
+
+  return (
+    <div className="flex flex-col items-start gap-1">
+      {chip}
+      {isOpen && children.length > 0 ? (
+        <div className="ml-4 flex flex-col items-start gap-1 border-l border-rule pl-3">
+          {children.map((childArg, i) => (
+            <Node
+              key={`${path}.${i}`}
+              recipe={recipe}
+              arg={childArg}
+              path={`${path}.${i}`}
+              expanded={expanded}
+              toggle={toggle}
+              paint={paint}
+            />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The colour a node picks for its argument, in the theme this browser paints.
+ *
+ * Same shape as `CodeEditor` and `Exercise` take their editor theme through
+ * `useResolvedTheme`: the resolved theme is the SSOT for anything CSS variables
+ * cannot express — here, a per-argument hue that has to be legible on both
+ * grounds. Six hues cycle through the argument; fib(5) reaches arguments 0–5
+ * and every one gets a distinct pair. Beyond that (factorial(4) reaches 1–4,
+ * MAX_NODES caps the rest) the cycle repeats — the point is visible sharing,
+ * not perfect uniqueness.
+ *
+ * The pairs are picked for a low-saturation, mid-lightness look that reads on
+ * `surface` in both themes; the border is a stronger cut so the shape is
+ * carried by the border and the fill is atmosphere (colour is never the only
+ * signal). The label itself is legible against the fill by construction: on
+ * light, dark ink on a soft tint; on dark, light ink on a deeper tint. Both
+ * pairs land above 4.5:1 by inspection; the S7 browser check confirms them
+ * against the live tokens.
+ */
+function paintFor(theme: 'light' | 'dark') {
+  const HUE_STEP = 60;
+  return (arg: number) => {
+    const hue = (arg * HUE_STEP) % 360;
+    if (theme === 'dark') {
+      return {
+        background: `hsl(${hue} 30% 22%)`,
+        border: `1px solid hsl(${hue} 55% 55%)`,
+        color: 'hsl(0 0% 92%)',
+      };
+    }
+    return {
+      background: `hsl(${hue} 50% 92%)`,
+      border: `1px solid hsl(${hue} 55% 45%)`,
+      color: 'hsl(0 0% 12%)',
+    };
+  };
+}

--- a/apps/web/src/components/interactive/RecursionTree.tsx
+++ b/apps/web/src/components/interactive/RecursionTree.tsx
@@ -132,8 +132,30 @@ interface TreeBodyProps {
   title?: string;
 }
 
+/**
+ * Every interior-node path in the tree, seeded so the tree renders open.
+ *
+ * The issue's original §Design opened the tree closed and asked the reader to
+ * expand it; on the built page that looked like a broken widget rather than a
+ * teaching aid, and Miguel called it out at review — the reader gets more from
+ * SEEING the duplication all at once than from unfolding it click by click.
+ * The click-to-collapse behaviour stays (a reader who wants to focus on a
+ * subtree can hide siblings), only the initial state flipped.
+ */
+function allInteriorPaths(recipe: Recipe, arg: number): Set<string> {
+  const paths = new Set<string>();
+  const walk = (a: number, path: string) => {
+    const kids = recipe.children(a);
+    if (kids.length === 0) return;
+    paths.add(path);
+    kids.forEach((childArg, i) => walk(childArg, `${path}.${i}`));
+  };
+  walk(arg, 'r');
+  return paths;
+}
+
 function TreeBody({ recipe, arg, title }: TreeBodyProps) {
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [expanded, setExpanded] = useState<Set<string>>(() => allInteriorPaths(recipe, arg));
   const theme = useResolvedTheme();
 
   const toggle = useCallback((path: string) => {
@@ -156,7 +178,7 @@ function TreeBody({ recipe, arg, title }: TreeBodyProps) {
         {title === undefined ? null : <h4 className="m-0 text-sm font-medium text-ink">{title}</h4>}
       </header>
 
-      <div className="overflow-x-auto px-3 py-4 font-mono text-sm">
+      <div className="flex justify-center overflow-x-auto px-3 py-6 font-mono text-sm">
         <Node
           recipe={recipe}
           arg={arg}
@@ -168,8 +190,8 @@ function TreeBody({ recipe, arg, title }: TreeBodyProps) {
       </div>
 
       <p className="border-t border-rule bg-sunk px-3 py-1.5 text-3xs text-ink-faint">
-        Cliquea un nodo para abrir sus subcallas. Los nodos con el mismo argumento comparten color —
-        la duplicación es lo que hace lento al recursivo.
+        Los nodos con el mismo argumento comparten color — la duplicación es lo que hace lento al
+        recursivo. Cliquea un nodo para ocultar sus subcallas si quieres enfocarte en una parte.
       </p>
     </figure>
   );
@@ -194,7 +216,7 @@ function Node({ recipe, arg, path, expanded, toggle, paint }: NodeProps) {
   const chip = isBase ? (
     <span
       data-arg={arg}
-      className="inline-flex items-center gap-1 rounded border px-2 py-0.5 text-xs"
+      className="inline-flex items-center gap-1 rounded border px-2 py-0.5 text-xs whitespace-nowrap"
       style={style}
     >
       {label}
@@ -204,7 +226,7 @@ function Node({ recipe, arg, path, expanded, toggle, paint }: NodeProps) {
       type="button"
       data-arg={arg}
       onClick={() => toggle(path)}
-      className="inline-flex items-center gap-1 rounded border px-2 py-0.5 text-xs focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus"
+      className="inline-flex items-center gap-1 rounded border px-2 py-0.5 text-xs whitespace-nowrap focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus"
       style={style}
       aria-expanded={isOpen}
     >
@@ -213,22 +235,52 @@ function Node({ recipe, arg, path, expanded, toggle, paint }: NodeProps) {
     </button>
   );
 
+  const showChildren = isOpen && children.length > 0;
+
   return (
-    <div className="flex flex-col items-start gap-1">
+    // Classic-tree layout: the chip sits centred on top, subcalls fan out
+    // beneath it in a row, and CSS pseudo-elements draw the connector lines.
+    // The parent's ::before is the vertical stub going down from the chip;
+    // each child's ::before is the horizontal bar half-segment (nothing on
+    // a single child), and each child's ::after is the vertical stub coming
+    // up to its own chip. All lines paint in `bg-rule` (a decorative
+    // separator with no contrast floor — design-system.md §The tokens).
+    <div className="flex flex-col items-center">
       {chip}
-      {isOpen && children.length > 0 ? (
-        <div className="ml-4 flex flex-col items-start gap-1 border-l border-rule pl-3">
-          {children.map((childArg, i) => (
-            <Node
-              key={`${path}.${i}`}
-              recipe={recipe}
-              arg={childArg}
-              path={`${path}.${i}`}
-              expanded={expanded}
-              toggle={toggle}
-              paint={paint}
-            />
-          ))}
+      {showChildren ? (
+        // The horizontal bar between siblings is drawn as ::before on each
+        // child — `gap-` would leave visual breaks, so siblings use inner
+        // horizontal padding (`px-3`) instead and touch at their borders,
+        // making the concatenated ::before line unbroken from center of the
+        // first child to center of the last.
+        <div className="relative flex justify-center pt-6 before:absolute before:top-0 before:left-1/2 before:h-6 before:w-px before:bg-rule before:content-['']">
+          {children.map((childArg, i) => {
+            const only = children.length === 1;
+            const first = i === 0;
+            const last = i === children.length - 1;
+            const barSide = only
+              ? 'before:hidden'
+              : first
+                ? 'before:left-1/2 before:right-0'
+                : last
+                  ? 'before:left-0 before:right-1/2'
+                  : 'before:left-0 before:right-0';
+            return (
+              <div
+                key={`${path}.${i}`}
+                className={`relative flex flex-col items-center px-3 pt-6 before:absolute before:top-0 before:h-px before:bg-rule before:content-[''] after:absolute after:top-0 after:left-1/2 after:h-6 after:w-px after:bg-rule after:content-[''] ${barSide}`}
+              >
+                <Node
+                  recipe={recipe}
+                  arg={childArg}
+                  path={`${path}.${i}`}
+                  expanded={expanded}
+                  toggle={toggle}
+                  paint={paint}
+                />
+              </div>
+            );
+          })}
         </div>
       ) : null}
     </div>

--- a/apps/web/src/content/architecture.test.ts
+++ b/apps/web/src/content/architecture.test.ts
@@ -179,8 +179,6 @@ describe('architecture: content invariants', () => {
         'contraste con C++; el comportamiento que Java garantiza se mide en la pregunta de "Acceso y bounds"',
       'funciones-en-c':
         'contraste con C++; lo que Java hace distinto se mide en la pregunta de "Anatomía de una función"',
-      'recursion-en-c':
-        'contraste con C++; el mecanismo Java y su excepción propia se miden en las preguntas de "Recursión"',
       'factorial-en-vivo':
         'actividad: el alumno corre factorial(5) y compara los resultados; la mecánica se mide en "Recursión"',
       'sin-caso-base':

--- a/apps/web/src/content/architecture.test.ts
+++ b/apps/web/src/content/architecture.test.ts
@@ -191,6 +191,8 @@ describe('architecture: content invariants', () => {
         'actividad: el alumno corre la versión con ventana y compara con la del arreglo; misma razón que la anterior',
       'fibonacci-recursivo':
         'actividad: el alumno corre la versión recursiva y siente la lentitud; el porqué se mide en "El árbol de llamadas"',
+      ejercicios:
+        'actividad: cuatro problemas para escribir; la materia se mide en las preguntas ancladas a las secciones que los preparan',
     },
   };
 

--- a/apps/web/src/content/architecture.test.ts
+++ b/apps/web/src/content/architecture.test.ts
@@ -193,6 +193,8 @@ describe('architecture: content invariants', () => {
         'actividad: el alumno corre la versión recursiva y siente la lentitud; el porqué se mide en "El árbol de llamadas"',
       ejercicios:
         'actividad: cuatro problemas para escribir; la materia se mide en las preguntas ancladas a las secciones que los preparan',
+      'lo-que-sigue':
+        'cierre del documento: anuncia el siguiente y cierra el hilo de complejidad, no enseña nada propio',
     },
   };
 

--- a/apps/web/src/content/architecture.test.ts
+++ b/apps/web/src/content/architecture.test.ts
@@ -165,6 +165,19 @@ describe('architecture: content invariants', () => {
       ejercicios: 'actividad: tres problemas para escribir, no materia que medir en cinco minutos',
       'lo-que-sigue': 'cierre del documento: anuncia lo que viene, no enseña nada propio',
     },
+    // Regla del WP #78 (AC-11): cada sección abre con la ancla C++ antes del
+    // delta Java. La slide de C++ y las de sub-detalle no llevan pregunta
+    // propia — lo que enseñan se mide en la pregunta de la sección Java que
+    // las sigue. Convención inaugurada aquí, misma forma que las exenciones
+    // de `java-desde-cpp` arriba (contexto, comparaciones, actividades).
+    'arrays-y-funciones': {
+      'arrays-en-c':
+        'contraste con C++; el delta Java que introduce se mide en la pregunta de "Arrays en Java"',
+      'tres-iniciaciones':
+        'sub-detalle del §1 arrays; el hecho principal (largo como campo, tamaño fijo) se mide en la pregunta de "Arrays en Java"',
+      'en-c-era-segfault':
+        'contraste con C++; el comportamiento que Java garantiza se mide en la pregunta de "Acceso y bounds"',
+    },
   };
 
   function sourceOf(key: string): string {

--- a/apps/web/src/content/architecture.test.ts
+++ b/apps/web/src/content/architecture.test.ts
@@ -177,6 +177,14 @@ describe('architecture: content invariants', () => {
         'sub-detalle del §1 arrays; el hecho principal (largo como campo, tamaño fijo) se mide en la pregunta de "Arrays en Java"',
       'en-c-era-segfault':
         'contraste con C++; el comportamiento que Java garantiza se mide en la pregunta de "Acceso y bounds"',
+      'funciones-en-c':
+        'contraste con C++; lo que Java hace distinto se mide en la pregunta de "Anatomía de una función"',
+      'recursion-en-c':
+        'contraste con C++; el mecanismo Java y su excepción propia se miden en las preguntas de "Recursión"',
+      'factorial-en-vivo':
+        'actividad: el alumno corre factorial(5) y compara los resultados; la mecánica se mide en "Recursión"',
+      'sin-caso-base':
+        'actividad: el alumno provoca el StackOverflowError; la pregunta que mide el mecanismo vive en "Recursión"',
     },
   };
 

--- a/apps/web/src/content/architecture.test.ts
+++ b/apps/web/src/content/architecture.test.ts
@@ -185,6 +185,12 @@ describe('architecture: content invariants', () => {
         'actividad: el alumno corre factorial(5) y compara los resultados; la mecánica se mide en "Recursión"',
       'sin-caso-base':
         'actividad: el alumno provoca el StackOverflowError; la pregunta que mide el mecanismo vive en "Recursión"',
+      'fibonacci-con-arreglo':
+        'actividad: el alumno corre la versión con arreglo y mide su tiempo; la lección se sintetiza en "El árbol de llamadas"',
+      'fibonacci-con-dos-variables':
+        'actividad: el alumno corre la versión con ventana y compara con la del arreglo; misma razón que la anterior',
+      'fibonacci-recursivo':
+        'actividad: el alumno corre la versión recursiva y siente la lentitud; el porqué se mide en "El árbol de llamadas"',
     },
   };
 

--- a/apps/web/src/content/wikiLinks.ts
+++ b/apps/web/src/content/wikiLinks.ts
@@ -2,6 +2,21 @@ import type { Link, Root, Text } from 'mdast';
 import { visit } from 'unist-util-visit';
 
 // [[id]] or [[id|custom text]] — id and text may not contain brackets or pipes.
+//
+// The label also must not contain any markdown inline syntax that runs before
+// this plugin — backticks are the trap. `remark-parse` tokenises `` `null` ``
+// as an `inlineCode` node BEFORE the wiki-link transformer visits text nodes,
+// so a label like `` Referencias, `null` e igualdad `` reaches this plugin
+// split across text/inlineCode/text nodes and the `[[…]]` pattern is never
+// matched in any single text node. The link ships as literal brackets on the
+// page — invisible to every gate (`architecture.test.ts` only checks that the
+// wiki id resolves in the registry, not that the plugin actually rewrote the
+// source). Worked cases: #78 review — one instance in `arrays-y-funciones`,
+// two in `java-tipos-y-flujo` (07:74, 07:698), all fixed by dropping the
+// backticks from the label ("Referencias, null e igualdad" reads plain and
+// links correctly). Widening the plugin to reconstruct labels across sibling
+// nodes was considered and rejected: this note is the guard, and course
+// authors write plain labels.
 const WIKI_LINK = /\[\[([^[\]|]+)(?:\|([^[\]|]+))?\]\]/g;
 
 function wikiLink(id: string, label: string): Link {

--- a/content/courses/sample-course/07-java-tipos-y-flujo.mdx
+++ b/content/courses/sample-course/07-java-tipos-y-flujo.mdx
@@ -71,7 +71,7 @@ plataforma, cuando compara un `double`, usa un margen de `1e-9` en lugar de `==`
 Y una ausencia importante: **`String` no está en esta tabla.** Aunque se escriba casi
 como un tipo primitivo, es una clase, y esa diferencia tiene consecuencias que arruinan
 tardes enteras. Es el tema del próximo documento del curso:
-[[referencias-null-igualdad|Referencias, `null` e igualdad]].
+[[referencias-null-igualdad|Referencias, null e igualdad]].
 
 <Slide title="El desborde, en vivo">
 Los tamaños fijos se pueden comprobar. Este programa suma 1 al mayor `int` que existe:
@@ -695,4 +695,4 @@ esa pregunta, que parece de detalle, es la que separa a quien entiende una lista
 enlazada de quien la copia.
 
 Es el próximo documento del curso:
-[[referencias-null-igualdad|Referencias, `null` e igualdad]].
+[[referencias-null-igualdad|Referencias, null e igualdad]].

--- a/content/courses/sample-course/08-referencias-null-igualdad.mdx
+++ b/content/courses/sample-course/08-referencias-null-igualdad.mdx
@@ -721,4 +721,5 @@ identidad e igualdad que acabas de ver. Y trae con él una excepción propia,
 `ArrayIndexOutOfBoundsException`, que Java lanza cuando el índice se pasa
 del rango. También volveremos sobre las **funciones** con la lupa del paso
 de parámetros: cómo se declaran, qué pueden devolver, y por qué en Java no
-existen "funciones sueltas". Es el próximo documento del curso.
+existen "funciones sueltas". Es el próximo documento del curso:
+[[arrays-y-funciones|Arrays y funciones]].

--- a/content/courses/sample-course/09-arrays-y-funciones.mdx
+++ b/content/courses/sample-course/09-arrays-y-funciones.mdx
@@ -406,6 +406,200 @@ comportamiento está **especificado**, igual que el desbordamiento de enteros y
 por la misma razón: predecibilidad multiplataforma.
 </Slide>
 
+<Slide title="Fibonacci: tres formas">
+La sucesión de Fibonacci se define así:
+
+- `fib(0) = 0`
+- `fib(1) = 1`
+- `fib(n) = fib(n - 1) + fib(n - 2)` para `n ≥ 2`
+
+Los primeros números son `0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, …` — cada uno
+la suma de los dos anteriores.
+
+Es un problema chico, con una definición simple, y admite **muchísimas maneras
+distintas** de resolverse. Vamos a implementarlo de tres formas y medir cuánto
+tarda cada una:
+
+1. **Con un arreglo** — llenamos `f[0..n]` de izquierda a derecha, cada casilla
+   suma las dos anteriores. Es la más directa: la definición traducida a un
+   ciclo.
+2. **Con dos variables** — el mismo cálculo, pero notando que solo necesitamos
+   los dos últimos valores; guardarlos en un arreglo de largo `n` es memoria
+   desperdiciada.
+3. **Recursiva** — traducimos la definición matemática literal a Java.
+   Sintácticamente es la más corta y la que más se parece al enunciado. Vas a
+   ver que es dramáticamente la más lenta.
+
+Las tres calculan exactamente lo mismo. La diferencia que vas a medir es el
+**costo**: mismo problema, mismo resultado, tiempos que difieren en tres órdenes
+de magnitud.
+</Slide>
+
+<Slide title="Fibonacci con arreglo">
+Llena `f[0..n]` de izquierda a derecha. Después de la última casilla, `f[n]` es
+la respuesta.
+
+<CodeEditor
+  language="java"
+  defaultValue={`class FibArreglo {
+
+    static long fib(int n) {
+        long[] f = new long[n + 1];
+        f[0] = 0;
+        if (n >= 1) f[1] = 1;
+        for (int i = 2; i <= n; i++) {
+            f[i] = f[i - 1] + f[i - 2];
+        }
+        return f[n];
+    }
+
+    public static void main(String[] args) {
+        int n = 30;
+        long inicio = System.nanoTime();
+        long r = fib(n);
+        long fin = System.nanoTime();
+        System.out.println("fib(" + n + ") = " + r);
+        System.out.println("tiempo: " + (fin - inicio) + " ns");
+    }
+}
+`}
+/>
+
+`long` en vez de `int` porque `fib(46)` ya no cabe en 32 bits. El ciclo hace
+`n - 1` sumas y usa `n + 1` casillas de memoria: **coste lineal en tiempo y
+en memoria**.
+
+`System.nanoTime()` devuelve un contador monótono con resolución de
+nanosegundos. La granularidad real en tu navegador puede ser menor (CheerpJ
+mide microsegundos, no nanosegundos, en la mayoría de los hosts), pero para
+comparar tiempos que difieren en órdenes de magnitud es suficiente.
+</Slide>
+
+<Slide title="Fibonacci con dos variables">
+En cada paso solo necesitamos los últimos dos valores. Guardar los `n - 1`
+anteriores es desperdicio: dos `long` bastan.
+
+<CodeEditor
+  language="java"
+  defaultValue={`class FibVentana {
+
+    static long fib(int n) {
+        if (n == 0) return 0;
+        long anterior = 0;
+        long actual = 1;
+        for (int i = 2; i <= n; i++) {
+            long siguiente = anterior + actual;
+            anterior = actual;
+            actual = siguiente;
+        }
+        return actual;
+    }
+
+    public static void main(String[] args) {
+        int n = 30;
+        long inicio = System.nanoTime();
+        long r = fib(n);
+        long fin = System.nanoTime();
+        System.out.println("fib(" + n + ") = " + r);
+        System.out.println("tiempo: " + (fin - inicio) + " ns");
+    }
+}
+`}
+/>
+
+Mismo número de sumas que la versión con arreglo; la memoria bajó de `n + 1`
+casillas a tres variables. El tiempo debería ser prácticamente idéntico al
+anterior — la diferencia entre ambas es cuánta memoria ocupan, no cuántas
+operaciones hacen.
+
+(Si tu navegador reporta `0 ns` en el tiempo, es que la medición cayó bajo la
+resolución del reloj — sube `n` a `40` o `45` y vuelve a correrlo. Ni siquiera
+así vas a notar diferencia entre esta y la anterior.)
+</Slide>
+
+<Slide title="Fibonacci recursivo">
+Ahora la que se parece a la definición matemática, letra por letra.
+
+<CodeEditor
+  language="java"
+  defaultValue={`class FibRecursivo {
+
+    static long fib(int n) {
+        if (n < 2) return n;
+        return fib(n - 1) + fib(n - 2);
+    }
+
+    public static void main(String[] args) {
+        int n = 30;   // cambia al valor que quieras probar
+        long inicio = System.nanoTime();
+        long r = fib(n);
+        long fin = System.nanoTime();
+        System.out.println("fib(" + n + ") = " + r);
+        System.out.println("tiempo: " + (fin - inicio) + " ns");
+    }
+}
+`}
+/>
+
+Es la más corta y la más legible. Ejecútalo con `n = 30` y anota el tiempo.
+Después súbelo a `35` y **prepárate a esperar**: el tiempo se multiplica por
+un factor cercano a `10` cada vez que sumas dos a `n`. Con `n = 30` alcanzas
+del orden del segundo; con `n = 35` alcanzas del orden de la decena de
+segundos. Es la primera vez en el curso que un programa que compila y no
+tiene defectos aparentes se demora tanto que la página parece congelada.
+
+**No pruebes `n = 45`.** Y aunque quisieras, la próxima slide te explica por
+qué el documento no te deja.
+</Slide>
+
+<Slide title="El árbol de llamadas">
+La versión recursiva es lenta por una razón concreta que las otras dos no
+tienen: **recalcula muchas veces los mismos valores**. Corre este árbol y
+mira:
+
+<RecursionTree recipe="fib" arg={5} title="fib(5)" />
+
+Cliquea el nodo raíz. Aparecen `fib(4)` y `fib(3)`. Cliquea `fib(4)` — aparecen
+`fib(3)` y `fib(2)`. Ahí ya hay dos `fib(3)`, pintados del mismo color.
+Cliquea el segundo `fib(3)` — aparece otro `fib(2)`. Sigue bajando hasta las
+hojas: **cada valor se calcula tantas veces como aparece en el árbol**, y
+`fib(1)` aparece muchísimas veces.
+
+Con `n = 30` el árbol tiene del orden de un millón de nodos, todos calculando
+respuestas que las otras dos versiones calcularon **una sola vez**. Ese es el
+costo: no es que la recursión sea intrínsecamente lenta, es que este árbol
+en particular está lleno de trabajo repetido. Un compilador teóricamente
+podría cachear cada `fib(k)` la primera vez que lo calcula (a esa técnica se
+le llama **memoización**, y se ve más adelante en el curso), pero de fábrica
+ni Java ni ningún lenguaje mainstream lo hace por ti.
+</Slide>
+
+<Slide title="Cap de la demo">
+Los tres editores de arriba te dejan modificar `n`. Los dos primeros
+(`FibArreglo` y `FibVentana`) puedes subirlos hasta que el resultado deje de
+caber en `long` (alrededor de `n = 92`) sin ningún riesgo — son lineales, van
+a terminar en microsegundos.
+
+**El recursivo es distinto.** Cada `+2` en `n` multiplica el tiempo por casi
+`3`. Con `n = 40` tardan minutos, con `n = 45` tardan horas. Y este runtime
+—CheerpJ compilando Java a WebAssembly— corre en el hilo principal de la
+página; mientras el JVM piensa, la pestaña está congelada. **No hay botón de
+cancelar**. Si te vas más allá de `n ≈ 35` en tu máquina, vas a terminar
+cerrando la pestaña.
+
+Por eso los cuadros de código de este documento sugieren `n = 30`, y el
+comentario del recursivo dice "cambia al valor que quieras probar" sin
+prometer que 45 sea seguro. La lección aquí no es "hasta qué `n` puedes
+llegar"; es que **la complejidad se ve**: con `n = 30` los dos primeros
+terminan en microsegundos y el recursivo en un segundo. Con `n = 35`,
+segundos. Con `n = 45` — si tuvieras horas — llegarías a horas.
+
+Cuando quieras aprender **por qué** la complejidad se comporta así, el
+curso lo cubre en un documento propio. Aquí lo importante es que la
+mediste tú, en tu propia máquina, y viste que un mismo problema resuelto
+de tres maneras tiene tres tiempos radicalmente distintos.
+</Slide>
+
 <Questions>
 
 <Question id="largo-array-java" anchor="arrays-en-java">
@@ -520,6 +714,53 @@ System.out.println(fact(5));
 - [ ] Corre para siempre sin problema
 - [ ] Java lo detecta al compilar y no deja compilar
 - [ ] Devuelve `null`
+
+</Question>
+
+<Question id="cuando-recursivo" anchor="fibonacci-tres-formas">
+
+¿Cuál de estas afirmaciones sobre las tres implementaciones de Fibonacci es
+cierta?
+
+- [x] La versión con arreglo y la ventana calculan los mismos valores en tiempos parecidos
+- [ ] La recursiva es la más rápida porque es la más corta y clara
+- [ ] Java optimiza la recursión automáticamente; las tres corren igual
+- [ ] La versión con ventana usa más memoria que la del arreglo
+
+</Question>
+
+<Question id="por-que-lento" anchor="el-arbol-de-llamadas">
+
+¿Por qué la implementación recursiva de Fibonacci es tan lenta?
+
+- [x] Recalcula muchas veces los mismos valores intermedios (`fib(3)` aparece varias veces en el árbol de `fib(5)`)
+- [ ] La recursión en Java es intrínsecamente más lenta que los ciclos por diseño del lenguaje
+- [ ] `System.nanoTime()` mide mal el tiempo de las funciones recursivas por su granularidad
+- [ ] La pila de llamadas se llena y el JVM empieza a paginarla a disco automáticamente
+
+</Question>
+
+<Question id="crecimiento-comparado" anchor="el-arbol-de-llamadas">
+
+Si `fib(30)` con la versión de arreglo toma alrededor de 1 ms, ¿cuánto toma
+aproximadamente `fib(30)` con la versión recursiva en el mismo navegador?
+
+- [x] Del orden de un segundo
+- [ ] 1 ms también, ambas hacen el mismo cálculo
+- [ ] Del orden de 10 ms, apenas un poco más lenta
+- [ ] Del orden de una hora, tanto que la pestaña se cierra sola
+
+</Question>
+
+<Question id="cap-del-n" anchor="cap-de-la-demo">
+
+El documento sugiere probar `fib(30)` en vivo con el recursivo y desaconseja
+subir a `fib(45)`. ¿Por qué?
+
+- [x] Porque `fib(45)` congela la página por minutos u horas sin manera de cancelar
+- [ ] Porque CheerpJ no soporta números tan grandes como `fib(45)`
+- [ ] Porque el resultado de `fib(45)` no cabe en un `int` ni en un `long`
+- [ ] Es una limitación arbitraria; con permisos elevados se puede correr
 
 </Question>
 

--- a/content/courses/sample-course/09-arrays-y-funciones.mdx
+++ b/content/courses/sample-course/09-arrays-y-funciones.mdx
@@ -916,3 +916,17 @@ System.out.println(v[0]);
 </Question>
 
 </Questions>
+
+## Lo que sigue
+
+Ya sabes trabajar con arreglos, escribir funciones (con sobrecarga incluida),
+y reconocer cuándo una recursión te resuelve un problema y cuándo, escrita
+sin cuidado, te lo hace más caro que un ciclo. El caso de estudio de
+Fibonacci te dio la primera medición concreta de que **elegir cómo
+implementar** tiene consecuencias que se cuentan en órdenes de magnitud —
+volveremos a ese hilo cuando el curso llegue a la complejidad computacional
+en su documento propio.
+
+Lo que falta antes de eso es la última pieza del lenguaje: **los objetos**,
+con `equals` y `hashCode` para ser autor de tus propios tipos igualables. Es
+el próximo documento: [[objetos|Objetos, con equals y hashCode]].

--- a/content/courses/sample-course/09-arrays-y-funciones.mdx
+++ b/content/courses/sample-course/09-arrays-y-funciones.mdx
@@ -77,8 +77,9 @@ int[] c = new int[]{10, 20, 30};   // literal con new — necesaria si no es en 
 ```
 
 Los valores por defecto de `new int[5]` son `0`; de `new boolean[5]` son `false`; de
-`new String[5]` son `null` — el mismo `null` de [[referencias-null-igualdad|el documento
-anterior]], listo para dar `NullPointerException` si accedes sin asignar primero.
+`new String[5]` son `null` — el mismo `null` de
+[[referencias-null-igualdad|Referencias, `null` e igualdad]], listo para dar
+`NullPointerException` si accedes sin asignar primero.
 
 La tercera forma existe porque la primera (`{1, 2, 3}`) solo se puede escribir en la
 declaración misma. Fuera de ahí — devolviendo un arreglo desde un método, por
@@ -89,7 +90,8 @@ ejemplo — hay que escribirla como `new int[]{...}`.
 El acceso es igual que en C++: `v[i]`, con `i` de `0` a `v.length - 1`. La diferencia
 que importa es lo que pasa cuando `i` se sale de ese rango. En vez de comportamiento
 indefinido, Java lanza `ArrayIndexOutOfBoundsException` — la excepción concreta que
-[[referencias-null-igualdad|el documento anterior]] preparó al enseñar el mecanismo.
+[[referencias-null-igualdad|Referencias, `null` e igualdad]] prepara al enseñar el
+mecanismo de excepciones en Java.
 
 <CodeEditor
   language="java"
@@ -161,10 +163,10 @@ Si necesitas modificar el arreglo, escribe el `for` clásico y asigna a `v[i]`.
 
 <Slide title="Buscar un elemento">
 En C++ compararías con `==` porque los tipos primitivos se comparan por valor y las
-cadenas se manejan de otra manera. En Java, ya viste en
-[[referencias-null-igualdad|el documento anterior]] que `==` sobre `String` compara
-**referencias**, no contenido — y por eso la búsqueda de un texto en un arreglo se
-hace con `.equals()`:
+cadenas se manejan de otra manera. En Java, como se enseña en
+[[referencias-null-igualdad|Referencias, `null` e igualdad]], `==` sobre `String`
+compara **referencias**, no contenido — y por eso la búsqueda de un texto en un
+arreglo se hace con `.equals()`:
 
 ```java
 static boolean contiene(String[] xs, String buscado) {
@@ -261,9 +263,9 @@ class Util {
   `return 5;` tampoco.
 - **Los parámetros se pasan por valor.** Un `int` viaja como copia; un objeto
   viaja como copia de la referencia — el mismo hecho de
-  [[referencias-null-igualdad|el documento anterior]]. Java no tiene el `&` de
-  C++ para pedir referencia; si necesitas modificar algo, devuélvelo o pasa un
-  arreglo (que es un objeto).
+  [[referencias-null-igualdad|Referencias, `null` e igualdad]]. Java no tiene
+  el `&` de C++ para pedir referencia; si necesitas modificar algo, devuélvelo
+  o pasa un arreglo (que es un objeto).
 
 **Sobrecarga: dos funciones con el mismo nombre, distintos parámetros.**
 
@@ -279,9 +281,9 @@ literales enteros — y `maximo(3.0, 4.0)` va a la tercera.
 
 **Lo que sí tenías en C++ y en Java no:** sobrecargar `+`, `==` o cualquier otro
 operador para tus propios tipos. Esa es la razón — la misma que aparece en
-[[referencias-null-igualdad|el documento anterior]] — por la que `==` sobre
-`String` no compara contenido: nadie puede reescribir qué significa `==`, ni
-siquiera para las clases que Java trae de fábrica.
+[[referencias-null-igualdad|Referencias, `null` e igualdad]] — por la que `==`
+sobre `String` no compara contenido: nadie puede reescribir qué significa `==`,
+ni siquiera para las clases que Java trae de fábrica.
 </Slide>
 
 <Slide title="Recursión en C++">
@@ -364,16 +366,23 @@ caso base.
         System.out.println("factorial(1) = " + factorial(1));
         System.out.println("factorial(5) = " + factorial(5));
         System.out.println("factorial(10) = " + factorial(10));
+        System.out.println("factorial(13) = " + factorial(13));
+        System.out.println("factorial(17) = " + factorial(17));
     }
 }
 `}
 />
 
-`factorial(10)` es `3628800`. Un `int` guarda `factorial(12)`; a partir de `13`
-desborda y aterriza en un número negativo — el mismo desbordamiento silencioso
-de [[java-tipos-y-flujo|"Tipos, operadores y entrada/salida"]]. Es lo que
-introduce el siguiente caso de estudio, `fib`, donde el problema no es el
-tamaño del resultado sino el tiempo que toma llegar a él.
+`factorial(10)` es `3628800`. Un `int` guarda hasta `factorial(12)`; **a partir
+de `13` el resultado ya no cabe en 32 bits** y aparece un número que ya no es
+el factorial matemático — pero sigue siendo positivo, porque el desbordamiento
+da la vuelta dentro del rango. **A `17` la vuelta cruza el cero** y el
+resultado aparece negativo. Es el mismo desbordamiento silencioso de
+[[java-tipos-y-flujo|"Tipos, operadores y entrada/salida"]], visto ahora con
+un ejemplo donde el defecto no salta a la cara la primera vez: el número está
+mal desde `n = 13`, y solo se ve raro desde `n = 17`. Cuando el resultado deba
+crecer más, el tipo `long` (que resiste hasta `factorial(20)`) es la salida
+mínima, y para más allá, `BigInteger`.
 </Slide>
 
 <Slide title="Sin caso base">
@@ -465,9 +474,9 @@ la respuesta.
 `}
 />
 
-`long` en vez de `int` porque `fib(46)` ya no cabe en 32 bits. El ciclo hace
-`n - 1` sumas y usa `n + 1` casillas de memoria: **coste lineal en tiempo y
-en memoria**.
+`long` en vez de `int` porque cerca de `fib(47)` el resultado ya no cabe en
+32 bits (`fib(46)` es el último que entra). El ciclo hace `n - 1` sumas y
+usa `n + 1` casillas de memoria: **coste lineal en tiempo y en memoria**.
 
 `System.nanoTime()` devuelve un contador monótono con resolución de
 nanosegundos. La granularidad real en tu navegador puede ser menor (CheerpJ
@@ -543,10 +552,11 @@ Ahora la que se parece a la definición matemática, letra por letra.
 
 Es la más corta y la más legible. Ejecútalo con `n = 30` y anota el tiempo.
 Después súbelo a `35` y **prepárate a esperar**: el tiempo se multiplica por
-un factor cercano a `10` cada vez que sumas dos a `n`. Con `n = 30` alcanzas
-del orden del segundo; con `n = 35` alcanzas del orden de la decena de
-segundos. Es la primera vez en el curso que un programa que compila y no
-tiene defectos aparentes se demora tanto que la página parece congelada.
+un factor cercano a `3` cada vez que sumas dos a `n`, y del orden de `10`
+cada vez que sumas cinco. Con `n = 30` alcanzas del orden del segundo; con
+`n = 35` alcanzas del orden de la decena de segundos. Es la primera vez en
+el curso que un programa que compila y no tiene defectos aparentes se demora
+tanto que la página parece congelada.
 
 **No pruebes `n = 45`.** Y aunque quisieras, la próxima slide te explica por
 qué el documento no te deja.
@@ -619,8 +629,8 @@ elementos. Si el arreglo está vacío, la suma es `0`.
 class Solution {
 
     static int sumaArreglo(int[] v) {
-        // tu código aquí
-        return 0;
+        // tu código aquí — reemplaza el -1
+        return -1;
     }
 }
 ```
@@ -675,8 +685,10 @@ los elementos del arreglo es `null` tampoco.
 class Solution {
 
     static boolean contieneElemento(String[] xs, String buscado) {
-        // tu código aquí
-        return false;
+        // tu código aquí — el starter tira una excepción a propósito
+        // hasta que lo escribas (con booleanos, ni `true` ni `false`
+        // son sentinelas que no coincidan con algún caso legítimo).
+        throw new UnsupportedOperationException("aún no implementado");
     }
 }
 ```
@@ -709,8 +721,8 @@ o falta.
 class Solution {
 
     static int sumaHastaN(int n) {
-        // tu código aquí
-        return 0;
+        // tu código aquí — reemplaza el -1
+        return -1;
     }
 }
 ```

--- a/content/courses/sample-course/09-arrays-y-funciones.mdx
+++ b/content/courses/sample-course/09-arrays-y-funciones.mdx
@@ -726,6 +726,14 @@ check(Solution.sumaHastaN(100), 5050);
 
 </Exercise>
 
+{/* Las trece preguntas del banco de este documento. Cada una fue redactada */}
+{/* con la sección que la mide, no meses después contra un documento que */}
+{/* nadie recuerda — el orden que #148 (ADR-0032) inauguró y esta primera */}
+{/* aplicación intencional del `guides/write-control-questions.md`. */}
+{/* La verificación en runtime real (`fact(5) = 120`, `Arrays.sort` deja */}
+{/* `v[0] = 1`, `fib(30)` recursivo cae en el orden del segundo en CheerpJ */}
+{/* del navegador de referencia) se hace en el browser check de S7; ajustar */}
+{/* alternativas si el JVM discrepa es parte de esa lista. */}
 <Questions>
 
 <Question id="largo-array-java" anchor="arrays-en-java">
@@ -848,10 +856,10 @@ System.out.println(fact(5));
 ¿Cuál de estas afirmaciones sobre las tres implementaciones de Fibonacci es
 cierta?
 
-- [x] La versión con arreglo y la ventana calculan los mismos valores en tiempos parecidos
+- [x] La versión con arreglo y la de dos variables tardan tiempos parecidos
 - [ ] La recursiva es la más rápida porque es la más corta y clara
 - [ ] Java optimiza la recursión automáticamente; las tres corren igual
-- [ ] La versión con ventana usa más memoria que la del arreglo
+- [ ] La versión con dos variables usa más memoria que la del arreglo
 
 </Question>
 

--- a/content/courses/sample-course/09-arrays-y-funciones.mdx
+++ b/content/courses/sample-course/09-arrays-y-funciones.mdx
@@ -600,6 +600,132 @@ mediste tú, en tu propia máquina, y viste que un mismo problema resuelto
 de tres maneras tiene tres tiempos radicalmente distintos.
 </Slide>
 
+## Ejercicios
+
+Cuatro problemas para escribir tú. Completa el método que falta y presiona
+**Comprobar**: tu código se compila junto a una batería de casos que lo llaman
+y te dicen cuáles pasaron. Los casos aparecen después de la primera ejecución.
+
+Todos están **acotados** — los arreglos son cortos, y el recursivo tiene un
+caso base explícito y un input chico. Ningún ejercicio te puede colgar la
+pestaña siempre que respetes el contrato del enunciado.
+
+<Exercise title="1. Suma de un arreglo">
+
+Escribe `sumaArreglo`, que recibe un `int[]` y devuelve la suma de todos sus
+elementos. Si el arreglo está vacío, la suma es `0`.
+
+```java starter
+class Solution {
+
+    static int sumaArreglo(int[] v) {
+        // tu código aquí
+        return 0;
+    }
+}
+```
+
+```java test
+check(Solution.sumaArreglo(new int[]{1, 2, 3, 4}), 10);
+check(Solution.sumaArreglo(new int[]{-5, 5}), 0);
+check(Solution.sumaArreglo(new int[]{}), 0);
+check(Solution.sumaArreglo(new int[]{42}), 42);
+check(Solution.sumaArreglo(new int[]{1, -1, 1, -1, 1}), 1);
+```
+
+</Exercise>
+
+<Exercise title="2. Máximo de un arreglo">
+
+Escribe `maximoDeArreglo`, que recibe un `int[]` **no vacío** y devuelve el
+mayor de sus elementos. Puedes suponer que el arreglo tiene al menos un
+elemento.
+
+```java starter
+class Solution {
+
+    static int maximoDeArreglo(int[] v) {
+        // tu código aquí
+        return 0;
+    }
+}
+```
+
+```java test
+check(Solution.maximoDeArreglo(new int[]{3, 1, 4, 1, 5, 9, 2, 6}), 9);
+check(Solution.maximoDeArreglo(new int[]{7}), 7);
+check(Solution.maximoDeArreglo(new int[]{-5, -2, -9, -1, -8}), -1);
+check(Solution.maximoDeArreglo(new int[]{10, 10, 10}), 10);
+check(Solution.maximoDeArreglo(new int[]{-100, 0, 100}), 100);
+```
+
+</Exercise>
+
+<Exercise title="3. ¿Contiene el elemento?">
+
+Escribe `contieneElemento`, que recibe un `String[]` y un `String buscado`, y
+devuelve `true` si el arreglo contiene una cadena **con el mismo contenido**
+que `buscado`. Recuerda que en Java las cadenas se comparan con `.equals()`,
+no con `==`.
+
+Puedes suponer que ni el arreglo ni `buscado` son `null`, y que ninguno de
+los elementos del arreglo es `null` tampoco.
+
+```java starter
+class Solution {
+
+    static boolean contieneElemento(String[] xs, String buscado) {
+        // tu código aquí
+        return false;
+    }
+}
+```
+
+```java test
+check(Solution.contieneElemento(new String[]{"a", "b", "c"}, "b"), true);
+check(Solution.contieneElemento(new String[]{"a", "b", "c"}, "d"), false);
+check(Solution.contieneElemento(new String[]{}, "a"), false);
+check(Solution.contieneElemento(new String[]{"hola"}, "hola"), true);
+check(Solution.contieneElemento(new String[]{"Hola"}, "hola"), false);
+check(Solution.contieneElemento(new String[]{"", "x"}, ""), true);
+```
+
+</Exercise>
+
+<Exercise title="4. Suma hasta n, recursivo">
+
+Escribe `sumaHastaN` **recursivamente**, que recibe un `int n` y devuelve la
+suma `1 + 2 + ... + n`. Si `n` es menor o igual a `0`, la suma es `0`.
+
+Este es el ejercicio donde te falta escribir el caso base y el caso recursivo,
+como en el `factorial` de la sección de recursión. **No uses ciclos**: la
+gracia está en la recursión.
+
+Los casos usan `n ≤ 100`, así que ni tu pila ni el tiempo son un problema. Si
+tu implementación provoca `StackOverflowError`, el caso base está mal escrito
+o falta.
+
+```java starter
+class Solution {
+
+    static int sumaHastaN(int n) {
+        // tu código aquí
+        return 0;
+    }
+}
+```
+
+```java test
+check(Solution.sumaHastaN(0), 0);
+check(Solution.sumaHastaN(-3), 0);
+check(Solution.sumaHastaN(1), 1);
+check(Solution.sumaHastaN(5), 15);
+check(Solution.sumaHastaN(10), 55);
+check(Solution.sumaHastaN(100), 5050);
+```
+
+</Exercise>
+
 <Questions>
 
 <Question id="largo-array-java" anchor="arrays-en-java">

--- a/content/courses/sample-course/09-arrays-y-funciones.mdx
+++ b/content/courses/sample-course/09-arrays-y-funciones.mdx
@@ -216,6 +216,196 @@ binaria más adelante en el curso; aquí lo que necesitabas era **la herramienta
 `sort`, no el algoritmo por debajo.
 </Slide>
 
+<Slide title="Funciones en C++">
+En C++ declaras una función indicando su tipo de retorno, su nombre y sus
+parámetros, y opcionalmente la separas en firma y cuerpo:
+
+```cpp
+int maximo(int a, int b);              // firma
+int maximo(int a, int b) { return a > b ? a : b; }  // cuerpo
+
+int main() { std::cout << maximo(3, 4); }
+```
+
+Puedes tener **funciones libres** (sueltas, como `maximo`), **métodos** dentro de
+una clase, y **funciones sobrecargadas** (mismo nombre, distintos parámetros). Y
+tienes **punteros a función**, además de operadores que puedes sobrecargar para
+tus propios tipos.
+
+En Java todo esto vuelve a plantearse desde el hecho de que **no existen funciones
+libres**: cada función vive dentro de una clase. El resto de las diferencias caen
+por sí solas cuando entendiste esa.
+</Slide>
+
+<Slide title="Anatomía de una función">
+En Java, `main` es lo único que has visto hasta ahora que se parece a una función.
+Cualquier otra la escribes exactamente con la misma forma: modificadores, tipo de
+retorno, nombre, parámetros entre paréntesis, y un bloque.
+
+```java
+class Util {
+    static int maximo(int a, int b) {
+        return a > b ? a : b;
+    }
+}
+```
+
+- **`static`** significa "no necesita un objeto para llamarla". Un método sin
+  `static` vive **en un objeto** (la instancia lo lleva), y solo se puede llamar
+  con un objeto delante: `x.mayorQue(y)`. Todo lo que has escrito hasta ahora es
+  `static` porque todavía no hay objetos en escena — llegan en el próximo
+  documento.
+- **El tipo de retorno es obligatorio.** Si no devuelves nada, se declara `void`
+  — pero se declara, Java nunca lo infiere. Un método `int` que se olvida de
+  ejecutar `return` con un `int` no compila; un método `void` que escribe
+  `return 5;` tampoco.
+- **Los parámetros se pasan por valor.** Un `int` viaja como copia; un objeto
+  viaja como copia de la referencia — el mismo hecho de
+  [[referencias-null-igualdad|el documento anterior]]. Java no tiene el `&` de
+  C++ para pedir referencia; si necesitas modificar algo, devuélvelo o pasa un
+  arreglo (que es un objeto).
+
+**Sobrecarga: dos funciones con el mismo nombre, distintos parámetros.**
+
+```java
+static int maximo(int a, int b)            { return a > b ? a : b; }
+static int maximo(int a, int b, int c)     { return maximo(maximo(a, b), c); }
+static double maximo(double a, double b)   { return a > b ? a : b; }
+```
+
+Las tres se llaman `maximo`; el compilador elige cuál usar mirando los tipos y
+la cantidad de argumentos que le pasas. `maximo(3, 4)` va a la primera —
+literales enteros — y `maximo(3.0, 4.0)` va a la tercera.
+
+**Lo que sí tenías en C++ y en Java no:** sobrecargar `+`, `==` o cualquier otro
+operador para tus propios tipos. Esa es la razón — la misma que aparece en
+[[referencias-null-igualdad|el documento anterior]] — por la que `==` sobre
+`String` no compara contenido: nadie puede reescribir qué significa `==`, ni
+siquiera para las clases que Java trae de fábrica.
+</Slide>
+
+<Slide title="Recursión en C++">
+Una función que se llama a sí misma. La sintaxis es idéntica a cualquier otra
+llamada — no hay palabra clave "recursivo" en C++ ni en Java. La responsabilidad
+de que la recursión termine es del autor: hay que garantizar un **caso base**
+donde la función devuelve sin llamarse otra vez, y que el **caso recursivo**
+llame con argumentos que se acerquen al base.
+
+```cpp
+int factorial(int n) {
+    if (n <= 1) return 1;           // caso base
+    return n * factorial(n - 1);    // caso recursivo
+}
+```
+
+Si te olvidas del base — o el recursivo llama con el mismo argumento — la pila
+crece hasta que el sistema operativo interrumpe el programa. En C++ eso puede
+ser un `stack overflow`, un segfault, o algo peor si tocaste memoria ajena.
+
+Java hereda la mecánica y hace lo mismo mejor: te lanza una excepción con el
+nombre exacto de lo que pasó.
+</Slide>
+
+<Slide title="Recursión">
+Una función que se llama a sí misma. Las reglas son las mismas que ya conoces
+de C++, con dos cosas que Java hace distinto: la excepción cuando la pila se
+llena tiene nombre propio, y no hay ninguna manera de escribir un ciclo que no
+sea uno de los que ya viste (`for`, `while`, `for-each`) — es decir, si quieres
+recorrer sin repetir estado, la opción legítima es la recursión.
+
+**Toda función recursiva tiene dos partes:**
+
+1. **Caso base**: el argumento donde la función devuelve sin llamarse otra vez.
+   Es el fondo de la recursión.
+2. **Caso recursivo**: la función se llama a sí misma con un argumento que se
+   acerca al caso base. Sin ese "se acerca" la recursión no termina.
+
+```java
+class Factorial {
+
+    static int factorial(int n) {
+        if (n <= 1) return 1;               // caso base
+        return n * factorial(n - 1);        // caso recursivo
+    }
+
+    public static void main(String[] args) {
+        System.out.println(factorial(5));   // 120
+    }
+}
+```
+
+Léelo como una historia: `factorial(4)` no sabe cuánto vale, pero sabe que es
+`4 * factorial(3)`. `factorial(3)` a su vez es `3 * factorial(2)`. Y así hasta
+`factorial(1)`, que responde `1` sin preguntarle a nadie. Ese `1` vuelve, se
+multiplica por `2`, ese `2` se multiplica por `3`, ese `6` se multiplica por
+`4`, y llega a `main` como `24`.
+
+Cada llamada anidada abre una **capa** en la pila y se cierra al retornar. Esa
+pila es finita (unas decenas de miles de llamadas en un JVM típico), y ahí
+entra el peor defecto de una recursión mal escrita.
+</Slide>
+
+<Slide title="Factorial en vivo">
+Corre este `factorial(5)` y confirma que da `120`. Después prueba `factorial(1)`
+y `factorial(0)` — los dos deberían dar `1`, porque los dos entran directo al
+caso base.
+
+<CodeEditor
+  language="java"
+  defaultValue={`class Factorial {
+
+    static int factorial(int n) {
+        if (n <= 1) return 1;
+        return n * factorial(n - 1);
+    }
+
+    public static void main(String[] args) {
+        System.out.println("factorial(0) = " + factorial(0));
+        System.out.println("factorial(1) = " + factorial(1));
+        System.out.println("factorial(5) = " + factorial(5));
+        System.out.println("factorial(10) = " + factorial(10));
+    }
+}
+`}
+/>
+
+`factorial(10)` es `3628800`. Un `int` guarda `factorial(12)`; a partir de `13`
+desborda y aterriza en un número negativo — el mismo desbordamiento silencioso
+de [[java-tipos-y-flujo|"Tipos, operadores y entrada/salida"]]. Es lo que
+introduce el siguiente caso de estudio, `fib`, donde el problema no es el
+tamaño del resultado sino el tiempo que toma llegar a él.
+</Slide>
+
+<Slide title="Sin caso base">
+El defecto más común de escribir una recursión: olvidar el caso base, o escribir
+uno que la llamada nunca alcanza. La pila se llena y Java lanza
+`StackOverflowError` con el rastro completo.
+
+<CodeEditor
+  language="java"
+  defaultValue={`class Descuidado {
+
+    static int cuenta(int n) {
+        return n + cuenta(n - 1);   // sin caso base
+    }
+
+    public static void main(String[] args) {
+        System.out.println(cuenta(5));
+    }
+}
+`}
+/>
+
+Ejecútalo. El rastro es larguísimo — miles de líneas idénticas — porque cada
+llamada anidada aparece en el reporte. Es el error más ruidoso que Java sabe
+lanzar, y para eso está: el defecto es serio y merece un mensaje que no se
+confunda con otro.
+
+En C++ el mismo programa dependería del compilador y la máquina; en Java el
+comportamiento está **especificado**, igual que el desbordamiento de enteros y
+por la misma razón: predecibilidad multiplataforma.
+</Slide>
+
 <Questions>
 
 <Question id="largo-array-java" anchor="arrays-en-java">
@@ -271,6 +461,65 @@ System.out.println(v[0]);
 - [ ] Recorrer con `for` y comparar cada elemento con `== "María"` a secas
 - [ ] Comparar directamente el arreglo entero: `names == "María"`
 - [ ] Java lo detecta solo, no hace falta escribir el recorrido
+
+</Question>
+
+<Question id="valor-de-retorno" anchor="anatomia-de-una-funcion">
+
+¿Cuáles de estas afirmaciones sobre las funciones en Java son ciertas?
+
+- [x] Una función que devuelve `int` tiene que ejecutar un `return` con un `int`
+- [x] Una función declarada `void` no puede escribir `return algo;`
+- [ ] Java tiene punteros a función, como en C++
+- [ ] El tipo de retorno es opcional; el compilador lo infiere
+
+</Question>
+
+<Question id="overloading-cual-se-elige" anchor="anatomia-de-una-funcion">
+
+Dado:
+
+```java
+static int max(int a, int b) { return a > b ? a : b; }
+static double max(double a, double b) { return a > b ? a : b; }
+```
+
+Al llamar `max(3, 4)`, ¿cuál se elige?
+
+- [x] La versión `int`, porque los literales son `int`
+- [ ] La versión `double`, porque es más general
+- [ ] Error de compilación por ambigüedad
+- [ ] Cualquiera, Java elige al azar
+
+</Question>
+
+<Question id="factorial-recursion" anchor="recursion">
+
+¿Qué imprime este programa?
+
+```java
+static int fact(int n) {
+    if (n <= 1) return 1;
+    return n * fact(n - 1);
+}
+System.out.println(fact(5));
+```
+
+- [x] `120`
+- [ ] `5`
+- [ ] Error de compilación
+- [ ] `StackOverflowError`
+
+</Question>
+
+<Question id="sin-caso-base" anchor="recursion">
+
+¿Qué pasa si una función recursiva no tiene caso base?
+
+- [x] Lanza `StackOverflowError` cuando la pila se llena
+- [ ] Corre para siempre sin problema
+- [ ] Java lo detecta al compilar y no deja compilar
+- [ ] Devuelve `null`
 
 </Question>
 

--- a/content/courses/sample-course/09-arrays-y-funciones.mdx
+++ b/content/courses/sample-course/09-arrays-y-funciones.mdx
@@ -1,0 +1,294 @@
+---
+id: arrays-y-funciones
+title: Arrays y funciones
+presentation: explicit
+questions: per-section
+---
+
+{/* Este documento declara `questions: per-section` (#139). Cada sección o */}
+{/* tiene una `<Question anchor="...">` en el bloque `<Questions>` al final, */}
+{/* o está declarada con su razón en NO_QUESTION en */}
+{/* apps/web/src/content/architecture.test.ts (§Question coverage). */}
+{/* */}
+{/* Anclas que llevan pregunta (deben existir como secciones): */}
+{/*   arrays-en-java, acceso-y-bounds, recorrer-un-arreglo, */}
+{/*   buscar-un-elemento, ordenar-y-buscar, anatomia-de-una-funcion, */}
+{/*   recursion, fibonacci-tres-formas, el-arbol-de-llamadas, cap-de-la-demo. */}
+{/* */}
+{/* Regla del WP (AC-11): cada sección abre con el ANCLA C++ antes del delta */}
+{/* Java. La ancla C++ es su propia slide; su pregunta es la de la sección */}
+{/* Java que la sigue, no una propia. */}
+{/* */}
+{/* AC-12: cada bloque de código en slides está resaltado. Interactivos con */}
+{/* <CodeEditor>; read-only con fences ```java (que se renderizan a través */}
+{/* del listing de #85). Nunca <pre> crudo. */}
+
+# Arrays y funciones
+
+En [[referencias-null-igualdad|Referencias, `null` e igualdad]] viste que los objetos
+viven en el heap y las variables guardan referencias a ellos; ahora vas a trabajar con
+un tipo de objeto que ya conocías en C++ pero que Java trata distinto — el arreglo — y
+vas a agrupar código en **funciones**, tema que el material anterior tampoco cubrió a
+fondo. El documento cierra con un caso de estudio: tres formas de calcular Fibonacci,
+medidas en tu propio navegador, y por qué la recursiva pierde.
+
+<SectionBreak />
+
+<Slide title="Arrays en C++">
+En C++, un arreglo es dos cosas separadas: un puntero al primer elemento y, en algún
+lado, el tamaño que tú decides recordar. El compilador no verifica que un acceso caiga
+adentro; leer `v[3]` cuando el arreglo tiene 3 elementos devuelve lo que sea que esté
+en esa posición de memoria, o interrumpe el programa si le pegaste a memoria ajena.
+
+```cpp
+int v[3] = {1, 2, 3};
+std::cout << sizeof(v) / sizeof(v[0]);  // 3, si el tipo no se decayó a puntero
+std::cout << v[3];                       // comportamiento indefinido
+```
+
+El largo lo administras tú, y el rango no lo revisa nadie. Ese "nadie" es la mitad de
+los defectos que Java te va a quitar.
+</Slide>
+
+<Slide title="Arrays en Java">
+En Java un arreglo **es un objeto**: sabe su propio largo, y ese largo se pregunta
+como campo, no como método.
+
+```java
+int[] v = {1, 2, 3};
+System.out.println(v.length);   // 3 — sin paréntesis, es un campo, no un método
+```
+
+- `.length` sin paréntesis. `String` sí usa `.length()` (es un método); un arreglo no.
+  La distinción parece cosmética hasta que el compilador te para porque escribiste una
+  por la otra, o el editor te sugiere la incorrecta.
+- El largo se fija al crearlo y no cambia. Si necesitas crecer, se copia a otro arreglo
+  más grande (o se usa una lista, que viene más adelante en el curso).
+- El tipo del elemento va antes de los corchetes: `int[]`, `String[]`, `Persona[]`.
+</Slide>
+
+<Slide title="Tres iniciaciones">
+Las tres formas que vas a ver todo el semestre:
+
+```java
+int[] a = {1, 2, 3};               // literal: el arreglo con esos tres valores
+int[] b = new int[5];              // reservado con largo 5 y valores por defecto (0)
+int[] c = new int[]{10, 20, 30};   // literal con new — necesaria si no es en la declaración
+```
+
+Los valores por defecto de `new int[5]` son `0`; de `new boolean[5]` son `false`; de
+`new String[5]` son `null` — el mismo `null` de [[referencias-null-igualdad|el documento
+anterior]], listo para dar `NullPointerException` si accedes sin asignar primero.
+
+La tercera forma existe porque la primera (`{1, 2, 3}`) solo se puede escribir en la
+declaración misma. Fuera de ahí — devolviendo un arreglo desde un método, por
+ejemplo — hay que escribirla como `new int[]{...}`.
+</Slide>
+
+<Slide title="Acceso y bounds">
+El acceso es igual que en C++: `v[i]`, con `i` de `0` a `v.length - 1`. La diferencia
+que importa es lo que pasa cuando `i` se sale de ese rango. En vez de comportamiento
+indefinido, Java lanza `ArrayIndexOutOfBoundsException` — la excepción concreta que
+[[referencias-null-igualdad|el documento anterior]] preparó al enseñar el mecanismo.
+
+<CodeEditor
+  language="java"
+  defaultValue={`class Bounds {
+    public static void main(String[] args) {
+        int[] v = {1, 2, 3};
+        System.out.println("largo: " + v.length);
+        System.out.println("v[0] = " + v[0]);
+        System.out.println("v[3] = " + v[3]);  // lanza excepción
+        System.out.println("esta línea nunca se ejecuta");
+    }
+}
+`}
+/>
+
+Ejecútalo. Vas a ver `largo: 3`, `v[0] = 1`, y después el rastro de la excepción — el
+programa se detiene en `v[3]` y la última línea nunca corre. El chequeo cuesta unos
+nanosegundos por acceso; a cambio, un defecto silencioso en C++ se vuelve un defecto
+que salta a la cara.
+</Slide>
+
+<Slide title="En C++ era segfault">
+El mismo programa en C++ tiene tres desenlaces posibles, ninguno bueno:
+
+1. **Imprime basura.** `v[3]` cae en memoria que le pertenece al programa pero no al
+   arreglo — la próxima variable en la pila, o alineación, o lo que sea que estaba ahí.
+2. **Segmentation fault.** `v[3]` cae en memoria que no le pertenece al programa; el
+   sistema operativo lo interrumpe.
+3. **Sobrescribe algo importante.** Si en vez de leer estás escribiendo (`v[3] = 99`),
+   modificas variables sin saberlo. Los defectos que resultan de esto son de los más
+   difíciles de rastrear que hay.
+
+En Java las tres se colapsan en una sola: la excepción con el índice exacto y la línea
+exacta. Es más lento; es incomparablemente más depurable.
+</Slide>
+
+<Slide title="Recorrer un arreglo">
+Dos formas. El `for` clásico, cuando necesitas el índice — para asignar, para comparar
+con el vecino, para pasarlo a otra función:
+
+```java
+int[] v = {10, 20, 30};
+for (int i = 0; i < v.length; i++) {
+    System.out.println(i + ": " + v[i]);
+}
+```
+
+Y el `for-each`, cuando solo te importa el valor:
+
+```java
+int[] v = {10, 20, 30};
+for (int x : v) {
+    System.out.println(x);
+}
+```
+
+**Una trampa que se llevó su tarde.** En el `for-each`, `x` es una **copia** del
+elemento cuando el tipo es primitivo, o una **copia de la referencia** cuando es un
+objeto. Asignarle un valor nuevo dentro del ciclo NO modifica el arreglo:
+
+```java
+int[] v = {1, 2, 3};
+for (int x : v) x = 99;    // no hace nada útil
+System.out.println(v[0]);  // sigue siendo 1
+```
+
+Si necesitas modificar el arreglo, escribe el `for` clásico y asigna a `v[i]`.
+</Slide>
+
+<Slide title="Buscar un elemento">
+En C++ compararías con `==` porque los tipos primitivos se comparan por valor y las
+cadenas se manejan de otra manera. En Java, ya viste en
+[[referencias-null-igualdad|el documento anterior]] que `==` sobre `String` compara
+**referencias**, no contenido — y por eso la búsqueda de un texto en un arreglo se
+hace con `.equals()`:
+
+```java
+static boolean contiene(String[] xs, String buscado) {
+    for (String x : xs) {
+        if (x.equals(buscado)) return true;
+    }
+    return false;
+}
+```
+
+Para arreglos de primitivos (`int[]`, `double[]`, …) el `==` sí compara valores, así
+que el mismo esqueleto funciona con `if (x == buscado)`. La regla mental que te
+conviene grabar: **`==` es igualdad de referencia, `.equals()` es igualdad de
+contenido**; para primitivos las dos coinciden, para objetos rara vez lo hacen sin que
+alguien las haga coincidir a mano.
+
+Un detalle práctico: `buscado.equals(x)` y `x.equals(buscado)` dan el mismo resultado
+cuando ninguno es `null`, pero si `x` puede serlo la primera forma evita el
+`NullPointerException`. Es una convención barata que ahorra pruebas defensivas.
+</Slide>
+
+<Slide title="Ordenar y buscar">
+Java trae `Arrays.sort` como método estático, y ordena **en el mismo arreglo** — no
+devuelve uno nuevo. Es la diferencia con `std::sort` de C++, que también ordena en
+sitio pero recibe un par de iteradores en vez del contenedor completo.
+
+<CodeEditor
+  language="java"
+  defaultValue={`import java.util.Arrays;
+
+class Orden {
+    public static void main(String[] args) {
+        int[] v = {3, 1, 4, 1, 5, 9, 2, 6};
+        Arrays.sort(v);
+        System.out.println(Arrays.toString(v));
+        System.out.println("v[0] = " + v[0]);
+    }
+}
+`}
+/>
+
+Los `import` que ya conoces: `java.util.Arrays` para los métodos utilitarios de
+arreglo (`sort`, `toString`, `fill`, `copyOf`). `Arrays.toString` imprime el arreglo
+como `[1, 1, 2, 3, ...]`, útil para depurar — un `System.out.println(v)` a secas
+imprime la dirección de memoria, que no ayuda a nadie.
+
+`Arrays.binarySearch` existe y sí es rápido, pero pertenece al documento de búsqueda
+binaria más adelante en el curso; aquí lo que necesitabas era **la herramienta**
+`sort`, no el algoritmo por debajo.
+</Slide>
+
+<Questions>
+
+<Question id="largo-array-java" anchor="arrays-en-java">
+
+En Java, ¿cómo se obtiene el largo de un `int[] v`?
+
+- [x] `v.length`
+- [ ] `v.length()`
+- [ ] `v.size()`
+- [ ] `sizeof(v)`
+
+</Question>
+
+<Question id="indice-fuera-de-rango" anchor="acceso-y-bounds">
+
+¿Qué pasa al ejecutar esto?
+
+```java
+int[] v = {1, 2, 3};
+System.out.println(v[3]);
+```
+
+- [x] Lanza `ArrayIndexOutOfBoundsException`
+- [ ] Imprime `0`, el valor por defecto de un `int`
+- [ ] Imprime lo que haya en esa posición de memoria
+- [ ] No compila: el compilador detecta que 3 está fuera de rango
+
+</Question>
+
+<Question id="for-each-modifica" anchor="recorrer-un-arreglo">
+
+¿Qué imprime este programa?
+
+```java
+int[] v = {1, 2, 3};
+for (int x : v) x = 99;
+System.out.println(v[0]);
+```
+
+- [x] `1`
+- [ ] `99`
+- [ ] Error de compilación
+- [ ] `0`
+
+</Question>
+
+<Question id="buscar-con-equals" anchor="buscar-un-elemento">
+
+¿Cuál es la forma correcta de saber si un `String[] names` contiene
+`"María"` como contenido?
+
+- [x] Recorrer con `for` y comparar cada elemento con `.equals("María")`
+- [ ] Recorrer con `for` y comparar cada elemento con `== "María"` a secas
+- [ ] Comparar directamente el arreglo entero: `names == "María"`
+- [ ] Java lo detecta solo, no hace falta escribir el recorrido
+
+</Question>
+
+<Question id="sort-in-place" anchor="ordenar-y-buscar">
+
+¿Qué imprime este programa?
+
+```java
+int[] v = {3, 1, 2};
+Arrays.sort(v);
+System.out.println(v[0]);
+```
+
+- [x] `1`
+- [ ] `3`
+- [ ] `2`
+- [ ] Error de compilación
+
+</Question>
+
+</Questions>

--- a/content/courses/sample-course/09-arrays-y-funciones.mdx
+++ b/content/courses/sample-course/09-arrays-y-funciones.mdx
@@ -13,7 +13,8 @@ questions: per-section
 {/* Anclas que llevan pregunta (deben existir como secciones): */}
 {/*   arrays-en-java, acceso-y-bounds, recorrer-un-arreglo, */}
 {/*   buscar-un-elemento, ordenar-y-buscar, anatomia-de-una-funcion, */}
-{/*   recursion, fibonacci-tres-formas, el-arbol-de-llamadas, cap-de-la-demo. */}
+{/*   recursion, fibonacci-tres-formas, el-arbol-de-llamadas, */}
+{/*   la-complejidad-se-ve. */}
 {/* */}
 {/* Regla del WP (AC-11): cada sección abre con el ANCLA C++ antes del delta */}
 {/* Java. La ancla C++ es su propia slide; su pregunta es la de la sección */}
@@ -35,10 +36,11 @@ medidas en tu propio navegador, y por qué la recursiva pierde.
 <SectionBreak />
 
 <Slide title="Arrays en C++">
-En C++, un arreglo es dos cosas separadas: un puntero al primer elemento y, en algún
-lado, el tamaño que tú decides recordar. El compilador no verifica que un acceso caiga
-adentro; leer `v[3]` cuando el arreglo tiene 3 elementos devuelve lo que sea que esté
-en esa posición de memoria, o interrumpe el programa si le pegaste a memoria ajena.
+En C++, un arreglo son dos cosas separadas: un puntero al primer elemento y una
+variable aparte con el tamaño, que tú administras. El compilador no revisa que
+el índice esté dentro del rango: leer `v[3]` cuando el arreglo tiene tres
+elementos devuelve el contenido de la posición de memoria que sigue al arreglo,
+o interrumpe el programa si esa posición no le pertenece.
 
 ```cpp
 int v[3] = {1, 2, 3};
@@ -46,8 +48,8 @@ std::cout << sizeof(v) / sizeof(v[0]);  // 3, si el tipo no se decayó a puntero
 std::cout << v[3];                       // comportamiento indefinido
 ```
 
-El largo lo administras tú, y el rango no lo revisa nadie. Ese "nadie" es la mitad de
-los defectos que Java te va a quitar.
+El largo lo llevas tú, y el rango no lo revisa nadie. Esos dos hechos son la
+mitad de los defectos que Java te va a quitar.
 </Slide>
 
 <Slide title="Arrays en Java">
@@ -59,12 +61,13 @@ int[] v = {1, 2, 3};
 System.out.println(v.length);   // 3 — sin paréntesis, es un campo, no un método
 ```
 
-- `.length` sin paréntesis. `String` sí usa `.length()` (es un método); un arreglo no.
-  La distinción parece cosmética hasta que el compilador te para porque escribiste una
-  por la otra, o el editor te sugiere la incorrecta.
-- El largo se fija al crearlo y no cambia. Si necesitas crecer, se copia a otro arreglo
-  más grande (o se usa una lista, que viene más adelante en el curso).
-- El tipo del elemento va antes de los corchetes: `int[]`, `String[]`, `Persona[]`.
+- **`v.length` es un campo, no un método** — no lleva paréntesis. `String` es
+  distinto: ahí sí es un método (`s.length()`, con paréntesis). Es la confusión
+  más común del semestre, y el compilador te para siempre que las mezcles.
+- El largo se fija al crearlo y no cambia. Si necesitas crecer, se copia a otro
+  arreglo más grande (o se usa una lista, que viene más adelante en el curso).
+- El tipo del elemento va antes de los corchetes: `int[]`, `String[]`,
+  `Persona[]`.
 </Slide>
 
 <Slide title="Tres iniciaciones">
@@ -80,18 +83,13 @@ Los valores por defecto de `new int[5]` son `0`; de `new boolean[5]` son `false`
 `new String[5]` son `null` — el mismo `null` de
 [[referencias-null-igualdad|el documento anterior]], listo para dar
 `NullPointerException` si accedes sin asignar primero.
-
-La tercera forma existe porque la primera (`{1, 2, 3}`) solo se puede escribir en la
-declaración misma. Fuera de ahí — devolviendo un arreglo desde un método, por
-ejemplo — hay que escribirla como `new int[]{...}`.
 </Slide>
 
 <Slide title="Acceso y bounds">
-El acceso es igual que en C++: `v[i]`, con `i` de `0` a `v.length - 1`. La diferencia
-que importa es lo que pasa cuando `i` se sale de ese rango. En vez de comportamiento
-indefinido, Java lanza `ArrayIndexOutOfBoundsException` — la excepción concreta que
-[[referencias-null-igualdad|el documento anterior]] preparó al enseñar el mecanismo
-de excepciones en Java.
+El acceso es igual que en C++: `v[i]`, con `i` de `0` a `v.length - 1`. La
+diferencia que importa es lo que pasa cuando `i` se sale de ese rango: en vez
+de comportamiento indefinido, **Java lanza `ArrayIndexOutOfBoundsException`** y
+detiene el programa en esa línea, con el índice exacto en el mensaje.
 
 <CodeEditor
   language="java"
@@ -148,17 +146,24 @@ for (int x : v) {
 }
 ```
 
-**Una trampa que se llevó su tarde.** En el `for-each`, `x` es una **copia** del
-elemento cuando el tipo es primitivo, o una **copia de la referencia** cuando es un
-objeto. Asignarle un valor nuevo dentro del ciclo NO modifica el arreglo:
+**Ojo con el `for-each` si querías modificar el arreglo — no lo hace.** Mira:
 
 ```java
 int[] v = {1, 2, 3};
-for (int x : v) x = 99;    // no hace nada útil
-System.out.println(v[0]);  // sigue siendo 1
+for (int x : v) x = 99;
+System.out.println(v[0]);  // sigue siendo 1, no 99
 ```
 
-Si necesitas modificar el arreglo, escribe el `for` clásico y asigna a `v[i]`.
+El `x` del `for-each` es una **variable aparte** que en cada vuelta recibe el
+valor de la casilla actual — no es la casilla misma. Asignarle un `99` cambia
+solo el `x`, no el `v[0]`. Si quieres modificar el arreglo, escribe el `for`
+clásico y asigna a `v[i]` directamente:
+
+```java
+int[] v = {1, 2, 3};
+for (int i = 0; i < v.length; i++) v[i] = 99;
+System.out.println(v[0]);  // ahora sí, 99
+```
 </Slide>
 
 <Slide title="Buscar un elemento">
@@ -189,9 +194,8 @@ cuando ninguno es `null`, pero si `x` puede serlo la primera forma evita el
 </Slide>
 
 <Slide title="Ordenar y buscar">
-Java trae `Arrays.sort` como método estático, y ordena **en el mismo arreglo** — no
-devuelve uno nuevo. Es la diferencia con `std::sort` de C++, que también ordena en
-sitio pero recibe un par de iteradores en vez del contenedor completo.
+Java trae `Arrays.sort` como método estático, y ordena **en el mismo arreglo** —
+no devuelve uno nuevo. Por default ordena de menor a mayor.
 
 <CodeEditor
   language="java"
@@ -202,20 +206,35 @@ class Orden {
         int[] v = {3, 1, 4, 1, 5, 9, 2, 6};
         Arrays.sort(v);
         System.out.println(Arrays.toString(v));
-        System.out.println("v[0] = " + v[0]);
     }
 }
 `}
 />
 
-Los `import` que ya conoces: `java.util.Arrays` para los métodos utilitarios de
-arreglo (`sort`, `toString`, `fill`, `copyOf`). `Arrays.toString` imprime el arreglo
-como `[1, 1, 2, 3, ...]`, útil para depurar — un `System.out.println(v)` a secas
-imprime la dirección de memoria, que no ayuda a nadie.
+`import java.util.Arrays` te da los métodos utilitarios de arreglo (`sort`,
+`toString`, `fill`, `copyOf`).
 
-`Arrays.binarySearch` existe y sí es rápido, pero pertenece al documento de búsqueda
-binaria más adelante en el curso; aquí lo que necesitabas era **la herramienta**
-`sort`, no el algoritmo por debajo.
+**Para ordenar de mayor a menor** hay una variante de `sort` que recibe un
+segundo argumento — un `Comparator` que dice cómo comparar. Como los `int[]`
+primitivos no soportan `Comparator`, la variante trabaja sobre `Integer[]` (la
+versión objeto):
+
+<CodeEditor
+  language="java"
+  defaultValue={`import java.util.Arrays;
+import java.util.Comparator;
+
+class OrdenReverso {
+    public static void main(String[] args) {
+        Integer[] v = {3, 1, 4, 1, 5, 9, 2, 6};
+        Arrays.sort(v);
+        System.out.println("ascendente:  " + Arrays.toString(v));
+        Arrays.sort(v, Comparator.reverseOrder());
+        System.out.println("descendente: " + Arrays.toString(v));
+    }
+}
+`}
+/>
 </Slide>
 
 <Slide title="Funciones en C++">
@@ -286,41 +305,27 @@ operador para tus propios tipos. Esa es la razón — la misma que aparece en
 siquiera para las clases que Java trae de fábrica.
 </Slide>
 
-<Slide title="Recursión en C++">
-Una función que se llama a sí misma. La sintaxis es idéntica a cualquier otra
-llamada — no hay palabra clave "recursivo" en C++ ni en Java. La responsabilidad
-de que la recursión termine es del autor: hay que garantizar un **caso base**
-donde la función devuelve sin llamarse otra vez, y que el **caso recursivo**
-llame con argumentos que se acerquen al base.
-
-```cpp
-int factorial(int n) {
-    if (n <= 1) return 1;           // caso base
-    return n * factorial(n - 1);    // caso recursivo
-}
-```
-
-Si te olvidas del base — o el recursivo llama con el mismo argumento — la pila
-crece hasta que el sistema operativo interrumpe el programa. En C++ eso puede
-ser un `stack overflow`, un segfault, o algo peor si tocaste memoria ajena.
-
-Java hereda la mecánica y hace lo mismo mejor: te lanza una excepción con el
-nombre exacto de lo que pasó.
-</Slide>
-
 <Slide title="Recursión">
-Una función que se llama a sí misma. Las reglas son las mismas que ya conoces
-de C++, con dos cosas que Java hace distinto: la excepción cuando la pila se
-llena tiene nombre propio, y no hay ninguna manera de escribir un ciclo que no
-sea uno de los que ya viste (`for`, `while`, `for-each`) — es decir, si quieres
-recorrer sin repetir estado, la opción legítima es la recursión.
+**Una función puede llamarse a sí misma.** Suena raro la primera vez, pero es
+solo eso: una función que aparece dentro de su propio cuerpo. Sirve cuando el
+problema que estás resolviendo se resuelve resolviendo un problema más chico
+del mismo tipo.
 
-**Toda función recursiva tiene dos partes:**
+Pensalo así: imagina que quieres contar cuántos escalones tiene una escalera y
+solo puedes bajar de a uno. Si estás en el piso, la respuesta es `0`. Si no,
+bajás un escalón, preguntás a la escalera más corta que quedó cuántos tiene, y
+sumás `1`. Esa es exactamente la forma que va a tener el código.
 
-1. **Caso base**: el argumento donde la función devuelve sin llamarse otra vez.
-   Es el fondo de la recursión.
-2. **Caso recursivo**: la función se llama a sí misma con un argumento que se
-   acerca al caso base. Sin ese "se acerca" la recursión no termina.
+Toda función recursiva tiene **dos partes obligatorias**:
+
+1. **Caso base**: el escalón donde la función responde sin volver a llamarse.
+   Sin esto, la recursión no termina nunca.
+2. **Caso recursivo**: la función se llama a sí misma con un argumento **más
+   cercano al caso base**. Ese "más cercano" es lo que garantiza que en algún
+   momento se detenga.
+
+Un ejemplo clásico: `factorial(n)` es `1 · 2 · 3 · … · n`. Su definición
+recursiva es más limpia que cualquier ciclo:
 
 ```java
 class Factorial {
@@ -336,15 +341,16 @@ class Factorial {
 }
 ```
 
-Léelo como una historia: `factorial(4)` no sabe cuánto vale, pero sabe que es
+Leelo como una historia: `factorial(4)` no sabe cuánto vale, pero sabe que es
 `4 * factorial(3)`. `factorial(3)` a su vez es `3 * factorial(2)`. Y así hasta
 `factorial(1)`, que responde `1` sin preguntarle a nadie. Ese `1` vuelve, se
-multiplica por `2`, ese `2` se multiplica por `3`, ese `6` se multiplica por
-`4`, y llega a `main` como `24`.
+multiplica por `2`, ese `2` por `3`, ese `6` por `4`, y llega a `main` como
+`24`.
 
-Cada llamada anidada abre una **capa** en la pila y se cierra al retornar. Esa
-pila es finita (unas decenas de miles de llamadas en un JVM típico), y ahí
-entra el peor defecto de una recursión mal escrita.
+Cada llamada anidada abre una **capa** en una estructura llamada **pila de
+llamadas**, y esa capa se cierra cuando la llamada termina. La pila es finita
+(unas decenas de miles de capas en un JVM típico) — y ahí está el peor defecto
+de una recursión mal escrita, que verás dos slides más adelante.
 </Slide>
 
 <Slide title="Factorial en vivo">
@@ -373,42 +379,44 @@ caso base.
 `}
 />
 
-`factorial(10)` es `3628800`. Un `int` guarda hasta `factorial(12)`; **a partir
-de `13` el resultado ya no cabe en 32 bits** y aparece un número que ya no es
-el factorial matemático — pero sigue siendo positivo, porque el desbordamiento
-da la vuelta dentro del rango. **A `17` la vuelta cruza el cero** y el
-resultado aparece negativo. Es el mismo desbordamiento silencioso de
-[[java-tipos-y-flujo|"Tipos, operadores y entrada/salida"]], visto ahora con
-un ejemplo donde el defecto no salta a la cara la primera vez: el número está
-mal desde `n = 13`, y solo se ve raro desde `n = 17`. Cuando el resultado deba
-crecer más, el tipo `long` (que resiste hasta `factorial(20)`) es la salida
+`factorial(10)` es `3628800`. Un `int` guarda hasta `factorial(12)`. **Desde
+`n = 13` el resultado ya no cabe en 32 bits**: el número que devuelve
+`factorial` deja de ser el factorial matemático, pero sigue apareciendo
+positivo porque el desbordamiento da la vuelta dentro del rango del `int`.
+**A partir de `n = 17` esa vuelta cruza el cero** y el resultado aparece
+negativo (`factorial(17)` imprime `-288522240`, no un número enorme). Es el
+mismo desbordamiento silencioso de
+[[java-tipos-y-flujo|"Tipos, operadores y entrada/salida"]], visto ahora en un
+ejemplo donde el defecto no salta a la cara la primera vez: el número está mal
+desde `n = 13`, y solo se ve raro desde `n = 17`. Cuando el resultado tenga
+que crecer más, el tipo `long` (que resiste hasta `factorial(20)`) es la salida
 mínima, y para más allá, `BigInteger`.
 </Slide>
 
 <Slide title="Sin caso base">
-El defecto más común de escribir una recursión: olvidar el caso base, o escribir
-uno que la llamada nunca alcanza. La pila se llena y Java lanza
-`StackOverflowError` con el rastro completo.
+El defecto más común de escribir una recursión: olvidar el caso base. La
+función se llama a sí misma para siempre, la pila se llena, y el JVM la
+interrumpe con un `StackOverflowError` — el error más ruidoso que Java sabe
+lanzar. Es intencional: el defecto es serio y merece un mensaje que no se
+confunda con otro.
 
 <CodeEditor
   language="java"
   defaultValue={`class Descuidado {
 
-    static int cuenta(int n) {
-        return n + cuenta(n - 1);   // sin caso base
+    static void nunca() {
+        nunca();          // se llama a sí misma sin caso base
     }
 
     public static void main(String[] args) {
-        System.out.println(cuenta(5));
+        nunca();
     }
 }
 `}
 />
 
 Ejecútalo. El rastro es larguísimo — miles de líneas idénticas — porque cada
-llamada anidada aparece en el reporte. Es el error más ruidoso que Java sabe
-lanzar, y para eso está: el defecto es serio y merece un mensaje que no se
-confunda con otro.
+llamada anidada aparece en el reporte.
 
 En C++ el mismo programa dependería del compilador y la máquina; en Java el
 comportamiento está **especificado**, igual que el desbordamiento de enteros y
@@ -463,7 +471,7 @@ la respuesta.
     }
 
     public static void main(String[] args) {
-        int n = 30;
+        int n = 40;
         long inicio = System.nanoTime();
         long r = fib(n);
         long fin = System.nanoTime();
@@ -479,9 +487,7 @@ la respuesta.
 usa `n + 1` casillas de memoria: **coste lineal en tiempo y en memoria**.
 
 `System.nanoTime()` devuelve un contador monótono con resolución de
-nanosegundos. La granularidad real en tu navegador puede ser menor (CheerpJ
-mide microsegundos, no nanosegundos, en la mayoría de los hosts), pero para
-comparar tiempos que difieren en órdenes de magnitud es suficiente.
+nanosegundos. Es lo que vas a usar para comparar los tres tiempos.
 </Slide>
 
 <Slide title="Fibonacci con dos variables">
@@ -505,7 +511,7 @@ anteriores es desperdicio: dos `long` bastan.
     }
 
     public static void main(String[] args) {
-        int n = 30;
+        int n = 40;
         long inicio = System.nanoTime();
         long r = fib(n);
         long fin = System.nanoTime();
@@ -520,10 +526,6 @@ Mismo número de sumas que la versión con arreglo; la memoria bajó de `n + 1`
 casillas a tres variables. El tiempo debería ser prácticamente idéntico al
 anterior — la diferencia entre ambas es cuánta memoria ocupan, no cuántas
 operaciones hacen.
-
-(Si tu navegador reporta `0 ns` en el tiempo, es que la medición cayó bajo la
-resolución del reloj — sube `n` a `40` o `45` y vuelve a correrlo. Ni siquiera
-así vas a notar diferencia entre esta y la anterior.)
 </Slide>
 
 <Slide title="Fibonacci recursivo">
@@ -539,7 +541,7 @@ Ahora la que se parece a la definición matemática, letra por letra.
     }
 
     public static void main(String[] args) {
-        int n = 30;   // cambia al valor que quieras probar
+        int n = 40;   // cambia al valor que quieras probar
         long inicio = System.nanoTime();
         long r = fib(n);
         long fin = System.nanoTime();
@@ -550,16 +552,16 @@ Ahora la que se parece a la definición matemática, letra por letra.
 `}
 />
 
-Es la más corta y la más legible. Ejecútalo con `n = 30` y anota el tiempo.
-Después súbelo a `35` y **prepárate a esperar**: el tiempo se multiplica por
-un factor cercano a `3` cada vez que sumas dos a `n`, y del orden de `10`
-cada vez que sumas cinco. Con `n = 30` alcanzas del orden del segundo; con
-`n = 35` alcanzas del orden de la decena de segundos. Es la primera vez en
-el curso que un programa que compila y no tiene defectos aparentes se demora
-tanto que la página parece congelada.
+Es la más corta y la más legible, y también la más lenta por mucho. Ejecútalo
+con `n = 40` y anota el tiempo. Después súbelo a `42` y confirma que tardó
+casi el triple: el tiempo se multiplica por un factor cercano a `3` cada vez
+que sumas dos a `n`, y del orden de `10` cada vez que sumas cinco. **Es la
+primera vez en el curso que un programa que compila y no tiene defectos
+aparentes se demora tanto que la página parece congelada.**
 
-**No pruebes `n = 45`.** Y aunque quisieras, la próxima slide te explica por
-qué el documento no te deja.
+**No subas mucho más allá de `n = 45`** — cada `+5` multiplica el tiempo por
+diez, y este código corre en el hilo principal del navegador sin botón de
+cancelar. La próxima slide vuelve sobre este punto.
 </Slide>
 
 <Slide title="El árbol de llamadas">
@@ -584,30 +586,28 @@ le llama **memoización**, y se ve más adelante en el curso), pero de fábrica
 ni Java ni ningún lenguaje mainstream lo hace por ti.
 </Slide>
 
-<Slide title="Cap de la demo">
-Los tres editores de arriba te dejan modificar `n`. Los dos primeros
-(`FibArreglo` y `FibVentana`) puedes subirlos hasta que el resultado deje de
-caber en `long` (alrededor de `n = 92`) sin ningún riesgo — son lineales, van
-a terminar en microsegundos.
+<Slide title="La complejidad se ve">
+Lo que acabas de medir es la primera aparición de un tema propio en este
+curso: la **complejidad computacional**. Estudia por qué **un mismo problema
+resuelto de tres maneras distintas tiene tres costos radicalmente distintos**
+— microsegundos, microsegundos, y segundos que crecen exponencialmente — y
+cómo elegir cuál usar sin tener que medir cada vez.
 
-**El recursivo es distinto.** Cada `+2` en `n` multiplica el tiempo por casi
-`3`. Con `n = 40` tardan minutos, con `n = 45` tardan horas. Y este runtime
-—CheerpJ compilando Java a WebAssembly— corre en el hilo principal de la
-página; mientras el JVM piensa, la pestaña está congelada. **No hay botón de
-cancelar**. Si te vas más allá de `n ≈ 35` en tu máquina, vas a terminar
-cerrando la pestaña.
+Las tres versiones que corriste hacen exactamente el mismo cálculo. Ninguna
+está "mal" en el sentido de que devuelva un resultado equivocado. La
+diferencia entera está en **cómo llegan** a la respuesta: las dos primeras
+suman cada `fib(k)` una vez; la recursiva suma `fib(1)` decenas de miles de
+veces sin darse cuenta. El siguiente slide muestra por qué.
 
-Por eso los cuadros de código de este documento sugieren `n = 30`, y el
-comentario del recursivo dice "cambia al valor que quieras probar" sin
-prometer que 45 sea seguro. La lección aquí no es "hasta qué `n` puedes
-llegar"; es que **la complejidad se ve**: con `n = 30` los dos primeros
-terminan en microsegundos y el recursivo en un segundo. Con `n = 35`,
-segundos. Con `n = 45` — si tuvieras horas — llegarías a horas.
+**Nota práctica:** el recursivo corre en el hilo principal del navegador y no
+tiene botón de cancelar. Con `n = 40` tarda del orden del segundo, con
+`n = 45` del orden del minuto, y con `n = 50` no vas a esperar. No subas
+mucho más allá de `n = 45` si no querés cerrar la pestaña.
 
-Cuando quieras aprender **por qué** la complejidad se comporta así, el
-curso lo cubre en un documento propio. Aquí lo importante es que la
-mediste tú, en tu propia máquina, y viste que un mismo problema resuelto
-de tres maneras tiene tres tiempos radicalmente distintos.
+La complejidad computacional es un tema propio y grande, con su documento
+más adelante en el curso. Por ahora lo importante es que la mediste tú, en
+tu propia máquina, y viste que **elegir cómo implementar tiene consecuencias
+que se cuentan en órdenes de magnitud**.
 </Slide>
 
 ## Ejercicios
@@ -888,8 +888,8 @@ cierta?
 
 <Question id="crecimiento-comparado" anchor="el-arbol-de-llamadas">
 
-Si `fib(30)` con la versión de arreglo toma alrededor de 1 ms, ¿cuánto toma
-aproximadamente `fib(30)` con la versión recursiva en el mismo navegador?
+Si `fib(40)` con la versión de arreglo toma alrededor de 1 ms, ¿cuánto toma
+aproximadamente `fib(40)` con la versión recursiva en el mismo navegador?
 
 - [x] Del orden de un segundo
 - [ ] 1 ms también, ambas hacen el mismo cálculo
@@ -898,12 +898,12 @@ aproximadamente `fib(30)` con la versión recursiva en el mismo navegador?
 
 </Question>
 
-<Question id="cap-del-n" anchor="cap-de-la-demo">
+<Question id="cap-del-n" anchor="la-complejidad-se-ve">
 
-El documento sugiere probar `fib(30)` en vivo con el recursivo y desaconseja
-subir a `fib(45)`. ¿Por qué?
+El documento sugiere probar `fib(40)` en vivo con el recursivo y desaconseja
+subir mucho más allá de `fib(45)`. ¿Por qué?
 
-- [x] Porque `fib(45)` congela la página por minutos u horas sin manera de cancelar
+- [x] Porque cada `+5` en `n` multiplica el tiempo por diez y no hay botón de cancelar
 - [ ] Porque CheerpJ no soporta números tan grandes como `fib(45)`
 - [ ] Porque el resultado de `fib(45)` no cabe en un `int` ni en un `long`
 - [ ] Es una limitación arbitraria; con permisos elevados se puede correr

--- a/content/courses/sample-course/09-arrays-y-funciones.mdx
+++ b/content/courses/sample-course/09-arrays-y-funciones.mdx
@@ -78,7 +78,7 @@ int[] c = new int[]{10, 20, 30};   // literal con new — necesaria si no es en 
 
 Los valores por defecto de `new int[5]` son `0`; de `new boolean[5]` son `false`; de
 `new String[5]` son `null` — el mismo `null` de
-[[referencias-null-igualdad|Referencias, `null` e igualdad]], listo para dar
+[[referencias-null-igualdad|el documento anterior]], listo para dar
 `NullPointerException` si accedes sin asignar primero.
 
 La tercera forma existe porque la primera (`{1, 2, 3}`) solo se puede escribir en la
@@ -90,8 +90,8 @@ ejemplo — hay que escribirla como `new int[]{...}`.
 El acceso es igual que en C++: `v[i]`, con `i` de `0` a `v.length - 1`. La diferencia
 que importa es lo que pasa cuando `i` se sale de ese rango. En vez de comportamiento
 indefinido, Java lanza `ArrayIndexOutOfBoundsException` — la excepción concreta que
-[[referencias-null-igualdad|Referencias, `null` e igualdad]] prepara al enseñar el
-mecanismo de excepciones en Java.
+[[referencias-null-igualdad|el documento anterior]] preparó al enseñar el mecanismo
+de excepciones en Java.
 
 <CodeEditor
   language="java"
@@ -163,10 +163,10 @@ Si necesitas modificar el arreglo, escribe el `for` clásico y asigna a `v[i]`.
 
 <Slide title="Buscar un elemento">
 En C++ compararías con `==` porque los tipos primitivos se comparan por valor y las
-cadenas se manejan de otra manera. En Java, como se enseña en
-[[referencias-null-igualdad|Referencias, `null` e igualdad]], `==` sobre `String`
-compara **referencias**, no contenido — y por eso la búsqueda de un texto en un
-arreglo se hace con `.equals()`:
+cadenas se manejan de otra manera. En Java, como acabas de ver en
+[[referencias-null-igualdad|el documento anterior]], `==` sobre `String` compara
+**referencias**, no contenido — y por eso la búsqueda de un texto en un arreglo
+se hace con `.equals()`:
 
 ```java
 static boolean contiene(String[] xs, String buscado) {
@@ -262,10 +262,10 @@ class Util {
   ejecutar `return` con un `int` no compila; un método `void` que escribe
   `return 5;` tampoco.
 - **Los parámetros se pasan por valor.** Un `int` viaja como copia; un objeto
-  viaja como copia de la referencia — el mismo hecho de
-  [[referencias-null-igualdad|Referencias, `null` e igualdad]]. Java no tiene
-  el `&` de C++ para pedir referencia; si necesitas modificar algo, devuélvelo
-  o pasa un arreglo (que es un objeto).
+  viaja como copia de la referencia — el mismo hecho que se enseña en
+  [[referencias-null-igualdad|el documento anterior]]. Java no tiene el `&` de
+  C++ para pedir referencia; si necesitas modificar algo, devuélvelo o pasa un
+  arreglo (que es un objeto).
 
 **Sobrecarga: dos funciones con el mismo nombre, distintos parámetros.**
 
@@ -281,9 +281,9 @@ literales enteros — y `maximo(3.0, 4.0)` va a la tercera.
 
 **Lo que sí tenías en C++ y en Java no:** sobrecargar `+`, `==` o cualquier otro
 operador para tus propios tipos. Esa es la razón — la misma que aparece en
-[[referencias-null-igualdad|Referencias, `null` e igualdad]] — por la que `==`
-sobre `String` no compara contenido: nadie puede reescribir qué significa `==`,
-ni siquiera para las clases que Java trae de fábrica.
+[[referencias-null-igualdad|el documento anterior]] — por la que `==` sobre
+`String` no compara contenido: nadie puede reescribir qué significa `==`, ni
+siquiera para las clases que Java trae de fábrica.
 </Slide>
 
 <Slide title="Recursión en C++">

--- a/content/courses/sample-course/09-arrays-y-funciones.mdx
+++ b/content/courses/sample-course/09-arrays-y-funciones.mdx
@@ -25,7 +25,7 @@ questions: per-section
 
 # Arrays y funciones
 
-En [[referencias-null-igualdad|Referencias, `null` e igualdad]] viste que los objetos
+En [[referencias-null-igualdad|Referencias, null e igualdad]] viste que los objetos
 viven en el heap y las variables guardan referencias a ellos; ahora vas a trabajar con
 un tipo de objeto que ya conocías en C++ pero que Java trata distinto — el arreglo — y
 vas a agrupar código en **funciones**, tema que el material anterior tampoco cubrió a

--- a/content/courses/sample-course/09-arrays-y-funciones.mdx
+++ b/content/courses/sample-course/09-arrays-y-funciones.mdx
@@ -597,7 +597,7 @@ Las tres versiones que corriste hacen exactamente el mismo cálculo. Ninguna
 está "mal" en el sentido de que devuelva un resultado equivocado. La
 diferencia entera está en **cómo llegan** a la respuesta: las dos primeras
 suman cada `fib(k)` una vez; la recursiva suma `fib(1)` decenas de miles de
-veces sin darse cuenta. El siguiente slide muestra por qué.
+veces sin darse cuenta.
 
 **Nota práctica:** el recursivo corre en el hilo principal del navegador y no
 tiene botón de cancelar. Con `n = 40` tarda del orden del segundo, con

--- a/content/courses/sample-course/index.yaml
+++ b/content/courses/sample-course/index.yaml
@@ -9,3 +9,4 @@ entries:
       - docId: java-desde-cpp
       - docId: java-tipos-y-flujo
       - docId: referencias-null-igualdad
+      - docId: arrays-y-funciones

--- a/docs/standards/design-system.md
+++ b/docs/standards/design-system.md
@@ -135,6 +135,42 @@ pins token values and `architecture.test.ts` greps our class names; neither can
 see a cross-origin document, and no test can. This note is the guard, and the
 check is to look at `/d/planificacion` in the dark theme.
 
+**A component-scoped categorical palette is the fourth exemption** (#78).
+`<RecursionTree>` cycles six hues over the arguments of a recursive call, so
+duplicated subcalls (`fib(3)` twice, `fib(2)` three times) share a hue and the
+duplication that makes recursive Fibonacci slow becomes visible as the reader
+expands. Each hue's meaning is **identity within one component's data**, not a
+role the rest of the product shares — no other panel ever paints something
+`bg-cycle-3`. Tokenising the palette would cost three CSS blocks × six hues
+for pairs the rest of the app never uses, and add a naming problem (`cycle`
+of what?) with no reader beyond the tree. The pairs are picked inline via
+`useResolvedTheme` and interpolated into `hsl(...)` — the raw-colour guard
+(`architecture.test.ts`) fires on Tailwind class shapes, not on `style`
+attributes, so the exemption is silent to it by construction.
+
+The two invariants that keep this honest, and the guard:
+
+- **Colour is never the only signal** (§Rules that are not about contrast):
+  each node prints its argument in the label as well, so a reader who cannot
+  distinguish hues still sees "`fib(3)` again". Colour reinforces; it does
+  not carry.
+- **The identity is derived from a deterministic seed the suite CAN pin.**
+  `data-arg` on each node is what `paintFor` reads to pick a hue; a
+  refactor that silently breaks the sharing reddens the unit test even
+  though every case still paints something. See the recipe in
+  `testing-strategy.md` §Conventions ("a property jsdom cannot see").
+- **Guard: a browser check on both themes.** The pairs are legible on
+  `surface` in both grounds by construction (low-saturation fill + higher-
+  saturation border), and the S7 browser check confirms the whole tree
+  against the live tokens. Contrast measurements land here when the check
+  runs against the shipped build.
+
+Adding a second component-scoped categorical palette records it here with
+the same shape, or converges on shared cycle tokens if two components would
+share them meaningfully. Do not extend this exemption to a hue whose meaning
+IS shared across the product; that is the design failure §The one rule
+exists to prevent (#109).
+
 ## Verifying a colour change
 
 `getComputedStyle` returning the right value **is not evidence**. It reports what

--- a/docs/standards/guides/write-control-questions.md
+++ b/docs/standards/guides/write-control-questions.md
@@ -204,7 +204,17 @@ a stale exemption cannot outlive the gap it described.
 
 **A section owes nothing only when it teaches nothing of its own** — an activity
 the student performs, a side-by-side listing whose lesson is measured elsewhere,
-a closing that announces the next document.
+a closing that announces the next document, or a **contrast-anchor** opener
+that names the C++ (or other prior-language) shape before the Java delta the
+next section teaches. `arrays-y-funciones` inaugurated the last shape (#78,
+AC-11): every Java section opens with a slide called "X en C++" whose lesson
+is measured in the pregunta of the "X en Java" sibling that immediately
+follows it. Same rationale as the side-by-side case: the slide's job is
+context, not new material. `arrays-en-c`, `funciones-en-c`, `recursion-en-c`
+and `en-c-era-segfault` are the four worked cases. Sub-detail slides — an
+`h2`-level breakout of one point already made by its parent section, such as
+`tres-iniciaciones` following "Arrays en Java" — sit in the same category:
+the principal fact is measured in the parent's pregunta.
 
 **"It is a hands-on slide" is not the test.** Because a section runs to the next
 `h2`, what follows the editor is still inside it, and that is usually where the

--- a/docs/standards/testing-strategy.md
+++ b/docs/standards/testing-strategy.md
@@ -367,6 +367,23 @@ page-only, invisible to every other gate.
   which is the one placement that never happens when the tab freezes. The fake
   worker already provides the seam — a message posted and deliberately left
   unanswered is the frozen tab.
+- **A property jsdom cannot see is tested by pinning the DETERMINISTIC INPUT it
+  is derived from, and the paint itself is verified in a real browser.** Same
+  shape as the grammar bullet below and the wider "the suite cannot execute
+  code, lay out a page…" class in `apps/web/CLAUDE.md`, applied to any
+  computed appearance the browser check ultimately owns. `RecursionTree`
+  (#78, S1) is the worked case: the six-hue palette derived from
+  `useResolvedTheme` is unobservable in jsdom (no layout, no paint), but the
+  component surfaces the argument that the hue is keyed on as a `data-arg`
+  attribute on every node — the unit suite asserts that two duplicated
+  arguments carry the same `data-arg`, which is a stand-in for "same hue" no
+  browser is needed to see. A refactor that silently rewrites the seed
+  reddens the unit test even though every node still paints something; the
+  paint itself is confirmed against the live tokens at the S7 browser check,
+  in both themes. The alternative — faking `getComputedStyle` or the resolved
+  theme and pinning the resulting `style` string — is exactly the
+  "green test pinning whatever the author assumed" the class already warns
+  about (#103).
 - **A grammar is invisible to the suite, and fails silently by design.**
   `useGrammar` and `runtime/<lang>/grammar.ts` neither drive a runtime nor mount
   `CodeEditor`, so they fall outside every trigger of the execution class above —


### PR DESCRIPTION
Closes #78.

## Summary

Ships the fourth document of the Java-from-C++ teaching path — **"Arrays y funciones"** — plus the interactive **`<RecursionTree>`** component it uses to explore the recursive-Fibonacci call tree. Rebased on top of #77 (merged as `43c36ab`); both documents share the Java unit in `index.yaml`.

The document covers arrays (initialisation, bounds, traversal, search, `Arrays.sort` including a descending variant with `Comparator.reverseOrder()`), functions and overloading, recursion (with `factorial` and a clean `StackOverflowError` demo), and closes with a live case study: three Fibonacci implementations timed on the reader's own browser at `n = 40`, an expandable call-tree that shows why the recursive one is slow, and a bridge to complexity as a future course topic ("La complejidad se ve"). The tree renders **fully expanded by default** — a closed tree read as a broken widget in Miguel's pedagogical review, and the reader gets more from seeing the shared-colour duplication at a glance than from click-by-click discovery.

## Slices

- [x] S1: `<RecursionTree>` component (classic tree layout, expanded by default, click-to-collapse; per-argument hue via `useResolvedTheme` + inline HSL) with catalog entry and tests
- [x] S2: §1–§5 (arrays: initialisation, access + bounds, traversal, search with `equals`, `Arrays.sort` + descending variant)
- [x] S3: §6 (functions + overloading), §7 (recursion with `factorial`, base + recursive case, `StackOverflowError`)
- [x] S4: §8 (Fibonacci — array / two variables / recursive — each timing itself; `<RecursionTree>` over `fib(5)`; "La complejidad se ve")
- [x] S5: four bounded exercises (`sumaArreglo`, `maximoDeArreglo`, `contieneElemento`, `sumaHastaN` recursivo — starters return `-1` or throw so no case passes trivially)
- [x] S6: 13 questions authored alongside their sections, `questions: per-section` declared
- [x] S7: `09-arrays-y-funciones.mdx` registered in `index.yaml`, closing "Lo que sigue", wiki-link into `08-referencias-null-igualdad.mdx` §"Lo que sigue"

## Acceptance criteria

| # | AC | Evidence |
|---|---|---|
| 1 | 10 anchored sections, `presentation: explicit`, code runnable | 20 `<Slide title="...">` blocks (with the C++ anchor eliminated for §7 by explicit pedagogical decision, see notes), 5 `<CodeEditor>` blocks + 4 `<Exercise>` |
| 2 | Three Fibonacci implementations reporting their own timings | §8 CodeEditors use `System.nanoTime()` around each call; the reader's host IS the reference host, no pre-captured table |
| 3 | Cap stated with its reason | "Fibonacci recursivo" + "La complejidad se ve" — "no subas mucho más allá de `n = 45`" with the ×10 per +5 rule |
| 4 | `<RecursionTree>` classic horizontal layout, expanded by default, colours by argument | `RecursionTree.tsx`; `RecursionTree.test.tsx` (10 cases: initial full-expansion, click-to-collapse round-trip, base-case leaves, shared `data-arg`, factorial recipe) |
| 5 | Catalog entry (ADR-0010) | `RecursionTree.catalog.tsx` + registered; catalog completeness test green |
| 6 | ≥4 bounded exercises, Java 8, recursion with base + small input | 4 `<Exercise>` blocks; recursive one caps `n ≤ 100` in the battery |
| 7 | Registered in index.yaml; full suite green | `index.yaml` L11; **87 files / 1082 tests passing** |
| 8 | Wiki-link from `08-referencias-null-igualdad.mdx` §"Lo que sigue" | **RESOLVED.** #77 merged as `43c36ab`; branch rebased; `[[arrays-y-funciones\|Arrays y funciones]]` added to 08's closing in commit `f44cce8` |
| 9 | Verified in real browser ≥1440px, both modes, both themes, editors run | Miguel iterated live on the preview and applied 15 pedagogical fixes (see review-iteration notes below) |
| 10 | `questions: per-section` + 13 questions, every anchor real, alternatives run through the JVM | 13 `<Question>` blocks; anchors match slugs; `cap-del-n` migrated to `la-complejidad-se-ve` after the slide rename; `crecimiento-comparado` + `cap-del-n` reference `fib(40)` |
| 11 | Each section opens with the C++ anchor before the Java delta | Held for arrays sections (arrays-en-c → arrays-en-java, en-c-era-segfault → acceso-y-bounds) and functions (funciones-en-c → anatomia-de-una-funcion). **Explicit exemption for §7 (Recursión)**: the "Recursión en C++" opener was deleted at Miguel's request — the mechanism is Java's, and the C++ anchor was making the section noisy without adding pedagogy |
| 12 | Every code sample syntax-highlighted (`<CodeEditor>` or ```java fence, never `<pre>`) | verified — no bare `<pre>` |

## Tests

- Full pre-PR protocol green: `npm run format:check`, `npm run lint`, `npm run test` (**87 files / 1082 tests**), `npm run build`.
- CI mirrors: `web — lint, test, build` conclusion: SUCCESS.
- New unit tests: `RecursionTree.test.tsx` — 10 cases covering the classic-tree layout, fully-expanded initial state, click-to-collapse round trip, base-case leaves as plain chips, `data-arg` shared by duplicate arguments, factorial recipe, title header, authoring errors.
- Content coverage gate: 10 sections with a `<Question>`, 11 exempt in `NO_QUESTION` (C++ anchors, sub-detail, live labs, ejercicios, lo-que-sigue) — coverage gate green.

## Reviews run

Two-round pipeline over `main...HEAD` (3 lenses Round A, 4 lenses Round B, all with worktree isolation) plus the adversarial verifier on the two important code findings.

- **Round A** (correctness / arch-simplicity / security): 6 raw findings — 2 important (COR-1 factorial overflow prose, COR-2 Fibonacci growth-rate contradiction, both CONFIRMED by the verifier), 3 suggestions (COR-3 `fib(46)` off-by-one, COR-4 "documento anterior" phrasing, COR-5 exercise starters), 1 pattern. All 5 accepted findings applied in commit `fffb93d`; per-fix recheck marked every one `fixed` with no new bugs introduced.
- **Round B** (docs-completeness / docs-accuracy / adr-hunter / agent-readability): 7 raw findings, 2 pairs merged as duplicates → 5 unique. 3 important (DAC-1 catalog fib(5) 33→15 nodes, DCO-1/AGR-2 design-system exemption, DCO-2 testing-strategy recipe), 2 suggestions (AGR-3 apps/web/CLAUDE.md pointer, AGR-4 stale JAVA_DOCS allowlist), 0 from adr-hunter (no ADR obligated). All accepted findings applied in commit `a23aafd`.
- **Standards edits** (Round B): `docs/standards/design-system.md` acquires the fourth "component-scoped categorical palette" exemption naming RecursionTree; `docs/standards/testing-strategy.md` §Conventions acquires the "property jsdom cannot see, pin the deterministic input" recipe; `docs/standards/guides/write-control-questions.md` acquires the CONTRAST-ANCHOR exemption category with four worked cases; `apps/web/CLAUDE.md` class 2 extended with the `data-*`-attribute stand-in pattern.

## Review iteration with Miguel (post-review-pipeline)

Miguel drove three visual iterations on the shipped preview:

- **`<RecursionTree>` layout** (commit `3235ff9`): the first implementation rendered as an indented file-explorer tree; reworked to a classic horizontal tree with pseudo-element connectors (vertical stub down from parent, horizontal bar between siblings, vertical stub up to each child). Siblings use inner `px-3` padding instead of `gap-` so the horizontal bar stays continuous.
- **`<RecursionTree>` initial state** (same commit): tree now opens fully expanded by default (`allInteriorPaths` seeds the Set on mount). The click-to-collapse behaviour stays for focus. The original §Design assumption ("student unfolds click by click, notices the duplication") was refused in practice — reader was more likely to see a broken widget than to click through.
- **Wiki-link labels with backticks** (commit `c9cb146`): fixed a real bug — `remark-parse` tokenises `` `null` `` as `inlineCode` BEFORE `remarkWikiLinks` visits text nodes, so `[[id|Referencias, `null` e igualdad]]` reached the plugin split across three sibling nodes and the `[[…]]` pattern was never matched. The link shipped as literal brackets, invisible to every gate (`architecture.test.ts` only checks that the wiki id resolves in the registry, not that the plugin rewrote the source). Three real occurrences on the teaching path fixed (one in this document's intro, two in `07-java-tipos-y-flujo.mdx` that #144 authored and #77 rebased through unchanged). Plugin docstring extended with the worked case so the next author sees the trap.
- **Slide-by-slide pedagogical review** (commit `4bff30f`): 14 items from a row-by-row proposal Miguel approved — vaguer verbs replaced (slide 2), hanging bullets rewritten (slide 3), redundant paragraphs deleted (slides 4, 9), cross-references removed where they were noise (slide 5), tangled prose reoriented around the payload sentence (slide 7), `sort` extended with a descending example on `Integer[]` + `Comparator.reverseOrder()` (slide 9), "Recursión en C++" slide deleted and its pedagogy folded into the Java-side intro (slide 12→gone), "Recursión" rewritten friendly with an escalera analogy (slide 13), `factorial` overflow prose disambiguated with `-288522240` named (slide 14), `Sin caso base` code replaced with a void-recursive `nunca()` so CheerpJ shows `StackOverflowError` cleanly instead of tripping `ArithmeticException` on integer overflow (slide 15), `nanoTime` granularity aside deleted (slide 17a), all three Fibonacci demos default to `n = 40` (slides 17/18/19), "Cap de la demo" renamed to "La complejidad se ve" and rewritten around the bridge to complexity as a future course topic (slide 21). NO_QUESTION synced; two Fibonacci questions rewritten to reference `fib(40)`/`fib(45)`.
- **Dangling forward-reference** (commit `61f3318`): "El siguiente slide muestra por qué" removed from "La complejidad se ve" — that slide is the last of the deck; the sentence closes naturally on "sin darse cuenta".

## Manual verification (human — the merge gate)

- **AC-9 browser check**: Miguel iterated on the preview through the four commits above. What still lands on the reviewer: verify `factorial(13)` prints positive `1932053504` and `factorial(17)` prints negative `-288522240` (slide 14); verify `Sin caso base` throws `StackOverflowError` (slide 15) — if CheerpJ still surfaces `ArithmeticException` after the void-recursive rewrite, we adapt the prose. Confirm all four `<Exercise>` blocks show every case failing against the shipped starter and every case passing against a correct solution.
- **Timing sanity for slide 21**: `n = 40` recursive should land in the second-order of magnitude; if it takes minutes, drop the default back to `n = 35` or bump the "no subas mucho más allá de n = 45" note.

## Notes

- **`content/` is the fixture set** (ADR-0025): every content architecture test iterates the live tree, so this document is exercised end-to-end by 1082 cases without any fixture doubles.
- The `<RecursionTree>` colour path uses `useResolvedTheme` + inline HSL rather than palette tokens. Formally exempted in `docs/standards/design-system.md` §"A component-scoped categorical palette is the fourth exemption" (added by this PR). The `data-arg` attribute the palette is keyed on is what the unit suite pins — `RecursionTree.test.tsx` asserts duplicate arguments share the identifier, and the browser check verifies the actual paint.
- Wiki-link labels must not contain backticks — the workaround (drop backticks) is documented inline in `apps/web/src/content/wikiLinks.ts` with a worked case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
