### PR TITLE
fix(server): escape bank statement and alternatives before emitting LaTeX

### DIFF
--- a/apps/server/internal/domain/controls/tex/tex.go
+++ b/apps/server/internal/domain/controls/tex/tex.go
@@ -158,7 +158,7 @@ func writeQuestion(b *strings.Builder, q bank.Question, listingsDir string) {
 		// (ADR-0033 §The sheet carries its own arithmetic).
 		fmt.Fprintf(b, "  \\begin{%s}{%s}\n", env, q.ID)
 	}
-	fmt.Fprintf(b, "    %s\n", strings.TrimSpace(q.Statement))
+	fmt.Fprintf(b, "    %s\n", escapeLatex(strings.TrimSpace(q.Statement)))
 
 	if q.Code != nil {
 		// Absolute path: AMC compiles from its own working directory, so
@@ -205,7 +205,7 @@ func emitAlternative(b *strings.Builder, text string, correct bool) {
 	if correct {
 		macro = "\\correctchoice"
 	}
-	fmt.Fprintf(b, "      %s{%s}\n", macro, strings.TrimSpace(text))
+	fmt.Fprintf(b, "      %s{%s}\n", macro, escapeLatex(strings.TrimSpace(text)))
 }
 
 func writeSheet(b *strings.Builder, in Input) {
@@ -278,8 +278,16 @@ func fourZeroClause(questions int) string {
 	return fmt.Sprintf("son %d,5 puntos", questions/2)
 }
 
-// escapeLatex escapes the ten TeX specials in a professor-typed name.
-// Statements from the bank are trusted LaTeX and are not run through this.
+// escapeLatex escapes the ten TeX specials in text that arrived as plain text
+// from a human author — the professor-typed control name AND the bank's
+// Statement / Alternatives (which come from MDX where `70%` means "seventy
+// percent", not "start of LaTeX comment"). Issue #183 is the follow-up that
+// formalises the policy and designs the opt-in for a bank field that WANTS to
+// carry LaTeX (formulas). Regression from prod 2026-08-18: the pregunta
+// `peso-de-la-presentacion` had alternatives ending in `%`, which without
+// escaping opened a LaTeX comment inside `\correctchoice{...}` and cascaded
+// up to a runaway argument in `\element{clase}{...}` — the whole
+// generation returned exit 1 without producing a PDF.
 func escapeLatex(s string) string {
 	replacer := strings.NewReplacer(
 		"\\", "\\textbackslash{}",

--- a/apps/server/internal/domain/controls/tex/tex_test.go
+++ b/apps/server/internal/domain/controls/tex/tex_test.go
@@ -241,6 +241,52 @@ func TestNameIsEscapedBeforeEmission(t *testing.T) {
 	}
 }
 
+// A bank Statement and its alternatives arrive from the MDX author as plain
+// text; the generator escapes them like it escapes the professor-typed name.
+// Regression from prod 2026-08-18: the pregunta `peso-de-la-presentacion` had
+// alternatives `70%`/`50%`/`30%`, and `%` is a LaTeX comment, so
+// `\correctchoice{70%}` swallowed the closing brace and cascaded up to a
+// runaway argument in `\element{clase}{...}`. See issue #183 for the future
+// opt-in that would let a professor emit real LaTeX (formulas).
+func TestStatementAndAlternativesAreEscapedBeforeEmission(t *testing.T) {
+	out := compile(t, func(in *tex.Input) {
+		in.Pool = []bank.Question{
+			{
+				ID: "peso", Document: "welcome", Anchor: "hola",
+				Type:      bank.TypeSimple,
+				Statement: "¿Cuánto pesa la nota en el 100% final?",
+				Alternatives: []string{
+					"70% & algo",
+					"50%",
+					"30%",
+				},
+				Correct: []int{0},
+			},
+		}
+		in.QuestionsPerCopy = 1
+	})
+	for _, want := range []string{
+		`el 100\% final`,
+		`\correctchoice{70\% \& algo}`,
+		`\wrongchoice{50\%}`,
+		`\wrongchoice{30\%}`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("bank text was not LaTeX-escaped: missing %q in output", want)
+		}
+	}
+	for _, unwant := range []string{
+		"100% final",
+		"70% & algo",
+		"{70%}",
+		"{50%}",
+	} {
+		if strings.Contains(out, unwant) {
+			t.Errorf("bank text emitted UNESCAPED: %q found in output — the raw %% would open a LaTeX comment and break brace matching", unwant)
+		}
+	}
+}
+
 func TestCompileRefusesShapesThatCannotProduceASheet(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
Hotfix del incidente 2026-08-18 en producción — generación de controls devolvía 500.

## Problem

`tex.go` asumía que `q.Statement` y las alternativas del bank eran LaTeX válido (comentario textual: *"Statements from the bank are trusted LaTeX and are not run through this."*). Sólo el nombre del control (typed by profesor en la form) pasaba por \`escapeLatex\`.

La suposición no calza con cómo se autora: las preguntas viven en MDX (\`content/courses/.../*.mdx\`) donde se escribe texto natural. La pregunta \`peso-de-la-presentacion\` en \`01-bienvenida.mdx\` tiene alternativas \`70%\`, \`50%\`, \`30%\`. \`%\` en LaTeX abre un comentario, así que \`\correctchoice{70%}\` deja el \`}\` fuera del argumento, el runaway sube por \`\begin{choices}\` → \`\begin{question}\` → \`\element{clase}{...}\` y AMC prepare exita 1 sin PDF. Cada intento de generación en el backoffice = 500.

Diagnosticado en la Jetson vía patch efímero al \`worker.py\` para volcar el stderr de AMC + el proyecto entero antes de que la rollback lo borre. Log de AMC:

```
Runaway argument?
{ \begin{question}[\unaSymbole]{peso-de-la-presentacion} ¿Cuánto \ETC.
! File ended while scanning use of \element.
```

## Fix

\`escapeLatex\` sobre \`q.Statement\` (\`tex.go:161\`) y sobre el texto de la alternativa (\`tex.go:208\`) — la misma función que ya usa el nombre del control. El comentario de \`escapeLatex\` actualizado nombra la nueva política y apunta a #183.

## Test

Nuevo: \`TestStatementAndAlternativesAreEscapedBeforeEmission\`. Reproduce el shape exacto del incidente (statement con \`100%\`, alternativas con \`70%\`, \`50%\`, \`30%\`, más un \`&\` para verificar los otros specials). Aserta ambos lados: el output contiene el escapado (\`\correctchoice{70\% \& algo}\`) y NO contiene el crudo (\`{70%}\`). Rojo antes del fix (7 checks fallan), verde después.

Per-commit protocol verde localmente. Full suite (7 packages) verde.

## Follow-up (#183)

Mover el límite del escape aguas arriba: el bank guarda texto plano; un opt-in tipado (\`latex: true\` en el frontmatter MDX, o delimitadores explícitos) permite que una pregunta con fórmula matemática (\`\$x^2\$\`) declare que su statement es LaTeX válido. Este hotfix cierra el camino de "todo el bank es LaTeX crudo" y deja abierta la puerta al opt-in.

## Manual verification (post-merge)

- [ ] CI publica \`nalanda-server:latest\` → Watchtower actualiza la Jetson en ≤5 min
- [ ] Miguel vuelve al backoffice y regenera el mismo control que fallaba (5 preguntas / 3 copias con \`peso-de-la-presentacion\` incluida) — el PDF sale
- [ ] Sanity: \`docker stats amc-worker\` idle+peak, DocumentBuddy sigue OK
- [ ] Llenar measurement block de ADR-0038 y cerrar review trigger de #175 como CLOSED-VERIFIED
- [ ] Deshacer el patch efímero al \`worker.py\` en la Jetson (\`docker restart local-amc-worker-1\`; el próximo pull de Watchtower lo revierte igual, pero mejor limpiar antes)