### PR TITLE
feat: umbral de oscuridad end-to-end (upload → note → annotate) con default que lee marcas X

### DIFF
--- a/apps/amc-worker/Makefile
+++ b/apps/amc-worker/Makefile
@@ -138,7 +138,7 @@ read-paper-min:
 		    --n-copies "$$N" \
 		    --data /work/project/data --prefix /work/project \
 		    /work/src/control-paper-min.tex >/dev/null; \
-		  auto-multiple-choice note --data /work/project/data --seuil 0.3 >/dev/null; \
+		  auto-multiple-choice note --data /work/project/data --seuil 0.15 >/dev/null; \
 		  python3 /opt/amc-worker/read_capture.py --data /work/project/data'
 
 ## read-paper — read the scanned batch back (step 4 of PAPER-CHECK.md)
@@ -168,5 +168,5 @@ read-paper:
 		    --n-copies "$$N" \
 		    --data /work/project/data --prefix /work/project \
 		    /work/src/control-demo.tex >/dev/null; \
-		  auto-multiple-choice note --data /work/project/data --seuil 0.3 >/dev/null; \
+		  auto-multiple-choice note --data /work/project/data --seuil 0.15 >/dev/null; \
 		  python3 /opt/amc-worker/read_capture.py --data /work/project/data'

--- a/apps/amc-worker/PAPER-CHECK-MIN.md
+++ b/apps/amc-worker/PAPER-CHECK-MIN.md
@@ -103,10 +103,10 @@ first-cycle question, not a full validation.
    `digits: []`. The hand-written `RUT:` line on the sheet gives the
    correct value.
 4. **Sheet 2 Q1 doubtful.** The light-pencil answer should come back with
