### PR TITLE
feat(controls): generate control sheets on Letter paper, not A4 (#206)

### DIFF
--- a/apps/amc-worker/PAPER-CHECK-MIN.md
+++ b/apps/amc-worker/PAPER-CHECK-MIN.md
@@ -33,8 +33,8 @@ That produces `tests/work/paper-min/out/control-min-para-imprimir.pdf` — three
 copies, three pages.
 
 **Print single-sided, at 100% scale.** Not "fit to page": AMC finds the sheet
-by the four corner marks, and scaling moves them. Plain white A4; three sheets
-come out.
+by the four corner marks, and scaling moves them. Plain white US Letter; three
+sheets come out (paper size is a printer-facing contract per ADR-0042).
 
 ## 2. Mark them
 

--- a/apps/amc-worker/PAPER-CHECK.md
+++ b/apps/amc-worker/PAPER-CHECK.md
@@ -46,8 +46,8 @@ failed.
 
 **Print double-sided (dúplex), at 100% scale.** Not "fit to page": AMC finds
 the sheet by the four corner marks, and scaling moves them. If your dialog
-offers "actual size" or "100%", that is the one. Plain white A4; six sheets
-come out.
+offers "actual size" or "100%", that is the one. Plain white US Letter; six
+sheets come out (paper size is a printer-facing contract per ADR-0042).
 
 ## 2. Mark them like a student would
 

--- a/apps/amc-worker/tests/fixtures/control-demo.tex
+++ b/apps/amc-worker/tests/fixtures/control-demo.tex
@@ -19,7 +19,7 @@
 % digits-only and a DV can be K, and with an enrolled-student list the body
 % alone identifies the student (§C5).
 
-\documentclass[a4paper,11pt]{article}
+\documentclass[letterpaper,11pt]{article}
 
 \usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}

--- a/apps/amc-worker/tests/fixtures/control-paper-min.tex
+++ b/apps/amc-worker/tests/fixtures/control-paper-min.tex
@@ -36,7 +36,7 @@
 % (`apps/amc-worker/CLAUDE.md` §Language). Identifiers, filenames and the code
 % around this stay English.
 
-\documentclass[a4paper,11pt]{article}
+\documentclass[letterpaper,11pt]{article}
 
 \usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}

--- a/apps/amc-worker/tests/fixtures/control-tres.tex
+++ b/apps/amc-worker/tests/fixtures/control-tres.tex
@@ -12,7 +12,7 @@
 % because adding to that pool moves the seeded draw and re-points every
 % expectation keyed to it — twice already in this WP.
 
-\documentclass[a4paper,11pt]{article}
+\documentclass[letterpaper,11pt]{article}
 
 \usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}

--- a/apps/server/CLAUDE.md
+++ b/apps/server/CLAUDE.md
@@ -148,6 +148,14 @@ the `avisoNo*` / `flash.Set(…)` string literals in `internal/app/web/handler/`
   `oidctest.Provider`; the real round trip is `GOOGLE-CHECK.md`, and a change to
   the login path is unfinished while a human has not run it. Same rule, and the
   same reason, as `apps/amc-worker/PAPER-CHECK.md`.
+- **Nothing here can test paper, either.** The tex generator lives in
+  `internal/domain/controls/tex/**`, and the suite pins tokens
+  (`TestPreambleDeclaresLetterPaperNotA4` pins `letterpaper` and the absence of
+  `a4paper`, ADR-0042) but sees no printer, no scanner and no ink. Any change to
+  the preamble — paper option, font size, margin package, an added `\usepackage`
+  — is unfinished while `apps/amc-worker/PAPER-CHECK.md` has not run against it.
+  Same rule, and the same reason, as the Google bullet above; the failure mode
+  is on paper (2026-08-19: 44 pages `+0/0/0+`, ADR-0042 §Context).
 - **The two surfaces do not share an auth gate** (§C12). Everything auth-shaped
   is mounted inside `internal/app/web`; `internal/app/api` is anonymous by
   construction, and `/health` sits deliberately outside the gate because the

