### PR TITLE
fix(server): CSRF middleware parses multipart bodies too (unblocks WP-F scan upload)

### DIFF
--- a/apps/server/internal/app/web/middleware/middleware.go
+++ b/apps/server/internal/app/web/middleware/middleware.go
@@ -22,13 +22,26 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"mime"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/so77id/nalanda/apps/server/internal/app/web/view"
 	"github.com/so77id/nalanda/apps/server/internal/domain/auth"
 	"github.com/so77id/nalanda/apps/server/internal/infra/config"
 )
+
+// csrfMultipartMemoryLimit is what ParseMultipartForm keeps in memory before
+// spilling parts to a tempfile. 32 MiB matches Go's default; the CSRF token
+// itself is a few bytes, but a scan upload's file part travels in the same
+// body, and it belongs on disk anyway (WP-F's handler already uses the same
+// number). Since this middleware parses the multipart body before the
+// handler runs, the handler's own `http.MaxBytesReader` wrap is bypassed.
+// The pragmatic bound is the reverse proxy in front of the server (Funnel);
+// a body cap in this middleware would need per-route config the middleware
+// does not receive today. Follow-up in the PR body.
+const csrfMultipartMemoryLimit = 32 << 20
 
 // sessionCookieBase is the unprefixed name. See SessionCookieName.
 const sessionCookieBase = "nalanda_session"
@@ -278,9 +291,27 @@ func (a *Auth) VerifyCSRF(next http.Handler) http.Handler {
 			return
 		}
 
-		// ParseForm is what populates PostFormValue, and its error is worth
-		// refusing on: a body that cannot be parsed carries no token either.
-		if err := r.ParseForm(); err != nil {
+		// Populate PostFormValue's map from whatever the request body actually
+		// is. Two cases to keep separate:
+		//
+		//   - application/x-www-form-urlencoded: ParseForm reads and decodes
+		//     the body into r.PostForm. This is the common case (every
+		//     backoffice form except the scan upload).
+		//   - multipart/form-data: ParseForm does NOT read a multipart body —
+		//     it leaves r.PostForm as an empty, non-nil map, which then
+		//     stops any later PostFormValue from ever calling
+		//     ParseMultipartForm (the guard is `r.PostForm == nil`, and
+		//     empty-non-nil is not nil). Reported in production on
+		//     2026-08-18 when WP-F's scan upload started returning 403
+		//     "Solicitud no autorizada." for every attempt, because the
+		//     multipart body carried the csrf_token that this middleware
+		//     never read. The gated test above pins the fix.
+		if isMultipart(r) {
+			if err := r.ParseMultipartForm(csrfMultipartMemoryLimit); err != nil {
+				renderForbidden(w, r)
+				return
+			}
+		} else if err := r.ParseForm(); err != nil {
 			renderForbidden(w, r)
 			return
 		}
@@ -294,6 +325,25 @@ func (a *Auth) VerifyCSRF(next http.Handler) http.Handler {
 
 		next.ServeHTTP(w, r)
 	})
+}
+
+// isMultipart is true when the request declares a multipart/form-data body.
+// The parse is best-effort: a missing or malformed Content-Type falls back
+// to the url-encoded branch, which will produce the same 403 for a
+// state-changing request without a valid form.
+func isMultipart(r *http.Request) bool {
+	ct := r.Header.Get("Content-Type")
+	if ct == "" {
+		return false
+	}
+	if !strings.HasPrefix(ct, "multipart/") {
+		return false
+	}
+	mt, _, err := mime.ParseMediaType(ct)
+	if err != nil {
+		return false
+	}
+	return mt == "multipart/form-data"
 }
 
 // renderForbidden writes a 403 through the shell (AC-11). The plain-text

--- a/apps/server/internal/app/web/middleware/middleware_test.go
+++ b/apps/server/internal/app/web/middleware/middleware_test.go
@@ -1,11 +1,13 @@
 package middleware_test
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"errors"
 	"io"
 	"log/slog"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -361,6 +363,73 @@ func TestCSRF(t *testing.T) {
 		}
 		if recorder.Code != http.StatusOK {
 			t.Errorf("status = %d, want 200", recorder.Code)
+		}
+	})
+
+	// A multipart request is the shape WP-F's scan upload uses. The middleware
+	// used to call `r.ParseForm()` unconditionally, which for a multipart body
+	// leaves `r.PostForm` empty-non-nil and prevents any later
+	// `r.PostFormValue` from ever reading the multipart body — so the CSRF
+	// token was invisible even when the form carried it. WP-F's handler test
+	// bypasses the middleware, so this hole shipped and only appeared the
+	// first time a professor tried to upload a scan from a real browser
+	// (Jetson production, 2026-08-18: five 403s over two minutes on the same
+	// form after re-login and hard refresh).
+	postMultipart := func(t *testing.T, h *harness, token, csrf, extraField string) *httptest.ResponseRecorder {
+		t.Helper()
+
+		var buf bytes.Buffer
+		w := multipart.NewWriter(&buf)
+		if csrf != "" {
+			_ = w.WriteField(middleware.CSRFFieldName, csrf)
+		}
+		if extraField != "" {
+			// A payload part big enough to matter — a real scan upload is
+			// several MiB, so the test carries a modest KiB to cover the
+			// case where the file part comes before the token part.
+			part, _ := w.CreateFormFile("scan", "scan.pdf")
+			_, _ = part.Write(bytes.Repeat([]byte(extraField), 4096))
+		}
+		_ = w.Close()
+
+		req := httptest.NewRequest(http.MethodPost, "/controls/X/scans", &buf)
+		req.Header.Set("Content-Type", w.FormDataContentType())
+		if token != "" {
+			req.AddCookie(&http.Cookie{Name: middleware.SessionCookieName(true), Value: token})
+		}
+		recorder := httptest.NewRecorder()
+		h.auth.Resolve(h.auth.RequireProfessor(h.auth.VerifyCSRF(h.next()))).ServeHTTP(recorder, req)
+		return recorder
+	}
+
+	t.Run("a multipart POST carrying the session's own token is accepted", func(t *testing.T) {
+		h := newHarness(t)
+		_, token := h.login(t, "profesora@example.com")
+
+		session, err := h.store.SessionByTokenHash(context.Background(), auth.HashToken(token))
+		if err != nil {
+			t.Fatalf("SessionByTokenHash: %v", err)
+		}
+
+		recorder := postMultipart(t, h, token, session.CSRFToken, "a")
+		if !h.handlerRan {
+			t.Error("the handler did not run for a multipart POST with the session's token — the middleware never read the token from the multipart body (WP-F upload was silently unreachable)")
+		}
+		if recorder.Code != http.StatusOK {
+			t.Errorf("status = %d, want 200; body:\n%s", recorder.Code, recorder.Body.String())
+		}
+	})
+
+	t.Run("a multipart POST with no token is still refused", func(t *testing.T) {
+		h := newHarness(t)
+		_, token := h.login(t, "profesora@example.com")
+
+		recorder := postMultipart(t, h, token, "", "a")
+		if h.handlerRan {
+			t.Error("the handler ran for a multipart POST with no CSRF token")
+		}
+		if recorder.Code != http.StatusForbidden {
+			t.Errorf("status = %d, want 403", recorder.Code)
 		}
 	})
 


