### PR TITLE
feat: print the fill-the-box marking instruction on every sheet

### DIFF
--- a/apps/amc-worker/tests/fixtures/control-demo.tex
+++ b/apps/amc-worker/tests/fixtures/control-demo.tex
@@ -281,6 +281,8 @@
       \smallskip
       Cada pregunta dice cuántas respuestas admite.
       \textbf{Respóndelas todas: equivocarse no descuenta.}
+      \textbf{Rellena por completo el cuadrado de tu respuesta.}
+      No marques con X ni con tilde.
     \end{minipage}}
   \vspace{2mm}
 

--- a/apps/server/internal/domain/controls/tex/tex.go
+++ b/apps/server/internal/domain/controls/tex/tex.go
@@ -245,6 +245,13 @@ func writeSheet(b *strings.Builder, in Input) {
 	b.WriteString("\n      \\smallskip\n")
 	b.WriteString("      Cada pregunta dice cuántas respuestas admite.\n")
 	b.WriteString("      \\textbf{Respóndelas todas: equivocarse no descuenta.}\n")
+	// Issue #203: the reader is calibrated for a FULLY FILLED box. Measured
+	// on the first real batch: painted squares read 0.62-1.00 darkness
+	// while pencil X marks read 0.14-0.32, right at the threshold — a faint
+	// X lands in the review queue or is lost. The sheet says so, because a
+	// rule the professor announces once is forgotten by question five.
+	b.WriteString("      \\textbf{Rellena por completo el cuadrado de tu respuesta.}\n")
+	b.WriteString("      No marques con X ni con tilde.\n")
 	b.WriteString("    \\end{minipage}}\n")
 	b.WriteString("  \\vspace{2mm}\n\n")
 

--- a/apps/server/internal/domain/controls/tex/tex_test.go
+++ b/apps/server/internal/domain/controls/tex/tex_test.go
@@ -192,6 +192,14 @@ func TestHeaderBlockCarriesThisSheetsArithmetic(t *testing.T) {
 	if !strings.Contains(out, `\textbf{Respóndelas todas: equivocarse no descuenta.}`) {
 		t.Error("header block is missing the 'answering everything is free' line (§C7)")
 	}
+	// Issue #203: the marking instruction travels on the printed sheet —
+	// a filled box reads at 4x the threshold margin of an X (measured).
+	if !strings.Contains(out, "Rellena por completo el cuadrado de tu respuesta.") {
+		t.Error("header block is missing the fill-the-box instruction (issue #203)")
+	}
+	if !strings.Contains(out, "No marques con X ni con tilde.") {
+		t.Error("header block is missing the no-X-no-tilde line (issue #203)")
+	}
 	// The one instruction that stopped being true once a control could
 	// draw a multiple must not appear (ADR-0033 §Context).
 	if strings.Contains(out, "Marca una sola alternativa por pregunta") {
@@ -466,6 +474,7 @@ func TestFixtureAndGeneratorAgreeOnTheLoadBearingRules(t *testing.T) {
 			{`\lastchoices before "Ninguna de las anteriores"`, lastchoicesPinsCorrectly(source), "pin has no effect (ADR-0033) — a \\lastchoices comment mention does not satisfy the rule the CODE version has to obey"},
 			{"deleted 'Marca una sola alternativa'", !containsOutsideComments(source, "Marca una sola alternativa por pregunta"), "false when a multiple is drawn"},
 			{"answering everything is free", strings.Contains(source, "equivocarse no descuenta"), "§C7"},
+			{"fill the box instruction", strings.Contains(source, "Rellena por completo el cuadrado"), "issue #203: X marks sit at the threshold; a filled box reads at 4x margin"},
 		}
 		for _, c := range checks {
 			if !c.ok {


### PR DESCRIPTION
**Refs #197**

The sheet now tells the student how to mark: the reader is calibrated for a
fully filled box (painted squares measure 0.62-1.00 darkness; pencil X marks
0.14-0.32, right at the threshold). Two lines in the header block of every
copy: 'Rellena por completo el cuadrado de tu respuesta. No marques con X ni
con tilde.' Pinned in the tex tests and mirrored in the worker fixture (the
generator/fixture agreement guard required it).

Tests: server suite 25/25; worker make build + make test green (66 checks).

Manual: after deploy, regenerate a control and eyeball the printed sheet —
the instruction must appear in the header box of every copy.