### PR TITLE
fix: honour ADR-0037 scan-page naming contract (worker links, server accepts jpg)

### DIFF
--- a/apps/amc-worker/.gitignore
+++ b/apps/amc-worker/.gitignore
@@ -1,3 +1,9 @@
 # Scratch: AMC projects, generated PDFs and layout files produced by the
 # verification scripts. Everything here is rebuilt by `make test`.
 tests/work/
+
+# Python bytecode: never source, always regenerable. Committed once by a
+# doctest run mid-development (#188) — the .gitignore did not name it and
+# `git add -A` swept it up.
+__pycache__/
+*.pyc

--- a/apps/amc-worker/tests/06-http.sh
+++ b/apps/amc-worker/tests/06-http.sh
@@ -92,6 +92,15 @@ check_eq "and reads copy 1's RUT back" "20123456" "$(echo "$rep" | field 'd["cop
 check_eq "and queues exactly the damaged copies" "['3', '4', '5']" \
   "$(echo "$rep" | field 'sorted(d["needs_review"])')"
 
+# ADR-0037: the server serves review-page images at
+# `<work>/controls/<id>/scans/copy-<N>-page-<M>.<ext>`. After /analyse the
+# worker links every captured page under that naming so the server does
+# not have to know AMC's own batch-<K>.pdf-page-<seq>-<idx> shape. Missing
+# in production 2026-08-19 (the review page 404'd on every real scan).
+check "copy-1-page-1 symlink exists after /analyse" \
+  test -L "${work}/project/scans/copy-1-page-1.png" -o \
+       -L "${work}/project/scans/copy-1-page-1.jpg"
+
 # --- associate ----------------------------------------------------------------
 
 as="$(post /associate '{"project":"project","roster":"curso.csv","code":"rut","key":"rut"}')"

--- a/apps/amc-worker/worker.py
+++ b/apps/amc-worker/worker.py
@@ -210,7 +210,67 @@ def analyse(body):
         "--data", data, "--prefix", project, source)
     amc("note", "--data", data, "--seuil", str(TICKED))
 
+    # ADR-0037: the server serves review-page images at
+    # `<work>/controls/<id>/scans/copy-<N>-page-<M>.<ext>`. AMC's `getimages`
+    # names its outputs `batch-<K>.pdf-page-<seq>-<idx>.<ext>` and only
+    # `capture_page` knows which batch file is which physical (copy, page).
+    # Create symlinks under the contract's naming beside the originals so
+    # the server finds them and AMC's own downstream tools (annotate,
+    # re-analyse) still resolve their capture.sqlite src references.
+    # Reported in production 2026-08-19 when the review page returned 404
+    # on every scanned copy of Miguel's first real batch.
+    link_scans_to_contract_names(data, os.path.join(project, "scans"))
+
     return read_capture.read(data, TICKED, UNSURE)
+
+
+def scan_link_targets(rows):
+    """Compute the (source_basename, link_basename) pairs to symlink into the
+    scans directory. Pure — takes the capture_page rows and returns what
+    caller should link. Extension follows what AMC actually produced (`.jpg`
+    for raster scans, `.png` for vector).
+
+    >>> scan_link_targets([(1, 1, "%PROJET/scans/batch-1.pdf-page-014-013.jpg")])
+    [('batch-1.pdf-page-014-013.jpg', 'copy-1-page-1.jpg')]
+    >>> scan_link_targets([(6, 2, "batch-1.pdf-page-018-017.png")])
+    [('batch-1.pdf-page-018-017.png', 'copy-6-page-2.png')]
+    """
+    out = []
+    for student, page, src in rows:
+        original = os.path.basename(src)
+        ext = os.path.splitext(original)[1]
+        out.append((original, f"copy-{student}-page-{page}{ext}"))
+    return out
+
+
+def link_scans_to_contract_names(data, scans):
+    """Symlink `copy-<student>-page-<page>.<ext>` for every capture_page row.
+
+    Idempotent: replaces any stale symlink from a previous run. Skips a row
+    whose src file is not on disk (a capture that never actually produced an
+    image — should not happen in practice, but noise here would hide the
+    real error the caller was going to look at).
+    """
+    capture_db = os.path.join(data, "capture.sqlite")
+    if not os.path.isfile(capture_db):
+        return
+    conn = sqlite3.connect(capture_db)
+    try:
+        rows = conn.execute(
+            "SELECT student, page, src FROM capture_page"
+        ).fetchall()
+    finally:
+        conn.close()
+    for original, link_name in scan_link_targets(rows):
+        source_path = os.path.join(scans, original)
+        if not os.path.exists(source_path):
+            continue
+        link_path = os.path.join(scans, link_name)
+        try:
+            os.remove(link_path)
+        except FileNotFoundError:
+            pass
+        os.symlink(original, link_path)
 
 
 def reanalyse(body):

