### PR TITLE
feat(issue-185): opt out del padding a página par en el .tex del control

### DIFF
--- a/apps/server/internal/app/web/handler/controls.go
+++ b/apps/server/internal/app/web/handler/controls.go
@@ -294,6 +294,9 @@ func defaultFormValues() view.ControlFormValues {
 	return view.ControlFormValues{
 		QuestionsPerCopy: strconv.Itoa(defaultQuestionsPerCopy),
 		Copies:           strconv.Itoa(defaultCopies),
+		// Historical AMC layout by default (issue #185): the professor
+		// opts out for simplex printing.
+		DuplexPadding: true,
 	}
 }
 
@@ -313,6 +316,9 @@ func valuesFromRequest(r *http.Request) view.ControlFormValues {
 		ToSection:        toSec,
 		QuestionsPerCopy: strings.TrimSpace(r.PostFormValue("questions_per_copy")),
 		Copies:           strings.TrimSpace(r.PostFormValue("copies")),
+		// HTML checkbox convention: absent means unchecked. `on` is what
+		// the browser sends when the checkbox has no explicit value.
+		DuplexPadding: r.PostFormValue("duplex_padding") == "on",
 	}
 }
 
@@ -372,6 +378,7 @@ func validateCreate(v view.ControlFormValues, b *bank.Bank) (map[string]string, 
 		RangeTo:          to,
 		QuestionsPerCopy: qpc,
 		Copies:           copies,
+		DuplexPadding:    v.DuplexPadding,
 	}
 	return errs, req
 }

--- a/apps/server/internal/app/web/handler/controls.go
+++ b/apps/server/internal/app/web/handler/controls.go
@@ -703,9 +703,19 @@ func toDetailedControl(c controls.Control, b *bank.Bank) view.DetailedControl {
 		ApplicationDate: formatOptionalDate(c.ApplicationDate),
 		Range:           formatRangeWithTitles(c.RangeFrom, c.RangeTo, b),
 		Shape:           fmt.Sprintf("%d preguntas × %d copias", c.QuestionsPerCopy, c.Copies),
+		PrintLayout:     printLayoutWord(c.DuplexPadding),
 		State:           stateWordControl(c.State),
 		CreatedAt:       spanishDate(c.CreatedAt),
 	}
+}
+
+// printLayoutWord names the two layout modes for the detail page, so the
+// professor sees which one their PDF carries. Issue #185, ADR-0039.
+func printLayoutWord(duplexPadding bool) string {
+	if duplexPadding {
+		return "dúplex (con página en blanco por copia)"
+	}
+	return "simplex (una página por copia)"
 }
 
 func formatOptionalDate(t *time.Time) string {

--- a/apps/server/internal/app/web/handler/controls_test.go
+++ b/apps/server/internal/app/web/handler/controls_test.go
@@ -126,7 +126,77 @@ func validForm() url.Values {
 		"to":                 {"flujo:bucles"},
 		"questions_per_copy": {"3"},
 		"copies":             {"2"},
-		"csrf_token":         {"csrf-1"},
+		// The form's default checkbox state is checked (padded, the
+		// historical layout), so a POST that mirrors the rendered form
+		// carries this value. An unchecked checkbox sends nothing —
+		// TestCreateStoresDuplexPaddingFalseWhenTheCheckboxIsUnchecked
+		// covers that.
+		"duplex_padding": {"on"},
+		"csrf_token":     {"csrf-1"},
+	}
+}
+
+// Issue #185: the form carries a duplex-padding checkbox, checked by
+// default so the historical layout requires no action. Unchecking it means
+// simplex printing: no blank filler page between prints.
+func TestNewRendersTheDuplexPaddingCheckboxCheckedByDefault(t *testing.T) {
+	f := newControlsFixture(t)
+	rec := httptest.NewRecorder()
+	f.handler.New(rec, f.authedRequest(t, http.MethodGet, handler.ControlsNewPath, nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `name="duplex_padding"`) {
+		t.Error("form is missing the duplex_padding checkbox")
+	}
+	if !strings.Contains(body, `type="checkbox"`) {
+		t.Error("duplex_padding is not a checkbox input")
+	}
+	if !strings.Contains(body, `name="duplex_padding" value="on" checked`) &&
+		!strings.Contains(body, `checked name="duplex_padding"`) &&
+		!strings.Contains(body, `type="checkbox" name="duplex_padding"`) {
+		// Accept any attribute order; assert `checked` is present near the checkbox.
+	}
+	if !strings.Contains(body, "checked") {
+		t.Error("duplex_padding checkbox is not checked by default")
+	}
+}
+
+func TestCreateStoresDuplexPaddingTrueWhenTheCheckboxIsOn(t *testing.T) {
+	f := newControlsFixture(t)
+	rec := httptest.NewRecorder()
+	f.handler.Create(rec, f.authedRequest(t, http.MethodPost, handler.ControlsPath, validForm()))
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303; body:\n%s", rec.Code, rec.Body.String())
+	}
+	rows, err := f.service.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(rows) != 1 || !rows[0].DuplexPadding {
+		t.Errorf("stored DuplexPadding = false, want true (form sent duplex_padding=on)")
+	}
+}
+
+func TestCreateStoresDuplexPaddingFalseWhenTheCheckboxIsUnchecked(t *testing.T) {
+	f := newControlsFixture(t)
+	form := validForm()
+	form.Del("duplex_padding") // HTML omits unchecked checkboxes entirely
+	rec := httptest.NewRecorder()
+	f.handler.Create(rec, f.authedRequest(t, http.MethodPost, handler.ControlsPath, form))
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303; body:\n%s", rec.Code, rec.Body.String())
+	}
+	rows, err := f.service.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(rows) != 1 || rows[0].DuplexPadding {
+		t.Errorf("stored DuplexPadding = true, want false (form omitted the checkbox)")
 	}
 }
 

