### PR TITLE
feat(controls): make paper size configurable per control (letter or a4) (#208)

### DIFF
--- a/apps/amc-worker/PAPER-CHECK-MIN.md
+++ b/apps/amc-worker/PAPER-CHECK-MIN.md
@@ -33,10 +33,17 @@ That produces `tests/work/paper-min/out/control-min-para-imprimir.pdf` — three
 copies, three pages.
 
 **Print single-sided, at 100% scale.** Not "fit to page": AMC finds the sheet
-by the four corner marks, and scaling moves them. Use the paper you picked
-when the control was created — Letter by default (Chile), A4 if you opened
-"Opciones avanzadas" in the create form and switched (ADR-0043 supersedes
-the fixed-Letter of ADR-0042). Three sheets come out on that paper.
+by the four corner marks, and scaling moves them. Use the paper the control
+was created for — Letter by default (Chile), A4 if you opened "Opciones
+avanzadas" in the create form and switched (ADR-0043 supersedes the
+fixed-Letter of ADR-0042). Three sheets come out on that paper.
+
+**A4 leg of this MIN check.** `make paper-min` copies
+`tests/fixtures/control-paper-min.tex`, hardcoded to `letterpaper`. To run
+the A4 pass, either temporarily flip the class option in that fixture from
+`letterpaper` to `a4paper` (then `git checkout` to revert), or drop a
+server-generated `paper=a4` source into `tests/work/paper-min/src/` and
+run `meptex` on it. Same guidance as PAPER-CHECK.md §1.
 
 ## 2. Mark them
 

--- a/apps/amc-worker/PAPER-CHECK-MIN.md
+++ b/apps/amc-worker/PAPER-CHECK-MIN.md
@@ -33,8 +33,10 @@ That produces `tests/work/paper-min/out/control-min-para-imprimir.pdf` — three
 copies, three pages.
 
 **Print single-sided, at 100% scale.** Not "fit to page": AMC finds the sheet
-by the four corner marks, and scaling moves them. Plain white US Letter; three
-sheets come out (paper size is a printer-facing contract per ADR-0042).
+by the four corner marks, and scaling moves them. Use the paper you picked
+when the control was created — Letter by default (Chile), A4 if you opened
+"Opciones avanzadas" in the create form and switched (ADR-0043 supersedes
+the fixed-Letter of ADR-0042). Three sheets come out on that paper.
 
 ## 2. Mark them
 

--- a/apps/amc-worker/PAPER-CHECK.md
+++ b/apps/amc-worker/PAPER-CHECK.md
@@ -46,10 +46,30 @@ failed.
 
 **Print double-sided (dúplex), at 100% scale.** Not "fit to page": AMC finds
 the sheet by the four corner marks, and scaling moves them. If your dialog
-offers "actual size" or "100%", that is the one. Use the paper you picked
-when the control was created — Letter by default (Chile), A4 if you opened
-"Opciones avanzadas" in the create form and switched (ADR-0043 supersedes
-the fixed-Letter of ADR-0042). Six sheets come out on that paper.
+offers "actual size" or "100%", that is the one. Use the paper the control
+was created for — Letter by default (Chile), A4 if you opened "Opciones
+avanzadas" in the create form and switched (ADR-0043 supersedes the
+fixed-Letter of ADR-0042). Six sheets come out on that paper.
+
+**To run the A4 leg of the check** (`ADR-0043 §Not yet proven` schedules
+one Letter cycle and one A4 cycle), `make paper` alone is not enough: it
+copies `tests/fixtures/control-demo.tex`, which is hardcoded to
+`\documentclass[letterpaper,11pt]{article}`. Two ways to produce the A4
+batch:
+
+- **Simplest — temporarily flip the fixture.** In
+  `tests/fixtures/control-demo.tex` change the class option from
+  `letterpaper` to `a4paper`, run `make paper`, do steps 2–5 below,
+  then revert the file (`git checkout tests/fixtures/control-demo.tex`).
+  Nothing else in the fixture changes.
+- **End-to-end — go through the server.** Create a control with
+  `paper=a4` from the create form (open "Opciones avanzadas" first),
+  copy the generated `source.tex` from the shared volume into
+  `tests/work/paper/src/`, and run `meptex` on it by hand. Slower but
+  exercises the full generator path.
+
+Whichever you pick, run the Letter cycle first (`make paper` unchanged)
+so the two comparisons stay side by side.
 
 ## 2. Mark them like a student would
 

--- a/apps/amc-worker/PAPER-CHECK.md
+++ b/apps/amc-worker/PAPER-CHECK.md
@@ -46,8 +46,10 @@ failed.
 
 **Print double-sided (dúplex), at 100% scale.** Not "fit to page": AMC finds
 the sheet by the four corner marks, and scaling moves them. If your dialog
-offers "actual size" or "100%", that is the one. Plain white US Letter; six
-sheets come out (paper size is a printer-facing contract per ADR-0042).
+offers "actual size" or "100%", that is the one. Use the paper you picked
+when the control was created — Letter by default (Chile), A4 if you opened
+"Opciones avanzadas" in the create form and switched (ADR-0043 supersedes
+the fixed-Letter of ADR-0042). Six sheets come out on that paper.
 
 ## 2. Mark them like a student would
 

--- a/apps/server/CLAUDE.md
+++ b/apps/server/CLAUDE.md
@@ -150,12 +150,17 @@ the `avisoNo*` / `flash.Set(…)` string literals in `internal/app/web/handler/`
   same reason, as `apps/amc-worker/PAPER-CHECK.md`.
 - **Nothing here can test paper, either.** The tex generator lives in
   `internal/domain/controls/tex/**`, and the suite pins tokens
-  (`TestPreambleDeclaresLetterPaperNotA4` pins `letterpaper` and the absence of
-  `a4paper`, ADR-0042) but sees no printer, no scanner and no ink. Any change to
-  the preamble — paper option, font size, margin package, an added `\usepackage`
-  — is unfinished while `apps/amc-worker/PAPER-CHECK.md` has not run against it.
-  Same rule, and the same reason, as the Google bullet above; the failure mode
-  is on paper (2026-08-19: 44 pages `+0/0/0+`, ADR-0042 §Context).
+  (`TestPreambleDeclaresLetterPaperWhenInputSaysLetter` and its A4/empty
+  twins pin each `\documentclass` option's presence and the others'
+  absence, ADR-0043) but sees no printer, no scanner and no ink. Any change
+  to the preamble — paper option, font size, margin package, an added
+  `\usepackage` — is unfinished while `apps/amc-worker/PAPER-CHECK.md` has
+  not run against it. Since ADR-0043 the professor picks paper per
+  control, so a real check now needs one Letter batch and one A4 batch
+  (PAPER-CHECK.md §1). Same rule, and the same reason, as the Google
+  bullet above; the failure mode is on paper (2026-08-19: 44 pages
+  `+0/0/0+`, ADR-0042 §Context — the fixed-Letter that ADR-0043 makes
+  configurable).
 - **The two surfaces do not share an auth gate** (§C12). Everything auth-shaped
   is mounted inside `internal/app/web`; `internal/app/api` is anonymous by
   construction, and `/health` sits deliberately outside the gate because the

--- a/apps/server/internal/app/web/handler/controls.go
+++ b/apps/server/internal/app/web/handler/controls.go
@@ -323,6 +323,9 @@ func defaultFormValues() view.ControlFormValues {
 		// Historical AMC layout by default (issue #185): the professor
 		// opts out for simplex printing.
 		DuplexPadding: true,
+		// Issue #208: Letter is the operational default (ADR-0043); A4
+		// requires opening `<details> Opciones avanzadas` first.
+		Paper: string(controls.DefaultPaper),
 	}
 }
 
@@ -345,6 +348,10 @@ func valuesFromRequest(r *http.Request) view.ControlFormValues {
 		// HTML checkbox convention: absent means unchecked. `on` is what
 		// the browser sends when the checkbox has no explicit value.
 		DuplexPadding: r.PostFormValue("duplex_padding") == "on",
+		// Issue #208: read the radio verbatim. Empty means the professor
+		// never opened `<details>` — validateCreate resolves that to the
+		// default; anything outside {"letter","a4"} is refused there.
+		Paper: strings.TrimSpace(r.PostFormValue("paper")),
 	}
 }
 
@@ -397,6 +404,17 @@ func validateCreate(v view.ControlFormValues, b *bank.Bank) (map[string]string, 
 		errs["copies"] = copiesErr
 	}
 
+	// Issue #208: empty is the "professor never opened <details>" path,
+	// resolved to the default. Anything else must be one of the two
+	// enumerated values; a stray third string is refused here so the
+	// schema CHECK never has to.
+	paper := controls.Paper(v.Paper)
+	if v.Paper == "" {
+		paper = controls.DefaultPaper
+	} else if !controls.ValidPaper(paper) {
+		errs["paper"] = "El papel debe ser Letter o A4."
+	}
+
 	req := controls.CreateRequest{
 		Name:             v.Name,
 		ApplicationDate:  appDate,
@@ -405,6 +423,7 @@ func validateCreate(v view.ControlFormValues, b *bank.Bank) (map[string]string, 
 		QuestionsPerCopy: qpc,
 		Copies:           copies,
 		DuplexPadding:    v.DuplexPadding,
+		Paper:            paper,
 	}
 	return errs, req
 }
