### PR TITLE
fix: Control 1 creation 500s in AMC prepare; review the bank questions that feed it

### DIFF
--- a/apps/amc-worker/README.md
+++ b/apps/amc-worker/README.md
@@ -51,6 +51,13 @@ under `/work` and asks the worker to act on it; requests and responses name
 paths. A scan batch is a multi-page PDF of ~40 sheets, and putting that through
 an HTTP body would buy nothing.
 
+The wrapper and the AMC tools it drives run as **root**; the caller
+(`apps/server`) runs as UID 65532. After every request that names a project —
+succeeded or failed — the wrapper chowns that project to 65532, so the
+caller's rollback can always delete what a failed request left behind
+(regression: a failed `/generate` left a root-owned `data/` and the server's
+rollback died on it, issue #193).
+
 ```
 GET  /health                                          → { ok, amc }
 POST /generate      { project, source, copies }       → { sujet, corrige, calage, copies }

--- a/apps/amc-worker/tests/06-http.sh
+++ b/apps/amc-worker/tests/06-http.sh
@@ -145,6 +145,19 @@ check_eq "annotating twice into the same directory is REFUSED" "400" \
 check_eq "an unknown route is a 404, not a stack trace" "404" \
   "$(post_status /definitely-not-a-route '{}')"
 check_eq "a missing field is a 400" "400" "$(post_status /generate '{"project":"project"}')"
+
+# The wrapper and AMC run as root; apps/server runs as UID 65532 and rolls a
+# failed request back by deleting the whole project. Everything the failed
+# request touched must be handed back owned by the caller's UID, or the
+# rollback dies on a root-owned file (prod 2026-08-19, issue #193). A fresh
+# project makes the check real: project_paths creates its data/ as root
+# BEFORE the missing `source` field is even looked at, so a green result
+# proves the hand-back ran on the failure path, not on an earlier success.
+check_eq "a missing field on a fresh project is a 400" "400" \
+  "$(post_status /generate '{"project":"project-fail"}')"
+check_eq "a failed request hands the project back to the caller's UID" "65532" \
+  "$(docker run --rm -v "${work}:/work" "$IMAGE" stat -c %u /work/project-fail/data)"
+
 check_eq "a path escaping the volume is refused" "400" \
   "$(post_status /generate '{"project":"../../etc","source":"src/control-demo.tex","copies":1}')"
 

--- a/apps/amc-worker/worker.py
+++ b/apps/amc-worker/worker.py
@@ -66,6 +66,14 @@ MAX_BODY = 1 << 20  # 1 MiB
 # without a bound it would hold a worker thread forever.
 AMC_TIMEOUT = 1800
 
+# apps/server runs as this UID (its Dockerfile, `USER 65532:65532`). The
+# shared volume is the hand-off point between the two containers: a project
+# this wrapper creates as root must go back owned by this UID, or the
+# server's rollback cannot delete it. Regression from prod 2026-08-19
+# (issue #193): a failed generate left a root-owned data/ behind and the
+# server logged "rollback failed … permission denied".
+CALLER_UID = 65532
+
 # A capture is only trustworthy if we agree with AMC about which boxes are dark.
 # The same two defaults read_capture.py declares — stated here rather than
 # derived from each other, because they are independent tunables and PAPER-CHECK
@@ -133,6 +141,37 @@ def project_paths(body):
     for d in (data, os.path.join(project, "cr"), os.path.join(project, "scans")):
         os.makedirs(d, exist_ok=True)
     return project, data
+
+
+def hand_back_project(body):
+    """Chown the request's project to the caller's UID, best-effort.
+
+    The wrapper and the AMC tools it drives run as root; apps/server runs
+    as CALLER_UID and, after a failed request, removes the whole project
+    directory as a rollback. Files this process created as root are then
+    undeletable for the server — a failed generate left a root-owned data/
+    behind in production (issue #193, 2026-08-19). Every request that names
+    a project hands it back owned by the caller, so the rollback always
+    works. Best-effort by design: the AMC work already succeeded or already
+    failed, and a chown problem must not rewrite that answer.
+    """
+    if not isinstance(body, dict):
+        return
+    try:
+        project = under_work(body.get("project", ""))
+    except Failed:
+        return
+    try:
+        proc = subprocess.run(
+            ["chown", "-R", "%d:%d" % (CALLER_UID, CALLER_UID), project],
+            capture_output=True, text=True, timeout=60,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return
+    if proc.returncode != 0:
+        sys.stderr.write(
+            "amc-worker chown failed for %s: %s\n"
+            % (project, (proc.stderr or "").strip()))
 
 
 # --- handlers ----------------------------------------------------------------
@@ -467,6 +506,8 @@ class Handler(BaseHTTPRequestHandler):
             self._respond(400, {"error": f"missing field: {exc.args[0]}"})
         except Exception as exc:  # noqa: BLE001 — the wire needs a JSON answer
             self._respond(500, {"error": type(exc).__name__, "detail": str(exc)})
+
+        hand_back_project(body)
 
     def do_GET(self):
         self._dispatch("GET")

--- a/apps/server/internal/domain/controls/tex/tex.go
+++ b/apps/server/internal/domain/controls/tex/tex.go
@@ -290,7 +290,7 @@ func fourZeroClause(questions int) string {
 	return fmt.Sprintf("son %d,5 puntos", questions/2)
 }
 
-// escapeLatex escapes the ten TeX specials in text that arrived as plain text
+// escapeLatex escapes the TeX specials in text that arrived as plain text
 // from a human author — the professor-typed control name AND the bank's
 // Statement / Alternatives (which come from MDX where `70%` means "seventy
 // percent", not "start of LaTeX comment"). Issue #183 is the follow-up that
@@ -300,6 +300,18 @@ func fourZeroClause(questions int) string {
 // escaping opened a LaTeX comment inside `\correctchoice{...}` and cascaded
 // up to a runaway argument in `\element{clase}{...}` — the whole
 // generation returned exit 1 without producing a PDF.
+//
+// `<` and `>` join the list even though they are not TeX specials in
+// general: babel-spanish makes them ACTIVE. An active `>` decides what it
+// means by looking at the token that follows it, and a `>` followed by the
+// `}` that closes a `\correctchoice{...}` swallows that brace — the whole
+// question's group structure unwinds and `auto-multiple-choice prepare`
+// exits 1. Regression from prod 2026-08-19 (issue #193): the pregunta
+// `tres-diferencias-de-operadores` carried the alternative
+// "`>>` rellena siempre con ceros…", and creating Control 1 failed with a
+// 500 whose server log showed only "prepare failed (1)". Reproduced against
+// the worker image: the single question fails alone; the same .tex without
+// babel-spanish, or with `>` written `\textgreater`, compiles clean.
 func escapeLatex(s string) string {
 	replacer := strings.NewReplacer(
 		"\\", "\\textbackslash{}",
@@ -312,6 +324,8 @@ func escapeLatex(s string) string {
 		"_", "\\_",
 		"^", "\\^{}",
 		"~", "\\~{}",
+		"<", "\\textless{}",
+		">", "\\textgreater{}",
 	)
 	return replacer.Replace(s)
 }

--- a/apps/server/internal/domain/controls/tex/tex.go
+++ b/apps/server/internal/domain/controls/tex/tex.go
@@ -163,7 +163,7 @@ func writeQuestion(b *strings.Builder, q bank.Question, listingsDir string) {
 		// (ADR-0033 §The sheet carries its own arithmetic).
 		fmt.Fprintf(b, "  \\begin{%s}{%s}\n", env, q.ID)
 	}
-	fmt.Fprintf(b, "    %s\n", escapeLatex(strings.TrimSpace(q.Statement)))
+	fmt.Fprintf(b, "    %s\n", escapeBankText(strings.TrimSpace(q.Statement)))
 
 	if q.Code != nil {
 		// Absolute path: AMC compiles from its own working directory, so
@@ -210,7 +210,7 @@ func emitAlternative(b *strings.Builder, text string, correct bool) {
 	if correct {
 		macro = "\\correctchoice"
 	}
-	fmt.Fprintf(b, "      %s{%s}\n", macro, escapeLatex(strings.TrimSpace(text)))
+	fmt.Fprintf(b, "      %s{%s}\n", macro, escapeBankText(strings.TrimSpace(text)))
 }
 
 func writeSheet(b *strings.Builder, in Input) {
@@ -328,4 +328,22 @@ func escapeLatex(s string) string {
 		">", "\\textgreater{}",
 	)
 	return replacer.Replace(s)
+}
+
+// codeFontPattern matches an MDX-style backtick pair: the book's inline
+// code, which the sheet renders as \texttt. A backtick without its pair is
+// not matched and stays where it was — it renders as a quote mark, which is
+// the same behaviour the sheet had before this transform existed.
+var codeFontPattern = regexp.MustCompile("`([^`]+)`")
+
+// escapeBankText is the Statement / Alternatives pipeline: TeX specials
+// escaped, then backtick pairs rendered as code. Escaping runs FIRST so the
+// \texttt command itself is not escaped, and the pair pattern survives it
+// intact because backticks are not special to TeX.
+//
+// A raw backtick is a quote mark on paper: the sheet would read 'int' where
+// the author wrote `int`. The professor-typed control NAME goes through
+// escapeLatex alone — it is plain text, not MDX (issue #193 S3).
+func escapeBankText(s string) string {
+	return codeFontPattern.ReplaceAllString(escapeLatex(s), `\texttt{$1}`)
 }

--- a/apps/server/internal/domain/controls/tex/tex_test.go
+++ b/apps/server/internal/domain/controls/tex/tex_test.go
@@ -330,6 +330,40 @@ func TestAngleBracketsAreEscapedBeforeEmission(t *testing.T) {
 	}
 }
 
+// MDX writes code identifiers between backticks and the book renders them as
+// code. The sheet's answer is \texttt: a raw backtick is a quote mark on
+// paper, so the bank would read 'int' where the author wrote `int`
+// (issue #193 S3). The professor-typed NAME keeps escapeLatex alone — it is
+// not MDX.
+func TestBacktickPairsRenderAsTypewriterText(t *testing.T) {
+	out := compile(t, func(in *tex.Input) {
+		in.Pool = []bank.Question{
+			{
+				ID: "backtick", Document: "welcome", Anchor: "hola",
+				Type:      bank.TypeSimple,
+				Statement: "¿Cuántos bits ocupa un `char` en Java?",
+				Alternatives: []string{
+					"16 `bits`",
+					"8",
+				},
+				Correct: []int{0},
+			},
+		}
+		in.QuestionsPerCopy = 1
+	})
+	for _, want := range []string{
+		`un \texttt{char} en Java`,
+		`16 \texttt{bits}`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("backtick pair was not rendered as \\texttt: missing %q in output", want)
+		}
+	}
+	if strings.Contains(out, "`char`") {
+		t.Error("a backtick pair survived into the .tex — on paper it renders as a quote mark")
+	}
+}
+
 // Issue #185: the generator branches on Input.DuplexPadding.
 //
 //   - true (historical): emits \AMCcleardoublepage inside \onecopy so each