--- a/apps/server/internal/app/web/handler/controls_test.go
+++ b/apps/server/internal/app/web/handler/controls_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -139,6 +140,14 @@ func validForm() url.Values {
 // Issue #185: the form carries a duplex-padding checkbox, checked by
 // default so the historical layout requires no action. Unchecking it means
 // simplex printing: no blank filler page between prints.
+//
+// Pinned against the duplex_padding INPUT (attribute-order agnostic) rather
+// than a stray "checked" anywhere in the page, so a second checkbox or a
+// class="check-something" would not silently keep this test green
+// (Round A local-review, item 1).
+var duplexPaddingCheckedRe = regexp.MustCompile(
+	`<input[^>]*(?:name="duplex_padding"[^>]*\bchecked\b|\bchecked\b[^>]*name="duplex_padding")[^>]*>`)
+
 func TestNewRendersTheDuplexPaddingCheckboxCheckedByDefault(t *testing.T) {
 	f := newControlsFixture(t)
 	rec := httptest.NewRecorder()
@@ -154,13 +163,8 @@ func TestNewRendersTheDuplexPaddingCheckboxCheckedByDefault(t *testing.T) {
 	if !strings.Contains(body, `type="checkbox"`) {
 		t.Error("duplex_padding is not a checkbox input")
 	}
-	if !strings.Contains(body, `name="duplex_padding" value="on" checked`) &&
-		!strings.Contains(body, `checked name="duplex_padding"`) &&
-		!strings.Contains(body, `type="checkbox" name="duplex_padding"`) {
-		// Accept any attribute order; assert `checked` is present near the checkbox.
-	}
-	if !strings.Contains(body, "checked") {
-		t.Error("duplex_padding checkbox is not checked by default")
+	if !duplexPaddingCheckedRe.MatchString(body) {
+		t.Errorf("the duplex_padding <input> is not `checked` on the empty GET form\nbody:\n%s", body)
 	}
 }
 
@@ -178,6 +182,26 @@ func TestCreateStoresDuplexPaddingTrueWhenTheCheckboxIsOn(t *testing.T) {
 	}
 	if len(rows) != 1 || !rows[0].DuplexPadding {
 		t.Errorf("stored DuplexPadding = false, want true (form sent duplex_padding=on)")
+	}
+}
+
+// The negative-render case: DuplexPadding = false in the form values must
+// produce an <input> WITHOUT the `checked` attribute, else a refusal that
+// preserves the professor's unchecked state silently returns to padded on
+// re-render.
+func TestNewDoesNotRenderCheckedWhenTheFormValueIsFalse(t *testing.T) {
+	f := newControlsFixture(t)
+	form := validForm()
+	form.Del("duplex_padding")
+	form.Del("name") // force a refusal so the same form is re-rendered
+	rec := httptest.NewRecorder()
+	f.handler.Create(rec, f.authedRequest(t, http.MethodPost, handler.ControlsPath, form))
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422 (form refusal); body:\n%s", rec.Code, rec.Body.String())
+	}
+	if duplexPaddingCheckedRe.MatchString(rec.Body.String()) {
+		t.Error("re-rendered form carries `checked` on duplex_padding after the professor unchecked it")
 	}
 }
 
@@ -484,6 +508,12 @@ func TestDetailRendersMetadataAndDownloadLinks(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("detail body missing %q", want)
 		}
+	}
+	// Issue #185: the detail page surfaces the print layout so the professor
+	// can tell duplex-padded controls from simplex ones without opening the
+	// PDF. validForm() sends duplex_padding=on, so this control is padded.
+	if !strings.Contains(body, "dúplex") {
+		t.Errorf("detail body missing the print-layout row (\"dúplex\")")
 	}
 }
 

--- a/apps/server/internal/app/web/view/templates/pages/controls_detail.html
+++ b/apps/server/internal/app/web/view/templates/pages/controls_detail.html
@@ -8,6 +8,7 @@
         <tr><th>Aplicación</th><td>{{ .Control.ApplicationDate }}</td></tr>
         <tr><th>Rango</th><td>{{ .Control.Range }}</td></tr>
         <tr><th>Formato</th><td>{{ .Control.Shape }}</td></tr>
+        <tr><th>Impresión</th><td>{{ .Control.PrintLayout }}</td></tr>
         <tr><th>Estado</th><td>{{ .Control.State }}</td></tr>
         <tr><th>Creado</th><td>{{ .Control.CreatedAt }}</td></tr>
       </tbody>

--- a/apps/server/internal/app/web/view/templates/pages/controls_form.html
+++ b/apps/server/internal/app/web/view/templates/pages/controls_form.html
@@ -82,6 +82,15 @@
       {{ end }}
     </p>
 
+    <p class="field">
+      <label>
+        <input type="checkbox" name="duplex_padding" value="on"
+               {{ if .Values.DuplexPadding }}checked{{ end }} />
+        Página en blanco por copia (impresión duplex)
+      </label>
+      <small>Desactívalo si vas a imprimir simplex — te ahorra una hoja por prueba.</small>
+    </p>
+
     <p><button type="submit">{{ .Submit }}</button>
        <a href="/controls" class="boton">Cancelar</a></p>
   </form>

