### PR TITLE
feat: download the uploaded scan batch from the control page

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -214,6 +214,7 @@ Routes today:
 | `GET /controls/{id}/copies/{copy}/review` · `POST` | Split view — corrected PDF (or raw scan) + editable form; POST saves overrides through `answer_override` / `rut_override` and re-annotates the copy |
 | `GET /controls/{id}/copies/{copy}/page/{n}` | Streams the scanned page image from the shared volume |
 | `GET /controls/{id}/copies/{copy}/annotated.pdf` | Streams the corrected PDF from the shared volume; 404 while none exists (issue #190) |
+| `GET /controls/{id}/uploads/{batch}.pdf` | Downloads an uploaded scan batch (`batch-N.pdf`) from the shared volume; the detail page links every batch (issue #204) |
 | `GET /professors` | The list: address, name, state, created, last sign-in |
 | `GET /professors/new` · `POST /professors` | Create by address and name — the `Authenticate` path (2) round trip |
 | `GET /professors/{id}/edit` · `POST /professors/{id}` | Rename. The address is not editable |

--- a/apps/server/internal/app/web/handler/controls.go
+++ b/apps/server/internal/app/web/handler/controls.go
@@ -28,6 +28,8 @@ const (
 	ControlSujetPath    = "/controls/{id}/sujet.pdf"
 	ControlCorrigePath  = "/controls/{id}/corrige.pdf"
 	ControlPoolJSONPath = "/controls/{id}/pool.json"
+	// ControlUploadPath serves an uploaded scan batch (issue #204).
+	ControlUploadPath = "/controls/{id}/uploads/{batch}"
 )
 
 // Defaults for the form fields. §C17: a control is four questions under a
@@ -179,6 +181,14 @@ func (h *Controls) Detail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	uploads, err := h.Service.UploadList(id)
+	if err != nil {
+		h.Log.Error("listing upload batches", "control", id, "error", err)
+		middleware.WriteError(w, r, http.StatusInternalServerError,
+			"Algo se rompió en el servidor. Vuelve a intentarlo en unos segundos.")
+		return
+	}
+
 	page := view.ControlDetailPage{
 		Page:         middleware.PageFor(r, c.Name),
 		Control:      toDetailedControl(c, h.Bank),
@@ -194,6 +204,12 @@ func (h *Controls) Detail(w http.ResponseWriter, r *http.Request) {
 		CurrentTicked: c.Ticked,
 		CurrentUnsure: c.Unsure,
 		Graded:        c.State == controls.Graded,
+	}
+	for _, name := range uploads {
+		page.Uploads = append(page.Uploads, view.UploadedBatch{
+			Name: name,
+			URL:  controlUploadURL(id, name),
+		})
 	}
 	readings, err := h.Service.ReadingsFor(r.Context(), c.ID)
 	if err != nil {
@@ -481,6 +497,11 @@ func controlDetailURL(id string) string {
 
 func controlSujetURL(id string) string {
 	return controlDetailURL(id) + "/sujet.pdf"
+}
+
+// controlUploadURL is one uploaded batch's download URL (issue #204).
+func controlUploadURL(id, batch string) string {
+	return ControlsPath + "/" + id + "/uploads/" + batch
 }
 
 func controlCorrigeURL(id string) string {

--- a/apps/server/internal/app/web/handler/scans.go
+++ b/apps/server/internal/app/web/handler/scans.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -49,11 +48,6 @@ const uploadWriteWindow = 15 * time.Minute
 
 // scanFormField is the multipart field the upload form posts under.
 const scanFormField = "scan"
-
-// uploadBatchPattern is the URL-boundary validation for the uploaded batch
-// segment (issue #204): the on-disk contract is batch-<positive int>.pdf,
-// and a segment that does not match it never reaches os.Open.
-var uploadBatchPattern = regexp.MustCompile(`^batch-[0-9]+\.pdf$`)
 
 // UploadScan reads the multipart form, streams the PDF onto disk through the
 // Service, and redirects back to /controls/:id with a flash message. Failure
@@ -290,7 +284,14 @@ func (h *Controls) CloseCorrection(w http.ResponseWriter, r *http.Request) {
 func (h *Controls) UploadsPDF(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	batch := r.PathValue("batch")
-	if !isValidControlID(id) || !uploadBatchPattern.MatchString(batch) {
+	if !isValidControlID(id) {
+		middleware.WriteError(w, r, http.StatusNotFound, "Ese control no existe.")
+		return
+	}
+	// The domain owns the batch-naming contract (IsBatchName, the same
+	// rule nextBatchNumber and UploadList use); a segment outside it never
+	// reaches os.Open.
+	if !controls.IsBatchName(batch) {
 		middleware.WriteError(w, r, http.StatusNotFound, "Ese archivo no existe.")
 		return
 	}

--- a/apps/server/internal/app/web/handler/scans.go
+++ b/apps/server/internal/app/web/handler/scans.go
@@ -4,7 +4,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -47,6 +49,11 @@ const uploadWriteWindow = 15 * time.Minute
 
 // scanFormField is the multipart field the upload form posts under.
 const scanFormField = "scan"
+
+// uploadBatchPattern is the URL-boundary validation for the uploaded batch
+// segment (issue #204): the on-disk contract is batch-<positive int>.pdf,
+// and a segment that does not match it never reaches os.Open.
+var uploadBatchPattern = regexp.MustCompile(`^batch-[0-9]+\.pdf$`)
 
 // UploadScan reads the multipart form, streams the PDF onto disk through the
 // Service, and redirects back to /controls/:id with a flash message. Failure
@@ -273,6 +280,53 @@ func (h *Controls) CloseCorrection(w http.ResponseWriter, r *http.Request) {
 	}
 	flash.Set(w, h.secureCookie, "Corrección cerrada.")
 	http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
+}
+
+// UploadsPDF serves an uploaded scan batch from the shared volume
+// (issue #204). The batch name comes from a URL segment, so the pattern
+// above is the barrier: only the on-disk contract's shape can reach the
+// file system. The control must exist (same list-then-serve pattern as
+// servePDF); a batch that is not on disk is a 404.
+func (h *Controls) UploadsPDF(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	batch := r.PathValue("batch")
+	if !isValidControlID(id) || !uploadBatchPattern.MatchString(batch) {
+		middleware.WriteError(w, r, http.StatusNotFound, "Ese archivo no existe.")
+		return
+	}
+	if _, err := h.Service.Get(r.Context(), id); err != nil {
+		if errors.Is(err, controls.ErrControlNotFound) {
+			middleware.WriteError(w, r, http.StatusNotFound, "Ese control no existe.")
+			return
+		}
+		h.Log.Error("serving upload batch: reading control", "error", err, "id", id)
+		middleware.WriteError(w, r, http.StatusInternalServerError,
+			"Algo se rompió en el servidor. Vuelve a intentarlo en unos segundos.")
+		return
+	}
+
+	path := h.Service.UploadPath(id, batch)
+	f, err := os.Open(path)
+	if err != nil {
+		h.Log.Warn("serving upload batch", "id", id, "batch", batch, "error", err)
+		middleware.WriteError(w, r, http.StatusNotFound,
+			"Ese archivo no existe en el volumen compartido.")
+		return
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
+	if err != nil {
+		h.Log.Error("stat upload batch", "id", id, "batch", batch, "error", err)
+		middleware.WriteError(w, r, http.StatusInternalServerError,
+			"Algo se rompió en el servidor. Vuelve a intentarlo en unos segundos.")
+		return
+	}
+	// It is a download, not an embed: Content-Disposition attachment with
+	// the stored batch name (the professor's original filename is not kept,
+	// issue #204 §Non-goals).
+	w.Header().Set("Content-Type", "application/pdf")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, batch))
+	http.ServeContent(w, r, batch, info.ModTime(), f)
 }
 
 func parseFloatField(raw string, fallback float64) float64 {

--- a/apps/server/internal/app/web/handler/scans_test.go
+++ b/apps/server/internal/app/web/handler/scans_test.go
@@ -479,9 +479,10 @@ func TestUploadsPDFServesTheStoredBatch(t *testing.T) {
 	}
 }
 
-// The batch name is a URL segment, so the pattern is the barrier: names
-// outside the on-disk contract 404 before any file is opened, as do an
-// unknown control and a batch that is not on disk.
+// The batch name is a URL segment validated against the domain's batch
+// contract (IsBatchName): names outside it 404 before any file is opened
+// — including batch-0.pdf, which nextBatchNumber can never produce — as
+// do an unknown control and a batch that is not on disk.
 func TestUploadsPDFRefusesBadNamesMissingFilesAndUnknownControls(t *testing.T) {
 	f := newControlsFixture(t)
 	controlID := f.createControl(t, "Control batch 404", 1)

--- a/apps/server/internal/app/web/handler/scans_test.go
+++ b/apps/server/internal/app/web/handler/scans_test.go
@@ -443,3 +443,121 @@ func TestReanalyzeRefusesAnInvertedBand(t *testing.T) {
 		t.Errorf("Reanalyze called %d times with an inverted band, want 0", count)
 	}
 }
+
+// Issue #204: the uploaded batch is downloadable from the control page —
+// the endpoint streams the stored batch-N.pdf with download headers.
+func TestUploadsPDFServesTheStoredBatch(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control batch", 1)
+
+	uploads := filepath.Join(f.workDir, "controls", controlID, "uploads")
+	if err := os.MkdirAll(uploads, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(uploads, "batch-1.pdf"), []byte("%PDF-batch"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	req := f.authedRequest(t, http.MethodGet, "/controls/"+controlID+"/uploads/batch-1.pdf", nil)
+	req.SetPathValue("id", controlID)
+	req.SetPathValue("batch", "batch-1.pdf")
+	rec := httptest.NewRecorder()
+	f.handler.UploadsPDF(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d\nbody: %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != "%PDF-batch" {
+		t.Errorf("body = %q, want the stored batch bytes", got)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/pdf" {
+		t.Errorf("Content-Type = %q, want application/pdf", got)
+	}
+	if got := rec.Header().Get("Content-Disposition"); !strings.Contains(got, "attachment") ||
+		!strings.Contains(got, "batch-1.pdf") {
+		t.Errorf("Content-Disposition = %q, want an attachment named batch-1.pdf", got)
+	}
+}
+
+// The batch name is a URL segment, so the pattern is the barrier: names
+// outside the on-disk contract 404 before any file is opened, as do an
+// unknown control and a batch that is not on disk.
+func TestUploadsPDFRefusesBadNamesMissingFilesAndUnknownControls(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control batch 404", 1)
+
+	cases := []struct {
+		name  string
+		id    string
+		batch string
+	}{
+		{"unknown control", "CTRLBADIDBADIDBADIDBADIDID", "batch-1.pdf"},
+		{"traversal-ish segment", controlID, ".."},
+		{"non-contract name", controlID, "notas.txt"},
+		{"zero batch", controlID, "batch-0.pdf"},
+		{"missing on disk", controlID, "batch-7.pdf"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req := f.authedRequest(t, http.MethodGet, "/controls/"+c.id+"/uploads/"+c.batch, nil)
+			req.SetPathValue("id", c.id)
+			req.SetPathValue("batch", c.batch)
+			rec := httptest.NewRecorder()
+			f.handler.UploadsPDF(rec, req)
+			if rec.Code != http.StatusNotFound {
+				t.Errorf("status = %d, want 404", rec.Code)
+			}
+		})
+	}
+}
+
+// Issue #204: the detail page lists the uploaded batches with download
+// links — and renders nothing when no batch exists yet.
+func TestDetailListsUploadedBatchesWithDownloadLinks(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control lista lotes", 1)
+
+	uploads := filepath.Join(f.workDir, "controls", controlID, "uploads")
+	if err := os.MkdirAll(uploads, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	for _, name := range []string{"batch-1.pdf", "batch-2.pdf"} {
+		if err := os.WriteFile(filepath.Join(uploads, name), []byte("%PDF"), 0o644); err != nil {
+			t.Fatalf("WriteFile %s: %v", name, err)
+		}
+	}
+
+	req := f.authedRequest(t, http.MethodGet, "/controls/"+controlID, nil)
+	req.SetPathValue("id", controlID)
+	rec := httptest.NewRecorder()
+	f.handler.Detail(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		"Lotes subidos",
+		`href="/controls/` + controlID + `/uploads/batch-1.pdf"`,
+		`href="/controls/` + controlID + `/uploads/batch-2.pdf"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("detail page missing %q\n--- body ---\n%s", want, body)
+		}
+	}
+}
+
+func TestDetailShowsNoUploadSectionWhenNothingWasUploaded(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control sin lotes", 1)
+
+	req := f.authedRequest(t, http.MethodGet, "/controls/"+controlID, nil)
+	req.SetPathValue("id", controlID)
+	rec := httptest.NewRecorder()
+	f.handler.Detail(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "Lotes subidos") {
+		t.Error("detail page shows the upload section with no batches on disk")
+	}
+}

--- a/apps/server/internal/app/web/router.go
+++ b/apps/server/internal/app/web/router.go
@@ -185,6 +185,12 @@ func routes(deps Deps) []Route {
 			Method: http.MethodGet, Path: handler.CopyAnnotatedPDF,
 			Handler: deps.Controls.AnnotatedPDF,
 		},
+		// Issue #204: the uploaded scan batch, downloadable from the detail
+		// page like the generated PDFs.
+		{
+			Method: http.MethodGet, Path: handler.ControlUploadPath,
+			Handler: deps.Controls.UploadsPDF,
+		},
 		{
 			Method: http.MethodGet, Path: handler.ProfessorsPath,
 			Handler: deps.Professors.List,

--- a/apps/server/internal/app/web/view/templates/pages/controls_detail.html
+++ b/apps/server/internal/app/web/view/templates/pages/controls_detail.html
@@ -44,6 +44,14 @@
       </p>
       <p><button type="submit">Subir escaneos</button></p>
     </form>
+    {{ if .Uploads }}
+      <h3>Lotes subidos</h3>
+      <ul>
+        {{ range $u := .Uploads }}
+          <li><a href="{{ $u.URL }}">{{ $u.Name }}</a></li>
+        {{ end }}
+      </ul>
+    {{ end }}
   </section>
 
   {{ if .Readings }}

--- a/apps/server/internal/app/web/view/view.go
+++ b/apps/server/internal/app/web/view/view.go
@@ -231,6 +231,11 @@ type ControlDetailPage struct {
 	QuestionColumns []string
 	// ReanalyzeURL is the POST target for "re-leer con otra sensibilidad".
 	ReanalyzeURL string
+	// Uploads lists the uploaded scan batches with their download URLs
+	// (issue #204). Empty while nothing was uploaded — the template then
+	// renders no section at all.
+	Uploads []UploadedBatch
+
 	// CurrentTicked / CurrentUnsure pre-fill the reanalyze form with the
 	// last thresholds used (or the defaults for a first read).
 	CurrentTicked float64
@@ -290,6 +295,12 @@ type DetailedControl struct {
 	PrintLayout string
 	State       string
 	CreatedAt   string
+}
+
+// UploadedBatch is one uploaded scan batch's download link (issue #204).
+type UploadedBatch struct {
+	Name string // the stored batch-N.pdf name (the original filename is not kept)
+	URL  string
 }
 
 // ReviewPage is what review.html renders (WP-F §The screens). Split view:

--- a/apps/server/internal/domain/controls/scans.go
+++ b/apps/server/internal/domain/controls/scans.go
@@ -412,11 +412,22 @@ func matchesRead(a Answer, edit AnswerEdit) bool {
 	return true
 }
 
+// IsBatchName reports whether a name matches the on-disk batch contract
+// batch-<positive int>.pdf (batchNumber). Exported because the upload
+// handler validates its URL segment against the SAME rule (issue #204
+// review) — the contract has one home, and every reader of the naming
+// goes through it.
+func IsBatchName(name string) bool {
+	_, ok := batchNumber(name)
+	return ok
+}
+
 // batchNumber parses a filename into its batch number when it matches the
 // on-disk contract batch-<positive int>.pdf, ok=false otherwise. One home
-// for the contract, shared by nextBatchNumber (naming the next batch) and
-// UploadList (listing the existing ones, issue #204) — two readers of the
-// same naming must not drift.
+// for the contract, shared by nextBatchNumber (naming the next batch),
+// UploadList (listing the existing ones, issue #204) and the handler's
+// URL validation (IsBatchName) — readers of the same naming must not
+// drift.
 func batchNumber(name string) (int, bool) {
 	if !strings.HasPrefix(name, scanFilePrefix) || !strings.HasSuffix(name, scanFileExt) {
 		return 0, false

--- a/apps/server/internal/domain/controls/scans.go
+++ b/apps/server/internal/domain/controls/scans.go
@@ -412,6 +412,23 @@ func matchesRead(a Answer, edit AnswerEdit) bool {
 	return true
 }
 
+// batchNumber parses a filename into its batch number when it matches the
+// on-disk contract batch-<positive int>.pdf, ok=false otherwise. One home
+// for the contract, shared by nextBatchNumber (naming the next batch) and
+// UploadList (listing the existing ones, issue #204) — two readers of the
+// same naming must not drift.
+func batchNumber(name string) (int, bool) {
+	if !strings.HasPrefix(name, scanFilePrefix) || !strings.HasSuffix(name, scanFileExt) {
+		return 0, false
+	}
+	trimmed := strings.TrimSuffix(strings.TrimPrefix(name, scanFilePrefix), scanFileExt)
+	n, err := strconv.Atoi(trimmed)
+	if err != nil || n <= 0 {
+		return 0, false
+	}
+	return n, true
+}
+
 // nextBatchNumber walks the uploads/ directory and returns one past the
 // highest existing batch-N.pdf (max+1). Empty dir → 1. If the highest
 // batch is deleted the next number goes back to fill the gap — the
@@ -427,16 +444,7 @@ func nextBatchNumber(dir string) (int, error) {
 		if e.IsDir() {
 			continue
 		}
-		name := e.Name()
-		if !strings.HasPrefix(name, scanFilePrefix) || !strings.HasSuffix(name, scanFileExt) {
-			continue
-		}
-		trimmed := strings.TrimSuffix(strings.TrimPrefix(name, scanFilePrefix), scanFileExt)
-		n, err := strconv.Atoi(trimmed)
-		if err != nil {
-			continue
-		}
-		if n > 0 {
+		if n, ok := batchNumber(e.Name()); ok {
 			used[n] = true
 		}
 	}
@@ -449,6 +457,44 @@ func nextBatchNumber(dir string) (int, error) {
 	}
 	sort.Ints(nums)
 	return nums[len(nums)-1] + 1, nil
+}
+
+// UploadList returns the names of the scan batches already on disk for a
+// control, ordered by batch number. Only files matching the on-disk
+// contract count (batch-N.pdf, batchNumber); the handler renders one
+// download link per entry (issue #204). Empty when nothing was uploaded
+// yet or the directory does not exist — the page then shows nothing.
+func (s *Service) UploadList(controlID string) ([]string, error) {
+	dir := filepath.Join(s.ProjectDir(controlID), uploadsDir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("controls.UploadList: read %s: %w", dir, err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if _, ok := batchNumber(e.Name()); ok {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Slice(names, func(i, j int) bool {
+		a, _ := batchNumber(names[i])
+		b, _ := batchNumber(names[j])
+		return a < b
+	})
+	return names, nil
+}
+
+// UploadPath composes the host-side path of one uploaded batch. The name
+// must already match the batch contract — the handler validates at the URL
+// boundary (issue #204); this is a path join, not a validation.
+func (s *Service) UploadPath(controlID, name string) string {
+	return filepath.Join(s.ProjectDir(controlID), uploadsDir, name)
 }
 
 func writeUpload(path string, r io.ReadCloser) error {

--- a/apps/server/internal/domain/controls/scans_internal_test.go
+++ b/apps/server/internal/domain/controls/scans_internal_test.go
@@ -44,3 +44,56 @@ func touch(t *testing.T, dir string, names ...string) {
 		}
 	}
 }
+
+// Issue #204: UploadList reads the on-disk batch contract through the same
+// batchNumber helper that names the next upload — two readers, one rule.
+func TestUploadListReturnsContractMatchingBatchesInOrder(t *testing.T) {
+	workDir := t.TempDir()
+	svc := &Service{WorkDir: workDir}
+	dir := filepath.Join(svc.ProjectDir("CTRLUPLOAD0000000000000000"), uploadsDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	// Noise: a non-contract name, a zero batch, a negative-ish name and a
+	// directory — all ignored, like nextBatchNumber ignores them.
+	touch(t, dir, "batch-2.pdf", "batch-1.pdf", "batch-10.pdf",
+		"notas.txt", "batch-0.pdf", "batch-abc.pdf", "batch--1.pdf")
+	if err := os.MkdirAll(filepath.Join(dir, "batch-3.pdf"), 0o755); err != nil {
+		t.Fatalf("MkdirAll subdir: %v", err)
+	}
+
+	names, err := svc.UploadList("CTRLUPLOAD0000000000000000")
+	if err != nil {
+		t.Fatalf("UploadList: %v", err)
+	}
+	want := []string{"batch-1.pdf", "batch-2.pdf", "batch-10.pdf"}
+	if len(names) != len(want) {
+		t.Fatalf("UploadList = %v, want %v", names, want)
+	}
+	for i := range want {
+		if names[i] != want[i] {
+			t.Errorf("UploadList[%d] = %q, want %q (full list %v)", i, names[i], want[i], names)
+		}
+	}
+}
+
+func TestUploadListIsEmptyWhenNothingWasUploaded(t *testing.T) {
+	svc := &Service{WorkDir: t.TempDir()}
+
+	names, err := svc.UploadList("CTRLUPLOAD0000000000000000")
+	if err != nil {
+		t.Fatalf("UploadList: %v", err)
+	}
+	if len(names) != 0 {
+		t.Errorf("UploadList = %v, want empty — the uploads dir does not exist yet", names)
+	}
+}
+
+func TestUploadPathJoinsUnderTheControlUploadsDir(t *testing.T) {
+	svc := &Service{WorkDir: "/work"}
+	got := svc.UploadPath("CTRLUPLOAD0000000000000000", "batch-1.pdf")
+	want := filepath.Join("/work", "controls", "CTRLUPLOAD0000000000000000", "uploads", "batch-1.pdf")
+	if got != want {
+		t.Errorf("UploadPath = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
**Closes #204**

## Summary

The uploaded scan batch is now downloadable from the control page: a new
professor-gated endpoint (`GET /controls/{id}/uploads/{batch}.pdf`) streams
the stored `batch-N.pdf` from the shared volume with download headers, and
the detail page lists every uploaded batch with a link. The batch segment is
validated against the domain's own on-disk contract (one home, shared with
nextBatchNumber and UploadList) before any file is opened.

## Slices

- [x] S1 — `UploadList`/`UploadPath` + `batchNumber` as the single naming contract
- [x] S2 — endpoint + route (404s pinned: unknown control, bad names, missing file)
- [x] S3 — detail page list when batches exist, nothing otherwise
- [x] S4 — README route table row
- [x] review fixes — contract-validated segment (no drifted regex), message consistency

## Acceptance criteria

1. `UploadList` ordering/noise/empty/join — `TestUploadListReturnsContractMatchingBatchesInOrder`, `TestUploadListIsEmptyWhenNothingWasUploaded`, `TestUploadPathJoinsUnderTheControlUploadsDir`.
2. Serves the stored batch with `application/pdf` + attachment — `TestUploadsPDFServesTheStoredBatch`.
3. 404s — `TestUploadsPDFRefusesBadNamesMissingFilesAndUnknownControls` (unknown control, traversal segment, non-contract name, zero batch, missing file).
4. Detail list — `TestDetailListsUploadedBatchesWithDownloadLinks`, `TestDetailShowsNoUploadSectionWhenNothingWasUploaded`.
5. README row.
6. Manual (Jetson): Control 0 shows its uploaded batch with a working download.

## Tests

- Server suite 25/25; `go test -race -count=1 ./...` 25/25; `govulncheck` clean (no dep changes); L8 compose: boot + both health probes 200.

## Reviews run

Adversarial review pass over the #204 diff (standalone; plugin pipeline unavailable). Verdict READY; one minor fixed (regex/contract drift) plus nits (test grouping reworded; the 'Descargar' label and the 500-on-UploadList-error choices kept as-is, both documented).

## Manual verification

- [ ] After deploy, open Control 0 → 'Lotes subidos' shows batch-1.pdf with a working download.

## Notes

- Pre-existing (not #204): a POST to a wildcard route renders the shell 404 instead of 405 — affects every `{id}` route equally; worth its own issue if it ever matters.