--- a/apps/server/internal/domain/controls/tex/tex_test.go
+++ b/apps/server/internal/domain/controls/tex/tex_test.go
@@ -287,6 +287,49 @@ func TestStatementAndAlternativesAreEscapedBeforeEmission(t *testing.T) {
 	}
 }
 
+// `<` and `>` arrive from MDX as plain text too (`>>`, `<<` in inline code)
+// and are not TeX specials in general — but babel-spanish makes them ACTIVE,
+// and an active `>` that meets the closing brace of a `\correctchoice{...}`
+// swallows it, unwinding the whole question's group structure.
+//
+// Regression from prod 2026-08-19 (issue #193): the pregunta
+// `tres-diferencias-de-operadores` carried the alternative "`>>` rellena
+// siempre con ceros…", and generating Control 1 failed in
+// `auto-multiple-choice prepare` — reproduced against the worker image with
+// that single question, and shown to compile clean once `>` is emitted as
+// `\textgreater` or babel-spanish is absent.
+func TestAngleBracketsAreEscapedBeforeEmission(t *testing.T) {
+	out := compile(t, func(in *tex.Input) {
+		in.Pool = []bank.Question{
+			{
+				ID: "corrimiento", Document: "welcome", Anchor: "hola",
+				Type:      bank.TypeSimple,
+				Statement: "¿Qué hace `>>` en Java?",
+				Alternatives: []string{
+					"corre `>>` a la derecha",
+					"corre `<<` a la izquierda",
+					"nada",
+				},
+				Correct: []int{0},
+			},
+		}
+		in.QuestionsPerCopy = 1
+	})
+	for _, want := range []string{
+		`\textgreater{}\textgreater{}`,
+		`\textless{}\textless{}`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("angle brackets were not escaped: missing %q in output", want)
+		}
+	}
+	for _, unwant := range []string{"`>>`", "`<<`"} {
+		if strings.Contains(out, unwant) {
+			t.Errorf("angle brackets emitted UNESCAPED: %q found in output — babel-spanish's active `>` would swallow the closing brace and break the compile", unwant)
+		}
+	}
+}
+
 // Issue #185: the generator branches on Input.DuplexPadding.
 //
 //   - true (historical): emits \AMCcleardoublepage inside \onecopy so each