--- a/apps/server/internal/app/web/view/view.go
+++ b/apps/server/internal/app/web/view/view.go
@@ -280,8 +280,13 @@ type DetailedControl struct {
 	ApplicationDate string
 	Range           string
 	Shape           string
-	State           string
-	CreatedAt       string
+	// PrintLayout is the human phrase for control.duplex_padding: "dúplex
+	// (con página en blanco)" or "simplex (una página por copia)". Shown
+	// on the detail page so the professor sees the layout their generated
+	// PDF actually carries (issue #185, ADR-0039).
+	PrintLayout string
+	State       string
+	CreatedAt   string
 }
 
 // ReviewPage is what review.html renders (WP-F §The screens). Split view:

--- a/apps/server/internal/app/web/view/view.go
+++ b/apps/server/internal/app/web/view/view.go
@@ -174,6 +174,12 @@ type ControlFormValues struct {
 	ToSection        string
 	QuestionsPerCopy string
 	Copies           string
+	// DuplexPadding echoes the checkbox state so the template can render
+	// `checked` after a refusal that preserves the professor's choice.
+	// Default true at the empty-GET form step (defaultFormValues), which
+	// keeps the historical layout without the professor having to think
+	// about it. Issue #185.
+	DuplexPadding bool
 }
 
 // DocumentSections carries one document's sections for the range

--- a/apps/server/internal/domain/controls/controls.go
+++ b/apps/server/internal/domain/controls/controls.go
@@ -43,9 +43,16 @@ type Control struct {
 	RangeTo          bank.SectionRef
 	QuestionsPerCopy int
 	Copies           int
-	State            State
-	CreatedAt        time.Time
-	CreatedBy        int64 // users.user_id
+	// DuplexPadding, when true, tells the tex generator to emit
+	// \AMCcleardoublepage inside \onecopy so each copy pads to an even
+	// page count for duplex printing. False emits \clearpage instead —
+	// one page per copy, no blank filler. Issue #185. The default at the
+	// SQL level is 1 (padded) so pre-migration controls stay padded, but
+	// every caller in Go passes an explicit value.
+	DuplexPadding bool
+	State         State
+	CreatedAt     time.Time
+	CreatedBy     int64 // users.user_id
 }
 
 // PoolEntry is one authored question that was actually drawn from at

--- a/apps/server/internal/domain/controls/service.go
+++ b/apps/server/internal/domain/controls/service.go
@@ -113,7 +113,12 @@ type CreateRequest struct {
 	RangeTo          bank.SectionRef
 	QuestionsPerCopy int
 	Copies           int
-	CreatedBy        int64
+	// DuplexPadding, when true, keeps the historical AMC layout (each copy
+	// padded to an even page count for duplex printing). False produces
+	// one page per copy for simplex printing. Handler always passes an
+	// explicit value; there is no Go-level default. Issue #185.
+	DuplexPadding bool
+	CreatedBy     int64
 }
 
 // Create is the whole orchestration: resolve the range against the bank,
@@ -226,6 +231,7 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (Control, error
 		RangeTo:          req.RangeTo,
 		QuestionsPerCopy: req.QuestionsPerCopy,
 		Copies:           req.Copies,
+		DuplexPadding:    req.DuplexPadding,
 		State:            Generated,
 		CreatedAt:        s.Now(),
 		CreatedBy:        req.CreatedBy,

--- a/apps/server/internal/domain/controls/service.go
+++ b/apps/server/internal/domain/controls/service.go
@@ -185,6 +185,7 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (Control, error
 		QuestionsPerCopy: req.QuestionsPerCopy,
 		Seed:             s.Seed,
 		ListingsDir:      workerPath(project, "inputs"),
+		DuplexPadding:    req.DuplexPadding,
 	})
 	if err != nil {
 		rollback()

--- a/apps/server/internal/domain/controls/tex/tex.go
+++ b/apps/server/internal/domain/controls/tex/tex.go
@@ -50,6 +50,11 @@ type Input struct {
 	// verbatim into \lstinputlisting{...}, so the caller (the Service, S5)
 	// must have staged the files before compile time.
 	ListingsDir string
+	// DuplexPadding, when true, closes each \onecopy with
+	// \AMCcleardoublepage so every copy pads to an even page count for
+	// duplex printing (historical layout). When false, emits \clearpage
+	// instead — one page per copy for simplex printing. Issue #185.
+	DuplexPadding bool
 }
 
 // Compile emits the .tex source. The output ends with a newline.
@@ -245,7 +250,14 @@ func writeSheet(b *strings.Builder, in Input) {
 
 	b.WriteString("  \\shufflegroup{clase}\n")
 	fmt.Fprintf(b, "  \\insertgroup[%d]{clase}\n\n", in.QuestionsPerCopy)
-	b.WriteString("  \\AMCcleardoublepage\n")
+	// Issue #185: padded closes the copy with \AMCcleardoublepage (blank
+	// filler page when the content ended on an odd page); unpadded uses
+	// \clearpage so the sujet.pdf is one page per copy.
+	if in.DuplexPadding {
+		b.WriteString("  \\AMCcleardoublepage\n")
+	} else {
+		b.WriteString("  \\clearpage\n")
+	}
 	b.WriteString("}\n\n")
 	b.WriteString("\\end{document}\n")
 }

--- a/apps/server/internal/domain/controls/tex/tex_test.go
+++ b/apps/server/internal/domain/controls/tex/tex_test.go
@@ -287,6 +287,38 @@ func TestStatementAndAlternativesAreEscapedBeforeEmission(t *testing.T) {
 	}
 }
 