--- a/apps/server/internal/app/web/view/templates/layout.html
+++ b/apps/server/internal/app/web/view/templates/layout.html
@@ -90,8 +90,8 @@
       }
 
       /* Scan images on the review page are the physical scan's native
-         resolution (300 dpi × A4 = a few thousand pixels wide). Without a
-         max-width the browser lays them out at natural size and the sheet
+         resolution (300 dpi × US Letter = ~2550×3300 px, ADR-0042). Without
+         a max-width the browser lays them out at natural size and the sheet
          overflows every viewport. */
       .review-image img { max-width: 100%; height: auto; }
       /* The corrected PDF (issue #190) renders in the browser's own viewer

--- a/apps/server/internal/domain/controls/tex/tex.go
+++ b/apps/server/internal/domain/controls/tex/tex.go
@@ -105,7 +105,7 @@ func validate(in Input) error {
 var lastChoicePattern = regexp.MustCompile(`(?i)\bninguna\b[^.]*\banteriores\b`)
 
 // preamble tails and heads that never change with the input.
-const preambleHead = `\documentclass[a4paper,11pt]{article}
+const preambleHead = `\documentclass[letterpaper,11pt]{article}
 
 \usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}

--- a/apps/server/internal/domain/controls/tex/tex_test.go
+++ b/apps/server/internal/domain/controls/tex/tex_test.go
@@ -88,6 +88,22 @@ func compile(t *testing.T, override func(*tex.Input)) string {
 	return out
 }
 
+// The paper size is the operational contract with the printer (ADR-0042).
+// Chile printer default is US Letter; an A4 preamble was printed clipped
+// 18mm at the bottom in the 2026-08-19 Jetson incident, losing the two
+// bottom fiducials and taking every one of 44 pages to +0/0/0+. The test
+// exists so that a future revert to a4paper does not ship silently — the
+// L8 print check is a manual step by design (ADR-0030 §Not yet proven).
+func TestPreambleDeclaresLetterPaperNotA4(t *testing.T) {
+	out := compile(t, nil)
+	if !strings.Contains(out, `\documentclass[letterpaper,11pt]{article}`) {
+		t.Error("preamble is missing letterpaper: printed in Chile it clips the bottom fiducials (ADR-0042)")
+	}
+	if strings.Contains(out, "a4paper") {
+		t.Error("preamble still declares a4paper: Chile's printer default is Letter (ADR-0042)")
+	}
+}
+
 func TestPreambleDeclaresLangESAndDoesNotUseCompletemulti(t *testing.T) {
 	out := compile(t, nil)
 	if !strings.Contains(out, `\usepackage[box,lang=ES]{automultiplechoice}`) {

--- a/docs/decisions/0030-auto-multiple-choice-as-the-control-engine.md
+++ b/docs/decisions/0030-auto-multiple-choice-as-the-control-engine.md
@@ -5,9 +5,9 @@
 **Decision-makers:** Miguel Rodriguez
 **Source:** #138 (the spike), design `docs/design/2026-08-controles.md` §C8, §C9
 **Amended by:** #206 (2026-08-20) — the paper is US Letter, not A4 (ADR-0042).
-The historical record below (§What was verified: "printed at 100% on A4")
-stays as evidence of what was measured then; the operational paper size for
-every future generate is Letter.
+The historical record below (§Partial evidence — 2026-08-17: "printed at
+100% on A4") stays as evidence of what was measured then; the operational
+paper size for every future generate is Letter.
 
 ## Context
 

--- a/docs/decisions/0030-auto-multiple-choice-as-the-control-engine.md
+++ b/docs/decisions/0030-auto-multiple-choice-as-the-control-engine.md
@@ -4,6 +4,10 @@
 **Date:** 2026-08-15
 **Decision-makers:** Miguel Rodriguez
 **Source:** #138 (the spike), design `docs/design/2026-08-controles.md` §C8, §C9
+**Amended by:** #206 (2026-08-20) — the paper is US Letter, not A4 (ADR-0042).
+The historical record below (§What was verified: "printed at 100% on A4")
+stays as evidence of what was measured then; the operational paper size for
+every future generate is Letter.
 
 ## Context
 

--- a/docs/decisions/0042-control-sheets-are-printed-on-us-letter.md
+++ b/docs/decisions/0042-control-sheets-are-printed-on-us-letter.md
@@ -33,9 +33,9 @@ The chain, reconstructed:
 Chile's printer default is Letter. It is the operating context of the
 one deployment there is (`docs/decisions/0038-the-jetson-is-the-first-test-bed.md`),
 and it is what every subsequent generate will meet. ADR-0030 recorded
-the paper as A4 because that is what was measured for it (§What was
-verified: "four sheets, printed at 100% on A4"); the choice was
-default-inherited, never argued. This ADR argues it.
+the paper as A4 because that is what was measured for it (§Partial
+evidence — 2026-08-17: "four sheets, printed at 100% on A4"); the
+choice was default-inherited, never argued. This ADR argues it.
 
 ## Decision
 
@@ -101,9 +101,9 @@ to future generates only.
   source; AMC computes the layout from that; the printed PDF matches
   the printer default; the four fiducials land where the scanner
   expects them.
-- ADR-0030 gains an `Amended by:` line. Its §What was verified stays
-  intact as the historical record of what was measured then (A4, four
-  sheets, blue marker); §Not yet proven still points at
+- ADR-0030 gains an `Amended by:` line. Its §Partial evidence —
+  2026-08-17 stays intact as the historical record of what was measured
+  then (A4, four sheets, blue marker); §Not yet proven still points at
   `PAPER-CHECK.md`, which now says Letter.
 - **A deployment outside Chile reopens this ADR.** The choice is
   Chilean-printer-facing; there is no branch of the code that decides

--- a/docs/decisions/0042-control-sheets-are-printed-on-us-letter.md
+++ b/docs/decisions/0042-control-sheets-are-printed-on-us-letter.md
@@ -1,0 +1,128 @@
+# ADR-0042: Control sheets are printed on US Letter paper
+
+**Status:** Accepted — one verification outstanding, see §Not yet proven
+**Date:** 2026-08-20
+**Decision-makers:** Miguel Rodriguez
+**Source:** #206, incident 2026-08-19 (Jetson, control WNME7QU6SZD26KFM5CBJD3QM4E,
+44 pages / 22 copies).
+
+## Context
+
+The generator has emitted `\documentclass[a4paper,11pt]` from its first
+commit — the AMC-in-a-container spike (ADR-0030) was written against A4,
+and every synthetic batch since has been fine. Real print on paper had
+never happened at the professor's desk until 2026-08-19.
+
+On that date, control 2 was printed on the professor's default printer
+and scanned back through DocumentBuddy. Every one of the 44 pages came
+back `+0/0/0+` — AMC's shorthand for "none of the four corner fiducials
+found" — and the worker returned exit 1 with "44 scans are not
+recognized". The professor saw the flash "El motor de lectura rechazó el
+archivo." and fell to manual grading for the whole batch.
+
+The chain, reconstructed:
+
+- Expected paint area at 300 DPI: **A4 = 2480×3508 px**.
+- Actual paint area on the scan: **US Letter = 2550×3300 px**.
+- The delta is not on the scanner (a scanner reports what the paper
+  under it measures). It is on the **printer**. The printer accepted an
+  A4 PDF, its default was Letter, and it scaled A4 down to Letter — which
+  clips ~18 mm off the bottom edge. AMC's two bottom fiducials sit in
+  that band. No bottom marks → no four-corner fix → `+0/0/0+`.
+
+Chile's printer default is Letter. It is the operating context of the
+one deployment there is (`docs/decisions/0038-the-jetson-is-the-first-test-bed.md`),
+and it is what every subsequent generate will meet. ADR-0030 recorded
+the paper as A4 because that is what was measured for it (§What was
+verified: "four sheets, printed at 100% on A4"); the choice was
+default-inherited, never argued. This ADR argues it.
+
+## Decision
+
+**The generator emits `\documentclass[letterpaper,11pt]` for every
+control source.** One line in `apps/server/internal/domain/controls/tex/tex.go`
+`preambleHead`; AMC's `prepare` and layout tables encode Letter geometry
+from the class option, and the printed PDF then matches the Chilean
+printer without scaling.
+
+The change is pinned by
+`TestPreambleDeclaresLetterPaperNotA4` in `tex_test.go`, which asserts
+both directions: the exact preamble line is present, and no `a4paper`
+token survives. The existing suite did not touch the paper option at
+all, so a silent revert would ship unnoticed — the L8 print check that
+would catch it belongs to Miguel, and it does not run per PR.
+
+Amc-worker's three test fixtures (`control-demo.tex`,
+`control-paper-min.tex`, `control-tres.tex`) also declare
+`letterpaper`. They are static test data — no golden compares the
+preamble — so the switch is documentary: they are the closest thing a
+reader of the worker has to "what a real control source looks like",
+and leaving them on A4 would tell a future contributor A4 was the
+default that mattered.
+
+Both `apps/amc-worker/PAPER-CHECK.md` and `PAPER-CHECK-MIN.md` say
+"Plain white US Letter" in their §1 print instruction and point at this
+ADR. The MIN variant was updated in the same PR — same paragraph shape,
+same fact, the "sweep every surface asserting the fact" rule.
+
+Already-printed A4 controls in manual grading (the 22 copies of control
+2, in progress at the time of the switch) are not regenerated. They
+were graded by hand and their reads are preserved; the switch applies
+to future generates only.
+
+## Alternatives considered
+
+- **Keep A4 and instruct professors to change their printer default to
+  A4.** Rejected. The printer default is the reality of the deployment
+  and is not ours to change; a chain of instructions that professors
+  must remember before every print is exactly what the fiducials were
+  supposed to make unnecessary. It also leaves a trap for the next
+  professor who forgets. The technical reality here is that A4 and
+  Letter are equally valid to AMC (`\documentclass` takes both,
+  geometry follows the option); the choice is operational, not
+  technical.
+- **Make the paper size configurable per-control (a form field, a
+  server flag).** Rejected. There is one printer context per deploy;
+  a variable buys nothing today but invites future controls printed
+  with the wrong size for their site. If a deployment outside Chile
+  ever needs A4, that is a reopening of this decision, not a
+  parameter — the failure mode ("professor picks the wrong option")
+  is worse than "no option exists".
+- **Add wildcards / auto-detection to the reader so both papers scan
+  correctly** (AMC's `analyse` given some tolerance for either
+  geometry). Rejected as scope. The reader is not the failure surface;
+  the printer is. Reading tolerance would let an A4 PDF that got
+  printed Letter-scaled succeed, which is the exact "silently ship
+  the wrong thing" the four-corner fiducial check exists to forbid.
+
+## Consequences
+
+- Every subsequent `POST /controls/{id}/generate` produces a Letter
+  source; AMC computes the layout from that; the printed PDF matches
+  the printer default; the four fiducials land where the scanner
+  expects them.
+- ADR-0030 gains an `Amended by:` line. Its §What was verified stays
+  intact as the historical record of what was measured then (A4, four
+  sheets, blue marker); §Not yet proven still points at
+  `PAPER-CHECK.md`, which now says Letter.
+- **A deployment outside Chile reopens this ADR.** The choice is
+  Chilean-printer-facing; there is no branch of the code that decides
+  paper size at runtime, so a US-East-of-Europe deploy would meet the
+  same shape of failure with the letters swapped.
+- **The L8 paper check gains its own reason to run first.** Any change
+  to the preamble touches this decision, and PAPER-CHECK.md is the
+  only place it is verified against ink.
+
+## Not yet proven
+
+**No sheet has been through the professor's printer with the new
+generator.** ADR-0030 §Not yet proven's whole point — "everything on
+paper is L8, and L8 belongs to the professor" — carries over unchanged:
+a real Letter batch has to be printed, marked, scanned and read before
+this decision is verified. The procedure is `apps/amc-worker/PAPER-CHECK.md`
+(now saying Letter in §1), and its outcome is recorded here on the next
+real cycle, alongside ADR-0030's own pending amendment.
+
+Until then, the incident above stands as evidence of the failure mode
+and this decision as its argued fix; the automated suite pins the
+generator's output and says nothing about paper.


### PR DESCRIPTION
Closes #206.

## Summary

Chile's printer default is US Letter. On 2026-08-19 a control was generated
with `\documentclass[a4paper,11pt]`, sent to the professor's Letter printer,
and scaled down to fit — clipping ~18 mm off the bottom and taking AMC's
two bottom fiducial markers with it. Every one of 44 pages came back
`+0/0/0+` ("no four-corner fix"), the worker returned exit 1, the server
flashed "El motor de lectura rechazó el archivo.", and the batch fell to
manual grading (control WNME7QU6SZD26KFM5CBJD3QM4E, 22 copies).

Swap the generator's `preambleHead` to `letterpaper`, pin the choice with a
bidirectional test (positive presence + negative absence), sweep the same
fact across every surface that asserts it, and record the decision as
ADR-0042 with `Amended by:` on ADR-0030.

## Slices

- [x] S1: `preambleHead` → `letterpaper` in `apps/server/.../tex/tex.go`,
      new `TestPreambleDeclaresLetterPaperNotA4` pins it both directions
      (`f62e3be`).
- [x] S2: three amc-worker fixtures declare `letterpaper` (`a25952b`).
- [x] S3: `PAPER-CHECK.md` §1 and `PAPER-CHECK-MIN.md` §1 say "Plain white
      US Letter" (`4f943a7`).
- [x] S4: new ADR-0042 + `Amended by:` on ADR-0030 (`4e27efa`).

Plus two review-fix commits — see §"Reviews run".

## Acceptance criteria

1. **`tex.go` declares `letterpaper`** —
   `apps/server/internal/domain/controls/tex/tex.go:108`
   (`const preambleHead = \`\documentclass[letterpaper,11pt]{article}`).
2. **All three amc-worker fixtures declare `letterpaper`** —
   `apps/amc-worker/tests/fixtures/control-demo.tex:22`,
   `control-paper-min.tex:39`, `control-tres.tex:15`.
3. **`PAPER-CHECK.md` says Letter** —
   `apps/amc-worker/PAPER-CHECK.md:49` and additionally the MIN variant
   `apps/amc-worker/PAPER-CHECK-MIN.md:36` (same paragraph shape; the sweep
   was extended to keep both procedures consistent).
4. **ADR-0030 carries `Amended by: ADR-0042`** —
   `docs/decisions/0030-auto-multiple-choice-as-the-control-engine.md:7`.
5. **New ADR committed** —
   `docs/decisions/0042-control-sheets-are-printed-on-us-letter.md`
   (Context · Decision · Alternatives considered · Consequences ·
   Not yet proven).
6. **`apps/server` per-commit protocol green** — gofmt, vet, build, test
   (S1 commit and every subsequent one).
7. **`apps/amc-worker` per-commit protocol green** — `make test` 66 checks,
   0 failed (S2 commit); no golden count changed (verified: no test asserts
   coordinates or paper geometry from the fixtures).
8. **Human paper check (L8) NOT part of this WP.** ADR-0030 §Not yet proven
   already schedules it for Miguel's next real control cycle; ADR-0042
   §Not yet proven inherits the same rule under the new preamble. This PR
   does not claim to have run PAPER-CHECK.md.

## Pre-PR protocol (both apps, line by line, all green)

`apps/server` (from `apps/server/`, per `docs/standards/testing-strategy.md`
§apps/server):

- `test -z "$(gofmt -l .)"` — nothing printed.
- `go vet ./...` — OK.
- `go test -race -count=1 ./...` — all 25 packages OK (`tex` 3.169s).
- `go build ./...` — OK.
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...` —
  "No vulnerabilities found."
- `docker build -t nalanda/server:dev .` — OK.
- `docker compose up -d --build --wait server` — healthy.
- `curl http://127.0.0.1:8081/health` → `{"process":"up","database":"up"}`.
- `curl http://127.0.0.1:8081/api/health` → same.
- `docker compose down` — clean teardown.

`apps/amc-worker` (from `apps/amc-worker/`):

- `make verify` — image rebuilt, 66 checks, 0 failed.

## Reviews run

Multi-agent review pipeline (integrated mode), post-fix state.

- **Round A — code.** Correctness, arch-simplicity, security in parallel
  (perf lens skipped — announced, no hot paths touched). Mechanical gate
  green (both apps' pre-PR). 1 unique finding (2 lenses agreed): stale
  "300 dpi × A4" citation in a review-page CSS comment
  (`apps/server/internal/app/web/view/templates/layout.html:93`). Fixed
  inline in `6eee650`; mechanical grep re-check confirms no A4 remains
  outside the deliberate historical/test contexts.
- **Round B — documentation.** docs-completeness, docs-accuracy,
  adr-hunter, agent-readability in parallel. 2 unique findings, both
  suggestion severity, both accepted:
  - `§What was verified` was cited three times as if it were an ADR-0030
    heading — it is not (it is a paragraph inside `### Partial evidence —
    2026-08-17`). Repointed in ADR-0042 (Context + Consequences) and in
    ADR-0030's own `Amended by:` line.
  - `apps/server/CLAUDE.md` had no bullet obligating PAPER-CHECK.md when a
    preamble change touches `internal/domain/controls/tex/**`. Added the
    mirror bullet next to the existing GOOGLE-CHECK one.
  Both fixed in `f415fc3`.

Totals: 3 accepted / 0 deferred / 0 dismissed; 0 critical, 0 important, 3
suggestions. No verifier round (suggestions skip it by design).

## Notes

- **ADR number chosen with the correct sweep.** `git fetch --all` +
  `git branch -r --list 'origin/*' | xargs -I{} git ls-tree -r --name-only
  {} | grep '^docs/decisions/[0-9]'` — 0041 is the highest live number
  across every remote branch, no open PRs, so 0042 is mine. A pre-existing
  0040 collision (mermaid + corrected-pdf, both on `main` from earlier
  merges) is not this PR's to resolve.
- **Follow-up items already recorded in the issue's §Notes** (worker
  `payload.Detail` not propagated to server log; `Service.UploadScan`
  rolling back the PDF on analyse failure; the flash text that drives the
  professor to redo the scan instead of the print) are separate issues by
  the issue-body's own decision. Not touched here.
- **Sweep beyond the letter of the AC.** Both `PAPER-CHECK-MIN.md`
  (S3) and the `layout.html` CSS comment (RA-1 review fix) were caught by
  the "sweep every surface that asserts the fact" rule and updated in this
  PR. Both are the same-class edit (same paragraph shape / same claim);
  neither adds behavior. Flagged here so a reader knows the sweep was
  deliberate.

## Manual verification (L8 for later; the review checklist below is for now)

The WP does not claim to have run PAPER-CHECK.md — that is Miguel's next
real cycle. What you can verify by reading this PR:

- [ ] `tex.go:108` reads `letterpaper`.
- [ ] `TestPreambleDeclaresLetterPaperNotA4` in `tex_test.go` (positive +
      negative). Optional: revert `letterpaper` → `a4paper` locally, run
      `go test -run TestPreambleDeclaresLetterPaperNotA4`, both assertions
      fire, restore.
- [ ] The three fixtures under `apps/amc-worker/tests/fixtures/` declare
      `letterpaper`.
- [ ] PAPER-CHECK.md and PAPER-CHECK-MIN.md §1 say "Plain white US Letter".
- [ ] ADR-0042 § Context, § Decision, § Alternatives considered,
      § Consequences, § Not yet proven — the argument holds, the
      alternatives are refuted with reasons that survive, the L8 gap is
      named.
- [ ] ADR-0030 line 7 carries `Amended by:` in the format spec's shape,
      and its historical `### Partial evidence — 2026-08-17` section is
      untouched.
- [ ] `apps/server/CLAUDE.md` "Nothing here can test paper, either." bullet
      lands next to the GOOGLE-CHECK one.

The one paper-truthing that IS on Miguel: the next real control cycle
prints and scans a Letter batch through DocumentBuddy and records the
outcome in ADR-0042 § Not yet proven, in the same shape ADR-0030 §
Partial evidence — 2026-08-17 uses today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMHoii5U8HsModCEzdytb7
