### PR TITLE
feat: snapshot the control's pool questions as a JSON artifact at generation time

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -207,6 +207,7 @@ Routes today:
 | `GET /controls/new` · `POST /controls` | Pick a section range, generate the PDF |
 | `GET /controls/{id}` | Detail: metadata, PDF downloads, the Escaneos upload form, the Resultados table and (after upload) the *Cerrar corrección* button |
 | `GET /controls/{id}/sujet.pdf` · `GET /controls/{id}/corrige.pdf` | Streamed from the shared volume |
+| `GET /controls/{id}/pool.json` | The pool snapshot written at Create time (issue #198) — attachment |
 | `POST /controls/{id}/scans` | Multipart PDF upload — hands the file to the worker's `/analyse` at the submitted thresholds, persists the report and the pair, annotates clean copies, flips the state to `in_review` |
 | `POST /controls/{id}/reanalyze` | Re-reads the stored captures at new `ticked`/`unsure` thresholds without a new capture, re-scores at them, and re-annotates the clean copies (issue #197) |
 | `POST /controls/{id}/close` | Moves the control to `graded` when every failure kind is resolved (WP-F S8), then fires `OnCorrectionClosed` (issue #190) |

--- a/apps/server/internal/app/web/handler/controls.go
+++ b/apps/server/internal/app/web/handler/controls.go
@@ -22,11 +22,12 @@ import (
 // every other route in this surface (issue #151 §Routes). WP-F extends the
 // set with the scan-upload target (ControlScansPath in scans.go).
 const (
-	ControlsPath       = "/controls"
-	ControlsNewPath    = "/controls/new"
-	ControlDetailPath  = "/controls/{id}"
-	ControlSujetPath   = "/controls/{id}/sujet.pdf"
-	ControlCorrigePath = "/controls/{id}/corrige.pdf"
+	ControlsPath        = "/controls"
+	ControlsNewPath     = "/controls/new"
+	ControlDetailPath   = "/controls/{id}"
+	ControlSujetPath    = "/controls/{id}/sujet.pdf"
+	ControlCorrigePath  = "/controls/{id}/corrige.pdf"
+	ControlPoolJSONPath = "/controls/{id}/pool.json"
 )
 
 // Defaults for the form fields. §C17: a control is four questions under a
@@ -183,6 +184,7 @@ func (h *Controls) Detail(w http.ResponseWriter, r *http.Request) {
 		Control:      toDetailedControl(c, h.Bank),
 		SujetURL:     controlSujetURL(c.ID),
 		CorrigeURL:   controlCorrigeURL(c.ID),
+		PoolJSONURL:  controlPoolJSONURL(c.ID),
 		ScansURL:     controlScansURL(c.ID),
 		ReanalyzeURL: controlReanalyzeURL(c.ID),
 		CloseURL:     controlCloseURL(c.ID),
@@ -213,18 +215,28 @@ func (h *Controls) Detail(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// SujetPDF and CorrigePDF stream the PDF files from the shared volume.
-// Wrote-through helpers so a caller cannot accidentally hand back
-// something outside the control's own directory.
+// SujetPDF, CorrigePDF and PoolJSON stream the control's files from the
+// shared volume. Paths are computed through the Service's wrote-through
+// helpers so a caller cannot accidentally hand back something outside the
+// control's own directory.
 func (h *Controls) SujetPDF(w http.ResponseWriter, r *http.Request) {
-	h.servePDF(w, r, "sujet.pdf")
+	h.serveControlFile(w, r, h.Service.SujetPath, "sujet.pdf", "application/pdf", "inline",
+		"El PDF del control no está disponible. Puede que se haya limpiado del volumen compartido.")
 }
 
 func (h *Controls) CorrigePDF(w http.ResponseWriter, r *http.Request) {
-	h.servePDF(w, r, "corrige.pdf")
+	h.serveControlFile(w, r, h.Service.CorrigePath, "corrige.pdf", "application/pdf", "inline",
+		"El PDF del control no está disponible. Puede que se haya limpiado del volumen compartido.")
 }
 
-func (h *Controls) servePDF(w http.ResponseWriter, r *http.Request, name string) {
+// PoolJSON streams the pool snapshot written at Create time (issue #198).
+// Attachment rather than inline: it is backup material, not a page.
+func (h *Controls) PoolJSON(w http.ResponseWriter, r *http.Request) {
+	h.serveControlFile(w, r, h.Service.PoolJSONPath, "pool.json", "application/json", "attachment",
+		"El respaldo de preguntas del control no está disponible.")
+}
+
+func (h *Controls) serveControlFile(w http.ResponseWriter, r *http.Request, pathFor func(string) string, name, contentType, disposition, missingMsg string) {
 	id := r.PathValue("id")
 	if !isValidControlID(id) {
 		middleware.WriteError(w, r, http.StatusNotFound, "Ese control no existe.")
@@ -238,41 +250,31 @@ func (h *Controls) servePDF(w http.ResponseWriter, r *http.Request, name string)
 			middleware.WriteError(w, r, http.StatusNotFound, "Ese control no existe.")
 			return
 		}
-		h.Log.Error("reading a control for PDF", "error", err, "id", id)
+		h.Log.Error("reading a control for a file", "error", err, "id", id)
 		middleware.WriteError(w, r, http.StatusInternalServerError,
 			"Algo se rompió en el servidor. Vuelve a intentarlo en unos segundos.")
 		return
 	}
 
-	var path string
-	switch name {
-	case "sujet.pdf":
-		path = h.Service.SujetPath(id)
-	case "corrige.pdf":
-		path = h.Service.CorrigePath(id)
-	default:
-		middleware.WriteError(w, r, http.StatusNotFound, "Descarga no disponible.")
-		return
-	}
+	path := pathFor(id)
 
 	f, err := os.Open(path)
 	if err != nil {
-		h.Log.Warn("serving control PDF", "id", id, "name", name, "error", err)
-		middleware.WriteError(w, r, http.StatusNotFound,
-			"El PDF del control no está disponible. Puede que se haya limpiado del volumen compartido.")
+		h.Log.Warn("serving control file", "id", id, "name", name, "error", err)
+		middleware.WriteError(w, r, http.StatusNotFound, missingMsg)
 		return
 	}
 	defer func() { _ = f.Close() }()
 
 	info, err := f.Stat()
 	if err != nil {
-		h.Log.Error("stat control PDF", "id", id, "name", name, "error", err)
+		h.Log.Error("stat control file", "id", id, "name", name, "error", err)
 		middleware.WriteError(w, r, http.StatusInternalServerError,
 			"Algo se rompió en el servidor. Vuelve a intentarlo en unos segundos.")
 		return
 	}
-	w.Header().Set("Content-Type", "application/pdf")
-	w.Header().Set("Content-Disposition", fmt.Sprintf(`inline; filename="control-%s-%s"`, id, name))
+	w.Header().Set("Content-Type", contentType)
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`%s; filename="control-%s-%s"`, disposition, id, name))
 	http.ServeContent(w, r, name, info.ModTime(), f)
 }
 
@@ -483,6 +485,10 @@ func controlSujetURL(id string) string {
 
 func controlCorrigeURL(id string) string {
 	return controlDetailURL(id) + "/corrige.pdf"
+}
+
+func controlPoolJSONURL(id string) string {
+	return controlDetailURL(id) + "/pool.json"
 }
 
 func controlScansURL(id string) string {

--- a/apps/server/internal/app/web/handler/controls_test.go
+++ b/apps/server/internal/app/web/handler/controls_test.go
@@ -3,6 +3,7 @@ package handler_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"log/slog"
 	"net/http"
@@ -538,7 +539,7 @@ func TestDetailRendersMetadataAndDownloadLinks(t *testing.T) {
 		t.Fatalf("Detail status = %d, want 200", rec.Code)
 	}
 	body := rec.Body.String()
-	for _, want := range []string{"Control 1", "Descargar prueba", "Descargar clave", "Aún no hay escaneos"} {
+	for _, want := range []string{"Control 1", "Descargar prueba", "Descargar clave", "Descargar respaldo", "Aún no hay escaneos"} {
 		if !strings.Contains(body, want) {
 			t.Errorf("detail body missing %q", want)
 		}
@@ -592,6 +593,61 @@ func TestSujetPDF404sWhenTheControlIsUnknown(t *testing.T) {
 	req = f.authedRequest(t, http.MethodGet, "/controls/short/sujet.pdf", nil)
 	req.SetPathValue("id", "short")
 	f.handler.SujetPDF(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status(bad shape) = %d, want 404", rec.Code)
+	}
+}
+
+func TestPoolJSONStreamsTheSnapshot(t *testing.T) {
+	f := newControlsFixture(t)
+	rec := httptest.NewRecorder()
+	f.handler.Create(rec, f.authedRequest(t, http.MethodPost, handler.ControlsPath, validForm()))
+	loc := rec.Header().Get("Location")
+	id := strings.TrimPrefix(loc, handler.ControlsPath+"/")
+
+	rec = httptest.NewRecorder()
+	req := f.authedRequest(t, http.MethodGet, loc+"/pool.json", nil)
+	req.SetPathValue("id", id)
+	f.handler.PoolJSON(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PoolJSON status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	if cd := rec.Header().Get("Content-Disposition"); !strings.Contains(cd, "attachment") {
+		t.Errorf("Content-Disposition = %q, want attachment (backup material, not a page)", cd)
+	}
+	// The body is the snapshot Create wrote — parse it back and check the
+	// control's id arrived.
+	var snap controls.PoolSnapshot
+	if err := json.Unmarshal(rec.Body.Bytes(), &snap); err != nil {
+		t.Fatalf("pool.json body does not parse: %v", err)
+	}
+	if snap.Control.ID != id {
+		t.Errorf("pool.json control id = %q, want %q", snap.Control.ID, id)
+	}
+	if len(snap.Pool) == 0 {
+		t.Error("pool.json pool is empty")
+	}
+}
+
+func TestPoolJSON404sWhenTheControlIsUnknown(t *testing.T) {
+	f := newControlsFixture(t)
+
+	rec := httptest.NewRecorder()
+	req := f.authedRequest(t, http.MethodGet, "/controls/AAAAAAAAAAAAAAAAAAAAAAAAAA/pool.json", nil)
+	req.SetPathValue("id", "AAAAAAAAAAAAAAAAAAAAAAAAAA")
+	f.handler.PoolJSON(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status(well-shaped unknown) = %d, want 404", rec.Code)
+	}
+
+	rec = httptest.NewRecorder()
+	req = f.authedRequest(t, http.MethodGet, "/controls/short/pool.json", nil)
+	req.SetPathValue("id", "short")
+	f.handler.PoolJSON(rec, req)
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("status(bad shape) = %d, want 404", rec.Code)
 	}

--- a/apps/server/internal/app/web/router.go
+++ b/apps/server/internal/app/web/router.go
@@ -149,6 +149,10 @@ func routes(deps Deps) []Route {
 			Method: http.MethodGet, Path: handler.ControlCorrigePath,
 			Handler: deps.Controls.CorrigePDF,
 		},
+		{
+			Method: http.MethodGet, Path: handler.ControlPoolJSONPath,
+			Handler: deps.Controls.PoolJSON,
+		},
 		// WP-F: the upload target. Gated by default (no Public), CSRF
 		// enforced because the method is POST.
 		{

--- a/apps/server/internal/app/web/view/templates/pages/controls_detail.html
+++ b/apps/server/internal/app/web/view/templates/pages/controls_detail.html
@@ -20,6 +20,7 @@
     <p>
       <a class="boton" href="{{ .SujetURL }}">Descargar prueba (sujet.pdf)</a>
       <a class="boton" href="{{ .CorrigeURL }}">Descargar clave (corrige.pdf)</a>
+      <a class="boton" href="{{ .PoolJSONURL }}">Descargar respaldo de preguntas (pool.json)</a>
     </p>
   </section>
 

--- a/apps/server/internal/app/web/view/view.go
+++ b/apps/server/internal/app/web/view/view.go
@@ -211,6 +211,9 @@ type ControlDetailPage struct {
 	Control    DetailedControl
 	SujetURL   string
 	CorrigeURL string
+	// PoolJSONURL is the download of the pool snapshot written at Create
+	// time (issue #198).
+	PoolJSONURL string
 	// ScansURL is the POST target of the upload form.
 	ScansURL string
 	// MaxScanMB is what the Spanish "máximo N MB" hint says on the

--- a/apps/server/internal/domain/controls/pool.go
+++ b/apps/server/internal/domain/controls/pool.go
@@ -1,0 +1,112 @@
+// The pool snapshot: a self-contained backup of what a generated control
+// drew from, written beside source.tex at Create time (issue #198). It is
+// backup material, not a join source — the database's control_pregunta
+// stays authoritative for grading, and this file exists so a control keeps
+// its historical questions even after the published bank evolves.
+package controls
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/course/bank"
+)
+
+// PoolSnapshot is the shape of pool.json. The question half mirrors the
+// published bank's questions.json (lowercase keys, same field names) so a
+// reader already knows it; the control half is the generation metadata.
+// It carries no student data: the pool is the public question bank.
+type PoolSnapshot struct {
+	Version int `json:"version"`
+	Control struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+		// Unix seconds, like the control row's column. Null when the form
+		// declared no date.
+		ApplicationDate  *int64 `json:"application_date"`
+		FromDocument     string `json:"from_document"`
+		FromSection      string `json:"from_section"`
+		ToDocument       string `json:"to_document"`
+		ToSection        string `json:"to_section"`
+		QuestionsPerCopy int    `json:"questions_per_copy"`
+		Copies           int    `json:"copies"`
+		DuplexPadding    bool   `json:"duplex_padding"`
+		Seed             int64  `json:"seed"`
+		// Unix seconds. The snapshot's own write time, evaluated when the
+		// file is written — the control row's created_at stays where it is
+		// (persist time), the two timestamps differ by the generation.
+		CreatedAt int64 `json:"created_at"`
+	} `json:"control"`
+	// Pool is in reading order, the order the generator emitted.
+	Pool []PoolQuestion `json:"pool"`
+}
+
+// PoolQuestion is one question as it entered the pool, in full — the
+// same shape questions.json publishes, so the two files read alike.
+type PoolQuestion struct {
+	ID           string    `json:"id"`
+	Document     string    `json:"document"`
+	Anchor       string    `json:"anchor"`
+	Type         string    `json:"type"`
+	Statement    string    `json:"statement"`
+	Code         *PoolCode `json:"code"`
+	Alternatives []string  `json:"alternatives"`
+	Correct      []int     `json:"correct"`
+}
+
+// PoolCode is a staged code listing, nil-safe like the bank's own field.
+type PoolCode struct {
+	Language string `json:"language"`
+	Source   string `json:"source"`
+}
+
+// writePoolSnapshot marshals the pool and writes it to path. Called inside
+// Create's guarded region: a failure anywhere afterwards rolls the whole
+// project directory away, snapshot included — the all-or-nothing contract
+// covers this file like any other.
+func writePoolSnapshot(path string, id string, req CreateRequest, pool []bank.Question, seed int64, now time.Time) error {
+	snap := PoolSnapshot{Version: 1}
+	snap.Control.ID = id
+	snap.Control.Name = req.Name
+	if req.ApplicationDate != nil {
+		unix := req.ApplicationDate.Unix()
+		snap.Control.ApplicationDate = &unix
+	}
+	snap.Control.FromDocument = req.RangeFrom.Document
+	snap.Control.FromSection = req.RangeFrom.Section
+	snap.Control.ToDocument = req.RangeTo.Document
+	snap.Control.ToSection = req.RangeTo.Section
+	snap.Control.QuestionsPerCopy = req.QuestionsPerCopy
+	snap.Control.Copies = req.Copies
+	snap.Control.DuplexPadding = req.DuplexPadding
+	snap.Control.Seed = seed
+	snap.Control.CreatedAt = now.Unix()
+
+	snap.Pool = make([]PoolQuestion, len(pool))
+	for i, q := range pool {
+		pq := PoolQuestion{
+			ID:           q.ID,
+			Document:     q.Document,
+			Anchor:       q.Anchor,
+			Type:         q.Type,
+			Statement:    q.Statement,
+			Alternatives: q.Alternatives,
+			Correct:      q.Correct,
+		}
+		if q.Code != nil {
+			pq.Code = &PoolCode{Language: q.Code.Language, Source: q.Code.Source}
+		}
+		snap.Pool[i] = pq
+	}
+
+	data, err := json.MarshalIndent(snap, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	if err := os.WriteFile(path, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}

--- a/apps/server/internal/domain/controls/service.go
+++ b/apps/server/internal/domain/controls/service.go
@@ -206,6 +206,14 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (Control, error
 		return Control{}, fmt.Errorf("controls.Create: write source: %w", err)
 	}
 
+	// The pool snapshot (issue #198) goes down beside the source, inside
+	// the same guarded region: a failure below rolls it away with the rest
+	// of the project.
+	if err := writePoolSnapshot(filepath.Join(projectDir, "pool.json"), id, req, pool, s.Seed, s.Now()); err != nil {
+		rollback()
+		return Control{}, fmt.Errorf("controls.Create: write pool snapshot: %w", err)
+	}
+
 	// Worker paths are relative to /work: it prefixes them itself with
 	// its own mount (worker.py's under_work).
 	assets, err := s.Generator.Generate(ctx, GenerateRequest{
@@ -298,6 +306,12 @@ func (s *Service) SujetPath(controlID string) string {
 // CorrigePath returns the corrige.pdf's full path on the server side.
 func (s *Service) CorrigePath(controlID string) string {
 	return filepath.Join(s.ProjectDir(controlID), "out", "corrige.pdf")
+}
+
+// PoolJSONPath returns the pool snapshot's full path on the server side
+// (issue #198).
+func (s *Service) PoolJSONPath(controlID string) string {
+	return filepath.Join(s.ProjectDir(controlID), "pool.json")
 }
 
 // workerPath joins components under WorkerWorkDir using forward slashes.

--- a/apps/server/internal/domain/controls/service_test.go
+++ b/apps/server/internal/domain/controls/service_test.go
@@ -2,6 +2,7 @@ package controls_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -240,6 +241,39 @@ func TestCreateWritesFilesAndPersistsTheControl(t *testing.T) {
 	}
 	if !strings.Contains(string(source), "\\AMCrandomseed{1242}") {
 		t.Errorf("source.tex is missing the configured seed")
+	}
+
+	// The pool snapshot (issue #198) sits beside the source: the control's
+	// metadata plus every pool question in full, self-contained.
+	snapPath := filepath.Join(workDir, "controls", got.ID, "pool.json")
+	raw, err := os.ReadFile(snapPath)
+	if err != nil {
+		t.Fatalf("read pool.json: %v", err)
+	}
+	var snap controls.PoolSnapshot
+	if err := json.Unmarshal(raw, &snap); err != nil {
+		t.Fatalf("pool.json does not parse: %v\n---\n%s", err, raw)
+	}
+	if snap.Version != 1 {
+		t.Errorf("pool.json version = %d, want 1", snap.Version)
+	}
+	if snap.Control.ID != got.ID || snap.Control.Name != "Control 1" {
+		t.Errorf("pool.json control = %+v", snap.Control)
+	}
+	if snap.Control.Seed != 1242 {
+		t.Errorf("pool.json seed = %d, want 1242", snap.Control.Seed)
+	}
+	if snap.Control.QuestionsPerCopy != 3 || snap.Control.Copies != 5 {
+		t.Errorf("pool.json counts = %d/%d, want 3/5",
+			snap.Control.QuestionsPerCopy, snap.Control.Copies)
+	}
+	if len(snap.Pool) != 4 {
+		t.Fatalf("pool.json pool = %d questions, want 4 (the fixture range)", len(snap.Pool))
+	}
+	for i, q := range snap.Pool {
+		if q.ID == "" || q.Statement == "" || len(q.Alternatives) == 0 || len(q.Correct) == 0 {
+			t.Errorf("pool.json pool[%d] is not self-contained: %+v", i, q)
+		}
 	}
 }
 


### PR DESCRIPTION
**Closes #198**

## Summary

A generated control now leaves a self-contained backup of what it drew
from: `controls/<id>/pool.json` beside its `source.tex`, with the control's
metadata (name, range, counts, seed, dates) and every pool question in
full — same shape as the published `questions.json`, so the two read
alike. The backoffice detail page grows a download link for it.

This exists because the database stores only the pool's question REFS
(`control_pregunta`), and the question content lives in the published
bank, which evolves — a control generated today would lose its historical
questions the day a bank question is edited or deleted. The snapshot is
backup material, not a join source.

## Slices completed

- [x] S1 — Service.Create writes the pool snapshot + test
- [x] S2 — backoffice detail offers the pool.json download + tests

## Acceptance criteria

- **Creating a control produces a readable `pool.json` with the full
  pool.** Pinned by `TestCreateWritesFilesAndPersistsTheControl`, which
  parses the written file back and asserts the metadata and the
  self-contained questions. The file is written inside Create's guarded
  region, so the existing rollback test covers its removal on failure.
- **The backoffice detail page offers its download.**
  `TestDetailRendersMetadataAndDownloadLinks` asserts the new button;
  `TestPoolJSONStreamsTheSnapshot` serves the real file written by the
  handler's own Create with `Content-Type: application/json` and
  `Content-Disposition: attachment`; `TestPoolJSON404sWhenTheControlIsUnknown`
  covers the unknown and badly-shaped ids.

## Tests

- `apps/server` per-commit: gofmt clean, `go vet`, `go build`,
  `go test ./...` — 25 packages green.
- `apps/server` pre-PR: `go test -race -count=1 ./...` green (25
  packages), `govulncheck` no findings, `docker compose up -d --build
  --wait server` boots healthy with `/health` and `/api/health`
  answering `{"process":"up","database":"up"}`.

## Reviews run

The pre-PR protocol above was run line by line from
`docs/standards/testing-strategy.md`. The review-pipeline run is not yet
done; it can be launched after this PR is opened.

## Manual verification

- [ ] Create a control in the backoffice and download its `pool.json` —
      it must contain the control's metadata and the full pool.
- [ ] `GOOGLE-CHECK.md` — not required (no login-path change).

## Notes

- The storage model: the snapshot lives inside the control's own random-id
  project directory on the shared `/work` volume, beside the PDFs — it
  cannot collide with other controls' files or with the scans (which live
  under `scans/`), and it carries no student data.
- The `/work` volume is not covered by the nightly S3 backup (that covers
  the database); the download link exists so the professor can keep a copy
  elsewhere.