+// Issue #185: the generator branches on Input.DuplexPadding.
+//
+//   - true (historical): emits \AMCcleardoublepage inside \onecopy so each
+//     copy pads to an even page count for duplex printing.
+//   - false: emits \clearpage instead — one page per copy for simplex
+//     printing, no blank filler between prints.
+//
+// The default of the bool at the Go level is false; the SQL default is 1;
+// the handler always passes an explicit value (form checkbox). See ADR-0033
+// §The sheet carries its own arithmetic for the surrounding layout.
+func TestDuplexPaddingBranchesOnAMCcleardoublepageVsClearpage(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		padding bool
+		want    string
+		unwant  string
+	}{
+		{"padded emits AMCcleardoublepage", true, `\AMCcleardoublepage`, "  \\clearpage\n}"},
+		{"unpadded emits clearpage only", false, "\n  \\clearpage\n}", `\AMCcleardoublepage`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out := compile(t, func(in *tex.Input) { in.DuplexPadding = tc.padding })
+			if !strings.Contains(out, tc.want) {
+				t.Errorf("missing %q in output", tc.want)
+			}
+			if strings.Contains(out, tc.unwant) {
+				t.Errorf("unexpected %q in output", tc.unwant)
+			}
+		})
+	}
+}
+
 func TestCompileRefusesShapesThatCannotProduceASheet(t *testing.T) {
 	cases := []struct {
 		name string

--- a/apps/server/internal/infra/storage/controlstore/controlstore.go
+++ b/apps/server/internal/infra/storage/controlstore/controlstore.go
@@ -32,7 +32,7 @@ func New(db *sql.DB) *Store {
 // Compile-time proof the shape here is the one the domain asked for.
 var _ controls.Store = (*Store)(nil)
 
-const controlColumns = "id, name, application_date, from_document, from_section, to_document, to_section, questions_per_copy, copies, state, created_at, created_by"
+const controlColumns = "id, name, application_date, from_document, from_section, to_document, to_section, questions_per_copy, copies, duplex_padding, state, created_at, created_by"
 
 // CreateControl writes the control, its pool and its copies in one
 // transaction. Rolled back on any failure so a control never appears in the
@@ -54,13 +54,14 @@ func (s *Store) CreateControl(ctx context.Context, control controls.Control, poo
 
 	if _, err := tx.ExecContext(ctx, `
         INSERT INTO control (`+controlColumns+`)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		control.ID,
 		control.Name,
 		nullableUnixSeconds(control.ApplicationDate),
 		control.RangeFrom.Document, control.RangeFrom.Section,
 		control.RangeTo.Document, control.RangeTo.Section,
 		control.QuestionsPerCopy, control.Copies,
+		boolToInt(control.DuplexPadding),
 		string(control.State),
 		control.CreatedAt.Unix(),
 		control.CreatedBy,
@@ -161,6 +162,7 @@ func scanControl(row interface{ Scan(...any) error }) (controls.Control, error) 
 	var (
 		c               controls.Control
 		applicationDate sql.NullInt64
+		duplexPadding   int
 		createdAt       int64
 		state           string
 	)
@@ -169,10 +171,12 @@ func scanControl(row interface{ Scan(...any) error }) (controls.Control, error) 
 		&c.RangeFrom.Document, &c.RangeFrom.Section,
 		&c.RangeTo.Document, &c.RangeTo.Section,
 		&c.QuestionsPerCopy, &c.Copies,
+		&duplexPadding,
 		&state, &createdAt, &c.CreatedBy,
 	); err != nil {
 		return controls.Control{}, err
 	}
+	c.DuplexPadding = duplexPadding != 0
 	c.State = controls.State(state)
 	c.CreatedAt = time.Unix(createdAt, 0).UTC()
 	if applicationDate.Valid {
@@ -180,6 +184,14 @@ func scanControl(row interface{ Scan(...any) error }) (controls.Control, error) 
 		c.ApplicationDate = &at
 	}
 	return c, nil
+}
+
+// boolToInt is the SQLite convention: 0 for false, 1 for true.
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
 }
 
 // notFound turns database/sql's absence sentinel into the domain's.

--- a/apps/server/internal/infra/storage/controlstore/controlstore_test.go
+++ b/apps/server/internal/infra/storage/controlstore/controlstore_test.go
@@ -108,6 +108,36 @@ func TestCreateControlWritesTheRowThePoolAndTheCopies(t *testing.T) {
 	}
 }
 
+// Issue #185: the professor's duplex-padding preference persists on the
+// control so a future WP-G regenerate honours it. Both values round-trip.
+func TestCreateControlPersistsDuplexPaddingBothWays(t *testing.T) {
+	ctx, db := migrated(t)
+	userID := insertProfessor(t, ctx, db, "p@example.com")
+	store := controlstore.New(db)
+
+	pool := []controls.PoolEntry{{Ref: "q-if-1", Order: 0}}
+	for _, tc := range []struct {
+		id  string
+		val bool
+	}{
+		{"CTRLPAD00000000000000000TT", true},
+		{"CTRLPAD00000000000000000FF", false},
+	} {
+		c := newControl(tc.id, userID, nil)
+		c.DuplexPadding = tc.val
+		if err := store.CreateControl(ctx, c, pool); err != nil {
+			t.Fatalf("CreateControl(%s, %v): %v", tc.id, tc.val, err)
+		}
+		got, err := store.ControlByID(ctx, tc.id)
+		if err != nil {
+			t.Fatalf("ControlByID(%s): %v", tc.id, err)
+		}
+		if got.DuplexPadding != tc.val {
+			t.Errorf("round-trip: DuplexPadding = %v, want %v", got.DuplexPadding, tc.val)
+		}
+	}
+}
+
 func TestCreateControlIsAllOrNothingOnAConflict(t *testing.T) {
 	ctx, db := migrated(t)
 	userID := insertProfessor(t, ctx, db, "p@example.com")

--- a/apps/server/internal/infra/storage/schema_test.go
+++ b/apps/server/internal/infra/storage/schema_test.go
@@ -244,6 +244,39 @@ func TestControlStateRefusesAnUnknownValue(t *testing.T) {
 	}
 }
 
+// Issue #185: the professor opts out of the padded-to-even-pages layout by
+// unchecking a form checkbox; the preference persists on the control so a
+// future WP-G regenerate honours it. Default = 1 (padded) so every control
+// created before the checkbox existed keeps its historical layout, and any
+// caller that omits the column (including this test) reads it back as such.
+func TestControlDuplexPaddingDefaultsToPaddedWhenTheColumnIsOmitted(t *testing.T) {
+	ctx, db := migrated(t)
+	userID := insertProfessor(t, ctx, db, "profesora@example.com")
+
+	if _, err := db.ExecContext(ctx, `
+        INSERT INTO control (
+            id, name, application_date,
+            from_document, from_section, to_document, to_section,
+            questions_per_copy, copies, state, created_at, created_by
+        ) VALUES (?, 'x', NULL, 'flujo', 'if-else', 'flujo', 'bucles', 4, 3, 'generated', 0, ?)`,
+		"CTRLPADDING000000000000000", userID,
+	); err != nil {
+		t.Fatalf("insert without duplex_padding: %v", err)
+	}
+
+	var padding int
+	err := db.QueryRowContext(ctx,
+		`SELECT duplex_padding FROM control WHERE id = ?`,
+		"CTRLPADDING000000000000000",
+	).Scan(&padding)
+	if err != nil {
+		t.Fatalf("read back duplex_padding: %v", err)
+	}
+	if padding != 1 {
+		t.Errorf("duplex_padding = %d, want 1 (a control without an explicit preference is duplex-padded, the historical layout)", padding)
+	}
+}
+
 // The one migration case that is about an operator rather than about the schema.
 //
 // #149 shipped migrations/00001_init.sql, a deliberate `SELECT 1;`, and anyone

--- a/apps/server/migrations/00006_duplex_padding.sql
+++ b/apps/server/migrations/00006_duplex_padding.sql
@@ -5,18 +5,25 @@
 -- arithmetic for the surrounding layout decisions.
 --
 -- Stored as INTEGER because SQLite has no native BOOL — 0/1 is the shape the
--- rest of the schema uses (see users.email_verified etc). Default 1 covers
--- three cases in one line: pre-migration controls (the check happens at
--- read), test inserts that omit the column (schema_test.go), and any
+-- rest of the schema uses (see users.is_active in 00002_auth.sql). Default 1
+-- covers three cases in one line: pre-migration controls (the check happens
+-- at read), test inserts that omit the column (schema_test.go), and any
 -- caller that forgets to send it. The default matches the current behaviour
 -- so nothing existing breaks.
 --
 -- NOT NULL for the same reason the sibling columns are: reading a NULL
 -- would leave the generator branching on Go's tri-state and open a bug the
 -- schema can refuse.
+--
+-- CHECK (duplex_padding IN (0, 1)) makes the two-value shape self-enforcing:
+-- the read path is `c.DuplexPadding = duplexPadding != 0`, which silently
+-- coerces 2 or -1 to true. No writer produces those today; the CHECK costs
+-- nothing and refuses the mistake at the schema (Round A local-review,
+-- item 6).
 
 -- +goose Up
-ALTER TABLE control ADD COLUMN duplex_padding INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE control ADD COLUMN duplex_padding INTEGER NOT NULL DEFAULT 1
+    CHECK (duplex_padding IN (0, 1));
 
 -- +goose Down
 ALTER TABLE control DROP COLUMN duplex_padding;

--- a/apps/server/migrations/00006_duplex_padding.sql
+++ b/apps/server/migrations/00006_duplex_padding.sql
@@ -1,0 +1,22 @@
+-- Issue #185: the professor opts out of the padded-to-even-pages layout by
+-- unchecking a form checkbox at creation time. The generator emits either
+-- \AMCcleardoublepage (padded, historical) or \clearpage (single page per
+-- copy) depending on this bit. See ADR-0033 §The sheet carries its own
+-- arithmetic for the surrounding layout decisions.
+--
+-- Stored as INTEGER because SQLite has no native BOOL — 0/1 is the shape the
+-- rest of the schema uses (see users.email_verified etc). Default 1 covers
+-- three cases in one line: pre-migration controls (the check happens at
+-- read), test inserts that omit the column (schema_test.go), and any
+-- caller that forgets to send it. The default matches the current behaviour
+-- so nothing existing breaks.
+--
+-- NOT NULL for the same reason the sibling columns are: reading a NULL
+-- would leave the generator branching on Go's tri-state and open a bug the
+-- schema can refuse.
+
+-- +goose Up
+ALTER TABLE control ADD COLUMN duplex_padding INTEGER NOT NULL DEFAULT 1;
+
+-- +goose Down
+ALTER TABLE control DROP COLUMN duplex_padding;

--- a/docs/decisions/0030-auto-multiple-choice-as-the-control-engine.md
+++ b/docs/decisions/0030-auto-multiple-choice-as-the-control-engine.md
@@ -198,9 +198,14 @@ cheap, and it is a property of our reporting layer rather than of AMC.
 
 ### Operational
 
-- **Each copy is two PDF pages**, padded to an even count. Printed duplex that
-  is one physical sheet per student and costs no paper; it does mean the scan
-  batch has a back side for every sheet.
+- **Each copy is two PDF pages by default**, padded to an even count via
+  `\AMCcleardoublepage` at the end of `\onecopy`. Printed duplex that is one
+  physical sheet per student and costs no paper; it does mean the scan batch
+  has a back side for every sheet. Since #185 (ADR-0039) the padding is a
+  per-control preference (form checkbox, `control.duplex_padding`): unchecked
+  emits `\clearpage` instead, so each copy is one PDF page for simplex
+  printing. The reader tolerates both — evidence in §"Second cycle —
+  2026-08-17" below.
 - **An unassociated copy still gets an annotated PDF**, named with the literal
   `_ID_` placeholder. Counting files is not a completeness check; the
   association table is.

--- a/docs/decisions/0039-the-professor-chooses-the-page-layout-per-control.md
+++ b/docs/decisions/0039-the-professor-chooses-the-page-layout-per-control.md
@@ -1,0 +1,136 @@
+# ADR-0039: The professor chooses the page layout per control, not the reader
+
+**Status:** Accepted
+**Date:** 2026-08-18
+**Decision-makers:** Miguel Rodriguez
+**Source:** #185 (opt-out padding), incident 2026-08-18 (the first real control
+generated from the Jetson printed with a blank filler page between copies).
+
+## Context
+
+AMC's `\onecopy{N}{...}` block ends with `\AMCcleardoublepage`, which pads each
+copy to an even page count so that duplex printing puts one physical sheet per
+student. When the professor prints **simplex** — Miguel's habitual case — that
+padding surfaces as a blank sheet of paper between every pair of prints, a
+per-copy waste that the physical world eats.
+
+Two shapes were considered:
+
+- **The layout is a global fact of the engine** (status quo). Every generated
+  control uses `\AMCcleardoublepage`; the professor either wastes paper or
+  post-processes the PDF.
+- **The layout is a preference of the control** (this ADR). A checkbox on the
+  create form persists a bit on the row; the tex generator emits
+  `\AMCcleardoublepage` or `\clearpage` based on it. Default padded, so nothing
+  existing changes shape.
+
+The second is what shipped. The bit lives on `control.duplex_padding`
+(migration `00006_duplex_padding.sql`) so a future WP-G regeneration honours
+the same preference — asking the professor again on regeneration would
+surface an accident, not a choice.
+
+The alternative to changing the .tex — post-processing the PDF to strip even
+pages — was rejected: it assumes AMC's layout is exactly "odd = content, even
+= padding" and would break silently the first time a question flowed to a
+second page. Emitting the correct source is the whole point of a generator.
+
+## Decision
+
+- `control.duplex_padding` is `1` (padded) by default; the form checkbox is
+  checked by default; the tex generator emits `\AMCcleardoublepage` when true
+  and `\clearpage` when false.
+- The preference is per control, not per course or per professor. Two
+  controls from the same professor in the same semester can differ (a long
+  duplex exam and a one-page simplex quiz).
+- The default direction of the checkbox stays `checked` even though Miguel
+  personally prints simplex most of the time: keeping historical shape
+  reversible is more valuable than saving a second click today. If in the
+  future every generated control turns out unpadded, a follow-up WP inverts
+  the default — but a data-driven inversion, not a guess-driven one.
+
+## Evidence the reader tolerates the unpadded shape
+
+The concern raised while spec'ing #185 was: does the AMC scan reader still
+work when each copy is one page rather than two? If AMC prints an identifier
+on every page and the reader expects to see every page for every copy,
+missing the padded blank could put copies into `needs_review` or fail the
+batch.
+
+**Already answered.** ADR-0030 §"Second cycle — 2026-08-17 (minimum paper
+check, pencil)" documents the exact test: three copies of
+`control-paper-min.tex` (which uses `\clearpage` instead of
+`\AMCcleardoublepage` at the end of `\onecopy`), printed one-page-per-copy,
+marked in pencil, scanned, read. Result: 3/3 pages captured, RUTs read on
+two copies, third copy correctly refused because the professor left a column
+blank on purpose. The reader handled the unpadded layout end-to-end.
+
+The mechanism is orthogonal to what our server adds around it: AMC's
+page-break machinery (`\clearpage` versus `\AMCcleardoublepage`) does not
+interact with `\shufflegroup{clase}` or `\insertgroup[N]{clase}`. A server-
+generated control with N random questions ending in `\clearpage` inherits
+the same paper evidence as the min fixture. This ADR **does not** open a
+new PAPER-CHECK — the min cycle covered the mechanism this WP toggles.
+
+Follow-up cycle worth doing when the paper budget allows: one full-shape
+server-generated control (say 5 questions × 3 copies) with the checkbox
+unchecked, to confirm the inherited evidence with the exact shape the
+server produces. Not blocking; documented here so it does not disappear
+from the queue.
+
+## Consequences
+
+**Positive:**
+- One paper sheet saved per copy for simplex-printing professors — the first
+  real production control (2026-08-18) generated 5 copies × 2 pages = 10
+  sheets, of which 5 were blank filler. With the checkbox unchecked the same
+  control produces 5 sheets, no filler.
+- The `.tex` source stays honest: the layout the professor wants is what the
+  generator emits, no post-processing.
+
+**Negative / trade-offs:**
+- Two shapes of `.tex` to reason about in `tex.go` and its tests. The branch
+  is one `if` and the tests pin both directions, so drift is caught by the
+  suite (`TestDuplexPaddingBranchesOnAMCcleardoublepageVsClearpage`).
+- A future engine swap (ADR-0030 §Reversibility: swap to OMRChecker) has to
+  honour the preference too. The bit is stored at the domain level, not on
+  the AMC side, so the swap is a matter of the new adapter reading it.
+- Regeneration (WP-G, when it lands) has to read the preference from the row
+  rather than re-asking. Column exists; the caller has to remember.
+
+## Review triggers
+
+- **The default direction is reconsidered** when we see a semester of
+  controls and the split is heavily one-sided. A run that produces >90%
+  unpadded is a signal that the default should flip.
+- **The evidence needs a full-shape cycle** when a professor generates a
+  multi-page control with the checkbox off and the reader misbehaves.
+  Today the min-fixture evidence is inherited on the argument that page-
+  break and question-insertion are orthogonal; a counter-example redirects
+  us here.
+
+## Alternatives considered
+
+- **Global config flag** — one professor's preference wins for the whole
+  server. Rejected: no reason to force it to be global, and per-control is
+  what the physical world already asks for.
+- **A `layout: duplex | simplex` enum** — three-value or more in the
+  future. Rejected: two values, one bit, and any future layout mode gets
+  its own field (e.g., `booklet: bool`) rather than a growing enum whose
+  values interact.
+- **`bool DuplexPadding` at Go zero value = false** — the SQL default is
+  `1` but the Go zero is `false`. A caller that forgets the field would
+  produce unpadded controls silently. Chose `bool` anyway because the
+  only caller is the handler and the handler always parses the form,
+  which always sets it. A struct-tag-driven "required" would add ceremony
+  the shape does not need.
+
+## References
+
+- ADR-0030 — the AMC engine and its traps, §"Second cycle — 2026-08-17"
+  for the reader evidence this ADR inherits.
+- ADR-0033 — the sheet carries its own arithmetic (surrounding tex layout
+  decisions).
+- `apps/server/internal/domain/controls/tex/tex.go` — the branch.
+- `apps/server/migrations/00006_duplex_padding.sql` — the column.
+- `apps/server/internal/app/web/view/templates/pages/controls_form.html` —
+  the checkbox.


### PR DESCRIPTION
Closes #185.

## Summary

El profesor opta out del padding a página par en el formulario de crear
control. Checkbox nuevo en `controls_form.html` (default checked = padded),
persistido en `control.duplex_padding`, y el generador de `.tex` branchea
entre `\AMCcleardoublepage` (padded) y `\clearpage` (simplex).

Motivación real: el primer control generado desde la Jetson (post-#175/#184)
salió con una página en blanco por copia. Miguel imprime simplex, así que
esa página era desperdicio literal. Con la casilla desmarcada, el `sujet.pdf`
sale con **una página por copia**.

Diseño y trade-offs completos: **ADR-0039** (nuevo). El bit vive por
control (no global, no por curso) — dos controles del mismo profesor en el
mismo semestre pueden diferir (una prueba larga duplex + un quiz simplex).

## Slices

- [x] **S1** — migración `00006_duplex_padding.sql` (default 1) · `b972aef`
- [x] **S2** — domain + `CreateRequest` + repo I/O + round-trip · `031890a`
- [x] **S3** — `tex.Compile` branchea macro final del `\onecopy` · `7862972`
- [x] **S4** — checkbox en el form + handler + tres tests · `d0971df`
- [x] **S5** — PAPER-CHECK: **inherited** (ver §Reviews run + §Manual verification) · `4f039ee`
- [x] **S6** — ADR-0039 + amendment ADR-0030 §Operational · `4f039ee`

Post-review: `6756077` (review fixes).

## AC + evidencia

| # | Criterio | Evidencia |
|---|----------|-----------|
| 1 | Migración `00006_duplex_padding.sql` + test que un control creado antes de la migración lee 1 | `apps/server/migrations/00006_duplex_padding.sql`; `TestControlDuplexPaddingDefaultsToPaddedWhenTheColumnIsOmitted` (schema_test.go) · verde |
| 2 | Form muestra checkbox con label spanish; unchecked → false; checked (default) → true | `controls_form.html` líneas 85-91; `TestNewRendersTheDuplexPaddingCheckboxCheckedByDefault`, `TestCreateStoresDuplexPaddingTrueWhenTheCheckboxIsOn`, `TestCreateStoresDuplexPaddingFalseWhenTheCheckboxIsUnchecked`, `TestNewDoesNotRenderCheckedWhenTheFormValueIsFalse` · verde |
| 3 | `tex.Compile` emite `\AMCcleardoublepage` cuando true y `\clearpage` cuando false | `tex.go` líneas 246-256; `TestDuplexPaddingBranchesOnAMCcleardoublepageVsClearpage` con ambos sub-casos · verde |
| 4 | Un control creado sin padding genera un `sujet.pdf` con 1 página por copia | **Manual, post-merge:** ver §Manual verification abajo. Inherited de ADR-0030 §"Second cycle — 2026-08-17" a nivel de mecanismo (3 copias × 1 página cada una vía `\clearpage` en `control-paper-min.tex`), pero no ejecutado con el shape server-generated de este PR. |
| 5 | PAPER-CHECK con 2 copias sin padding: reader lee correctamente | **Inherited (no re-ejecutado en este WP).** ADR-0030 §"Second cycle — 2026-08-17" ya validó el mecanismo `\clearpage`: 3/3 páginas capturadas, RUTs leídos en 2 de 3 copias (tercera correctamente rechazada por columna vacía real). El `\clearpage` que este PR emite es la misma macro, en la misma posición, dentro de `\onecopy`. El argumento en ADR-0039: `\clearpage` es ortogonal a `\shufflegroup{clase}` / `\insertgroup[N]{clase}`, así que la evidencia del min-fixture inherita al server-generated. Follow-up voluntario (no bloqueante) documentado en el ADR: un ciclo con la shape exacta del server. |

## Tests

Per-commit protocol verde en cada commit (`gofmt`, `vet`, `build`, `go test ./...`). Cobertura nueva:

- **Schema:** `TestControlDuplexPaddingDefaultsToPaddedWhenTheColumnIsOmitted`
- **Store:** `TestCreateControlPersistsDuplexPaddingBothWays`
- **Generator:** `TestDuplexPaddingBranchesOnAMCcleardoublepageVsClearpage/{padded,unpadded}`
- **Handler:** `TestNewRendersTheDuplexPaddingCheckboxCheckedByDefault`, `TestCreateStoresDuplexPaddingTrueWhenTheCheckboxIsOn`, `TestCreateStoresDuplexPaddingFalseWhenTheCheckboxIsUnchecked`, `TestNewDoesNotRenderCheckedWhenTheFormValueIsFalse`
- **Detail:** `TestDetailRendersMetadataAndDownloadLinks` extendido para "dúplex"

## Reviews run

**Modo:** develop-task variante — **local code-review** (agent-skills:code-reviewer single agent, no worktree isolation, no verifier, no metrics) en vez del review-pipeline multi-agente. Configuración pedida por Miguel.

**Resultado:** 6 findings, todos aplicados inline en el commit `6756077`:

| Sev | Item | Fix |
|-----|------|-----|
| Important | Test de checkbox tenía `strings.Contains(body, "checked")` global — un stray "checked" en la página lo dejaba silenciosamente verde | Regex-pin al `<input>` de `duplex_padding` con `bchecked\b`; nuevo test negativo `TestNewDoesNotRenderCheckedWhenTheFormValueIsFalse` |
| Important | ADR-0030 §Operational seguía diciendo *"Each copy is two PDF pages, padded to an even count"* como propiedad incondicional | Amendment: "Each copy is two PDF pages **by default**; since #185 es una preferencia por control (ver ADR-0039)" |
| Suggestion | Migration citaba `users.email_verified` (que no existe) como precedente del 0/1 encoding | Corregido: cita `users.is_active` de `00002_auth.sql` (que sí existe) |
| Suggestion | Sin `CHECK` constraint: `2` o `-1` en el INSERT se leerían como `true` silenciosamente | Añadido `CHECK (duplex_padding IN (0, 1))` |
| Suggestion | Detail page no exponía la preferencia: el profesor no sabía qué layout tiene su PDF sin abrirlo | Nueva fila "Impresión: dúplex (con página en blanco por copia) / simplex (una página por copia)" en `controls_detail.html`, con soporte en `view.DetailedControl` + `toDetailedControl` |
| Suggestion | `TestCreateEchoesValuesOnRefusal` no cubría el checkbox — un refusal podía revertir silenciosamente a checked | Ver el nuevo `TestNewDoesNotRenderCheckedWhenTheFormValueIsFalse` (POST con checkbox omitido y name vacío → 422 sin `checked` en el re-render) |

## Manual verification (Miguel, post-merge)

Todo esto es opt-in — el fix ya funciona con la evidencia inherited. Si querés confirmarla con el shape exacto server-generated:

1. Merge + esperar CI + Watchtower actualiza la Jetson (~5-10 min).
2. Backoffice: generar un control con **checkbox desmarcado**, 5 preguntas × 3 copias.
3. Descargar `sujet.pdf` — debe tener 3 páginas exactas (no 6).
4. Imprimir simplex.
5. Marcar 2-3 hojas a lápiz 2B.
6. Escanear a 300 dpi.
7. Subir al reader (Escaneos → analizar) → mandar a corregir.
8. **Verde:** todas las copias identificadas, marks leídos, RUTs leídos → inheritance confirmada, cerrar el follow-up del ADR-0039.
9. **Rojo:** commentá acá con detalle, abrimos un WP nuevo (probablemente: AMC pone el identifier en la página par que hoy imprime, y el reader lo espera).

## Notes

- **No se ejecutó un nuevo ciclo PAPER-CHECK en este WP.** La evidencia se INHERITA del `paper-min` cycle documentado en ADR-0030. El ADR-0039 nombra explícitamente la inheritance + el argumento de ortogonalidad + el follow-up voluntario.
- Sin cambios a `apps/amc-worker/**` — todo el fix vive en `apps/server`. La imagen del worker no necesita rebuild; solo publica `nalanda-server` la próxima CI.
- Sin cambios a `.github/workflows/**` ni a `infra/**`.
- Follow-up abierto de tu preferencia #183 (bank stores plain text) sigue en el backlog.
