### PR TITLE
fix(server): scan image on the review page respects the viewport width

### DIFF
--- a/apps/server/internal/app/web/view/templates/layout.html
+++ b/apps/server/internal/app/web/view/templates/layout.html
@@ -89,6 +89,12 @@
         justify-content: center;
       }
 
+      /* Scan images on the review page are the physical scan's native
+         resolution (300 dpi × A4 = a few thousand pixels wide). Without a
+         max-width the browser lays them out at natural size and the sheet
+         overflows every viewport. */
+      .review-image img { max-width: 100%; height: auto; }
+
       h1 { font-size: 1.5rem; margin-block: 0 0.5rem; }
       p { margin-block: 0 1rem; }
       .aviso, .flash {


### PR DESCRIPTION
Reported 2026-08-19: la review page mostraba el scan a resolución nativa (~2500 px), overflowaba cada viewport.

Fix: 1 regla CSS `.review-image img { max-width: 100%; height: auto }` en `layout.html` (donde ya vive todo el CSS del backoffice).

Yolo-adjacent: 5 líneas CSS (con comentario), sin lógica, cambio puro visual. Va por PR igual porque la regla es 'nada directo a main'.

**Follow-up (WP separado, backlog):** Miguel pidió que en el futuro la imagen del scan sea la **hoja anotada** (con las marcas del corrector encima, para poder enviársela al alumno). AMC ya tiene `POST /annotate` en el worker; falta: (a) asociar copy→alumno, (b) llamar /annotate al cerrar corrección, (c) servir el PDF anotado. Refino con `refine-idea` mañana si Miguel confirma.