-   `status: doubtful` (its `darkness` in `[0.10, 0.30)`) or `status: blank`
-   (below `0.10`). Either is informative — a doubtful means the professor
-   sees it in the review queue; a blank means the sensitivity needs
-   lowering. Write the number down.
+   `status: doubtful` (its `darkness` in `[0.05, 0.15)`, the issue #197
+   defaults) or `status: blank` (below `0.05`). Either is informative — a
+   doubtful means the professor sees it in the review queue; a blank means
+   the sensitivity needs lowering. Write the number down.
 5. **Sheet 3 Q1 ambiguous.** The double-marked answer should come back with
    `status: ambiguous` and both indices in `marked`. Sheet 3's RUT should
    read the CORRECTED digit (or come back unreadable if the erasure left

--- a/apps/amc-worker/PAPER-CHECK.md
+++ b/apps/amc-worker/PAPER-CHECK.md
@@ -136,12 +136,14 @@ becomes a confident answer, `--unsure` is where it stops being noticed at all. A
 mark that came back `blank` fell below `--unsure`, and lowering `--ticked` alone
 cannot rescue it.
 
-**A re-read at another `--ticked` comes back with `scoring.stale: true`**, and
-that is the report telling the truth rather than a fault: the marks moved and
-the per-question scores did not, because AMC scored them at its own threshold
-during `make read-paper`. The marks are what this step calibrates, so read
-them; the scores in a stale report belong to the previous threshold and are
-evidence of nothing before the batch is scored again.
+**A CLI re-read at another `--ticked` comes back with `scoring.stale: true`**,
+and that is the report telling the truth rather than a fault: the marks moved
+and the per-question scores did not, because this script scores at its own
+threshold during `make read-paper`. The marks are what this step calibrates,
+so read them; the scores in a stale report belong to the previous threshold
+and are evidence of nothing before the batch is scored again. (The SERVER's
+re-read does not have this caveat: since issue #197 `POST /reanalyse` re-runs
+`note` at the new threshold, so marks and scores move together.)
 
 ## 5. What to look for
 
@@ -163,8 +165,9 @@ of how badly a "no" would hurt:
 4. **How did the faint pencil on sheet 2 read?** `doubtful` is the right answer
    — the report should carry it under `doubtful` with its measured `darkness`,
    not under `marked`. If it came back `blank`, the mark was below `unsure`
-   (0.10) and the sensitivity needs lowering; if it came back a confident
-   `marked`, it was above `ticked` (0.30) and your "faint" was not faint. Both
+   (0.05, the issue #197 default) and the sensitivity needs lowering; if it
+   came back a confident `marked`, it was above `ticked` (0.15) and your
+   "faint" was not faint. Both
    are useful measurements of where a real pencil actually lands — write the
    number down. The two flags move different boundaries; see §4.
 5. **Did the corrected mark on sheet 6 read as the corrected value**, or as

--- a/apps/amc-worker/README.md
+++ b/apps/amc-worker/README.md
@@ -276,10 +276,12 @@ correct → 4/4; one correct and nothing wrong → 3/4; only a wrong one → 1/4
 score comes back negative.
 
 **The report says which threshold those scores were computed at.** AMC's `note`
-scores at its own `--seuil` while `--ticked` is ours and tunable, so a re-read of
-a stored capture at another sensitivity moves the marks and leaves the scores
-where they were. `scoring: {seuil, ticked, stale}` carries both and flags the
-disagreement rather than hiding it.
+scores at its own `--seuil` while `--ticked` is ours and tunable, so a CLI
+re-read of a stored capture at another sensitivity moves the marks and leaves
+the scores where they were — `scoring: {seuil, ticked, stale}` carries both
+and flags the disagreement rather than hiding it. The HTTP routes never
+produce it: since issue #197 `/analyse` and `/reanalyse` run `note` at the
+same `ticked` they read with, so marks and scores move together.
 
 **Reading requires a SCORED batch**, not only a captured one: the reader opens
 `scoring.sqlite` as well, which exists only after `prepare --mode b` and `note`

--- a/apps/amc-worker/README.md
+++ b/apps/amc-worker/README.md
@@ -68,11 +68,14 @@ POST /analyse       { project, scan_pdf, source,      → { pages, scoring, copi
                     note run at the same ticked — marks, scores and any
                     downstream annotated PDF agree on one threshold.
 POST /reanalyse     { project, [ticked], [unsure] }    → { pages, scoring, copies, needs_review }
+                    re-runs note at the new ticked, so the scores follow
+                    the marks (issue #197).
 POST /associate     { project, roster, code, key }    → { associations, refused_codes }
 POST /associate/set { project, copy, id }             → { copy, id, source }
 POST /annotate      { project, roster, key, out,      → { pdfs, unidentified }
                       [name_column], [verdict] }
-POST /annotate/copy { project, copy, [overrides] }   → { path, copy }
+POST /annotate/copy { project, copy, [overrides],     → { path, copy }
+                      [ticked] }
                     one annotated PDF for ONE copy (copy-N.pdf under
                     <project>/annotated/, overwritten on re-run).
                     overrides = { rut?, answers: [{question, marked}] }

--- a/apps/amc-worker/README.md
+++ b/apps/amc-worker/README.md
@@ -61,9 +61,13 @@ rollback died on it, issue #193).
 ```
 GET  /health                                          → { ok, amc }
 POST /generate      { project, source, copies }       → { sujet, corrige, calage, copies }
-POST /analyse       { project, scan_pdf, source }     → { pages, scoring, copies, needs_review }
-                    ⏱ MINUTES-CLASS — background job only, see below
-POST /reanalyse     { project, ticked, unsure }       → { pages, scoring, copies, needs_review }
+POST /analyse       { project, scan_pdf, source,      → { pages, scoring, copies, needs_review }
+                      [ticked], [unsure] }
+                    ⏱ MINUTES-CLASS — background job only, see below.
+                    ticked/unsure (issue #197): the darkness verdicts AND
+                    note run at the same ticked — marks, scores and any
+                    downstream annotated PDF agree on one threshold.
+POST /reanalyse     { project, [ticked], [unsure] }    → { pages, scoring, copies, needs_review }
 POST /associate     { project, roster, code, key }    → { associations, refused_codes }
 POST /associate/set { project, copy, id }             → { copy, id, source }
 POST /annotate      { project, roster, key, out,      → { pdfs, unidentified }
@@ -234,10 +238,14 @@ because they need different repairs:
 | answer `blank` / `ambiguous` / `doubtful` | what did they mark | a human looks at the sheet |
 | `status: incomplete` | the copy printed questions this batch never captured | find the sheet and scan it again |
 
-A box above `ticked` (0.30) is marked; above `unsure` (0.10) it is **doubtful**
-and reported separately, never counted as an answer. That band is where a
-half-erased pencil lands, and it is the one region a solid synthetic fill (~0.63)
-can never reach — so it is exercised by its own batch in `03-read.sh`.
+A box at or above `ticked` (0.15) is marked; at or above `unsure` (0.05) it
+is **doubtful** and reported separately, never counted as an answer. Those
+defaults are issue #197's, chosen from a real batch (Jetson 2026-08-19):
+pencil X marks measured 0.14-0.32 darkness, painted squares 0.62-1.00 and
+empty boxes ~0.0 — the old 0.30 cut straight through the X band. The
+doubtful band is where a half-erased pencil or a faint X lands, and it is
+the one region a solid synthetic fill (~0.63) can never reach — so it is
+exercised by its own batch in `03-read.sh`.
 
 **Each answer says which kind of question it is** — `type: "simple"` or
 `type: "multiple"` — and on a multiple one **several marks are the answer**, not

--- a/apps/amc-worker/read_capture.py
+++ b/apps/amc-worker/read_capture.py
@@ -6,8 +6,8 @@ Runs INSIDE the worker image. Emits JSON on stdout:
     {                                              // shape, not a real reading:
       "pages": {"captured": 10, "failed": 0},       // the fixture's own numbers
                                                     // are in tests/03-read.sh
-      "scoring": {"seuil": 0.3,                      // what AMC's `note` used
-                  "ticked": 0.3,                     // what THIS reading used
+      "scoring": {"seuil": 0.15,                     // what AMC's `note` used
+                  "ticked": 0.15,                    // what THIS reading used
                   "stale": false},                   // true when they differ
       "copies": {
         "1": {

--- a/apps/amc-worker/read_capture.py
+++ b/apps/amc-worker/read_capture.py
@@ -435,9 +435,9 @@ def read(data_dir, ticked, unsure):
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--data", required=True, help="AMC project data directory")
-    ap.add_argument("--ticked", type=float, default=0.30,
+    ap.add_argument("--ticked", type=float, default=0.15,
                     help="darkness at or above which a box counts as ticked")
-    ap.add_argument("--unsure", type=float, default=0.10,
+    ap.add_argument("--unsure", type=float, default=0.05,
                     help="darkness at or above which a box is reported as doubtful")
     args = ap.parse_args()
     try:

--- a/apps/amc-worker/tests/03-read.sh
+++ b/apps/amc-worker/tests/03-read.sh
@@ -120,7 +120,12 @@ note_scoring() {
 check "the batch can be scored" note_scoring
 
 report="${work}/report.json"
-if ! run python3 /opt/amc-worker/read_capture.py --data /work/project/data >"$report" 2>/dev/null; then
+# The 0.30/0.10 pins below are deliberate: this file documents the
+# historical band that issue #197's defaults replaced, and its fixtures
+# (a faint mark at 0.15) were tuned to it. Explicit flags keep the pins
+# true whatever the CLI defaults are.
+if ! run python3 /opt/amc-worker/read_capture.py --data /work/project/data \
+    --ticked 0.30 --unsure 0.10 >"$report" 2>/dev/null; then
   fail "capture is readable as a report" "read_capture.py failed"
   summary
 fi
@@ -352,7 +357,8 @@ damaged_pipeline() {
 check "a batch with a faint mark and a missing page can be read" damaged_pipeline
 
 drep="${dwork}/report.json"
-drun python3 /opt/amc-worker/read_capture.py --data /work/project/data >"$drep" 2>/dev/null || true
+drun python3 /opt/amc-worker/read_capture.py --data /work/project/data \
+    --ticked 0.30 --unsure 0.10 >"$drep" 2>/dev/null || true
 djq() { python3 -c "import json,sys; d=json.load(open('$drep')); print($1)" 2>/dev/null || echo ""; }
 
 # F-2: a faint mark must NOT be reported as a confident answer. The earlier code

--- a/apps/amc-worker/tests/06-http.sh
+++ b/apps/amc-worker/tests/06-http.sh
@@ -298,6 +298,14 @@ check_eq "the marks come back at the new threshold" "False" \
 check_eq "and the scores follow them" "False" \
   "$(echo "$reread_t" | field 'all(a["score"] == 0 for a in d["copies"]["1"]["answers"])')"
 
+# The other extreme (AC-2's second case): at ticked=0.01 everything counts
+# as a mark — the same sheets that were blank at 0.9.
+reread_low="$(post /reanalyse '{"project":"project-t","ticked":0.01,"unsure":0}' || true)"
+check_eq "at 0.01 every box counts as a mark" "False" \
+  "$(echo "$reread_low" | field 'all(a["marked"] == [] for a in d["copies"]["1"]["answers"])')"
+check_eq "and the seuil follows" "0.01" \
+  "$(echo "$reread_low" | field 'd["scoring"]["seuil"]')"
+
 # --- /annotate/copy — the corrected copy, issue #190 ---------------------------
 #
 # The worker half of the annotate loop: the server sends the professor's

--- a/apps/amc-worker/tests/06-http.sh
+++ b/apps/amc-worker/tests/06-http.sh
@@ -91,6 +91,12 @@ check_eq "with none failed" "0" "$(echo "$rep" | field 'd["pages"]["failed"]')"
 check_eq "and reads copy 1's RUT back" "20123456" "$(echo "$rep" | field 'd["copies"]["1"]["rut"]')"
 check_eq "and queues exactly the damaged copies" "['3', '4', '5']" \
   "$(echo "$rep" | field 'sorted(d["needs_review"])')"
+# Issue #197: the default threshold is 0.15 (X marks measure 0.14-0.32), and
+# the SAME value reaches AMC's note — the report says which seuil scored it.
+check_eq "the default threshold travels into scoring" "0.15" \
+  "$(echo "$rep" | field 'd["scoring"]["seuil"]')"
+check_eq "and the reader used the same default" "0.15" \
+  "$(echo "$rep" | field 'd["scoring"]["ticked"]')"
 
 # ADR-0037: the server serves review-page images at
 # `<work>/controls/<id>/scans/copy-<N>-page-<M>.<ext>`. After /analyse the
@@ -248,6 +254,36 @@ check_eq "and with a real denominator on every question" "False" \
   "$(echo "$rep6" | field 'any(a["max"] is None for a in d["copies"]["6"]["answers"])')"
 note "copy 6 over HTTP" \
   "$(echo "$rep6" | field '[(a["name"], a["score"], a["max"]) for a in d["copies"]["6"]["answers"]]')"
+
+# --- issue #197: the threshold travels, not only on paper ---------------------
+#
+# The same sheets analysed at two thresholds must produce two different
+# scorings. ticked=0.9 (above every real mark) blanks everything: the marks
+# the reader reports, the scores note computed, and the seuil recorded all
+# agree on 0.9 — one number, three consumers.
+
+printf '{"1": {"rut": "20123456", "answers": [1, 1, 1, 1]},\n' >"$work/plan-t.json"
+printf ' "2": {"rut": "19876543", "answers": [2, 2, 2, 2]}}\n' >>"$work/plan-t.json"
+
+gen_t="$(post /generate '{"project":"project-t","source":"src/control-demo.tex","copies":2}')"
+check_eq "two copies generate for the threshold probe" "2" \
+  "$(echo "$gen_t" | field 'd["copies"]')"
+
+check "the threshold-probe sheets can be filled" \
+  docker run --rm --env DISPLAY= -v "${work}:/work" -w /work "$IMAGE" \
+  python3 /work/fill_sheet.py --layout /work/project-t/data/layout.sqlite \
+  --sujet /work/project-t/out/sujet.pdf --out /work/scan-t \
+  --plan /work/plan-t.json --pdf /work/scan-t/lote.pdf
+
+rep_t="$(post /analyse '{"project":"project-t","scan_pdf":"scan-t/lote.pdf","source":"src/control-demo.tex","ticked":0.9,"unsure":0.05}' || true)"
+check_eq "the chosen threshold reaches note's --seuil" "0.9" \
+  "$(echo "$rep_t" | field 'd["scoring"]["seuil"]')"
+check_eq "at 0.9 no box counts as a mark" "True" \
+  "$(echo "$rep_t" | field 'all(a["marked"] == [] for a in d["copies"]["1"]["answers"])')"
+check_eq "and no question scores a point" "True" \
+  "$(echo "$rep_t" | field 'all(a["score"] == 0 for a in d["copies"]["1"]["answers"])')"
+check_eq "an inverted band is refused, not silently reordered" "400" \
+  "$(post_status /analyse '{"project":"project-t","scan_pdf":"scan-t/lote.pdf","source":"src/control-demo.tex","ticked":0.05,"unsure":0.2}')"
 
 # --- /annotate/copy — the corrected copy, issue #190 ---------------------------
 #

--- a/apps/amc-worker/tests/06-http.sh
+++ b/apps/amc-worker/tests/06-http.sh
@@ -285,6 +285,19 @@ check_eq "and no question scores a point" "True" \
 check_eq "an inverted band is refused, not silently reordered" "400" \
   "$(post_status /analyse '{"project":"project-t","scan_pdf":"scan-t/lote.pdf","source":"src/control-demo.tex","ticked":0.05,"unsure":0.2}')"
 
+# Issue #197, reanalyse half: re-reading at a new threshold re-runs note at
+# it too, so the scores follow the marks and the report can no longer go
+# stale through this route.
+reread_t="$(post /reanalyse '{"project":"project-t","ticked":0.15,"unsure":0.05}' || true)"
+check_eq "reanalyse re-runs note at the new seuil" "0.15" \
+  "$(echo "$reread_t" | field 'd["scoring"]["seuil"]')"
+check_eq "and the report is no longer stale" "False" \
+  "$(echo "$reread_t" | field 'd["scoring"]["stale"]')"
+check_eq "the marks come back at the new threshold" "False" \
+  "$(echo "$reread_t" | field 'all(a["marked"] == [] for a in d["copies"]["1"]["answers"])')"
+check_eq "and the scores follow them" "False" \
+  "$(echo "$reread_t" | field 'all(a["score"] == 0 for a in d["copies"]["1"]["answers"])')"
+
 # --- /annotate/copy — the corrected copy, issue #190 ---------------------------
 #
 # The worker half of the annotate loop: the server sends the professor's
@@ -335,6 +348,16 @@ check_eq "a no-overrides annotate restores the original reading" "Nota: 1/4" \
 # Go marshals an empty marked slice as null; the worker must read null as
 # a blank override, not as a malformed field (measured: the null body used
 # to answer 400 while the save itself had succeeded).
+# Issue #197, annotate half: the same capture annotated at two thresholds
+# produces two verdicts — the drawn score is what proves ticked reached
+# note, not a log line.
+ac_high="$(post /annotate/copy '{"project":"project","copy":1,"ticked":0.9}' || true)"
+check_eq "annotating at ticked 0.9 blanks every score" "Nota: 0/4" \
+  "$(annotated_text)"
+ac_restore="$(post /annotate/copy '{"project":"project","copy":1}' || true)"
+check_eq "and without ticked the default restores the original verdict" "Nota: 1/4" \
+  "$(annotated_text)"
+
 null_blank="$(python3 -c "
 import json
 rep = json.load(open('${work}/report.json'))

--- a/apps/amc-worker/worker.py
+++ b/apps/amc-worker/worker.py
@@ -78,8 +78,14 @@ CALLER_UID = 65532
 # The same two defaults read_capture.py declares — stated here rather than
 # derived from each other, because they are independent tunables and PAPER-CHECK
 # tells the professor to move one of them alone.
-TICKED = 0.30
-UNSURE = 0.10
+#
+# The values are the issue #197 defaults, chosen from a real batch (Jetson,
+# 2026-08-19): pencil X marks measured 0.14-0.32 darkness, painted squares
+# 0.62-1.00, empty boxes ~0.0 — 0.30 cut straight through the X band. 0.15
+# reads every X except the faintest tail, which falls into the doubtful band
+# (0.05-0.15) and stays visible in needs_review instead of being lost.
+TICKED = 0.15
+UNSURE = 0.05
 
 # AMC keeps its state in sqlite files inside the project directory, and nothing
 # about `prepare`/`analyse`/`note` is re-entrant over one project. Threading the
@@ -221,11 +227,35 @@ def generate(body):
     }
 
 
+def parse_thresholds(body):
+    """Read the optional ticked/unsure pair with the band rule enforced.
+
+    Absent fields fall back to the worker defaults. The band rule is the
+    reader's contract: unsure must sit strictly below ticked, or the
+    "doubtful" band the review queue relies on inverts. Issue #197: /analyse
+    takes the pair too (it used to be reanalyse-only), so the checks live
+    here once instead of twice.
+    """
+    ticked = float(body.get("ticked", TICKED))
+    unsure = float(body.get("unsure", UNSURE))
+    if not 0 < ticked < 1:
+        raise Failed(f"ticked must be in (0, 1), got {ticked}")
+    if not 0 <= unsure < ticked:
+        raise Failed(f"unsure must be in [0, ticked), got {unsure} vs ticked {ticked}")
+    return ticked, unsure
+
+
 def analyse(body):
-    """Read a scan batch and score it, in the one order that works."""
+    """Read a scan batch and score it, in the one order that works.
+
+    Optional `ticked`/`unsure` (issue #197): the darkness verdicts AND
+    AMC's `note` run at the same `ticked`, so the report's marks, scores
+    and any downstream annotated PDF agree on one threshold.
+    """
     project, data = project_paths(body)
     scan_pdf = under_work(body["scan_pdf"], must_exist=True)
     source = under_work(body["source"], must_exist=True)
+    ticked, unsure = parse_thresholds(body)
 
     scans = os.path.join(project, "scans")
     listing = os.path.join(scans, "list.txt")
@@ -247,7 +277,9 @@ def analyse(body):
     amc("prepare", "--mode", "b", "--with", "pdflatex",
         "--n-copies", read_capture.printed_copies(data),
         "--data", data, "--prefix", project, source)
-    amc("note", "--data", data, "--seuil", str(TICKED))
+    # Same threshold the reader will use: marks, scores and (later) the
+    # annotated PDF all agree — scoring.stale cannot come from this route.
+    amc("note", "--data", data, "--seuil", str(ticked))
 
     # ADR-0037: the server serves review-page images at
     # `<work>/controls/<id>/scans/copy-<N>-page-<M>.<ext>`. AMC's `getimages`
@@ -260,7 +292,7 @@ def analyse(body):
     # on every scanned copy of Miguel's first real batch.
     link_scans_to_contract_names(data, os.path.join(project, "scans"))
 
-    return read_capture.read(data, TICKED, UNSURE)
+    return read_capture.read(data, ticked, unsure)
 
 
 def scan_link_targets(rows):
@@ -316,17 +348,13 @@ def reanalyse(body):
     """Re-read a captured project at new thresholds, without a new capture.
 
     Same project directory as `/analyse`, no scan_pdf: the read runs against
-    the sqlite files AMC already wrote and only the darkness verdicts move.
-    The scores stay where `note` left them, and the report's `scoring.stale`
-    is the caller's cue (ADR-0031 §The report says which threshold).
+    the sqlite files AMC already wrote. Issue #197: `note` re-runs at the
+    NEW seuil too, so the scores follow the marks — the report's
+    `scoring.stale` can no longer come from this route (it survives for
+    whoever drives the CLI by hand with a divergent seuil, ADR-0031).
     """
     _project, data = project_paths(body)
-    ticked = float(body.get("ticked", TICKED))
-    unsure = float(body.get("unsure", UNSURE))
-    if not 0 < ticked < 1:
-        raise Failed(f"ticked must be in (0, 1), got {ticked}")
-    if not 0 <= unsure < ticked:
-        raise Failed(f"unsure must be in [0, ticked), got {unsure} vs ticked {ticked}")
+    ticked, unsure = parse_thresholds(body)
     return read_capture.read(data, ticked, unsure)
 
 

--- a/apps/amc-worker/worker.py
+++ b/apps/amc-worker/worker.py
@@ -236,8 +236,13 @@ def parse_thresholds(body):
     takes the pair too (it used to be reanalyse-only), so the checks live
     here once instead of twice.
     """
-    ticked = float(body.get("ticked", TICKED))
-    unsure = float(body.get("unsure", UNSURE))
+    try:
+        ticked = float(body.get("ticked", TICKED))
+        unsure = float(body.get("unsure", UNSURE))
+    except (TypeError, ValueError) as exc:
+        # A malformed field is the caller's mistake and can never succeed
+        # on retry — 400, not a 500 from the dispatcher's exception net.
+        raise Failed("ticked and unsure must be numbers", str(exc))
     if not 0 < ticked < 1:
         raise Failed(f"ticked must be in (0, 1), got {ticked}")
     if not 0 <= unsure < ticked:
@@ -459,7 +464,10 @@ def annotate_copy(body):
     if copy < 1:
         raise Failed("copy must be at least 1")
     overrides = body.get("overrides") or {}
-    ticked = float(body.get("ticked", TICKED))
+    try:
+        ticked = float(body.get("ticked", TICKED))
+    except (TypeError, ValueError) as exc:
+        raise Failed("ticked must be a number", str(exc))
     if not 0 < ticked < 1:
         raise Failed(f"ticked must be in (0, 1), got {ticked}")
 

--- a/apps/amc-worker/worker.py
+++ b/apps/amc-worker/worker.py
@@ -355,6 +355,7 @@ def reanalyse(body):
     """
     _project, data = project_paths(body)
     ticked, unsure = parse_thresholds(body)
+    amc("note", "--data", data, "--seuil", str(ticked))
     return read_capture.read(data, ticked, unsure)
 
 
@@ -442,6 +443,10 @@ def annotate_copy(body):
 
     Idempotent: re-annotating a copy overwrites its file, so the review
     page always sees the latest correction.
+
+    Optional `ticked` (issue #197): `note` runs at it, so the drawn marks
+    and the verdict agree with the reader's verdict — the server sends the
+    control's stored threshold.
     """
     project, data = project_paths(body)
     copy = body["copy"]
@@ -454,6 +459,9 @@ def annotate_copy(body):
     if copy < 1:
         raise Failed("copy must be at least 1")
     overrides = body.get("overrides") or {}
+    ticked = float(body.get("ticked", TICKED))
+    if not 0 < ticked < 1:
+        raise Failed(f"ticked must be in (0, 1), got {ticked}")
 
     if not os.path.isfile(os.path.join(data, "capture.sqlite")):
         raise Failed("no capture in this project", "run /analyse first")
@@ -485,7 +493,7 @@ def annotate_copy(body):
     # annotate: `note` reads capture_zone.manual, which is the override
     # channel (re-patched or reset) applied above. Unconditional on purpose
     # — after a reset the raw scores must come back too.
-    amc("note", "--data", data, "--seuil", str(TICKED))
+    amc("note", "--data", data, "--seuil", str(ticked))
 
     sujet = os.path.join(project, "out", "sujet.pdf")
     if not os.path.isfile(sujet):

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -192,6 +192,12 @@ scan while none exists. `NALANDA_ANNOTATE_ENABLED=false` switches the whole
 loop off. Closing a correction fires the `OnCorrectionClosed` hook — today a
 no-op logger, tomorrow the seam email/Canvas integrations hang off.
 
+Since issue #197 one darkness-threshold pair travels with every control
+(ADR-0041): the upload and reanalyse forms set it (defaults 0.15/0.05, the
+X-friendly pair measured on a real batch), and the same `ticked` drives the
+reader, AMC's `note` and the annotated PDF — marks, scores and the drawn
+sheet always agree.
+
 Routes today:
 
 | Route | What |
@@ -201,8 +207,8 @@ Routes today:
 | `GET /controls/new` · `POST /controls` | Pick a section range, generate the PDF |
 | `GET /controls/{id}` | Detail: metadata, PDF downloads, the Escaneos upload form, the Resultados table and (after upload) the *Cerrar corrección* button |
 | `GET /controls/{id}/sujet.pdf` · `GET /controls/{id}/corrige.pdf` | Streamed from the shared volume |
-| `POST /controls/{id}/scans` | Multipart PDF upload — hands the file to the worker's `/analyse`, persists the report, flips the state to `in_review` |
-| `POST /controls/{id}/reanalyze` | Re-reads the stored captures at new `ticked`/`unsure` thresholds without a new capture |
+| `POST /controls/{id}/scans` | Multipart PDF upload — hands the file to the worker's `/analyse` at the submitted thresholds, persists the report and the pair, annotates clean copies, flips the state to `in_review` |
+| `POST /controls/{id}/reanalyze` | Re-reads the stored captures at new `ticked`/`unsure` thresholds without a new capture, re-scores at them, and re-annotates the clean copies (issue #197) |
 | `POST /controls/{id}/close` | Moves the control to `graded` when every failure kind is resolved (WP-F S8), then fires `OnCorrectionClosed` (issue #190) |
 | `GET /controls/{id}/copies/{copy}/review` · `POST` | Split view — corrected PDF (or raw scan) + editable form; POST saves overrides through `answer_override` / `rut_override` and re-annotates the copy |
 | `GET /controls/{id}/copies/{copy}/page/{n}` | Streams the scanned page image from the shared volume |

--- a/apps/server/internal/app/web/handler/controls.go
+++ b/apps/server/internal/app/web/handler/controls.go
@@ -179,16 +179,18 @@ func (h *Controls) Detail(w http.ResponseWriter, r *http.Request) {
 	}
 
 	page := view.ControlDetailPage{
-		Page:          middleware.PageFor(r, c.Name),
-		Control:       toDetailedControl(c, h.Bank),
-		SujetURL:      controlSujetURL(c.ID),
-		CorrigeURL:    controlCorrigeURL(c.ID),
-		ScansURL:      controlScansURL(c.ID),
-		ReanalyzeURL:  controlReanalyzeURL(c.ID),
-		CloseURL:      controlCloseURL(c.ID),
-		MaxScanMB:     h.MaxScanBytes >> 20,
-		CurrentTicked: defaultTicked,
-		CurrentUnsure: defaultUnsure,
+		Page:         middleware.PageFor(r, c.Name),
+		Control:      toDetailedControl(c, h.Bank),
+		SujetURL:     controlSujetURL(c.ID),
+		CorrigeURL:   controlCorrigeURL(c.ID),
+		ScansURL:     controlScansURL(c.ID),
+		ReanalyzeURL: controlReanalyzeURL(c.ID),
+		CloseURL:     controlCloseURL(c.ID),
+		MaxScanMB:    h.MaxScanBytes >> 20,
+		// Issue #197: the pair the control was last read at — the prefill
+		// for both threshold forms and the "umbral actual" line.
+		CurrentTicked: c.Ticked,
+		CurrentUnsure: c.Unsure,
 		Graded:        c.State == controls.Graded,
 	}
 	readings, err := h.Service.ReadingsFor(r.Context(), c.ID)

--- a/apps/server/internal/app/web/handler/scans.go
+++ b/apps/server/internal/app/web/handler/scans.go
@@ -24,11 +24,18 @@ const ControlReanalyzePath = "/controls/{id}/reanalyze"
 // ControlClosePath is POST target for "Cerrar corrección" (S8).
 const ControlClosePath = "/controls/{id}/close"
 
-// Defaults for the reanalyze form, mirroring apps/amc-worker.
-const (
-	defaultTicked = 0.30
-	defaultUnsure = 0.10
-)
+// resolveThresholds parses the two optional form fields against the
+// control's stored pair (the form prefill), and enforces the band rule.
+// ok is false when a provided value fails to parse or the pair is
+// invalid. Issue #197.
+func resolveThresholds(rawTicked, rawUnsure string, c controls.Control) (float64, float64, bool) {
+	ticked := parseFloatField(rawTicked, c.Ticked)
+	unsure := parseFloatField(rawUnsure, c.Unsure)
+	if !controls.ThresholdsValid(ticked, unsure) {
+		return 0, 0, false
+	}
+	return ticked, unsure, true
+}
 
 // uploadWriteWindow is how long the upload handler may take before the
 // server's write deadline cuts it. /analyse is minutes-class (53s for a
@@ -109,10 +116,37 @@ func (h *Controls) UploadScan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Issue #197: the optional threshold fields resolve against the
+	// control's stored pair (the form prefill), so a crafted POST that
+	// omits one lands on the control's own pair, never on garbage.
+	control, err := h.Service.Get(r.Context(), id)
+	if err != nil {
+		_ = file.Close()
+		if errors.Is(err, controls.ErrControlNotFound) {
+			middleware.WriteError(w, r, http.StatusNotFound, "Ese control no existe.")
+			return
+		}
+		h.Log.Error("upload: reading control for thresholds", "error", err, "id", id)
+		middleware.WriteError(w, r, http.StatusInternalServerError,
+			"Algo se rompió en el servidor. Vuelve a intentarlo en unos segundos.")
+		return
+	}
+	ticked, unsure, ok := resolveThresholds(
+		r.PostFormValue("ticked"), r.PostFormValue("unsure"), control)
+	if !ok {
+		_ = file.Close()
+		flash.Set(w, h.secureCookie,
+			"Los umbrales deben cumplir 0 < inseguro < marcado < 1.")
+		http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
+		return
+	}
+
 	result, err := h.Service.UploadScan(r.Context(), controls.UploadRequest{
 		ControlID: id,
 		Filename:  header.Filename,
 		Content:   file,
+		Ticked:    ticked,
+		Unsure:    unsure,
 	})
 	if err != nil {
 		switch {
@@ -141,9 +175,9 @@ func (h *Controls) UploadScan(w http.ResponseWriter, r *http.Request) {
 }
 
 // ReanalyzeScans handles POST /controls/:id/reanalyze. Reads ticked/unsure
-// from the form (defaults if empty), asks the Service to re-read the
-// captured project at those thresholds, and redirects to detail with a
-// flash.
+// from the form (prefilled with the control's stored pair), asks the
+// Service to re-read the captured project at those thresholds, and
+// redirects to detail with a flash.
 func (h *Controls) ReanalyzeScans(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if !isValidControlID(id) {
@@ -155,14 +189,35 @@ func (h *Controls) ReanalyzeScans(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
 		return
 	}
-	ticked := parseFloatField(r.PostFormValue("ticked"), defaultTicked)
-	unsure := parseFloatField(r.PostFormValue("unsure"), defaultUnsure)
-	if ticked <= 0 || ticked >= 1 || unsure < 0 || unsure >= ticked {
+	control, err := h.Service.Get(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, controls.ErrControlNotFound) {
+			middleware.WriteError(w, r, http.StatusNotFound, "Ese control no existe.")
+			return
+		}
+		h.Log.Error("reanalyze: reading control for thresholds", "error", err, "id", id)
+		middleware.WriteError(w, r, http.StatusInternalServerError,
+			"Algo se rompió en el servidor. Vuelve a intentarlo en unos segundos.")
+		return
+	}
+	ticked, unsure, ok := resolveThresholds(
+		r.PostFormValue("ticked"), r.PostFormValue("unsure"), control)
+	if !ok {
 		flash.Set(w, h.secureCookie,
 			"Los umbrales deben cumplir 0 < inseguro < marcado < 1.")
 		http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
 		return
 	}
+
+	// Issue #197: the re-read now also re-runs note and re-annotates every
+	// clean copy — minutes-class work, so the route claims its own write
+	// deadline like the upload does.
+	controller := http.NewResponseController(w)
+	if err := controller.SetWriteDeadline(time.Now().Add(uploadWriteWindow)); err != nil &&
+		!errors.Is(err, http.ErrNotSupported) {
+		h.Log.Warn("controls: cannot extend the reanalyze write deadline", "error", err)
+	}
+
 	if _, err := h.Service.Reanalyze(r.Context(), id, ticked, unsure); err != nil {
 		switch {
 		case errors.Is(err, controls.ErrControlNotFound):

--- a/apps/server/internal/app/web/handler/scans_test.go
+++ b/apps/server/internal/app/web/handler/scans_test.go
@@ -8,6 +8,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,6 +41,13 @@ func (f *controlsFixture) createControl(t *testing.T, name string, copies int) s
 // buildScanUpload writes a multipart body with a single PDF part.
 func buildScanUpload(t *testing.T, filename, contentType string, body []byte) (*bytes.Buffer, string) {
 	t.Helper()
+	return buildScanUploadWithFields(t, filename, contentType, body, nil)
+}
+
+// buildScanUploadWithFields is buildScanUpload plus extra form fields —
+// the threshold pair since issue #197.
+func buildScanUploadWithFields(t *testing.T, filename, contentType string, body []byte, fields map[string]string) (*bytes.Buffer, string) {
+	t.Helper()
 	var buf bytes.Buffer
 	w := multipart.NewWriter(&buf)
 	partHeader := make(map[string][]string)
@@ -55,6 +63,11 @@ func buildScanUpload(t *testing.T, filename, contentType string, body []byte) (*
 	}
 	if _, err := part.Write(body); err != nil {
 		t.Fatalf("write body: %v", err)
+	}
+	for name, value := range fields {
+		if err := w.WriteField(name, value); err != nil {
+			t.Fatalf("WriteField %s: %v", name, err)
+		}
 	}
 	if err := w.Close(); err != nil {
 		t.Fatalf("close writer: %v", err)
@@ -317,5 +330,116 @@ func TestAnnotateDisabledServesRawEverywhere(t *testing.T) {
 	}
 	if !strings.Contains(body, `<img src="/controls/`+controlID+`/copies/1/page/1"`) {
 		t.Errorf("review page must serve the raw scan with the flow disabled\n%s", body)
+	}
+}
+
+// Issue #197: the optional threshold fields travel with the upload — the
+// analyzer is asked to read at them, the control stores them, and the
+// annotate calls carry the stored ticked so the PDFs agree.
+func TestUploadScanWithExplicitThresholds(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control umbral", 1)
+	f.fake.AnalyzeReports = []controls.Report{
+		{Copies: map[string]controls.ReportCopy{"1": okCopy("20100001")}},
+	}
+
+	body, ct := buildScanUploadWithFields(t, "batch.pdf", "application/pdf",
+		[]byte("%PDF-fake"), map[string]string{"ticked": "0.25", "unsure": "0.10"})
+	req := f.authedRequest(t, http.MethodPost, "/controls/"+controlID+"/scans", nil)
+	req.Body = io.NopCloser(body)
+	req.Header.Set("Content-Type", ct)
+	req.ContentLength = int64(body.Len())
+	req.SetPathValue("id", controlID)
+
+	rec := httptest.NewRecorder()
+	f.handler.UploadScan(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d\nbody: %s", rec.Code, rec.Body.String())
+	}
+
+	last, _ := f.fake.LastAnalyzeCall()
+	if last.Ticked != 0.25 || last.Unsure != 0.10 {
+		t.Errorf("Analyze called with (%v, %v), want (0.25, 0.10)", last.Ticked, last.Unsure)
+	}
+	got, err := f.service.Get(context.Background(), controlID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Ticked != 0.25 || got.Unsure != 0.10 {
+		t.Errorf("control stored (%v, %v), want (0.25, 0.10)", got.Ticked, got.Unsure)
+	}
+	annotate, ok := f.fake.LastAnnotateCall()
+	if !ok {
+		t.Fatal("no annotate call")
+	}
+	if annotate.Ticked != 0.25 {
+		t.Errorf("annotate called with ticked %v, want the stored 0.25", annotate.Ticked)
+	}
+}
+
+// The re-read persists the pair it used and re-annotates the copies the
+// new reading accepts (ruta A over the new report).
+func TestReanalyzePersistsThresholdsAndReannotates(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control re", 1)
+	f.fake.AnalyzeReports = []controls.Report{
+		{Copies: map[string]controls.ReportCopy{"1": okCopy("20100001")}},
+	}
+	uploadOnce(t, f, controlID)
+	before := f.fake.AnnotateCallCount()
+
+	f.fake.ReanalyzeReports = []controls.Report{
+		{Copies: map[string]controls.ReportCopy{"1": okCopy("20100001")}},
+	}
+	values := url.Values{"ticked": {"0.20"}, "unsure": {"0.05"}}
+	req := f.authedRequest(t, http.MethodPost, "/controls/"+controlID+"/reanalyze", values)
+	req.SetPathValue("id", controlID)
+	rec := httptest.NewRecorder()
+	f.handler.ReanalyzeScans(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d\nbody: %s", rec.Code, rec.Body.String())
+	}
+	got, err := f.service.Get(context.Background(), controlID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Ticked != 0.20 || got.Unsure != 0.05 {
+		t.Errorf("control stored (%v, %v), want (0.20, 0.05)", got.Ticked, got.Unsure)
+	}
+	if after := f.fake.AnnotateCallCount(); after != before+1 {
+		t.Errorf("AnnotateCallCount = %d after reanalyze, want %d (one re-annotated ok copy)",
+			after, before+1)
+	}
+	if _, exists, err := f.cstore.AnnotatedByCopy(context.Background(), controlID, 1); err != nil || !exists {
+		t.Errorf("annotated row after reanalyze: exists=%v err=%v, want the re-annotation", exists, err)
+	}
+	annotate, _ := f.fake.LastAnnotateCall()
+	if annotate.Ticked != 0.20 {
+		t.Errorf("re-annotate called with ticked %v, want the stored 0.20", annotate.Ticked)
+	}
+}
+
+// The band rule is enforced at the form boundary: an inverted pair never
+// reaches the worker.
+func TestReanalyzeRefusesAnInvertedBand(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control banda", 1)
+	f.fake.AnalyzeReports = []controls.Report{
+		{Copies: map[string]controls.ReportCopy{"1": okCopy("20100001")}},
+	}
+	uploadOnce(t, f, controlID)
+
+	values := url.Values{"ticked": {"0.05"}, "unsure": {"0.20"}}
+	req := f.authedRequest(t, http.MethodPost, "/controls/"+controlID+"/reanalyze", values)
+	req.SetPathValue("id", controlID)
+	rec := httptest.NewRecorder()
+	f.handler.ReanalyzeScans(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if count := len(f.fake.ReanalyzeCalls); count != 0 {
+		t.Errorf("Reanalyze called %d times with an inverted band, want 0", count)
 	}
 }

--- a/apps/server/internal/app/web/view/templates/pages/controls_detail.html
+++ b/apps/server/internal/app/web/view/templates/pages/controls_detail.html
@@ -39,7 +39,7 @@
       </p>
       <p>
         <label>Marcado (0–1): <input type="number" name="ticked" min="0.01" max="0.99" step="0.01" value="{{ printf "%.2f" .CurrentTicked }}"></label>
-        <label>Inseguro (0–marcado): <input type="number" name="unsure" min="0" max="0.99" step="0.01" value="{{ printf "%.2f" .CurrentUnsure }}"></label>
+        <label>Inseguro (0–marcado): <input type="number" name="unsure" min="0" step="0.01" value="{{ printf "%.2f" .CurrentUnsure }}"></label>
       </p>
       <p><button type="submit">Subir escaneos</button></p>
     </form>
@@ -68,7 +68,7 @@
           <input type="hidden" name="csrf_token" value="{{ .CSRFToken }}">
           <p>
             <label>Marcado (0–1): <input type="number" name="ticked" min="0.01" max="0.99" step="0.01" value="{{ printf "%.2f" .CurrentTicked }}"></label>
-            <label>Inseguro (0–marcado): <input type="number" name="unsure" min="0" max="0.99" step="0.01" value="{{ printf "%.2f" .CurrentUnsure }}"></label>
+            <label>Inseguro (0–marcado): <input type="number" name="unsure" min="0" step="0.01" value="{{ printf "%.2f" .CurrentUnsure }}"></label>
             <button type="submit">Re-leer</button>
           </p>
         </form>

--- a/apps/server/internal/app/web/view/templates/pages/controls_detail.html
+++ b/apps/server/internal/app/web/view/templates/pages/controls_detail.html
@@ -25,6 +25,7 @@
 
   <section>
     <h2>Escaneos</h2>
+    <p>Umbral actual: marcado {{ printf "%.2f" .CurrentTicked }} · inseguro {{ printf "%.2f" .CurrentUnsure }} — bájalo para leer marcas X.</p>
     {{ if not .Readings }}
       <p>Aún no hay escaneos subidos.</p>
     {{ else }}
@@ -35,6 +36,10 @@
       <p>
         <label for="scan">Archivo PDF (máximo {{ .MaxScanMB }} MB):</label><br>
         <input type="file" id="scan" name="scan" accept="application/pdf" required>
+      </p>
+      <p>
+        <label>Marcado (0–1): <input type="number" name="ticked" min="0.01" max="0.99" step="0.01" value="{{ printf "%.2f" .CurrentTicked }}"></label>
+        <label>Inseguro (0–marcado): <input type="number" name="unsure" min="0" max="0.99" step="0.01" value="{{ printf "%.2f" .CurrentUnsure }}"></label>
       </p>
       <p><button type="submit">Subir escaneos</button></p>
     </form>

--- a/apps/server/internal/domain/controls/annotate.go
+++ b/apps/server/internal/domain/controls/annotate.go
@@ -28,6 +28,11 @@ type AnnotateRequest struct {
 	Project   string
 	Copy      int
 	Overrides AnnotateOverrides
+	// Ticked is the darkness threshold the annotated PDF must agree with
+	// (issue #197): the worker re-runs `note` at it, so the drawn marks
+	// and the verdict match the reader's verdict. Always set by the
+	// Service from the control's stored pair.
+	Ticked float64
 }
 
 // AnnotateOverrides is the professor's corrections, keyed the way the
@@ -92,6 +97,7 @@ func (s *Service) Annotate(ctx context.Context, controlID string, copyNumber int
 		Project:   filepath.Join(projectPrefix, control.ID),
 		Copy:      copyNumber,
 		Overrides: overridesFromReading(reading),
+		Ticked:    control.Ticked,
 	})
 	if err != nil {
 		return AnnotatedCopy{}, err

--- a/apps/server/internal/domain/controls/annotate_test.go
+++ b/apps/server/internal/domain/controls/annotate_test.go
@@ -48,7 +48,12 @@ func newAnnotateFixture(t *testing.T, annotateEnabled bool) *annotateFixture {
 		Seed:            1242,
 		Log:             slog.New(slog.NewTextHandler(io.Discard, nil)),
 	})
-	control := controls.Control{ID: "CTRL0001ABC0000000000000AA", Copies: 5}
+	control := controls.Control{
+		ID:     "CTRL0001ABC0000000000000AA",
+		Copies: 5,
+		Ticked: controls.DefaultTicked,
+		Unsure: controls.DefaultUnsure,
+	}
 	store.controls = append(store.controls, control)
 	return &annotateFixture{svc: svc, store: store, readings: readings, fake: fake, control: control}
 }
@@ -96,6 +101,11 @@ func TestAnnotateSendsTheOverridesAndPersistsTheRecord(t *testing.T) {
 	}
 	if call.Copy != 3 {
 		t.Errorf("Copy = %d, want 3", call.Copy)
+	}
+	// Issue #197: the control's stored threshold travels with the annotate
+	// call — the PDF must agree with the reader's verdict.
+	if call.Ticked != controls.DefaultTicked {
+		t.Errorf("Ticked = %v, want the control's stored %v", call.Ticked, controls.DefaultTicked)
 	}
 	if want := "controls/" + f.control.ID; call.Project != want {
 		t.Errorf("Project = %q, want %q", call.Project, want)

--- a/apps/server/internal/domain/controls/controls.go
+++ b/apps/server/internal/domain/controls/controls.go
@@ -50,10 +50,29 @@ type Control struct {
 	// SQL level is 1 (padded) so pre-migration controls stay padded, but
 	// every caller in Go passes an explicit value.
 	DuplexPadding bool
-	State         State
-	CreatedAt     time.Time
-	CreatedBy     int64 // users.user_id
+	// Ticked/Unsure are the darkness thresholds this control's batches are
+	// read and scored at (issue #197). One pair per control, last-wins:
+	// the upload form can set them, the reanalyse form re-sets them, and
+	// the worker uses the same ticked for the reader, note and the
+	// annotated PDF. The zero value is not a valid pair; Create writes the
+	// product defaults below.
+	Ticked    float64
+	Unsure    float64
+	State     State
+	CreatedAt time.Time
+	CreatedBy int64 // users.user_id
 }
+
+// DefaultTicked / DefaultUnsure are the product defaults for a newly
+// generated control (issue #197). Measured on a real batch (Jetson
+// 2026-08-19): pencil X marks read 0.14-0.32 darkness, painted squares
+// 0.62-1.00, empty boxes ~0.0 — the previous 0.30 cut through the X band.
+// 0.15 reads every X except the faintest tail, which lands in the
+// doubtful band (0.05-0.15) and stays visible in needs_review.
+const (
+	DefaultTicked = 0.15
+	DefaultUnsure = 0.05
+)
 
 // PoolEntry is one authored question that was actually drawn from at
 // generation time, in the order it was drawn in. The pair (ControlID, Ref)
@@ -131,6 +150,11 @@ type Store interface {
 	// Reanalyze re-reads at new thresholds and invalidates the old
 	// drawings).
 	ClearAnnotated(ctx context.Context, controlID string) error
+
+	// SetControlThresholds persists the darkness pair a batch was read
+	// at (issue #197). Last-wins: each upload and each reanalyse writes
+	// the pair it used, and Annotate reads it back so the PDFs agree.
+	SetControlThresholds(ctx context.Context, controlID string, ticked, unsure float64) error
 }
 
 // Generator asks the AMC worker to compile a .tex into printable PDFs.

--- a/apps/server/internal/domain/controls/reading.go
+++ b/apps/server/internal/domain/controls/reading.go
@@ -129,6 +129,13 @@ type AnalyzeRequest struct {
 	Project string // AMC project directory, relative to /work
 	ScanPDF string // the batch to read, relative to /work
 	Source  string // the .tex the control was generated from, relative to /work
+	// Ticked/Unsure (issue #197): the darkness verdicts AND AMC's `note`
+	// run at the same Ticked, so marks, scores and the annotated PDF agree
+	// on one threshold. Always set by the Service (the control's stored
+	// pair or the form's new one); zero is not a valid Ticked and the
+	// client refuses it.
+	Ticked float64
+	Unsure float64
 }
 
 // ReanalyzeRequest re-reads the SAME captures at different thresholds.

--- a/apps/server/internal/domain/controls/scans.go
+++ b/apps/server/internal/domain/controls/scans.go
@@ -38,6 +38,12 @@ type UploadRequest struct {
 	// Content is where the bytes come from. The Service closes it when it
 	// has copied them (or on any failure).
 	Content io.ReadCloser
+	// Ticked/Unsure (issue #197): the thresholds THIS batch is read and
+	// scored at. Zero means "keep the control's stored pair" — the handler
+	// resolves the form's optional fields against the control before
+	// calling, so a concrete pair always arrives here.
+	Ticked float64
+	Unsure float64
 }
 
 // UploadResult reports what the upload produced. Not consumed today, but a
@@ -94,14 +100,31 @@ func (s *Service) UploadScan(ctx context.Context, req UploadRequest) (UploadResu
 	}
 
 	project := filepath.Join(projectPrefix, control.ID)
+	ticked, unsure := req.Ticked, req.Unsure
+	if ticked == 0 {
+		// The handler always resolves the form (optional fields fall back
+		// to the control's stored pair), but a caller that skips that step
+		// gets the stored pair rather than a refusal.
+		ticked, unsure = control.Ticked, control.Unsure
+	}
+	if !ThresholdsValid(ticked, unsure) {
+		return UploadResult{}, fmt.Errorf("%w: invalid thresholds (%v, %v)",
+			ErrAnalyzerRefused, ticked, unsure)
+	}
 	report, err := s.Analyzer.Analyze(ctx, AnalyzeRequest{
 		Project: project,
 		ScanPDF: filepath.ToSlash(filepath.Join(project, uploadsDir, batchName)),
 		Source:  filepath.ToSlash(filepath.Join(project, "inputs", "source.tex")),
+		Ticked:  ticked,
+		Unsure:  unsure,
 	})
 	if err != nil {
 		rollbackFile()
 		return UploadResult{}, err
+	}
+	if err := s.Store.SetControlThresholds(ctx, control.ID, ticked, unsure); err != nil {
+		rollbackFile()
+		return UploadResult{}, fmt.Errorf("controls.UploadScan: persist thresholds: %w", err)
 	}
 
 	now := s.Now()
@@ -115,30 +138,8 @@ func (s *Service) UploadScan(ctx context.Context, req UploadRequest) (UploadResu
 	}
 
 	// Issue #190, ruta A: every copy the reader accepted as clean gets its
-	// annotated PDF right away, before any human touches the queue. One
-	// /annotate/copy call per copy is seconds-class, and the batch as a
-	// whole was minutes-class anyway.
-	//
-	// A failure here must not fail the upload: the reading is already
-	// persisted and the professor can retry the same copy from the review
-	// page (ruta B) — or switch the whole loop off by config.
-	for key, copy := range report.Copies {
-		if copy.Status != CopyStatusOK {
-			continue
-		}
-		copyNumber, err := strconv.Atoi(key)
-		if err != nil {
-			// The worker keys copies by decimal string; a key that does not
-			// parse is a worker-side contract break, not something a retry
-			// would fix.
-			s.Log.Warn("controls.UploadScan: unparseable copy key", "control", control.ID, "key", key)
-			continue
-		}
-		if _, err := s.Annotate(ctx, control.ID, copyNumber); err != nil {
-			s.Log.Warn("controls.UploadScan: annotate failed",
-				"control", control.ID, "copy", copyNumber, "error", err)
-		}
-	}
+	// annotated PDF right away, before any human touches the queue.
+	s.annotateCleanCopies(ctx, control, report)
 
 	// Move the control forward — but never backwards. A re-upload to a
 	// graded control leaves state=graded (S8 renders the "editing a closed
@@ -174,15 +175,56 @@ func (s *Service) Reanalyze(ctx context.Context, controlID string, ticked, unsur
 	if err := s.Readings.UpsertReadingsFromReport(ctx, control.ID, report, s.Now()); err != nil {
 		return Report{}, fmt.Errorf("controls.Reanalyze: persist: %w", err)
 	}
+	// Issue #197: the pair this re-read used becomes the control's — the
+	// next annotate (and the next reanalyse's defaults) agree with it.
+	if err := s.Store.SetControlThresholds(ctx, control.ID, ticked, unsure); err != nil {
+		return Report{}, fmt.Errorf("controls.Reanalyze: persist thresholds: %w", err)
+	}
 	// The stored annotated PDFs were drawn at the PREVIOUS thresholds, so
 	// they no longer agree with the report just persisted — same class as
 	// the report-vs-grade disagreement ADR-0031 exists to forbid. Drop the
-	// rows: the review page falls back to the raw scan, and the next save
-	// (or upload) re-annotates at the new reading.
+	// rows and re-annotate the copies the new reading accepts as clean
+	// (issue #197: ruta A over the new report), so the professor does not
+	// have to save copy by copy to see corrected PDFs again.
 	if err := s.Store.ClearAnnotated(ctx, control.ID); err != nil {
 		return Report{}, fmt.Errorf("controls.Reanalyze: clear annotated: %w", err)
 	}
+	s.annotateCleanCopies(ctx, control, report)
 	return report, nil
+}
+
+// annotateCleanCopies runs ruta A over a report: one Service.Annotate per
+// status:ok copy. One /annotate/copy call per copy is seconds-class, and
+// the flows that call this were minutes-class anyway. A failure must not
+// fail the caller's operation: the reading is already persisted and the
+// professor can retry the same copy from the review page (ruta B) — or
+// switch the whole loop off by config.
+func (s *Service) annotateCleanCopies(ctx context.Context, control Control, report Report) {
+	for key, copy := range report.Copies {
+		if copy.Status != CopyStatusOK {
+			continue
+		}
+		copyNumber, err := strconv.Atoi(key)
+		if err != nil {
+			// The worker keys copies by decimal string; a key that does not
+			// parse is a worker-side contract break, not something a retry
+			// would fix.
+			s.Log.Warn("controls: unparseable copy key", "control", control.ID, "key", key)
+			continue
+		}
+		if _, err := s.Annotate(ctx, control.ID, copyNumber); err != nil {
+			s.Log.Warn("controls: annotate failed",
+				"control", control.ID, "copy", copyNumber, "error", err)
+		}
+	}
+}
+
+// ThresholdsValid reports whether a ticked/unsure pair respects the band
+// rule the reader's contract depends on: ticked inside (0,1) and unsure
+// strictly below it. Shared by the Service (defense in depth) and the
+// handlers (form validation) — the worker runs the same rule.
+func ThresholdsValid(ticked, unsure float64) bool {
+	return ticked > 0 && ticked < 1 && unsure >= 0 && unsure < ticked
 }
 
 // Readings returns every reading for a control, ordered by copy_number.

--- a/apps/server/internal/domain/controls/scans.go
+++ b/apps/server/internal/domain/controls/scans.go
@@ -76,6 +76,19 @@ func (s *Service) UploadScan(ctx context.Context, req UploadRequest) (UploadResu
 	if err != nil {
 		return UploadResult{}, err
 	}
+	// Issue #197: refuse a bad pair BEFORE anything touches the disk — the
+	// all-or-nothing promise covers the batch file too.
+	ticked, unsure := req.Ticked, req.Unsure
+	if ticked == 0 {
+		// The handler always resolves the form (optional fields fall back
+		// to the control's stored pair), but a caller that skips that step
+		// gets the stored pair rather than a refusal.
+		ticked, unsure = control.Ticked, control.Unsure
+	}
+	if !ThresholdsValid(ticked, unsure) {
+		return UploadResult{}, fmt.Errorf("%w: invalid thresholds (%v, %v)",
+			ErrAnalyzerRefused, ticked, unsure)
+	}
 
 	projectDir := s.ProjectDir(control.ID)
 	uploads := filepath.Join(projectDir, uploadsDir)
@@ -100,17 +113,6 @@ func (s *Service) UploadScan(ctx context.Context, req UploadRequest) (UploadResu
 	}
 
 	project := filepath.Join(projectPrefix, control.ID)
-	ticked, unsure := req.Ticked, req.Unsure
-	if ticked == 0 {
-		// The handler always resolves the form (optional fields fall back
-		// to the control's stored pair), but a caller that skips that step
-		// gets the stored pair rather than a refusal.
-		ticked, unsure = control.Ticked, control.Unsure
-	}
-	if !ThresholdsValid(ticked, unsure) {
-		return UploadResult{}, fmt.Errorf("%w: invalid thresholds (%v, %v)",
-			ErrAnalyzerRefused, ticked, unsure)
-	}
 	report, err := s.Analyzer.Analyze(ctx, AnalyzeRequest{
 		Project: project,
 		ScanPDF: filepath.ToSlash(filepath.Join(project, uploadsDir, batchName)),

--- a/apps/server/internal/domain/controls/service.go
+++ b/apps/server/internal/domain/controls/service.go
@@ -242,9 +242,13 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (Control, error
 		QuestionsPerCopy: req.QuestionsPerCopy,
 		Copies:           req.Copies,
 		DuplexPadding:    req.DuplexPadding,
-		State:            Generated,
-		CreatedAt:        s.Now(),
-		CreatedBy:        req.CreatedBy,
+		// Issue #197: the product defaults; the upload and reanalyse
+		// forms change them per batch afterwards.
+		Ticked:    DefaultTicked,
+		Unsure:    DefaultUnsure,
+		State:     Generated,
+		CreatedAt: s.Now(),
+		CreatedBy: req.CreatedBy,
 	}
 	entries := make([]PoolEntry, len(pool))
 	for i, q := range pool {

--- a/apps/server/internal/domain/controls/service_test.go
+++ b/apps/server/internal/domain/controls/service_test.go
@@ -387,3 +387,31 @@ func TestCreatePassesTheCorrectAbsoluteListingPathForCodeQuestions(t *testing.T)
 		t.Errorf("source.tex is missing %q — a listing under the server's mount would not resolve inside the worker", want)
 	}
 }
+
+// Issue #197: the defense-in-depth pair validation refuses before the
+// analyzer is called and before the batch file touches the disk.
+func TestUploadScanRefusesAnInvalidPair(t *testing.T) {
+	svc, store, gen, workDir := newService(t)
+	control, err := svc.Create(context.Background(), req(nil))
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	_, err = svc.UploadScan(context.Background(), controls.UploadRequest{
+		ControlID: control.ID,
+		Filename:  "batch.pdf",
+		Content:   io.NopCloser(strings.NewReader("%PDF-fake")),
+		Ticked:    0.05,
+		Unsure:    0.20, // inverted band
+	})
+	if !errors.Is(err, controls.ErrAnalyzerRefused) {
+		t.Fatalf("UploadScan = %v, want ErrAnalyzerRefused", err)
+	}
+	if n := gen.AnalyzeCallCount(); n != 0 {
+		t.Errorf("Analyze called %d times for an invalid pair, want 0", n)
+	}
+	if _, statErr := os.Stat(filepath.Join(workDir, "controls", control.ID, "uploads")); !os.IsNotExist(statErr) {
+		t.Errorf("uploads dir exists after the refusal: %v — the batch file must not touch the disk", statErr)
+	}
+	_ = store
+}

--- a/apps/server/internal/domain/controls/service_test.go
+++ b/apps/server/internal/domain/controls/service_test.go
@@ -107,6 +107,16 @@ func (s *fakeStore) ClearAnnotated(_ context.Context, controlID string) error {
 	return nil
 }
 
+func (s *fakeStore) SetControlThresholds(_ context.Context, controlID string, ticked, unsure float64) error {
+	for i := range s.controls {
+		if s.controls[i].ID == controlID {
+			s.controls[i].Ticked = ticked
+			s.controls[i].Unsure = unsure
+		}
+	}
+	return nil
+}
+
 // fakeReadingStore is the do-nothing double the pre-WP-F cases use. The
 // WP-F flows are exercised through Service.UploadScan in scans_internal_test.go
 // with a real controlstore. readingsByCopy holds stored readings for the

--- a/apps/server/internal/infra/amcworker/analyze.go
+++ b/apps/server/internal/infra/amcworker/analyze.go
@@ -30,6 +30,13 @@ func (c *Client) Analyze(ctx context.Context, req controls.AnalyzeRequest) (cont
 	if req.Source == "" {
 		return controls.Report{}, fmt.Errorf("%w: source path is required", controls.ErrAnalyzerRefused)
 	}
+	// Issue #197: the pair must respect the band rule before it crosses the
+	// wire — the worker runs the same checks, and a refusal here is closer
+	// to the caller that produced the bad pair.
+	if !controls.ThresholdsValid(req.Ticked, req.Unsure) {
+		return controls.Report{}, fmt.Errorf("%w: invalid thresholds (%v, %v)",
+			controls.ErrAnalyzerRefused, req.Ticked, req.Unsure)
+	}
 
 	c.generateLock.Lock()
 	defer c.generateLock.Unlock()
@@ -38,6 +45,8 @@ func (c *Client) Analyze(ctx context.Context, req controls.AnalyzeRequest) (cont
 		Project: req.Project,
 		ScanPDF: req.ScanPDF,
 		Source:  req.Source,
+		Ticked:  req.Ticked,
+		Unsure:  req.Unsure,
 	})
 	if err != nil {
 		return controls.Report{}, fmt.Errorf("amcworker: encode analyse request: %w", err)
@@ -124,9 +133,11 @@ var _ controls.Analyzer = (*Client)(nil)
 // --- wire shapes -------------------------------------------------------------
 
 type analyzeRequestBody struct {
-	Project string `json:"project"`
-	ScanPDF string `json:"scan_pdf"`
-	Source  string `json:"source"`
+	Project string  `json:"project"`
+	ScanPDF string  `json:"scan_pdf"`
+	Source  string  `json:"source"`
+	Ticked  float64 `json:"ticked,omitempty"`
+	Unsure  float64 `json:"unsure,omitempty"`
 }
 
 type reanalyzeRequestBody struct {

--- a/apps/server/internal/infra/amcworker/analyze.go
+++ b/apps/server/internal/infra/amcworker/analyze.go
@@ -136,8 +136,8 @@ type analyzeRequestBody struct {
 	Project string  `json:"project"`
 	ScanPDF string  `json:"scan_pdf"`
 	Source  string  `json:"source"`
-	Ticked  float64 `json:"ticked,omitempty"`
-	Unsure  float64 `json:"unsure,omitempty"`
+	Ticked  float64 `json:"ticked"`
+	Unsure  float64 `json:"unsure"`
 }
 
 type reanalyzeRequestBody struct {

--- a/apps/server/internal/infra/amcworker/analyze_test.go
+++ b/apps/server/internal/infra/amcworker/analyze_test.go
@@ -61,6 +61,8 @@ func TestAnalyzeSendsProjectScanPDFAndSource(t *testing.T) {
 		Project: "controls/abc",
 		ScanPDF: "controls/abc/scans/batch-1.pdf",
 		Source:  "controls/abc/inputs/source.tex",
+		Ticked:  controls.DefaultTicked,
+		Unsure:  controls.DefaultUnsure,
 	})
 	if err != nil {
 		t.Fatalf("Analyze: %v", err)
@@ -68,6 +70,11 @@ func TestAnalyzeSendsProjectScanPDFAndSource(t *testing.T) {
 	if got.Project != "controls/abc" || got.ScanPDF != "controls/abc/scans/batch-1.pdf" ||
 		got.Source != "controls/abc/inputs/source.tex" {
 		t.Errorf("worker received %+v", got)
+	}
+	// Issue #197: the pair travels on the wire, not only through validation.
+	if got.Ticked != controls.DefaultTicked || got.Unsure != controls.DefaultUnsure {
+		t.Errorf("worker received thresholds (%v, %v), want the defaults",
+			got.Ticked, got.Unsure)
 	}
 	// The report round-trips into the domain shape.
 	if report.Pages.Captured != 4 || len(report.Copies) != 1 {
@@ -97,6 +104,7 @@ func TestAnalyzeRefusedOn4xxWrapsErrAnalyzerRefused(t *testing.T) {
 	client := amcworker.New(amcworker.Config{BaseURL: srv.URL})
 	_, err := client.Analyze(context.Background(), controls.AnalyzeRequest{
 		Project: "controls/x", ScanPDF: "controls/x/s.pdf", Source: "controls/x/s.tex",
+		Ticked: controls.DefaultTicked, Unsure: controls.DefaultUnsure,
 	})
 	if !errors.Is(err, controls.ErrAnalyzerRefused) {
 		t.Errorf("Analyze on 400: %v, want ErrAnalyzerRefused", err)
@@ -114,9 +122,14 @@ func TestAnalyzeRefusesInvalidRequestBeforeCallingTheWorker(t *testing.T) {
 	client := amcworker.New(amcworker.Config{BaseURL: srv.URL})
 
 	cases := []controls.AnalyzeRequest{
-		{Project: "", ScanPDF: "s", Source: "t"},
-		{Project: "p", ScanPDF: "", Source: "t"},
-		{Project: "p", ScanPDF: "s", Source: ""},
+		{Project: "", ScanPDF: "s", Source: "t",
+			Ticked: controls.DefaultTicked, Unsure: controls.DefaultUnsure},
+		{Project: "p", ScanPDF: "", Source: "t",
+			Ticked: controls.DefaultTicked, Unsure: controls.DefaultUnsure},
+		{Project: "p", ScanPDF: "s", Source: "",
+			Ticked: controls.DefaultTicked, Unsure: controls.DefaultUnsure},
+		// Issue #197: the band rule is refused before the wire.
+		{Project: "p", ScanPDF: "s", Source: "t", Ticked: 0.05, Unsure: 0.20},
 	}
 	for _, req := range cases {
 		if _, err := client.Analyze(context.Background(), req); !errors.Is(err, controls.ErrAnalyzerRefused) {
@@ -173,9 +186,11 @@ func TestReanalyzeRefusesOutOfRangeThresholds(t *testing.T) {
 }
 
 type analyzeSent struct {
-	Project string `json:"project"`
-	ScanPDF string `json:"scan_pdf"`
-	Source  string `json:"source"`
+	Project string  `json:"project"`
+	ScanPDF string  `json:"scan_pdf"`
+	Source  string  `json:"source"`
+	Ticked  float64 `json:"ticked"`
+	Unsure  float64 `json:"unsure"`
 }
 
 type reanalyzeSent struct {

--- a/apps/server/internal/infra/amcworker/analyze_test.go
+++ b/apps/server/internal/infra/amcworker/analyze_test.go
@@ -76,6 +76,20 @@ func TestAnalyzeSendsProjectScanPDFAndSource(t *testing.T) {
 		t.Errorf("worker received thresholds (%v, %v), want the defaults",
 			got.Ticked, got.Unsure)
 	}
+
+	// unsure=0 is a legal pair (no doubtful band) and must reach the wire
+	// as 0 — an omitempty tag dropped it once, and the worker then silently
+	// read its own 0.05 default.
+	if _, err := client.Analyze(context.Background(), controls.AnalyzeRequest{
+		Project: "controls/abc", ScanPDF: "controls/abc/scans/batch-1.pdf",
+		Source: "controls/abc/inputs/source.tex",
+		Ticked: 0.30, Unsure: 0,
+	}); err != nil {
+		t.Fatalf("Analyze with unsure=0: %v", err)
+	}
+	if got.Unsure != 0 {
+		t.Errorf("worker received unsure %v, want the explicit 0", got.Unsure)
+	}
 	// The report round-trips into the domain shape.
 	if report.Pages.Captured != 4 || len(report.Copies) != 1 {
 		t.Errorf("Report = %+v", report)

--- a/apps/server/internal/infra/amcworker/annotate.go
+++ b/apps/server/internal/infra/amcworker/annotate.go
@@ -23,6 +23,9 @@ func (c *Client) AnnotateCopy(ctx context.Context, req controls.AnnotateRequest)
 	if req.Copy < 1 {
 		return "", fmt.Errorf("%w: copy must be at least 1, got %d", controls.ErrAnnotatorRefused, req.Copy)
 	}
+	if req.Ticked <= 0 || req.Ticked >= 1 {
+		return "", fmt.Errorf("%w: invalid ticked %v", controls.ErrAnnotatorRefused, req.Ticked)
+	}
 
 	c.generateLock.Lock()
 	defer c.generateLock.Unlock()
@@ -31,6 +34,7 @@ func (c *Client) AnnotateCopy(ctx context.Context, req controls.AnnotateRequest)
 		Project:   req.Project,
 		Copy:      req.Copy,
 		Overrides: toWireOverrides(req.Overrides),
+		Ticked:    req.Ticked,
 	})
 	if err != nil {
 		return "", fmt.Errorf("amcworker: encode annotate request: %w", err)
@@ -95,6 +99,7 @@ type annotateRequestBody struct {
 	Project   string                 `json:"project"`
 	Copy      int                    `json:"copy"`
 	Overrides *annotateOverridesBody `json:"overrides,omitempty"`
+	Ticked    float64                `json:"ticked,omitempty"`
 }
 
 type annotateOverridesBody struct {

--- a/apps/server/internal/infra/storage/controlstore/controlstore.go
+++ b/apps/server/internal/infra/storage/controlstore/controlstore.go
@@ -32,7 +32,7 @@ func New(db *sql.DB) *Store {
 // Compile-time proof the shape here is the one the domain asked for.
 var _ controls.Store = (*Store)(nil)
 
-const controlColumns = "id, name, application_date, from_document, from_section, to_document, to_section, questions_per_copy, copies, duplex_padding, state, created_at, created_by"
+const controlColumns = "id, name, application_date, from_document, from_section, to_document, to_section, questions_per_copy, copies, duplex_padding, ticked, unsure, state, created_at, created_by"
 
 // CreateControl writes the control, its pool and its copies in one
 // transaction. Rolled back on any failure so a control never appears in the
@@ -54,7 +54,7 @@ func (s *Store) CreateControl(ctx context.Context, control controls.Control, poo
 
 	if _, err := tx.ExecContext(ctx, `
         INSERT INTO control (`+controlColumns+`)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		control.ID,
 		control.Name,
 		nullableUnixSeconds(control.ApplicationDate),
@@ -62,6 +62,7 @@ func (s *Store) CreateControl(ctx context.Context, control controls.Control, poo
 		control.RangeTo.Document, control.RangeTo.Section,
 		control.QuestionsPerCopy, control.Copies,
 		boolToInt(control.DuplexPadding),
+		control.Ticked, control.Unsure,
 		string(control.State),
 		control.CreatedAt.Unix(),
 		control.CreatedBy,
@@ -172,6 +173,7 @@ func scanControl(row interface{ Scan(...any) error }) (controls.Control, error) 
 		&c.RangeTo.Document, &c.RangeTo.Section,
 		&c.QuestionsPerCopy, &c.Copies,
 		&duplexPadding,
+		&c.Ticked, &c.Unsure,
 		&state, &createdAt, &c.CreatedBy,
 	); err != nil {
 		return controls.Control{}, err
@@ -252,6 +254,19 @@ func (s *Store) AnnotatedByCopy(ctx context.Context, controlID string, copyNumbe
 	}
 	a.GeneratedAt = time.Unix(generated, 0).UTC()
 	return a, true, nil
+}
+
+// SetControlThresholds persists the darkness pair a batch was read at
+// (issue #197). Last-wins: each upload and each reanalyse writes the pair
+// it used, and Annotate reads it back so the PDFs agree.
+func (s *Store) SetControlThresholds(ctx context.Context, controlID string, ticked, unsure float64) error {
+	if _, err := s.db.ExecContext(ctx,
+		`UPDATE control SET ticked = ?, unsure = ? WHERE id = ?`,
+		ticked, unsure, controlID,
+	); err != nil {
+		return fmt.Errorf("controlstore.SetControlThresholds %s: %w", controlID, err)
+	}
+	return nil
 }
 
 // ClearAnnotated deletes every anotado record for a control — the review

--- a/apps/server/internal/infra/storage/controlstore/controlstore_test.go
+++ b/apps/server/internal/infra/storage/controlstore/controlstore_test.go
@@ -57,9 +57,12 @@ func newControl(id string, userID int64, appDate *time.Time) controls.Control {
 		RangeTo:          bank.SectionRef{Document: "flujo", Section: "bucles"},
 		QuestionsPerCopy: 4,
 		Copies:           3,
-		State:            controls.Generated,
-		CreatedAt:        time.Unix(1_755_360_000, 0).UTC(),
-		CreatedBy:        userID,
+		// Issue #197: the product defaults, like Service.Create writes.
+		Ticked:    controls.DefaultTicked,
+		Unsure:    controls.DefaultUnsure,
+		State:     controls.Generated,
+		CreatedAt: time.Unix(1_755_360_000, 0).UTC(),
+		CreatedBy: userID,
 	}
 }
 

--- a/apps/server/internal/infra/storage/schema_test.go
+++ b/apps/server/internal/infra/storage/schema_test.go
@@ -387,3 +387,58 @@ func TestTheAuthMigrationAppliesOverADatabaseThatRanThePlaceholder(t *testing.T)
 		t.Errorf("the auth schema is not usable after the upgrade: %v", err)
 	}
 }
+
+// Issue #197: control.ticked/unsure carry the darkness thresholds end-to-end.
+// The defaults are the X-friendly pair chosen from a real batch; a control
+// inserted without them inherits the defaults, and an UPDATE round-trips.
+func TestControlThresholdsDefaultAndRoundTrip(t *testing.T) {
+	ctx, db := migrated(t)
+	userID := insertProfessor(t, ctx, db, "profesora@example.com")
+
+	if _, err := db.ExecContext(ctx, `
+        INSERT INTO control (
+            id, name, from_document, from_section, to_document, to_section,
+            questions_per_copy, copies, state, created_at, created_by
+        ) VALUES (?, 'x', 'flujo', 'if-else', 'flujo', 'bucles', 4, 3, 'generated', 0, ?)`,
+		"CTRLTHRESH0000000000000000", userID,
+	); err != nil {
+		t.Fatalf("insert control: %v", err)
+	}
+
+	var ticked, unsure float64
+	if err := db.QueryRowContext(ctx,
+		`SELECT ticked, unsure FROM control WHERE id = ?`,
+		"CTRLTHRESH0000000000000000",
+	).Scan(&ticked, &unsure); err != nil {
+		t.Fatalf("read back thresholds: %v", err)
+	}
+	if ticked != 0.15 || unsure != 0.05 {
+		t.Errorf("defaults = (%v, %v), want (0.15, 0.05) — the X-friendly pair of issue #197",
+			ticked, unsure)
+	}
+
+	if _, err := db.ExecContext(ctx,
+		`UPDATE control SET ticked = 0.25, unsure = 0.10 WHERE id = ?`,
+		"CTRLTHRESH0000000000000000",
+	); err != nil {
+		t.Fatalf("update thresholds: %v", err)
+	}
+	if err := db.QueryRowContext(ctx,
+		`SELECT ticked, unsure FROM control WHERE id = ?`,
+		"CTRLTHRESH0000000000000000",
+	).Scan(&ticked, &unsure); err != nil {
+		t.Fatalf("read back updated thresholds: %v", err)
+	}
+	if ticked != 0.25 || unsure != 0.10 {
+		t.Errorf("updated = (%v, %v), want (0.25, 0.10)", ticked, unsure)
+	}
+
+	// The per-column CHECKs refuse out-of-band values; the band rule itself
+	// (unsure < ticked) is enforced in the domain, not expressible here.
+	if _, err := db.ExecContext(ctx,
+		`UPDATE control SET ticked = 1.5 WHERE id = ?`,
+		"CTRLTHRESH0000000000000000",
+	); err == nil {
+		t.Error("ticked = 1.5 accepted, want the CHECK to refuse it")
+	}
+}

--- a/apps/server/migrations/00008_thresholds.sql
+++ b/apps/server/migrations/00008_thresholds.sql
@@ -1,0 +1,31 @@
+-- Issue #197: one darkness-threshold pair per control, travelling end-to-end.
+--
+--   ticked  at or above this black/total ratio a box counts as a confident mark
+--   unsure  at or above this ratio (below ticked) a box is reported as doubtful
+--
+-- One pair PER CONTROL, last-wins: the upload form can set it, the reanalyse
+-- form re-sets it, and the worker uses the SAME ticked for the reader, for
+-- AMC's `note` and for the annotated PDF — marks, scores and the drawn sheet
+-- agree on one threshold (the report's scoring.stale can no longer be produced
+-- by the server flow).
+--
+-- Defaults 0.15/0.05, measured on a real batch (Jetson 2026-08-19): pencil X
+-- marks read 0.14-0.32 darkness, painted squares 0.62-1.00, empty boxes ~0.0.
+-- The previous hardcoded default 0.30 cut straight through the X band. Rows
+-- from before the migration inherit the new defaults, which is exactly what
+-- their next re-read should use.
+--
+-- The band rule (0 <= unsure < ticked < 1) cannot be expressed as column
+-- CHECKs — it spans two columns — so the SQL level guards each bound alone
+-- and the domain validates the pair (controls.Service, like the worker's
+-- parse_thresholds).
+
+-- +goose Up
+ALTER TABLE control
+    ADD COLUMN ticked REAL NOT NULL DEFAULT 0.15 CHECK (ticked > 0 AND ticked < 1);
+ALTER TABLE control
+    ADD COLUMN unsure REAL NOT NULL DEFAULT 0.05 CHECK (unsure >= 0 AND unsure < 1);
+
+-- +goose Down
+ALTER TABLE control DROP COLUMN unsure;
+ALTER TABLE control DROP COLUMN ticked;

--- a/docs/decisions/0041-one-darkness-threshold-pair-per-control.md
+++ b/docs/decisions/0041-one-darkness-threshold-pair-per-control.md
@@ -1,0 +1,65 @@
+# ADR-0041: One darkness-threshold pair per control, defaulted to read X marks
+
+**Status:** Accepted
+**Date:** 2026-08-19
+**Decision-makers:** Miguel Rodriguez
+**Source:** #197, measured on the first real batch read in the Jetson
+(Control 0, 30 copies, 2026-08-19).
+
+## Context
+
+The darkness thresholds existed on only one side of the pipeline: the
+reader decided "marked or not" with a configurable `ticked/unsure`, while
+AMC's `note` and the annotated-PDF drawing ran at a hardcoded 0.30. Two
+failures followed, both seen in production:
+
+- **X marks did not read.** Measured on the real batch: pencil X marks land
+  at 0.14-0.32 darkness, painted squares at 0.62-1.00, empty boxes at ~0.0.
+  The 0.30 default cut through the middle of the X band.
+- **Recalibrating did not recalibrate.** Re-reading at new thresholds moved
+  the marks and left the scores where `note` had put them (`scoring.stale`),
+  and #190's reanalyse even dropped the annotated PDFs without regenerating
+  them.
+
+## Decision
+
+- **One pair per control, last-wins.** `control.ticked/unsure` (migration
+  `00008`), chosen at upload, re-chosen at reanalyse, persisted, and used
+  by the worker for the reader, `note` AND the annotated PDF — one number,
+  three consumers. The server flow can no longer produce `scoring.stale`.
+- **Defaults 0.15/0.05.** Chosen from the measured X band: 0.15 accepts
+  every X except the faintest tail, which falls into the doubtful band
+  (0.05-0.15) and stays visible in `needs_review` instead of being lost.
+  Empty boxes (~0.0) stay far below.
+- **Reanalyse re-scores and re-annotates.** The re-read re-runs `note` at
+  the new threshold and re-runs ruta A over the copies the new reading
+  accepts, so corrected PDFs reappear without saving copy by copy.
+
+## Alternatives considered
+
+- **A global constant the operator edits** — one number for the whole
+  server, no UI. Rejected: darkness depends on the batch (pencil, scanner),
+  and the professor is the one who sees the sheets.
+- **Thresholds per answer/copy** — rejected: the failure mode is
+  batch-wide (same pencil, same scanner), and finer granularity is a
+  tuning surface nobody asked for.
+- **Automatic threshold inference** (histogram analysis of the capture) —
+  deferred, not rejected: a future WP could propose a value; today the
+  human chooses and the default is X-friendly.
+
+## Consequences
+
+- A dirty box (eraser smudge ~0.10-0.15) now lands in the doubtful band
+  more often — visible in needs_review, never silently counted.
+- The defaults may need another look with a semester of data: if 0.15
+  produces noise, it is one number in two places (migration + worker
+  constants), not a redesign.
+- `scoring.stale` survives in the report for CLI users who re-read at a
+  divergent seuil (PAPER-CHECK.md documents the difference).
+
+## References
+
+- ADR-0031 — the reading report contract (threshold reporting, `stale`).
+- ADR-0040 — the annotated PDF is drawn by AMC (the third consumer of the
+  threshold).
+- Issue #197 — full spec, slices and the measurement that chose the values.

--- a/docs/design/2026-08-controles.md
+++ b/docs/design/2026-08-controles.md
@@ -102,6 +102,8 @@ amc-worker  (separate container)   generate PDFs · read scans · annotate
 ```
 control            id, nombre, fecha, desde_ancla, hasta_ancla,
                    n_preguntas, n_copias, estado
+                   [+ issue #197: marcado, inseguro — the darkness pair the
+                    batch was read at; travels end-to-end, see ADR-0041]
 control_pregunta   control_id, pregunta_ref, puntaje
 copia              id, control_id, numero              ← one printed sheet, its own draw
 lectura            copia_id, rut_leido, estado         ← rut_leido is the identifier


### PR DESCRIPTION
**Closes #197**

## Summary

One darkness-threshold pair per control, travelling end-to-end
(ADR-0041). The upload and reanalyse forms set `ticked/unsure` (prefilled
with the control's stored pair), the worker uses the SAME `ticked` for the
reader, for AMC's `note` and for the annotated PDF — marks, scores and the
drawn sheet always agree, and `scoring.stale` can no longer come from the
server flow. Defaults changed from 0.30/0.10 to **0.15/0.05**: measured on
the Jetson's real batch, pencil X marks read 0.14–0.32 darkness, painted
squares 0.62–1.00, empty boxes ~0.0 — the old 0.30 cut straight through the
X band. Reanalyse now also re-scores and re-annotates every clean copy, so
recalibrating brings the corrected PDFs back without saving copy by copy.

## Slices completed

- [x] S1 — worker defaults 0.15/0.05 + `/analyse` takes the pair (note at the same ticked)
- [x] S2 — `/reanalyse` re-runs note; `/annotate/copy` takes `ticked`
- [x] S3 — migration `00008_thresholds.sql` (defaults 0.15/0.05, CHECKs)
- [x] S4 — domain: requests carry the pair, control persists it, Annotate sends the stored ticked
- [x] S5 — forms/UI: upload + reanalyse fields, "umbral actual" line, write deadlines
- [x] S6 — Reanalyze re-annotates the copies the new reading accepts (ruta A)
- [x] S7 — docs: ADR-0041, PAPER-CHECKs, READMEs, design doc data model
- [x] review fixes — CLI defaults aligned, strict parsing, ordering, extra pins

## Acceptance criteria

1. Migration + round-trip test — `TestControlThresholdsDefaultAndRoundTrip`.
2. `/analyse` thresholds — 06-http.sh: `ticked=0.9` blanks everything
   (seuil 0.9, no marks, no scores); `ticked=0.01` marks everything; the
   default 0.15 reaches `scoring.seuil`.
3. `/reanalyse` re-scores — 06-http.sh: re-read at 0.15 after a 0.9 analyse
   → `seuil=0.15`, `stale=false`, marks and scores return.
4. `/annotate/copy` ticked — 06-http.sh: same capture annotated at 0.9 vs
   default → `Nota: 0/4` vs `Nota: 1/4`.
5. Persist + Annotate carries the pair —
   `TestUploadScanWithExplicitThresholds`, `TestAnnotateSendsTheOverridesAndPersistsTheRecord`.
6. Reanalyse precarga/persiste/re-anota —
   `TestReanalyzePersistsThresholdsAndReannotates`, `TestReanalyzeRefusesAnInvertedBand`.
7. Write deadlines — upload + reanalyze routes set their own; `ErrNotSupported`
   ignored under recorders (AC-7's recorder tests green).
8. Docs — ADR-0041, PAPER-CHECKs, READMEs, design doc (§Data model).
9. **Manual (Jetson)** — pending: recalibrate Control 0 at 0.15/0.05 → X
   copies read, scores consistent, corrected PDFs reappear.

## Tests

- `apps/amc-worker`: `make build && make test` — green (06-http.sh includes
  the threshold probes; 03-read.sh threshold-sensitive pins made explicit).
- `apps/server`: per-commit protocol green; pre-PR battery: `gofmt`/`go
  vet`/`go build` green, `go test -race -count=1 ./...` green (25 packages),
  `govulncheck` clean, `docker build` + compose L8 path: migration 00008
  applies and both health endpoints answer 200.

## Reviews run

Adversarial review pass over `main...HEAD` (standalone; the plugin
review-pipeline is unavailable in this session). One blocker + minors, all
fixed in the `review fixes` commit: CLI reader defaults aligned with the
worker constants (Makefile `--seuil` too); strict float parsing in the
worker (garbage → 400, not 500); strict form parsing (garbage never
silently falls back to the stored pair); pair persisted BEFORE the report in
both flows; `unsure`'s bogus `max` attr dropped; `unsure=0` wire case
pinned; README stale-prose qualified; design doc data model updated.

## Manual verification

- [ ] **AC-9 / Jetson** — after the deploy lands (watchtower), open Control 0
      and re-read at 0.15/0.05: the X-marked copies should move to read, the
      scores should follow, and the corrected PDFs should reappear without
      saving copy by copy.
- [ ] `apps/server/GOOGLE-CHECK.md` — not required (no login-path change).

## Notes

- `scoring.stale` survives in the report for CLI users who re-read at a
  divergent seuil (PAPER-CHECK.md documents the difference).
- The defaults are one number in two places (migration + worker constants);
  a semester of data may justify revisiting them — that is a value change,
  not a redesign.