--- a/apps/server/internal/app/web/handler/review.go
+++ b/apps/server/internal/app/web/handler/review.go
@@ -253,21 +253,37 @@ func (h *Controls) PageImage(w http.ResponseWriter, r *http.Request) {
 		middleware.WriteError(w, r, http.StatusNotFound, "Ese control no existe.")
 		return
 	}
-	path := filepath.Join(h.Service.ProjectDir(id), "scans",
-		fmt.Sprintf("copy-%d-page-%d.png", copyNumber, pageNumber))
-	f, err := os.Open(path)
-	if err != nil {
-		middleware.WriteError(w, r, http.StatusNotFound, "La imagen escaneada no está disponible.")
+	// The extension follows whatever AMC's `getimages` produced: PNG for a
+	// vector-sourced page, JPG for a raster-sourced scan. Miguel's first
+	// real batch (2026-08-19) landed as JPG and this endpoint used to look
+	// only for PNG, returning 404 for every real scan. PNG wins when both
+	// exist so a future engine that produces both cannot silently flip
+	// which image the reviewer sees. Content-Type mirrors the extension —
+	// browsers accept both and the caller does not have to know.
+	scansDir := filepath.Join(h.Service.ProjectDir(id), "scans")
+	base := fmt.Sprintf("copy-%d-page-%d", copyNumber, pageNumber)
+	for _, ext := range []string{".png", ".jpg"} {
+		path := filepath.Join(scansDir, base+ext)
+		f, err := os.Open(path)
+		if err != nil {
+			continue
+		}
+		info, statErr := f.Stat()
+		if statErr != nil {
+			_ = f.Close()
+			middleware.WriteError(w, r, http.StatusInternalServerError, "")
+			return
+		}
+		defer func() { _ = f.Close() }()
+		if ext == ".png" {
+			w.Header().Set("Content-Type", "image/png")
+		} else {
+			w.Header().Set("Content-Type", "image/jpeg")
+		}
+		http.ServeContent(w, r, "page"+ext, info.ModTime(), f)
 		return
 	}
-	defer func() { _ = f.Close() }()
-	info, err := f.Stat()
-	if err != nil {
-		middleware.WriteError(w, r, http.StatusInternalServerError, "")
-		return
-	}
-	w.Header().Set("Content-Type", "image/png")
-	http.ServeContent(w, r, "page.png", info.ModTime(), f)
+	middleware.WriteError(w, r, http.StatusNotFound, "La imagen escaneada no está disponible.")
 }
 
 // parseCopyPathValue turns a path segment into a positive int. Empty and

--- a/apps/server/internal/app/web/handler/review_test.go
+++ b/apps/server/internal/app/web/handler/review_test.go
@@ -99,6 +99,75 @@ func TestPageImageServesPngWhenPresent(t *testing.T) {
 	}
 }
 