--- a/content/courses/sample-course/08-referencias-null-igualdad.mdx
+++ b/content/courses/sample-course/08-referencias-null-igualdad.mdx
@@ -586,9 +586,9 @@ static void swap(int[] x, int[] y) {
 Al llamarlo con dos arreglos `a` y `b`, no intercambia nada visto desde el
 llamador. ¿Por qué?
 
-- [x] `x` e `y` son variables locales de `swap`; reasignarlas no toca las variables `a` y `b` del llamador
+- [x] `x` e `y` son variables locales; reasignarlas no toca `a` y `b`
 - [ ] Los arreglos en Java son inmutables
-- [ ] Java lanza silenciosamente una excepción que hace fallar el swap
+- [ ] El método recibe copias de los arreglos, no las referencias
 - [ ] Falta declarar los parámetros con `final`
 
 </Question>


### PR DESCRIPTION
**Closes #193**

## Summary

Creating Control 1 in the backoffice answered 500. The cause, reproduced
locally against the worker image: the pregunta
`tres-diferencias-de-operadores` carries the alternative `` `>>` rellena
siempre con ceros… ``, and **babel-spanish makes `<` and `>` active** — the
`>` met the closing brace of `\correctchoice{...}`, swallowed it, and the
whole question's group structure unwound until `auto-multiple-choice
prepare` exited 1. The server log named no cause because the worker's
`detail` is deliberately not logged (`security-notes.md`).

The slice also covers the review of the Control 1 banks (07 + 08, 24
questions) and a second incident bug: the failed request left a root-owned
project directory the server's rollback could not delete.

## Slices completed

- [x] S1 — reproduced the failure locally and captured the AMC error
- [x] S2 — fixed the root cause: `escapeLatex` now escapes `<` and `>`
- [x] S3 — reviewed the Control 1 banks and fixed the questions
- [x] S4 — fixed the rollback permission issue (worker hands the project
  back chowned to the caller's UID)

## Acceptance criteria

- **Creating Control 1 succeeds end to end.** Locally: the generated
  `.tex` for the full 07+08 range (24 questions) compiles with
  `auto-multiple-choice prepare` exit 0, 0 LaTeX errors, and `sujet.pdf` /
  `corrige.pdf` / `calage.xy` produced. The `>>` alternative and the
  `\texttt` code render correctly in the extracted PDF text. On the
  Jetson: pending this PR reaching `main` (CD + Watchtower).
- **The bank questions that feed Control 1 are reviewed and fixed.**
  Review findings: the banks are aligned with the material (the string
  pool and the `Integer` cache are both taught in 08's slides). Fixed:
  the swap question's "silent exception" distractor (absurd → replaced
  with the classic misconception), and its correct alternative, which was
  the length tell the mechanical rules refuse.
- **A failed prepare leaves no orphan project dir.** The worker chowns
  every project it touched to 65532 (success or failure);
  `06-http.sh` pins the failure path. The 2026-08-19 orphan on the Jetson
  was removed by hand.

## Tests

- `apps/server` per-commit (gofmt/vet/build/test) — green.
- `apps/server` pre-PR — `go test -race -count=1 ./...` green,
  `govulncheck` clean, `docker build` + compose boot with `/health` and
  `/api/health` answering `{"process":"up","database":"up"}`.
- `apps/amc-worker` — `make build && make test` (worker.py was touched):
  every `tests/NN-*.sh` green, 06-http 35/35 including the new hand-back
  check (verified to fail against the pre-fix image).
- `apps/web` — `format:check`, `lint`, full vitest 1082/1082, `build`.
  The first run caught the length-tell violation in
  `por-que-swap-no-swappea` that the review then fixed.

## Reviews run

The pre-PR protocols above were run line by line from
`docs/standards/testing-strategy.md`. The review-pipeline run is not yet
done; it can be launched after this PR is opened.

## Manual verification

- [ ] Create the real Control 1 in the backoffice (Jetson) and print the
      PDF — the sheet must render `>>` and code identifiers as typewriter
      text.
- [ ] `GOOGLE-CHECK.md` / `PAPER-CHECK.md` — not required (no change to
      the login path or the paper pipeline; the worker change is HTTP-side
      and covered by 06-http.sh).

## Notes

- The `>>` bug is the second babel-spanish interaction in the generator;
  the first (`%` comments, #184) is the reason `escapeLatex` exists. Both
  are pinned by regression tests now.
- The worker's `detail` field stays unlogged by design.
- The throwaway repro harness used during S1 was not committed.