### PR DESCRIPTION
Hotfix reportado en producción 2026-08-18 mientras Miguel intentaba subir el primer batch de escaneos reales de sus alumnos.

## Problem

5 x `403 "Solicitud no autorizada."` seguidos en menos de 2 minutos, todos con la misma forma en logs:

```
level=WARN msg="refusing a request with no valid CSRF token"
  professor=1 path=/controls/LSLU.../scans method=POST
```

Sesión válida (`professor=1` en el log). Form correcto (renderizado por el server con el CSRF token de la session). Hard refresh + re-login no ayudaron.

## Cause

`VerifyCSRF` middleware:

```go
if err := r.ParseForm(); err != nil { renderForbidden(w, r); return }
if !auth.VerifyCSRF(session.CSRFToken, r.PostFormValue(CSRFFieldName)) { … }
```

Para un body multipart/form-data, **`r.ParseForm()` NO parsea el body** — inicializa `r.PostForm` a un mapa vacío no-nil y retorna nil. Después `r.PostFormValue` mira `if r.PostForm == nil` para decidir si llamar `ParseMultipartForm`; como está no-nil, no lo llama, y el token del multipart body queda invisible. Rechazo garantizado en todo POST multipart.

WP-F (#167) shipped este bug: el test `TestUploadScanCallsAnalyzerAndFlashesSuccess` llama directamente `f.handler.UploadScan(rec, req)` bypaseando la middleware, así que la cobertura nunca ejerció la combinación multipart+VerifyCSRF.

## Fix

Middleware detecta multipart y llama `ParseMultipartForm(32 MiB)` en vez de `ParseForm()`. La subsiguiente `PostFormValue` lee correctamente del multipart body.

Nueva helper `isMultipart(r)` (Content-Type prefix `multipart/` + `mime.ParseMediaType` validando `multipart/form-data`).

## Test

Dos subtests nuevos en `TestCSRF` (pasan por la middleware completa: `Resolve → RequireProfessor → VerifyCSRF`, sin bypass):

- `a multipart POST carrying the session's own token is accepted` — reddens contra `main`, pasa con el fix.
- `a multipart POST with no token is still refused` — pin del rechazo negativo (asegura que el fix no aflojó la comprobación).

Los 4 subtests existentes de `TestCSRF` mantienen su comportamiento. Full suite verde.

## Trade-off (documentado inline)

La middleware ahora consume el body multipart antes que el handler. La consecuencia:

- El wrap `http.MaxBytesReader(w, r.Body, h.MaxScanBytes)` que hace el handler `UploadScan` NO tiene efecto: cuando el handler corre, `r.Body` ya está al EOF.
- El bound práctico pasa a ser el reverse-proxy en frente del server (Tailscale Funnel en producción — bound de Funnel: no medido en este PR, ver follow-up).
- `NALANDA_MAX_SCAN_BYTES` sigue leyéndose desde config pero deja de enforzarse.

Solución completa (follow-up, no bloqueante): la middleware recibe el config y wrappea `r.Body` con `MaxBytesReader` usando `NALANDA_MAX_SCAN_BYTES` antes de parsear. Requiere plumbing por-ruta que hoy no existe. Abro issue cuando esto se mergee.

## Test plan (Miguel)

- [x] Local: `go test ./internal/app/web/middleware/...` → verde (todos los subtests de `TestCSRF`)
- [x] Full suite → verde
- [ ] Post-merge: `docker compose pull server && up -d server` en la Jetson, volver al backoffice, subir el mismo scan → 200 con redirect a `/controls/<id>` y flash message "Escaneos leídos" (o el mensaje que ponga el flow).

## Notes

- **Bloqueante:** sin este fix, el flow de escaneos de WP-F no es utilizable en producción con browser real. La cobertura de tests engañosamente verde.
- Este bug también afectaría cualquier futuro form multipart (uploads de assets, avatars, etc). El fix aplica a todo POST multipart.