@@ -739,6 +758,7 @@ func toDetailedControl(c controls.Control, b *bank.Bank) view.DetailedControl {
 		Range:           formatRangeWithTitles(c.RangeFrom, c.RangeTo, b),
 		Shape:           fmt.Sprintf("%d preguntas × %d copias", c.QuestionsPerCopy, c.Copies),
 		PrintLayout:     printLayoutWord(c.DuplexPadding),
+		Paper:           paperWord(c.Paper),
 		State:           stateWordControl(c.State),
 		CreatedAt:       spanishDate(c.CreatedAt),
 	}
@@ -751,6 +771,18 @@ func printLayoutWord(duplexPadding bool) string {
 		return "dúplex (con página en blanco por copia)"
 	}
 	return "simplex (una página por copia)"
+}
+
+// paperWord names the two paper sizes for the detail page. Issue #208,
+// ADR-0043. An empty value (a control from before the migration ran) reads
+// as the default, so the professor never sees a blank cell.
+func paperWord(p controls.Paper) string {
+	switch p {
+	case controls.PaperA4:
+		return "A4"
+	default:
+		return "US Letter"
+	}
 }
 
 func formatOptionalDate(t *time.Time) string {

--- a/apps/server/internal/app/web/handler/controls_test.go
+++ b/apps/server/internal/app/web/handler/controls_test.go
@@ -317,7 +317,10 @@ func TestCreateStoresPaperLetterByDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
-	if len(rows) != 1 || rows[0].Paper != controls.PaperLetter {
+	if len(rows) != 1 {
+		t.Fatalf("List returned %d rows, want 1", len(rows))
+	}
+	if rows[0].Paper != controls.PaperLetter {
 		t.Errorf("stored Paper = %q, want %q (default when the form omits it)", rows[0].Paper, controls.PaperLetter)
 	}
 }
@@ -336,7 +339,10 @@ func TestCreateStoresPaperA4WhenTheRadioIsA4(t *testing.T) {
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
-	if len(rows) != 1 || rows[0].Paper != controls.PaperA4 {
+	if len(rows) != 1 {
+		t.Fatalf("List returned %d rows, want 1", len(rows))
+	}
+	if rows[0].Paper != controls.PaperA4 {
 		t.Errorf("stored Paper = %q, want %q", rows[0].Paper, controls.PaperA4)
 	}
 }
@@ -346,6 +352,12 @@ func TestCreateStoresPaperA4WhenTheRadioIsA4(t *testing.T) {
 // side effects would have run and the error message would name a sqlite
 // constraint (leak). The handler catches it first (Round A local review
 // rationale: refuse where the meaning is known).
+//
+// Asserting the status alone was not enough — a mutation that removed the
+// handler's ValidPaper check reddened this test at the status line too, but
+// because a schema CHECK propagated as a 500 rather than because the handler
+// refused with a 422. Asserting the field-error string in the body pins the
+// layer this test claims to guard (Round A COR-4).
 func TestCreateRefusesAnUnknownPaperValue(t *testing.T) {
 	f := newControlsFixture(t)
 	form := validForm()
@@ -355,6 +367,15 @@ func TestCreateRefusesAnUnknownPaperValue(t *testing.T) {
 
 	if rec.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("status = %d, want 422 for paper='legal'; body:\n%s", rec.Code, rec.Body.String())
+	}
+	// The Spanish per-field error only appears on the handler's own 422
+	// refusal path (validateCreate → render with errs). A schema CHECK
+	// propagating as a 500 would render the generic server-error page
+	// instead — which never contains this exact string. Also assert the
+	// per-field error is scoped to `paper`, not any other field.
+	body := rec.Body.String()
+	if !strings.Contains(body, "El papel debe ser Letter o A4.") {
+		t.Errorf("422 body is missing the handler's per-field message — the 422 may be coming from a lower gate; body:\n%s", body)
 	}
 }
 

--- a/apps/server/internal/app/web/handler/controls_test.go
+++ b/apps/server/internal/app/web/handler/controls_test.go
@@ -259,6 +259,128 @@ func TestCreateStoresDuplexPaddingFalseWhenTheCheckboxIsUnchecked(t *testing.T) 
 	}
 }
 
+// Issue #208: the paper radio lives inside `<details> Opciones avanzadas`
+// and Letter is checked by default. The pattern mirrors the DuplexPadding
+// tests above: pin the paper input against name+checked (attribute-order
+// agnostic) so a stray checked= elsewhere on the page cannot silently keep
+// this test green. Two facts pinned in one test: the input exists, and
+// Letter is the checked one.
+var paperLetterCheckedRe = regexp.MustCompile(
+	`<input[^>]*(?:name="paper"[^>]*\bvalue="letter"[^>]*\bchecked\b|\bchecked\b[^>]*name="paper"[^>]*\bvalue="letter"|value="letter"[^>]*name="paper"[^>]*\bchecked\b)[^>]*>`)
+
+var paperA4CheckedRe = regexp.MustCompile(
+	`<input[^>]*(?:name="paper"[^>]*\bvalue="a4"[^>]*\bchecked\b|\bchecked\b[^>]*name="paper"[^>]*\bvalue="a4"|value="a4"[^>]*name="paper"[^>]*\bchecked\b)[^>]*>`)
+
+func TestNewRendersThePaperRadioWithLetterCheckedByDefault(t *testing.T) {
+	f := newControlsFixture(t)
+	rec := httptest.NewRecorder()
+	f.handler.New(rec, f.authedRequest(t, http.MethodGet, handler.ControlsNewPath, nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	// Both radios must exist.
+	if !strings.Contains(body, `name="paper"`) || !strings.Contains(body, `value="letter"`) {
+		t.Error("form is missing the paper=letter radio")
+	}
+	if !strings.Contains(body, `value="a4"`) {
+		t.Error("form is missing the paper=a4 radio")
+	}
+	// Letter is the default (ADR-0043).
+	if !paperLetterCheckedRe.MatchString(body) {
+		t.Errorf("the paper=letter radio is not `checked` on the empty GET form\nbody:\n%s", body)
+	}
+	// And A4 is NOT checked when Letter is — asserting the pair keeps a
+	// mutation that checks both from passing.
+	if paperA4CheckedRe.MatchString(body) {
+		t.Error("the paper=a4 radio is `checked` when Letter should be the default")
+	}
+	// The radios live inside `<details>` so the default case shows no
+	// friction (ADR-0043 §Decision).
+	if !strings.Contains(body, `<details`) {
+		t.Error("the paper radio is not inside a <details> block")
+	}
+}
+
+func TestCreateStoresPaperLetterByDefault(t *testing.T) {
+	f := newControlsFixture(t)
+	form := validForm()
+	form.Del("paper") // simulate a submission with the `<details>` never opened
+	rec := httptest.NewRecorder()
+	f.handler.Create(rec, f.authedRequest(t, http.MethodPost, handler.ControlsPath, form))
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303; body:\n%s", rec.Code, rec.Body.String())
+	}
+	rows, err := f.service.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Paper != controls.PaperLetter {
+		t.Errorf("stored Paper = %q, want %q (default when the form omits it)", rows[0].Paper, controls.PaperLetter)
+	}
+}
+
+func TestCreateStoresPaperA4WhenTheRadioIsA4(t *testing.T) {
+	f := newControlsFixture(t)
+	form := validForm()
+	form.Set("paper", "a4")
+	rec := httptest.NewRecorder()
+	f.handler.Create(rec, f.authedRequest(t, http.MethodPost, handler.ControlsPath, form))
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303; body:\n%s", rec.Code, rec.Body.String())
+	}
+	rows, err := f.service.List(context.Background())
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Paper != controls.PaperA4 {
+		t.Errorf("stored Paper = %q, want %q", rows[0].Paper, controls.PaperA4)
+	}
+}
+
+// A form value outside {letter, a4} must be refused at 422, not silently
+// coerced. The schema CHECK would refuse it too, but by then the disk-write
+// side effects would have run and the error message would name a sqlite
+// constraint (leak). The handler catches it first (Round A local review
+// rationale: refuse where the meaning is known).
+func TestCreateRefusesAnUnknownPaperValue(t *testing.T) {
+	f := newControlsFixture(t)
+	form := validForm()
+	form.Set("paper", "legal")
+	rec := httptest.NewRecorder()
+	f.handler.Create(rec, f.authedRequest(t, http.MethodPost, handler.ControlsPath, form))
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422 for paper='legal'; body:\n%s", rec.Code, rec.Body.String())
+	}
+}
+
+// After a refusal, the paper the professor CHOSE stays selected on
+// re-render — the same "echo back on refusal" convention every other
+// field follows. Mirror of TestNewDoesNotRenderCheckedWhenTheForm
+// ValueIsFalse for the checkbox.
+func TestFormRefusalEchoesBackTheA4Choice(t *testing.T) {
+	f := newControlsFixture(t)
+	form := validForm()
+	form.Set("paper", "a4")
+	form.Del("name") // force a refusal
+	rec := httptest.NewRecorder()
+	f.handler.Create(rec, f.authedRequest(t, http.MethodPost, handler.ControlsPath, form))
+
+	if rec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("status = %d, want 422; body:\n%s", rec.Code, rec.Body.String())
+	}
+	if !paperA4CheckedRe.MatchString(rec.Body.String()) {
+		t.Error("re-rendered form does not carry `checked` on paper=a4 after the professor chose it")
+	}
+	if paperLetterCheckedRe.MatchString(rec.Body.String()) {
+		t.Error("re-rendered form still carries `checked` on paper=letter after the professor picked a4")
+	}
+}
+
 func TestNewRendersTheFormWithBankSections(t *testing.T) {
 	f := newControlsFixture(t)
 	rec := httptest.NewRecorder()

--- a/apps/server/internal/app/web/view/templates/layout.html
+++ b/apps/server/internal/app/web/view/templates/layout.html
@@ -90,9 +90,10 @@
       }
 
       /* Scan images on the review page are the physical scan's native
-         resolution (300 dpi × US Letter = ~2550×3300 px, ADR-0042). Without
-         a max-width the browser lays them out at natural size and the sheet
-         overflows every viewport. */
+         resolution — either ~2550×3300 px (US Letter) or ~2480×3508 px
+         (A4), at 300 dpi (ADR-0043 makes the paper per-control). Without
+         a max-width the browser lays them out at natural size and the
+         sheet overflows every viewport. */
       .review-image img { max-width: 100%; height: auto; }
       /* The corrected PDF (issue #190) renders in the browser's own viewer
          through an iframe; a fixed height keeps the review form's left

--- a/apps/server/internal/app/web/view/templates/pages/controls_detail.html
+++ b/apps/server/internal/app/web/view/templates/pages/controls_detail.html
@@ -9,6 +9,7 @@
         <tr><th>Rango</th><td>{{ .Control.Range }}</td></tr>
         <tr><th>Formato</th><td>{{ .Control.Shape }}</td></tr>
         <tr><th>Impresión</th><td>{{ .Control.PrintLayout }}</td></tr>
+        <tr><th>Papel</th><td>{{ .Control.Paper }}</td></tr>
         <tr><th>Estado</th><td>{{ .Control.State }}</td></tr>
         <tr><th>Creado</th><td>{{ .Control.CreatedAt }}</td></tr>
       </tbody>

--- a/apps/server/internal/app/web/view/templates/pages/controls_form.html
+++ b/apps/server/internal/app/web/view/templates/pages/controls_form.html
@@ -91,6 +91,29 @@
       <small>Desactívalo si vas a imprimir simplex — te ahorra una hoja por prueba.</small>
     </p>
 
+    <details class="advanced">
+      <summary>Opciones avanzadas</summary>
+      <p class="field">
+        <label>Papel</label>
+        <label>
+          <input type="radio" name="paper" value="letter"
+                 {{ if eq .Values.Paper "letter" }}checked{{ end }} />
+          Letter (recomendado en Chile)
+        </label>
+        <label>
+          <input type="radio" name="paper" value="a4"
+                 {{ if eq .Values.Paper "a4" }}checked{{ end }} />
+          A4
+        </label>
+        <small>Debe coincidir con el papel real de tu impresora. Un PDF en A4
+          impreso en Letter pierde 18&nbsp;mm en el borde inferior y destruye
+          la lectura del batch entero (incidente 2026-08-19, ADR-0043).</small>
+        {{ with index .Errors "paper" }}
+          <span class="error">{{ . }}</span>
+        {{ end }}
+      </p>
+    </details>
+
     <p><button type="submit">{{ .Submit }}</button>
        <a href="/controls" class="boton">Cancelar</a></p>
   </form>

--- a/apps/server/internal/app/web/view/view.go
+++ b/apps/server/internal/app/web/view/view.go
@@ -180,6 +180,12 @@ type ControlFormValues struct {
 	// keeps the historical layout without the professor having to think
 	// about it. Issue #185.
 	DuplexPadding bool
+	// Paper echoes the radio the professor picked, so the template can
+	// re-render `checked` after a refusal. Two legal string values:
+	// "letter" (default) and "a4"; lives inside `<details> Opciones
+	// avanzadas` so the default requires no interaction. Issue #208,
+	// ADR-0043.
+	Paper string
 }
 
 // DocumentSections carries one document's sections for the range
@@ -293,8 +299,12 @@ type DetailedControl struct {
 	// on the detail page so the professor sees the layout their generated
 	// PDF actually carries (issue #185, ADR-0039).
 	PrintLayout string
-	State       string
-	CreatedAt   string
+	// Paper is the human phrase for control.paper: "US Letter" or "A4".
+	// Shown on the detail page so the professor can see which paper the
+	// PDF assumes for a print (issue #208, ADR-0043).
+	Paper     string
+	State     string
+	CreatedAt string
 }
 
 // UploadedBatch is one uploaded scan batch's download link (issue #204).

--- a/apps/server/internal/domain/controls/controls.go
+++ b/apps/server/internal/domain/controls/controls.go
@@ -50,6 +50,13 @@ type Control struct {
 	// SQL level is 1 (padded) so pre-migration controls stay padded, but
 	// every caller in Go passes an explicit value.
 	DuplexPadding bool
+	// Paper is the physical sheet the printed PDF is laid out for
+	// (issue #208, ADR-0043). Two values today: PaperLetter (default, the
+	// Chilean printer default from ADR-0042) and PaperA4. The generator
+	// reads this into \documentclass; the professor picks it in `<details>
+	// Opciones avanzadas` on the create form, so the default requires no
+	// interaction and the alternative asks for one.
+	Paper Paper
 	// Ticked/Unsure are the darkness thresholds this control's batches are
 	// read and scored at (issue #197). One pair per control, last-wins:
 	// the upload form can set them, the reanalyse form re-sets them, and
@@ -61,6 +68,33 @@ type Control struct {
 	State     State
 	CreatedAt time.Time
 	CreatedBy int64 // users.user_id
+}
+
+// Paper is the physical sheet a control's PDF is laid out for. The two
+// enumerated values map 1-1 to the two \documentclass options the generator
+// supports (issue #208, ADR-0043). New values are added here, in the SQL
+// CHECK constraint in migrations/00009_paper.sql, and in the generator's
+// preamble switch — all three or none.
+type Paper string
+
+const (
+	// PaperLetter is US Letter (8.5×11 in, 2550×3300 px @ 300 dpi). The
+	// Chilean printer default and this repo's operational default.
+	PaperLetter Paper = "letter"
+	// PaperA4 is A4 (210×297 mm, 2480×3508 px @ 300 dpi). Available when
+	// the professor explicitly asks for it under "Opciones avanzadas".
+	PaperA4 Paper = "a4"
+	// DefaultPaper is what the create form initialises Paper to, what the
+	// migration sets NULL rows to, and what Service.Create writes on any
+	// call that omits the field.
+	DefaultPaper = PaperLetter
+)
+
+// ValidPaper reports whether p is one of the two enumerated values. Handlers
+// use it to reject an unknown form value before it reaches the schema's
+// CHECK (which would refuse it too, one gate later).
+func ValidPaper(p Paper) bool {
+	return p == PaperLetter || p == PaperA4
 }
 
 // DefaultTicked / DefaultUnsure are the product defaults for a newly

--- a/apps/server/internal/domain/controls/pool.go
+++ b/apps/server/internal/domain/controls/pool.go
@@ -33,7 +33,12 @@ type PoolSnapshot struct {
 		QuestionsPerCopy int    `json:"questions_per_copy"`
 		Copies           int    `json:"copies"`
 		DuplexPadding    bool   `json:"duplex_padding"`
-		Seed             int64  `json:"seed"`
+		// Paper is "letter" or "a4" (issue #208, ADR-0043). Recorded like
+		// DuplexPadding: both are generation-time preferences the backup
+		// needs to reproduce source.tex from — ticked/unsure stay off the
+		// snapshot because they are read-time thresholds re-set per batch.
+		Paper string `json:"paper"`
+		Seed  int64  `json:"seed"`
 		// Unix seconds. The snapshot's own write time, evaluated when the
 		// file is written — the control row's created_at stays where it is
 		// (persist time), the two timestamps differ by the generation.
@@ -81,6 +86,7 @@ func writePoolSnapshot(path string, id string, req CreateRequest, pool []bank.Qu
 	snap.Control.QuestionsPerCopy = req.QuestionsPerCopy
 	snap.Control.Copies = req.Copies
 	snap.Control.DuplexPadding = req.DuplexPadding
+	snap.Control.Paper = string(paperOrDefault(req.Paper))
 	snap.Control.Seed = seed
 	snap.Control.CreatedAt = now.Unix()
 

--- a/apps/server/internal/domain/controls/service.go
+++ b/apps/server/internal/domain/controls/service.go
@@ -46,6 +46,17 @@ func (e PoolTooSmallErr) Error() string {
 }
 func (e PoolTooSmallErr) Unwrap() error { return ErrPoolTooSmall }
 
+// paperOrDefault resolves an empty request field to DefaultPaper. A caller
+// that omits the field never lands on a schema CHECK failure; a caller
+// that sends a garbage value does — the handler's own ValidPaper is the
+// gate for that path.
+func paperOrDefault(p Paper) Paper {
+	if p == "" {
+		return DefaultPaper
+	}
+	return p
+}
+
 // Service is the orchestration layer of §Design: it turns a form submission
 // into files on disk plus a row in the database, all-or-nothing.
 //
@@ -127,7 +138,13 @@ type CreateRequest struct {
 	// one page per copy for simplex printing. Handler always passes an
 	// explicit value; there is no Go-level default. Issue #185.
 	DuplexPadding bool
-	CreatedBy     int64
+	// Paper is the physical sheet the printed PDF is laid out for.
+	// Handler always passes one of the two enumerated values (PaperLetter
+	// or PaperA4) — an empty string arriving here is a caller bug that
+	// Create resolves to DefaultPaper as a defensive belt over the
+	// schema CHECK. Issue #208, ADR-0043.
+	Paper     Paper
+	CreatedBy int64
 }
 
 // Create is the whole orchestration: resolve the range against the bank,
@@ -250,11 +267,11 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (Control, error
 		QuestionsPerCopy: req.QuestionsPerCopy,
 		Copies:           req.Copies,
 		DuplexPadding:    req.DuplexPadding,
-		// Issue #208: S1 wires the schema and the default; S2 threads the
-		// form value through CreateRequest. Between the two slices Create
-		// always writes DefaultPaper, so the schema CHECK is satisfied and
-		// the tex generator sees Letter — the pre-#208 behaviour.
-		Paper: DefaultPaper,
+		// Issue #208: honour the professor's choice, falling back to the
+		// default when a caller (a test, a future JSON API, a bug) sends
+		// an empty value — the schema CHECK would refuse "" and this
+		// resolves it to the operational default instead of failing loud.
+		Paper: paperOrDefault(req.Paper),
 		// Issue #197: the product defaults; the upload and reanalyse
 		// forms change them per batch afterwards.
 		Ticked:    DefaultTicked,

--- a/apps/server/internal/domain/controls/service.go
+++ b/apps/server/internal/domain/controls/service.go
@@ -250,6 +250,11 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (Control, error
 		QuestionsPerCopy: req.QuestionsPerCopy,
 		Copies:           req.Copies,
 		DuplexPadding:    req.DuplexPadding,
+		// Issue #208: S1 wires the schema and the default; S2 threads the
+		// form value through CreateRequest. Between the two slices Create
+		// always writes DefaultPaper, so the schema CHECK is satisfied and
+		// the tex generator sees Letter — the pre-#208 behaviour.
+		Paper: DefaultPaper,
 		// Issue #197: the product defaults; the upload and reanalyse
 		// forms change them per batch afterwards.
 		Ticked:    DefaultTicked,

--- a/apps/server/internal/domain/controls/service.go
+++ b/apps/server/internal/domain/controls/service.go
@@ -212,6 +212,8 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (Control, error
 		Seed:             s.Seed,
 		ListingsDir:      workerPath(project, "inputs"),
 		DuplexPadding:    req.DuplexPadding,
+		// Issue #208, ADR-0043: same guard as the persisted field below.
+		Paper: string(paperOrDefault(req.Paper)),
 	})
 	if err != nil {
 		rollback()

--- a/apps/server/internal/domain/controls/service_test.go
+++ b/apps/server/internal/domain/controls/service_test.go
@@ -267,6 +267,13 @@ func TestCreateWritesFilesAndPersistsTheControl(t *testing.T) {
 		t.Errorf("pool.json counts = %d/%d, want 3/5",
 			snap.Control.QuestionsPerCopy, snap.Control.Copies)
 	}
+	// Issue #208: Paper is a generation-time preference the snapshot
+	// records like DuplexPadding, so a regenerate off pool.json (WP-G)
+	// can reproduce source.tex byte-for-byte. Empty request → default
+	// (Letter), same guard as paperOrDefault in Create.
+	if snap.Control.Paper != "letter" {
+		t.Errorf("pool.json paper = %q, want \"letter\" (default when the request omits it, ADR-0043)", snap.Control.Paper)
+	}
 	if len(snap.Pool) != 4 {
 		t.Fatalf("pool.json pool = %d questions, want 4 (the fixture range)", len(snap.Pool))
 	}

--- a/apps/server/internal/domain/controls/tex/tex.go
+++ b/apps/server/internal/domain/controls/tex/tex.go
@@ -55,6 +55,17 @@ type Input struct {
 	// duplex printing (historical layout). When false, emits \clearpage
 	// instead — one page per copy for simplex printing. Issue #185.
 	DuplexPadding bool
+	// Paper is one of "letter" or "a4" — the physical sheet the printed
+	// PDF is laid out for (issue #208, ADR-0043). The generator turns it
+	// into a \documentclass class option: "letter" → letterpaper,
+	// "a4" → a4paper. An empty string defaults to Letter (the ADR-0043
+	// operational default) so a caller stuck on the pre-#208 shape still
+	// gets a legal source. Kept as a plain string rather than a shared
+	// enum type because the tex package sits under domain/controls and
+	// cannot import controls without a cycle; the two-value set is
+	// enforced upstream (handler ValidPaper, schema CHECK) and defaulted
+	// here.
+	Paper string
 }
 
 // Compile emits the .tex source. The output ends with a newline.
@@ -104,10 +115,25 @@ func validate(in Input) error {
 // "ningunas" does not match and "anterior" alone does not match.
 var lastChoicePattern = regexp.MustCompile(`(?i)\bninguna\b[^.]*\banteriores\b`)
 
-// preamble tails and heads that never change with the input.
-const preambleHead = `\documentclass[letterpaper,11pt]{article}
+// preambleDocumentClassFmt is the one line the paper choice touches. Split
+// out of preambleHead because Sprintf-ing the whole preamble would try to
+// interpret every LaTeX `%` comment as a format verb. Two lines instead of
+// one abomination. Issue #208, ADR-0043.
+const preambleDocumentClassFmt = "\\documentclass[%s,11pt]{article}\n\n"
 
-\usepackage[utf8]{inputenc}
+// paperClassOption maps the domain enum ("letter"/"a4") to the LaTeX class
+// option AMC and geometry read ("letterpaper"/"a4paper"). Empty/unknown
+// falls back to letterpaper — the ADR-0043 operational default — so a
+// caller with a bug earlier in the chain still gets a legal source.
+func paperClassOption(paper string) string {
+	if paper == "a4" {
+		return "a4paper"
+	}
+	return "letterpaper"
+}
+
+// preamble tails and heads that never change with the input.
+const preambleHead = `\usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}
 \usepackage[spanish]{babel}
 \usepackage{multicol}
@@ -139,6 +165,7 @@ const preambleHead = `\documentclass[letterpaper,11pt]{article}
 `
 
 func writePreamble(b *strings.Builder, in Input) {
+	fmt.Fprintf(b, preambleDocumentClassFmt, paperClassOption(in.Paper))
 	b.WriteString(preambleHead)
 	// Fixed seed so a compile is reproducible. AMC uses this to derive the
 	// per-copy shuffle; nothing here reshuffles.

--- a/apps/server/internal/domain/controls/tex/tex_test.go
+++ b/apps/server/internal/domain/controls/tex/tex_test.go
@@ -88,19 +88,49 @@ func compile(t *testing.T, override func(*tex.Input)) string {
 	return out
 }
 
-// The paper size is the operational contract with the printer (ADR-0042).
-// Chile printer default is US Letter; an A4 preamble was printed clipped
-// 18mm at the bottom in the 2026-08-19 Jetson incident, losing the two
-// bottom fiducials and taking every one of 44 pages to +0/0/0+. The test
-// exists so that a future revert to a4paper does not ship silently — the
-// L8 print check is a manual step by design (ADR-0030 §Not yet proven).
-func TestPreambleDeclaresLetterPaperNotA4(t *testing.T) {
-	out := compile(t, nil)
+// Issue #208, ADR-0043: paper size is a per-control preference. The
+// generator writes whichever LaTeX class option matches Input.Paper. Two
+// tests, one per value, each asserting BOTH the presence of the chosen
+// option and the absence of the other — this is what the review of #206
+// established as the shape that catches a silent revert (a positive-only
+// test passes over a bug that emits both class options and a negative-only
+// test passes over a bug that emits neither).
+//
+// Empty Paper defaults to Letter — same guard the schema CHECK and
+// paperOrDefault (service) apply at their layers, mirrored here so a
+// caller landing at tex.Compile with a bug earlier in the chain still
+// gets a legal source rather than an invalid \documentclass.
+func TestPreambleDeclaresLetterPaperWhenInputSaysLetter(t *testing.T) {
+	out := compile(t, func(in *tex.Input) { in.Paper = "letter" })
 	if !strings.Contains(out, `\documentclass[letterpaper,11pt]{article}`) {
-		t.Error("preamble is missing letterpaper: printed in Chile it clips the bottom fiducials (ADR-0042)")
+		t.Error("preamble is missing letterpaper: Input.Paper=\"letter\" must produce the letterpaper class option (ADR-0043)")
 	}
 	if strings.Contains(out, "a4paper") {
-		t.Error("preamble still declares a4paper: Chile's printer default is Letter (ADR-0042)")
+		t.Error("preamble emits a4paper alongside letterpaper: the two are mutually exclusive")
+	}
+}
+
+func TestPreambleDeclaresA4PaperWhenInputSaysA4(t *testing.T) {
+	out := compile(t, func(in *tex.Input) { in.Paper = "a4" })
+	if !strings.Contains(out, `\documentclass[a4paper,11pt]{article}`) {
+		t.Error("preamble is missing a4paper: Input.Paper=\"a4\" must produce the a4paper class option (ADR-0043)")
+	}
+	if strings.Contains(out, "letterpaper") {
+		t.Error("preamble emits letterpaper alongside a4paper: the two are mutually exclusive")
+	}
+}
+
+// Empty Paper is the pre-#208 shape (and any caller that omits the new
+// field). Falls back to Letter so the source is legal even when a caller
+// has not yet been updated. Same guard as controls.paperOrDefault at the
+// service layer.
+func TestPreambleFallsBackToLetterWhenInputPaperIsEmpty(t *testing.T) {
+	out := compile(t, nil) // no Paper override
+	if !strings.Contains(out, `\documentclass[letterpaper,11pt]{article}`) {
+		t.Error("empty Input.Paper must default to letterpaper (ADR-0043 operational default)")
+	}
+	if strings.Contains(out, "a4paper") {
+		t.Error("empty Input.Paper produced a4paper: default is Letter, not A4")
 	}
 }
 

--- a/apps/server/internal/infra/storage/controlstore/controlstore.go
+++ b/apps/server/internal/infra/storage/controlstore/controlstore.go
@@ -32,7 +32,7 @@ func New(db *sql.DB) *Store {
 // Compile-time proof the shape here is the one the domain asked for.
 var _ controls.Store = (*Store)(nil)
 
-const controlColumns = "id, name, application_date, from_document, from_section, to_document, to_section, questions_per_copy, copies, duplex_padding, ticked, unsure, state, created_at, created_by"
+const controlColumns = "id, name, application_date, from_document, from_section, to_document, to_section, questions_per_copy, copies, duplex_padding, paper, ticked, unsure, state, created_at, created_by"
 
 // CreateControl writes the control, its pool and its copies in one
 // transaction. Rolled back on any failure so a control never appears in the
@@ -54,7 +54,7 @@ func (s *Store) CreateControl(ctx context.Context, control controls.Control, poo
 
 	if _, err := tx.ExecContext(ctx, `
         INSERT INTO control (`+controlColumns+`)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		control.ID,
 		control.Name,
 		nullableUnixSeconds(control.ApplicationDate),
@@ -62,6 +62,7 @@ func (s *Store) CreateControl(ctx context.Context, control controls.Control, poo
 		control.RangeTo.Document, control.RangeTo.Section,
 		control.QuestionsPerCopy, control.Copies,
 		boolToInt(control.DuplexPadding),
+		string(control.Paper),
 		control.Ticked, control.Unsure,
 		string(control.State),
 		control.CreatedAt.Unix(),
@@ -164,6 +165,7 @@ func scanControl(row interface{ Scan(...any) error }) (controls.Control, error) 
 		c               controls.Control
 		applicationDate sql.NullInt64
 		duplexPadding   int
+		paper           string
 		createdAt       int64
 		state           string
 	)
@@ -173,12 +175,14 @@ func scanControl(row interface{ Scan(...any) error }) (controls.Control, error) 
 		&c.RangeTo.Document, &c.RangeTo.Section,
 		&c.QuestionsPerCopy, &c.Copies,
 		&duplexPadding,
+		&paper,
 		&c.Ticked, &c.Unsure,
 		&state, &createdAt, &c.CreatedBy,
 	); err != nil {
 		return controls.Control{}, err
 	}
 	c.DuplexPadding = duplexPadding != 0
+	c.Paper = controls.Paper(paper)
 	c.State = controls.State(state)
 	c.CreatedAt = time.Unix(createdAt, 0).UTC()
 	if applicationDate.Valid {

--- a/apps/server/internal/infra/storage/controlstore/controlstore_test.go
+++ b/apps/server/internal/infra/storage/controlstore/controlstore_test.go
@@ -58,8 +58,10 @@ func newControl(id string, userID int64, appDate *time.Time) controls.Control {
 		QuestionsPerCopy: 4,
 		Copies:           3,
 		// Issue #197: the product defaults, like Service.Create writes.
-		Ticked:    controls.DefaultTicked,
-		Unsure:    controls.DefaultUnsure,
+		Ticked: controls.DefaultTicked,
+		Unsure: controls.DefaultUnsure,
+		// Issue #208: the operational default (ADR-0043).
+		Paper:     controls.DefaultPaper,
 		State:     controls.Generated,
 		CreatedAt: time.Unix(1_755_360_000, 0).UTC(),
 		CreatedBy: userID,
@@ -138,6 +140,36 @@ func TestCreateControlPersistsDuplexPaddingBothWays(t *testing.T) {
 		}
 		if got.DuplexPadding != tc.val {
 			t.Errorf("round-trip: DuplexPadding = %v, want %v", got.DuplexPadding, tc.val)
+		}
+	}
+}
+
+// Issue #208: the professor's paper choice persists on the control so a future
+// WP-G regenerate honours it. Both values round-trip.
+func TestCreateControlPersistsPaperBothWays(t *testing.T) {
+	ctx, db := migrated(t)
+	userID := insertProfessor(t, ctx, db, "p@example.com")
+	store := controlstore.New(db)
+
+	pool := []controls.PoolEntry{{Ref: "q-if-1", Order: 0}}
+	for _, tc := range []struct {
+		id  string
+		val controls.Paper
+	}{
+		{"CTRLPAPER000000000000000LT", controls.PaperLetter},
+		{"CTRLPAPER000000000000000A4", controls.PaperA4},
+	} {
+		c := newControl(tc.id, userID, nil)
+		c.Paper = tc.val
+		if err := store.CreateControl(ctx, c, pool); err != nil {
+			t.Fatalf("CreateControl(%s, %v): %v", tc.id, tc.val, err)
+		}
+		got, err := store.ControlByID(ctx, tc.id)
+		if err != nil {
+			t.Fatalf("ControlByID(%s): %v", tc.id, err)
+		}
+		if got.Paper != tc.val {
+			t.Errorf("round-trip: Paper = %v, want %v", got.Paper, tc.val)
 		}
 	}
 }

--- a/apps/server/internal/infra/storage/schema_test.go
+++ b/apps/server/internal/infra/storage/schema_test.go
@@ -277,6 +277,59 @@ func TestControlDuplexPaddingDefaultsToPaddedWhenTheColumnIsOmitted(t *testing.T
 	}
 }
 
+// Issue #208: the professor picks Letter or A4 in a `<details> Opciones
+// avanzadas` block of the create form; the preference persists on the control
+// so a future WP-G regenerate honours it. Default = 'letter' so every control
+// created before the column existed (and any test insert that omits it) reads
+// back as such — the operational default from ADR-0043.
+func TestControlPaperDefaultsToLetterWhenTheColumnIsOmitted(t *testing.T) {
+	ctx, db := migrated(t)
+	userID := insertProfessor(t, ctx, db, "profesora@example.com")
+
+	if _, err := db.ExecContext(ctx, `
+        INSERT INTO control (
+            id, name, application_date,
+            from_document, from_section, to_document, to_section,
+            questions_per_copy, copies, state, created_at, created_by
+        ) VALUES (?, 'x', NULL, 'flujo', 'if-else', 'flujo', 'bucles', 4, 3, 'generated', 0, ?)`,
+		"CTRLPAPER00000000000000000", userID,
+	); err != nil {
+		t.Fatalf("insert without paper: %v", err)
+	}
+
+	var paper string
+	err := db.QueryRowContext(ctx,
+		`SELECT paper FROM control WHERE id = ?`,
+		"CTRLPAPER00000000000000000",
+	).Scan(&paper)
+	if err != nil {
+		t.Fatalf("read back paper: %v", err)
+	}
+	if paper != "letter" {
+		t.Errorf("paper = %q, want %q (a control without an explicit choice is Letter, ADR-0043)", paper, "letter")
+	}
+}
+
+// Issue #208: only 'letter' and 'a4' are legal; the schema CHECK refuses
+// anything else so a caller that invents a third value fails at the write,
+// not at the read. Mirrors the duplex_padding CHECK in 00006.
+func TestControlPaperCheckRefusesUnknownValue(t *testing.T) {
+	ctx, db := migrated(t)
+	userID := insertProfessor(t, ctx, db, "profesora@example.com")
+
+	_, err := db.ExecContext(ctx, `
+        INSERT INTO control (
+            id, name, application_date,
+            from_document, from_section, to_document, to_section,
+            questions_per_copy, copies, paper, state, created_at, created_by
+        ) VALUES (?, 'x', NULL, 'flujo', 'if-else', 'flujo', 'bucles', 4, 3, ?, 'generated', 0, ?)`,
+		"CTRLPAPERBAD0000000000000A", "legal", userID,
+	)
+	if err == nil {
+		t.Error("insert with paper = 'legal' accepted; the CHECK constraint should refuse anything outside ('letter','a4')")
+	}
+}
+
 // Issue #190: the annotated_copy table records where the PDF anotado for one
 // copia lives on the shared volume, when it was generated, and which copia it
 // belongs to. Nothing about the contents in the DB — path is the whole point.

--- a/apps/server/migrations/00009_paper.sql
+++ b/apps/server/migrations/00009_paper.sql
@@ -1,0 +1,33 @@
+-- Issue #208: the professor picks Letter or A4 in a `<details> Opciones
+-- avanzadas` block on the create form. The value persists on the control so a
+-- future WP-G regenerate honours it, and the tex generator reads it into the
+-- \documentclass option (Letter → `letterpaper`, A4 → `a4paper`). See ADR-0043
+-- for the reversal that ADR-0042 predicted and rejected.
+--
+-- Stored as TEXT because the two values are named, not numeric — the same
+-- reason `state` is TEXT (00004) and `code_language` (00003) is. An INTEGER
+-- would force everyone reading the column to remember which bit means A4,
+-- which is exactly the "wrong-option trap" ADR-0042 §Alternatives named.
+--
+-- Default 'letter' covers three cases in one line: pre-migration controls (a
+-- read then answers with the ADR-0043 default), test inserts that omit the
+-- column (schema_test.go), and any caller that forgets to send it. The
+-- default also matches ADR-0042's operational choice for the Chilean
+-- printer default — the reversal makes it configurable, not the default.
+--
+-- NOT NULL for the same reason the sibling columns are: reading a NULL would
+-- leave the generator branching on Go's zero-value ("") and open a bug the
+-- schema can refuse.
+--
+-- CHECK (paper IN ('letter', 'a4')) makes the two-value shape self-enforcing.
+-- The domain type `Paper` in internal/domain/controls carries the same set,
+-- and the handler validates the form submission — but a stray writer that
+-- bypasses both would land here, and the CHECK is the last gate. Same shape
+-- as duplex_padding's CHECK in 00006.
+
+-- +goose Up
+ALTER TABLE control ADD COLUMN paper TEXT NOT NULL DEFAULT 'letter'
+    CHECK (paper IN ('letter', 'a4'));
+
+-- +goose Down
+ALTER TABLE control DROP COLUMN paper;

--- a/docs/decisions/0030-auto-multiple-choice-as-the-control-engine.md
+++ b/docs/decisions/0030-auto-multiple-choice-as-the-control-engine.md
@@ -6,8 +6,13 @@
 **Source:** #138 (the spike), design `docs/design/2026-08-controles.md` §C8, §C9
 **Amended by:** #206 (2026-08-20) — the paper is US Letter, not A4 (ADR-0042).
 The historical record below (§Partial evidence — 2026-08-17: "printed at
-100% on A4") stays as evidence of what was measured then; the operational
-paper size for every future generate is Letter.
+100% on A4") stays as evidence of what was measured then; ADR-0042 made
+Letter the operational default.
+**Amended by:** #208 (2026-08-20) — ADR-0043 supersedes ADR-0042 and makes
+paper a per-control preference (radio inside `<details> Opciones avanzadas`
+in the create form). Letter stays the default; A4 is available on demand.
+"For every future generate is Letter" from the previous amendment reads:
+every future generate is Letter *by default*.
 
 ## Context
 

--- a/docs/decisions/0042-control-sheets-are-printed-on-us-letter.md
+++ b/docs/decisions/0042-control-sheets-are-printed-on-us-letter.md
@@ -1,6 +1,6 @@
 # ADR-0042: Control sheets are printed on US Letter paper
 
-**Status:** Accepted — one verification outstanding, see §Not yet proven
+**Status:** Superseded by ADR-0043
 **Date:** 2026-08-20
 **Decision-makers:** Miguel Rodriguez
 **Source:** #206, incident 2026-08-19 (Jetson, control WNME7QU6SZD26KFM5CBJD3QM4E,

--- a/docs/decisions/0043-paper-size-is-a-per-control-preference.md
+++ b/docs/decisions/0043-paper-size-is-a-per-control-preference.md
@@ -147,10 +147,18 @@ Three UI shapes were considered for the wrong-option trap.
   rather than naming a paper size. Fixtures under `apps/amc-worker/tests/
   fixtures/` stay Letter (the default) and are documentary of the
   default case, not the whole space.
-- **The three surfaces that assert paper size stay in sync.** Domain
-  enum, schema CHECK, generator switch: adding a third value in future
-  is a three-file change and both L1 tests and the schema refuse the
-  intermediate state.
+- **The three surfaces that assert paper size stay in sync — at the
+  schema, and by convention at the two others.** Domain enum, schema
+  CHECK, generator switch. The schema CHECK refuses any value it does
+  not recognise (`TestControlPaperCheckRefusesUnknownValue`), so a
+  domain enum that grows a value the schema does not know goes red at
+  the first INSERT. The generator's `paperClassOption` and the
+  handler's `ValidPaper` are NOT covered by an iteration over the
+  enum today; adding a third value would silently fall back to
+  letterpaper in the generator until a test is written for it. If
+  the enum ever grows, add a table-driven L1 iteration; today the
+  two-value case is pinned exhaustively by
+  `TestPreamble*Paper*` and the handler tests.
 
 ## Not yet proven
 

--- a/docs/decisions/0043-paper-size-is-a-per-control-preference.md
+++ b/docs/decisions/0043-paper-size-is-a-per-control-preference.md
@@ -1,0 +1,169 @@
+# ADR-0043: Paper size is a per-control preference, defaulted to Letter
+
+**Status:** Accepted — one verification outstanding, see §Not yet proven
+**Date:** 2026-08-20
+**Decision-makers:** Miguel Rodriguez
+**Source:** #208, decided in the hilo del #206 (same day ADR-0042 landed).
+**Supersedes:** ADR-0042.
+
+## Context
+
+ADR-0042 hardcoded `letterpaper` in `preambleHead` and rejected making the
+paper size configurable, with a single argument in §Alternatives: "a variable
+buys nothing today but invites future controls printed with the wrong site
+for their site". The Chilean printer default was the whole context and one
+default fit it.
+
+The next day Miguel decided to reverse. Two reasons:
+
+1. **Simetría con el resto del formulario.** `DuplexPadding` (#185,
+   ADR-0039) is already a per-control preference that travels from a form
+   checkbox to the generator's `\clearpage` vs `\AMCcleardoublepage`
+   decision. Paper size is of the same shape: an operational choice by
+   the professor, not an architectural one. Leaving it as a global
+   constant is asymmetric, and the asymmetry was arbitrary — nothing
+   inherently distinguishes paper from padding except that one had a
+   real incident behind it and the other did not.
+2. **Opcionalidad genuina existe.** A colleague printing on A4, a demo
+   at another institution, a future setup change — any of these is a
+   preamble regeneration under ADR-0042 (with a code change to the const),
+   and a form radio under ADR-0043. The frequency does not matter; the
+   difference between "make Miguel edit `tex.go`" and "make Miguel
+   click a radio" is what a configuration flag exists to bridge.
+
+The wrong-option trap ADR-0042 named remains real. On 2026-08-19 the
+professor did NOT choose the wrong paper — there was no choice, and the
+printer's own default clipped 18 mm off the bottom, losing AMC's two
+bottom fiducials on all 44 pages of the batch (ADR-0042 §Context). Under
+this ADR the same failure mode reappears if a professor with prisa
+picks A4 while their printer is Letter. **This ADR does not eliminate
+that trap; it accepts it and mitigates it by UI.**
+
+## Decision
+
+**Paper size is a per-control field, defaulted to Letter, with A4
+available under `<details> Opciones avanzadas`.**
+
+- **Domain.** `type Paper string` with two enumerated values
+  (`PaperLetter = "letter"`, `PaperA4 = "a4"`), `DefaultPaper =
+  PaperLetter`, `ValidPaper(p) bool`. `Control.Paper Paper`. The tex
+  package sits under `internal/domain/controls/tex` and cannot import
+  controls without a cycle; it takes a plain `string` and defaults
+  empty/unknown to letterpaper — same guard as the domain, mirrored so
+  a caller landing at `tex.Compile` with a bug earlier in the chain
+  still gets a legal source.
+- **Persistence.** Migration `00009_paper.sql` adds
+  `paper TEXT NOT NULL DEFAULT 'letter' CHECK (paper IN ('letter','a4'))`.
+  Default covers pre-migration rows and any INSERT that omits the column
+  (test data, future JSON callers, bugs); CHECK refuses invented values
+  as the last gate.
+- **UI mitigation.** The form radios live inside
+  `<details><summary>Opciones avanzadas</summary>`, closed by default.
+  A professor who never opens it never picks — the default is Letter
+  and the friction is opening the block. The `<small>` inside the
+  block warns explicitly about the wrong-option trap and cites the
+  2026-08-19 incident. Chosen over two alternatives (see below).
+- **Handler validation.** `validateCreate` resolves empty → default,
+  refuses anything outside `{"letter","a4"}` with a per-field error
+  message. The schema CHECK would refuse the same value one layer
+  down, but by then the project directory would exist and the error
+  would name a sqlite constraint (leaks storage into the flash).
+- **Generator.** `Input.Paper` is a plain string; `preambleHead` is
+  split into a `\documentclass[%s,11pt]{article}` format string and
+  the stable rest, and `paperClassOption(paper)` maps
+  `"letter"`→`"letterpaper"`, `"a4"`→`"a4paper"`, empty/unknown →
+  `"letterpaper"`.
+- **PAPER-CHECK.** Both `PAPER-CHECK.md` and `PAPER-CHECK-MIN.md` say
+  "usa el papel que elegiste al crear el control (por defecto Letter;
+  A4 si lo cambiaste en Opciones avanzadas)" in §1 instead of naming
+  Letter fixed.
+- **ADR-0042 stays as history**, with `Status: Superseded by ADR-0043`
+  in its header. The reasoning it captured is intact — this ADR shows
+  what changed and why, not by editing 0042 but by writing 0043 on
+  top.
+
+## Alternatives considered
+
+### UI mitigation — chose `<details>` avanzadas
+
+Three UI shapes were considered for the wrong-option trap.
+
+- **Two radios visible in the main form, no friction.** Simplest. Most
+  faithful to the DuplexPadding pattern (a single checkbox in the main
+  flow). Rejected: DuplexPadding has no failure mode when misclicked
+  — a professor printing simplex a control padded for duplex wastes a
+  sheet. Paper has the ADR-0042 §Context failure mode: a wrong pick
+  kills the whole batch. A visible radio with no friction treats the
+  two the same and would ship the trap raw.
+- **Radio + amarilla warning banner when A4 is picked.** More friction
+  than the naked radio; the warning is contextual. Rejected as the
+  chosen path only because `<details>` is a smaller UI addition (no
+  banner, no styling for the warning state), and the fricción para
+  el caso raro is what the trap needs — not more copy for the caso
+  default. Reopen if the `<details>` proves too hidden for the rare
+  legitimate A4 case.
+- **A4 detrás de `<details> Opciones avanzadas`. Chosen.** The default
+  case is the default form; a professor who never opens `<details>`
+  never picks; the warning `<small>` lives inside so it is only shown
+  to a professor already considering A4. Fricción proporcional al
+  riesgo.
+
+### Whether to configure at all — chose Yes
+
+- **Keep ADR-0042's hardcoded Letter.** Rejected by Miguel's decision
+  the day after ADR-0042 landed; the argument in §Context stands.
+- **Server flag (env var) for the deploy default, no per-control
+  choice.** Rejected: the case Miguel described is a per-control
+  variability ("un colega imprime en A4", "una demo"), not a whole
+  Jetson pivot. A per-deploy flag would need every generate to remember
+  which deployment it is on, which is exactly the trap ADR-0042 named.
+
+### Whether to also change the reader — chose No, out of scope
+
+- **Auto-detect paper from the scanned image geometry.** Rejected by
+  ADR-0042 §Alternatives and inherited here. The reader is not the
+  failure surface; the printer is. Reading tolerance would let a
+  mismatched batch succeed, defeating the four-corner fiducial check
+  the printer→scanner contract depends on. Reopen if a real scenario
+  argues otherwise.
+
+## Consequences
+
+- **A form radio decides which `\documentclass` the source emits.**
+  The value persists on the row and travels through every re-emit
+  (WP-G regenerate honours it, when WP-G lands).
+- **Wrong-option trap is now a shared responsibility.** The system
+  defaults to Letter and warns explicitly when A4 is chosen; the
+  professor owns the pick-vs-printer match. Same failure mode as
+  the 2026-08-19 incident is possible under this ADR — just requires
+  a deliberate act (opening `<details>` and clicking A4 with the
+  wrong printer). The mitigation is UI, not correctness; whether the
+  friction is enough is measured in the next PAPER-CHECK cycles.
+- **ADR-0042 stays legible.** A future reader sees Letter argued as
+  the operational default (0042) then argued as the default of a
+  configurable choice (0043). Neither is deleted; the split is the
+  history of the decision.
+- **PAPER-CHECK.md instructions now reference the created control**
+  rather than naming a paper size. Fixtures under `apps/amc-worker/tests/
+  fixtures/` stay Letter (the default) and are documentary of the
+  default case, not the whole space.
+- **The three surfaces that assert paper size stay in sync.** Domain
+  enum, schema CHECK, generator switch: adding a third value in future
+  is a three-file change and both L1 tests and the schema refuse the
+  intermediate state.
+
+## Not yet proven
+
+**A real Letter batch printed with `paper=letter` and a real A4 batch
+printed with `paper=a4` have not both been through the professor's
+printer.** ADR-0042 §Not yet proven inherits here: the automated suite
+pins tokens and shape, and says nothing about ink. The A4 case is the
+one that most needs the check — the Letter case is what ADR-0042 was
+already awaiting.
+
+Procedure: two cycles of `apps/amc-worker/PAPER-CHECK.md`, one with a
+control created at `paper=letter` and one at `paper=a4`. Both are
+Miguel's L8 responsibility, scheduled for the next real control
+cycles; their outcomes get recorded here in the shape ADR-0030 §
+Partial evidence — 2026-08-17 uses today. Same rule and same reason
+as ADR-0042 §Not yet proven and ADR-0030 §Not yet proven.

--- a/docs/decisions/0043-paper-size-is-a-per-control-preference.md
+++ b/docs/decisions/0043-paper-size-is-a-per-control-preference.md
@@ -73,10 +73,13 @@ available under `<details> Opciones avanzadas`.**
   the stable rest, and `paperClassOption(paper)` maps
   `"letter"`→`"letterpaper"`, `"a4"`→`"a4paper"`, empty/unknown →
   `"letterpaper"`.
-- **PAPER-CHECK.** Both `PAPER-CHECK.md` and `PAPER-CHECK-MIN.md` say
-  "usa el papel que elegiste al crear el control (por defecto Letter;
-  A4 si lo cambiaste en Opciones avanzadas)" in §1 instead of naming
-  Letter fixed.
+- **PAPER-CHECK.** Both `PAPER-CHECK.md` and `PAPER-CHECK-MIN.md` §1
+  now instruct the operator to use the paper the control was created
+  for — Letter by default, A4 if picked under "Opciones avanzadas" —
+  instead of naming Letter fixed. Each file also names the concrete
+  A4 recipe (fixture flip vs server-generated source) so the A4 leg
+  ADR-0043 §Not yet proven schedules is actually runnable from the
+  docs.
 - **ADR-0042 stays as history**, with `Status: Superseded by ADR-0043`
   in its header. The reasoning it captured is intact — this ADR shows
   what changed and why, not by editing 0042 but by writing 0043 on

--- a/docs/standards/testing-strategy.md
+++ b/docs/standards/testing-strategy.md
@@ -287,6 +287,25 @@ did not exist when the compose file first referenced it (#149 S6), and only
 running the thing said so — which is why the pre-PR protocol ends in Docker
 rather than in `go test`.
 
+**A form-render test for an enum-valued input (radio or select) asserts the
+chosen value carries `checked` AND every other value does NOT, in the same
+test.** The pair kills two mutations at once — "both values render `checked`"
+and "no value renders `checked`" — either of which a presence-only test
+passes. Same shape as the printed-sheet tests one level down (a
+`\documentclass` test that asserts the presence of `letterpaper` AND the
+absence of `a4paper` is what caught the reversal of the #206 fix; a
+form-render test that asserts `paper=letter` is `checked` AND `paper=a4`
+is not is what pins the analogous mutation at the HTML). Worked cases:
+`TestNewRendersThePaperRadioWithLetterCheckedByDefault` and
+`TestFormRefusalEchoesBackTheA4Choice` in `controls_test.go` (#208), plus
+the `TestPreamble*Paper*` trio in `tex_test.go` (#208). The pair test also
+carries an attribute-order-agnostic regex when the assertion reads HTML
+directly — matching against `name="paper"` alone allows the same test to
+pass over `<input checked value="a4" name="paper">` and
+`<input name="paper" value="a4" checked>` alike, but every stray
+`checked` on any other input on the page then satisfies it. Anchor the
+regex on `name=` + `value=` + `checked` together.
+
 ## Conventions (all apps)
 
 These were learned in one app and apply to every one. They sit above the


### PR DESCRIPTION
Closes #208.

**Stacked PR: base is `feature/issue-206-letter-paper` (#207), not `main`.**
Merge order: #207 first, then this. GitHub retargets to `main` automatically
when the parent merges.

## Summary

The day after #207 shipped ADR-0042 (fixed Letter for every generate),
Miguel decided to make paper a per-control preference — a form radio,
default Letter, A4 available under `<details> Opciones avanzadas`. This WP
supersedes ADR-0042 with ADR-0043 and threads the choice through the whole
DuplexPadding pattern: schema → domain → handler → form → detail →
generator → pool snapshot.

The wrong-option trap ADR-0042 warned about (professor picks the wrong
paper, batch dies like 2026-08-19) is real and NOT eliminated — it is
mitigated by UI: A4 hides behind `<details>`, so a professor who never
opens the block never picks. ADR-0043 §Decision + §Consequences argue this
honestly.

## Slices

- [x] S1: `Control.Paper` + migration `00009_paper.sql` + storage
      round-trip (`42a01d1`).
- [x] S2: form radio inside `<details>` + handler validation + detail
      template (`e66b12d`).
- [x] S3: `tex.Input.Paper` + `paperClassOption` (letter→letterpaper,
      a4→a4paper, empty→letterpaper) + new bidirectional test trio
      (`2e39ade`).
- [x] S4: ADR-0043 supersedes ADR-0042 + PAPER-CHECK*.md rewrite +
      server/CLAUDE.md paper bullet updated (`e8c0d30`).

Plus two review-fix commits (`22b334e`, `0130ad2`) — see §"Reviews run".

## Acceptance criteria

1. **`Control.Paper Paper`** —
   `apps/server/internal/domain/controls/controls.go:59` (typed enum with
   `PaperLetter`, `PaperA4`, `DefaultPaper`, `ValidPaper`).
2. **Migration adds column with default+CHECK** —
   `apps/server/migrations/00009_paper.sql`
   (`TEXT NOT NULL DEFAULT 'letter' CHECK (paper IN ('letter','a4'))`).
   `TestControlPaperDefaultsToLetterWhenTheColumnIsOmitted` at
   `internal/infra/storage/schema_test.go:281`.
3. **Storage round-trip both values** —
   `TestCreateControlPersistsPaperBothWays` at
   `internal/infra/storage/controlstore/controlstore_test.go:117`.
4. **Handler parses + validates + defaults + refuses garbage** —
   `handler/controls.go`: `defaultFormValues` line 330,
   `valuesFromRequest` line 358, `validateCreate` (empty→default +
   ValidPaper) line 414. Tests:
   `TestCreateStoresPaperLetterByDefault`,
   `TestCreateStoresPaperA4WhenTheRadioIsA4`,
   `TestCreateRefusesAnUnknownPaperValue` (now asserts body carries the
   Spanish per-field message, so the 422 must come from the handler and
   not from a schema-CHECK-driven 500 — Round A COR-4),
   `TestFormRefusalEchoesBackTheA4Choice`.
5. **Form renders `<details>` with Letter checked** —
   `controls_form.html:94-115`. Test:
   `TestNewRendersThePaperRadioWithLetterCheckedByDefault` at
   `controls_test.go:274` (asserts letter checked AND a4 not checked in
   the same test — the bidirectional shape codified in
   `docs/standards/testing-strategy.md` as part of Round A COR-5).
6. **Detail shows "Papel:"** —
   `controls_detail.html:12` +
   `paperWord()` at `handler/controls.go:768`.
7. **Generator `Input.Paper` + bidirectional tests per value** —
   `apps/server/internal/domain/controls/tex/tex.go`: `Paper` field
   line 61, `preambleDocumentClassFmt` line 120, `paperClassOption`
   line 128. Tests: `TestPreambleDeclaresLetterPaperWhenInputSaysLetter`,
   `TestPreambleDeclaresA4PaperWhenInputSaysA4`,
   `TestPreambleFallsBackToLetterWhenInputPaperIsEmpty` — each pins
   presence of the chosen option AND absence of the other.
8. **Service passes through** —
   `service.go:210` `Paper: string(paperOrDefault(req.Paper))` in
   `tex.Compile`, and `service.go:262` `Paper: paperOrDefault(req.Paper)`
   in the persisted Control. `paperOrDefault` helper at `service.go:53`.
9. **ADR-0043 committed** —
   `docs/decisions/0043-paper-size-is-a-per-control-preference.md` with
   Context / Decision / Alternatives considered (three UI shapes, three
   architectural, one reader-side) / Consequences / Not yet proven.
10. **ADR-0042 marked superseded** —
    `docs/decisions/0042-control-sheets-are-printed-on-us-letter.md:3`
    (`Status: Superseded by ADR-0043`). Body intact — confirmed by diff.
11. **PAPER-CHECK rewritten** — `apps/amc-worker/PAPER-CHECK.md:47-73`
    and `PAPER-CHECK-MIN.md:35-46`. Both name the A4 recipe explicitly
    (Round B DC2/AGR-1 fix — the previous version told the operator to
    "use the paper you picked" without saying how to obtain the A4
    batch from `make paper`).
12. **`apps/server` per-commit + pre-PR protocols green** on every slice
    and on the post-fix state. Pre-PR run: gofmt/vet/tests-race/build/
    govulncheck/docker-build/compose-up/health×2.
13. **`apps/amc-worker`** unchanged in code — fixtures stay in Letter
    (documentary of the default case). `make verify` green regardless
    on the post-fix state (66 checks, 0 failed).
14. **Human L8 (A4 real paper) NOT part of this WP.** ADR-0043
    §Not yet proven schedules two cycles (Letter + A4) for Miguel's
    next real control cycles.

## Pre-PR protocol (both apps, line by line, all green)

`apps/server` (from `apps/server/`):

- `test -z "$(gofmt -l .)"` — silent.
- `go vet ./...` — OK.
- `go test -race -count=1 ./...` — 25 packages OK.
- `go build ./...` — OK.
- `go run golang.org/x/vuln/cmd/govulncheck@latest ./...` —
  "No vulnerabilities found."
- `docker build -t nalanda/server:dev .` — OK.
- `docker compose up -d --build --wait server` — healthy.
- `curl /health` → `{"process":"up","database":"up"}`.
- `curl /api/health` → same.
- `docker compose down` — clean.

`apps/amc-worker` (from `apps/amc-worker/`):

- `make verify` — 66 checks, 0 failed.

## Reviews run

Multi-agent review pipeline (integrated mode) over the STACKED diff
(`feature/issue-206-letter-paper...HEAD`, not `main...HEAD`).

- **Round A — code.** Correctness, arch-simplicity, security in
  parallel (perf lens skipped — announced; no hot paths touched).
  Mechanical gate green. 5 unique findings:
  - **ARQ-1/COR-2 (important, 2 lenses):** PoolSnapshot recorded
    DuplexPadding but not Paper — the pattern was not faithfully
    copied. Fix: added `Paper string` to `PoolSnapshot.Control` and
    wired it in `writePoolSnapshot`; extended
    `service_test.go`'s pool.json parse assertion. Skipped verifier
    (two lenses agreed, I verified by inspection).
  - **COR-1 (suggestion):** ADR-0043 §Consequences overclaimed "L1
    tests refuse the intermediate state" — a mutation proved
    otherwise. Softened the bullet to be honest.
  - **COR-3 (suggestion):** two `t.Errorf` messages dereferenced
    `rows[0]` inside a condition allowing `len==0`. Split the
    guards.
  - **COR-4 (suggestion):** the 422 refusal test only checked the
    status; a mutation showed the 422 could come from a
    schema-CHECK-driven 500 propagating. Added a body assertion for
    the Spanish per-field error string — now the test pins the
    layer it claims to.
  - **COR-5 (pattern):** recorded the enum-radio form-render pattern
    in `docs/standards/testing-strategy.md` §apps/server (assert
    chosen `checked` AND every other NOT `checked` in the same
    test).

- **Round B — documentation** (over post-fix state).
  docs-completeness, docs-accuracy, adr-hunter, agent-readability in
  parallel. 5 unique findings:
  - **DC1 (important):** ADR-0030's `Amended by` line from #206
    still said "the operational paper size for every future generate
    is Letter" — falsified by ADR-0043. Added a second amendment
    line pointing at #208/ADR-0043 (stacked amendment, no edit to
    the first per supersede-vs-amend contract).
  - **DC2/AGR-1 (important, 2 lenses):** PAPER-CHECK said "use the
    paper you picked" but `make paper` copies a `letterpaper`
    fixture; ADR-0043 §Not yet proven's A4 cycle was unrunnable.
    Added a two-option A4 recipe (temporary fixture flip, or
    server-generated source) to both PAPER-CHECK files. Skipped
    verifier (two lenses agreed, trivially verifiable).
  - **DC3 (suggestion):** `layout.html:93` CSS comment named US
    Letter only (a stale ADR-0042 reference from #206). Retitled to
    name both sizes and cite ADR-0043.
  - **DA1 (suggestion):** ADR-0043 §Decision quoted a Spanish phrase
    as if literal but PAPER-CHECK files are English. Replaced the
    quote with a description of what the files carry.
  - **AGR-2 (suggestion):** DEFERRED. Lens proposed a new
    "add-a-per-control-preference" standards guide covering the
    six-layer chain DuplexPadding and Paper now both walk. Codifying
    a formal guide from two data points is premature; ADR-0043
    §Context reason 1 already references DuplexPadding as the
    pattern to copy. Third instance is the trigger for a guide.

Totals: 10 unique findings across both rounds, 9 accepted / 1
deferred / 0 dismissed. Severities: 0 critical, 3 important
(ARQ-1/COR-2, DC1, DC2/AGR-1), 6 suggestions, 1 pattern.
No verifier round (importants were cross-lens agreed and trivially
inspectable — noted per finding).

## Manual verification

The WP does not claim to have run PAPER-CHECK.md — that is Miguel's
next real cycles. What you can verify by reading this PR:

- [ ] Diff base is `feature/issue-206-letter-paper` (not `main`).
- [ ] `tex.go:120,128` — `preambleDocumentClassFmt` + `paperClassOption`.
- [ ] Migration `00009_paper.sql` shape matches ADR-0043's claim.
- [ ] Create form on the running app: `<details> Opciones avanzadas`
      is closed by default, Letter is checked inside, warning `<small>`
      cites the 2026-08-19 incident.
- [ ] Detail page shows "Papel:" row.
- [ ] Optional mutation checks (all mutation-proven RED during
      review): revert `paperClassOption` to always return
      `"letterpaper"` → the A4 test reddens; revert the empty branch
      to `"a4paper"` → the empty-fallback test reddens.
- [ ] ADR-0043's §Context, §Alternatives, §Consequences argue the
      reversal rather than announce it; §Not yet proven schedules the
      A4 cycle and PAPER-CHECK's new §1 explains how to run it.

## Notes

- **Stacked PR.** Merge #207 first, then this. Rebase-and-merge if
  #207's history changes; otherwise squash-merge each in order.
- **Migration order.** `00009_paper.sql` comes after #197's `00008`
  (thresholds). No dependency on any concurrent branch.
- **amc-worker fixtures stay in Letter.** They are documentary of the
  default case; adding parallel A4 fixtures would double the surface
  without adding coverage.
- **AGR-2 deliberately NOT filed as a follow-up issue** — per Miguel's
  instruction, no follow-ups for what could reasonably be resolved
  here. This one is deliberately unresolved because two data points is
  not enough to codify a "per-control preference" guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMHoii5U8HsModCEzdytb7