+// AMC's `getimages --copy-to` writes raster-sourced pages as JPG. The
+// naming contract (ADR-0037) is `copy-<N>-page-<M>`; the extension follows
+// whatever AMC actually produced. This case pins the JPG branch —
+// production 2026-08-19: Miguel's first real scan batch landed as JPG and
+// this endpoint returned 404 for every page because it only knew about PNG.
+func TestPageImageServesJpgWhenOnlyJpgPresent(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control image jpg", 1)
+
+	scansDir := filepath.Join(f.workDir, "controls", controlID, "scans")
+	if err := os.MkdirAll(scansDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(scansDir, "copy-1-page-1.jpg"), fakeJPEG(), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	req := f.authedRequest(t, http.MethodGet, "/controls/"+controlID+"/copies/1/page/1", nil)
+	req.SetPathValue("id", controlID)
+	req.SetPathValue("copy", "1")
+	req.SetPathValue("n", "1")
+	rec := httptest.NewRecorder()
+	f.handler.PageImage(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d\nbody: %s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "image/jpeg" {
+		t.Errorf("Content-Type = %q, want image/jpeg", ct)
+	}
+	if rec.Body.Len() == 0 {
+		t.Error("empty body")
+	}
+}
+
+// PNG wins over JPG when both exist — a control that had a .png staged
+// (from a hypothetical vector source) plus a .jpg (from the raster path)
+// serves the PNG. Not a case that arises today; pinned so a future engine
+// that produces both does not silently flip which one the reviewer sees.
+func TestPageImagePrefersPngOverJpg(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control image both", 1)
+
+	scansDir := filepath.Join(f.workDir, "controls", controlID, "scans")
+	if err := os.MkdirAll(scansDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(scansDir, "copy-1-page-1.png"), fakePNG(), 0o644); err != nil {
+		t.Fatalf("WriteFile .png: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(scansDir, "copy-1-page-1.jpg"), fakeJPEG(), 0o644); err != nil {
+		t.Fatalf("WriteFile .jpg: %v", err)
+	}
+
+	req := f.authedRequest(t, http.MethodGet, "/controls/"+controlID+"/copies/1/page/1", nil)
+	req.SetPathValue("id", controlID)
+	req.SetPathValue("copy", "1")
+	req.SetPathValue("n", "1")
+	rec := httptest.NewRecorder()
+	f.handler.PageImage(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "image/png" {
+		t.Errorf("Content-Type = %q, want image/png (PNG wins over JPG)", ct)
+	}
+}
+
 func TestPageImageReturns404WhenNotOnDisk(t *testing.T) {
 	f := newControlsFixture(t)
 	controlID := f.createControl(t, "Control image missing", 1)
@@ -112,6 +181,28 @@ func TestPageImageReturns404WhenNotOnDisk(t *testing.T) {
 
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
+// fakeJPEG returns a minimal valid JPEG (1x1 grayscale). Small enough to
+// live as a byte literal; enough of a header to satisfy `http.ServeContent`
+// and any browser doing MIME sniffing.
+func fakeJPEG() []byte {
+	return []byte{
+		0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01,
+		0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0xFF, 0xDB, 0x00, 0x43,
+		0x00, 0x08, 0x06, 0x06, 0x07, 0x06, 0x05, 0x08, 0x07, 0x07, 0x07, 0x09,
+		0x09, 0x08, 0x0A, 0x0C, 0x14, 0x0D, 0x0C, 0x0B, 0x0B, 0x0C, 0x19, 0x12,
+		0x13, 0x0F, 0x14, 0x1D, 0x1A, 0x1F, 0x1E, 0x1D, 0x1A, 0x1C, 0x1C, 0x20,
+		0x24, 0x2E, 0x27, 0x20, 0x22, 0x2C, 0x23, 0x1C, 0x1C, 0x28, 0x37, 0x29,
+		0x2C, 0x30, 0x31, 0x34, 0x34, 0x34, 0x1F, 0x27, 0x39, 0x3D, 0x38, 0x32,
+		0x3C, 0x2E, 0x33, 0x34, 0x32, 0xFF, 0xC0, 0x00, 0x0B, 0x08, 0x00, 0x01,
+		0x00, 0x01, 0x01, 0x01, 0x11, 0x00, 0xFF, 0xC4, 0x00, 0x14, 0x00, 0x01,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0xFF, 0xC4, 0x00, 0x14, 0x10, 0x01, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0xFF, 0xDA, 0x00, 0x08, 0x01, 0x01, 0x00, 0x00, 0x3F, 0x00,
+		0x37, 0xFF, 0xD9,
 	}
 }
 


### PR DESCRIPTION
Hotfix reportado en producción 2026-08-19: después de subir el primer batch real de escaneos de alumnos con el fix del CSRF multipart (#187), el reader devolvió 200 y el `/analyse` completó bien, pero la página de revisión (`/controls/{id}/copies/{n}/review`) mostró un ícono roto donde debería ir la imagen del scan. Toda URL `/controls/{id}/copies/{N}/page/{M}` respondió 404.

## Cause

**Contract mismatch declarado en ADR-0037 pero no cumplido por ninguna de las dos partes.**

- **Server** (`review.go:257`, WP-F #167) construye el path del image así:
  ```go
  path := filepath.Join(h.Service.ProjectDir(id), "scans",
      fmt.Sprintf("copy-%d-page-%d.png", copyNumber, pageNumber))
  ```
- **Worker** (`worker.py:194`) llama `getimages --copy-to <scans>` que produce archivos con la naming de AMC:
  ```
  batch-1.pdf-page-014-013.jpg
  batch-1.pdf-page-018-017.jpg
  ...
  ```
- Y el mapping `(batch file) → (copy, page)` vive en `capture.sqlite` de AMC.

WP-F mergeó este hueco porque el test del handler `UploadScan` bypasea la middleware y ningún test corrió contra output real de AMC — la naming a nivel filesystem sólo se hizo evidente cuando un profesor navegó a la review page en producción por primera vez.

## Fix (dos lados del contract)

### Worker (`apps/amc-worker/worker.py`)

Después de `getimages` + `analyse`, leer `capture_page` de `capture.sqlite` y crear un **symlink** `copy-<student>-page-<page>.<ext>` al lado de cada `batch-<K>.pdf-page-<seq>-<idx>.<ext>`.

**Symlinks, no renames**: AMC guarda referencias a los path originales en `capture.sqlite` (`capture_page.src`). Un rename rompería `annotate` y `re-analyse` que resuelven contra esos path. Los symlinks preservan las referencias y agregan el naming que el server necesita.

**Idempotente**: reemplaza symlinks stale de un `/analyse` previo.

Pure name-mapping function con doctests:
```python
def scan_link_targets(rows):
    """
    >>> scan_link_targets([(1, 1, "%PROJET/scans/batch-1.pdf-page-014-013.jpg")])
    [('batch-1.pdf-page-014-013.jpg', 'copy-1-page-1.jpg')]
    >>> scan_link_targets([(6, 2, "batch-1.pdf-page-018-017.png")])
    [('batch-1.pdf-page-018-017.png', 'copy-6-page-2.png')]
    """
```

Los doctests corren local sin Docker (`python3 -m doctest worker.py`), verde.

### Server (`apps/server/internal/app/web/handler/review.go`)

`PageImage` ahora prueba `copy-N-page-M.png` primero, cae a `.jpg` después. Content-Type sigue la extensión.

**PNG gana cuando ambos existen** (pinneado por `TestPageImagePrefersPngOverJpg`) para que un futuro engine que produzca ambos formatos no cambie silenciosamente qué imagen ve el corrector.

## Tests

- **Server** (nuevos): `TestPageImageServesJpgWhenOnlyJpgPresent`, `TestPageImagePrefersPngOverJpg`. Reddens contra `main`, verde con el fix. Existing `TestPageImageServesPngWhenPresent` sigue verde. Full suite verde.
- **Worker**: doctests en `scan_link_targets` (pure), assertion nueva en `tests/06-http.sh` post-`/analyse`:
  ```bash
  check "copy-1-page-1 symlink exists after /analyse" \
    test -L "${work}/project/scans/copy-1-page-1.png" -o \
         -L "${work}/project/scans/copy-1-page-1.jpg"
  ```
- `.gitignore` de amc-worker gana `__pycache__/` y `*.pyc` (se me colaron en el commit inicial de este PR, los saqué + gitignore para que no vuelva a pasar).

## Manual verification (Miguel, post-merge)

1. CI corre server-cd + amc-worker-cd (~15 min para el segundo por texlive QEMU).
2. Watchtower actualiza server + amc-worker.
3. **Regenerar el flow completo** (el análisis previo tiene los archivos con nombre viejo — el fix rename sólo aplica a `/analyse` calls nuevos):
   - En el backoffice, entrá al control, botón "Re-analizar" (o si no existe, generar un control nuevo, imprimir 1-2 hojas, marcar, escanear, subir, analizar).
4. Volver a `/controls/{id}/copies/1/review` — la imagen del scan debería renderizar.
5. **O:** dejar el control actual como está — yo ya creé symlinks manualmente (23) para todos los `student` de `capture_page`. Miguel puede ver las hojas AHORA mismo con su control existente. Los symlinks tienen extensión `.png` apuntando a bytes JPG; el browser sniffea y renderiza. El fix del worker hará esto automáticamente para futuros analyse.

## Notes

- **Este bug bloqueaba WP-F end-to-end en producción con scan real.** Descubrimiento tardío: WP-F shippeó porque su cobertura test era mock-heavy (fake worker) y nunca ejerció el naming a nivel filesystem.
- Follow-up posible (no bloqueante): agregar un test de integración server↔worker que corra el flow entero contra Docker real. Habría atrapado esto hace días.
- `.pyc` files se colaron en la primera versión del commit (git add -A + doctest local). Amend + gitignore.
- ADR-0037 documenta el contract; este PR es la primera vez que se cumple.
