### PR TITLE
chore(controls): make scan failures diagnosable and recoverable

### DIFF
--- a/apps/server/CLAUDE.md
+++ b/apps/server/CLAUDE.md
@@ -148,6 +148,16 @@ the `avisoNo*` / `flash.Set(…)` string literals in `internal/app/web/handler/`
   `oidctest.Provider`; the real round trip is `GOOGLE-CHECK.md`, and a change to
   the login path is unfinished while a human has not run it. Same rule, and the
   same reason, as `apps/amc-worker/PAPER-CHECK.md`.
+- **The uploaded scan batch survives every downstream failure of
+  `UploadScan` (issue #210).** Reintroducing `os.Remove(batchHostPath)` on
+  a refusal — or on any post-copy error — is forbidden. The batch on disk
+  is the artefact an operator inspects and what the professor would
+  otherwise have to re-scan; erasing it on refusal was the pre-#210
+  behavior that made the 2026-08-19 incident cost twenty SSH minutes to
+  diagnose. `writeUpload` still cleans a PARTIAL file (its own `io.Copy`
+  failure); downstream failures do not. The rollback promise is scoped
+  to DB rows, not the file — see the `UploadScan` docstring for what is
+  transactional and what is not.
 - **The two surfaces do not share an auth gate** (§C12). Everything auth-shaped
   is mounted inside `internal/app/web`; `internal/app/api` is anonymous by
   construction, and `/health` sits deliberately outside the gate because the

--- a/apps/server/internal/app/web/handler/scans.go
+++ b/apps/server/internal/app/web/handler/scans.go
@@ -394,7 +394,12 @@ func firstDetailLine(err error) string {
 
 // truncateRunes caps s to n runes, adding an ellipsis when it did not
 // fit. Rune-safe so a multi-byte character does not get cut mid-sequence.
+// n <= 0 returns the empty string — a caller asking for "no room" gets
+// nothing rather than a lone ellipsis (review-fix, WP-210).
 func truncateRunes(s string, n int) string {
+	if n <= 0 {
+		return ""
+	}
 	runes := []rune(s)
 	if len(runes) <= n {
 		return s

--- a/apps/server/internal/app/web/handler/scans.go
+++ b/apps/server/internal/app/web/handler/scans.go
@@ -155,8 +155,11 @@ func (h *Controls) UploadScan(w http.ResponseWriter, r *http.Request) {
 			middleware.WriteError(w, r, http.StatusNotFound, "Ese control no existe.")
 		case errors.Is(err, controls.ErrAnalyzerRefused):
 			h.Log.Warn("controls: worker refused scan", "control", id, "error", err)
-			flash.Set(w, h.secureCookie,
-				"El motor de lectura rechazó el archivo. Revisa que sea un escaneo del control correcto.")
+			flash.Set(w, h.secureCookie, refusedFlash(
+				"El motor de lectura rechazó el escaneo.",
+				err,
+				"Revisa que la impresión y el escaneo estén completos y no cortados en los bordes.",
+			))
 			http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
 		case errors.Is(err, controls.ErrAnalyzerUnavailable):
 			h.Log.Error("controls: worker unreachable", "control", id, "error", err)
@@ -225,8 +228,11 @@ func (h *Controls) ReanalyzeScans(w http.ResponseWriter, r *http.Request) {
 			middleware.WriteError(w, r, http.StatusNotFound, "Ese control no existe.")
 		case errors.Is(err, controls.ErrAnalyzerRefused):
 			h.Log.Warn("controls: worker refused reanalyze", "control", id, "error", err)
-			flash.Set(w, h.secureCookie,
-				"El motor rechazó re-leer. Puede que aún no haya escaneos subidos.")
+			flash.Set(w, h.secureCookie, refusedFlash(
+				"El motor rechazó re-leer.",
+				err,
+				"Puede que aún no haya escaneos subidos.",
+			))
 			http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
 		case errors.Is(err, controls.ErrAnalyzerUnavailable):
 			h.Log.Error("controls: worker unreachable during reanalyze", "control", id, "error", err)
@@ -339,6 +345,61 @@ func parseFloatField(raw string, fallback float64) float64 {
 		return fallback
 	}
 	return v
+}
+
+// flashDetailMax caps the worker Detail excerpt embedded in the flash.
+// 500 chars fits a full "ERR: /work/…/scans/… scan not recognized" line
+// (~85 chars) with plenty of headroom, and keeps a runaway line from
+// blowing past the cookie payload the flash rides on (base64 of ~4 KiB
+// before the browser refuses it). The wrapped AnalyzerRefusedError keeps
+// the full Detail for a future consumer that needs it (issue #210).
+const flashDetailMax = 500
+
+// refusedFlash renders the flash for an ErrAnalyzerRefused branch:
+// verdict + (optional) worker Detail + hint. When the wrapped error
+// carries no usable detail — the detail was empty or only blank lines,
+// or the error is not an *AnalyzerRefusedError at all — the Detalle
+// clause is dropped and the verdict + hint stand on their own.
+//
+// Truncation keeps the FIRST non-empty line only, capped to flashDetailMax
+// runes; a truncation adds a trailing ellipsis. Callers own the verdict
+// and hint copy; this helper owns the shape.
+func refusedFlash(verdict string, err error, hint string) string {
+	detail := firstDetailLine(err)
+	if detail == "" {
+		return verdict + " " + hint
+	}
+	return verdict + " Detalle del motor: " + detail + ". " + hint
+}
+
+// firstDetailLine returns the first non-empty line of an
+// *AnalyzerRefusedError's Detail (trimmed), truncated to flashDetailMax
+// runes with a trailing ellipsis when it did not fit. Returns "" when
+// err does not carry a Detail — including when it is not an
+// *AnalyzerRefusedError.
+func firstDetailLine(err error) string {
+	var wrapped *controls.AnalyzerRefusedError
+	if !errors.As(err, &wrapped) || wrapped == nil {
+		return ""
+	}
+	for _, line := range strings.Split(wrapped.Detail, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		return truncateRunes(trimmed, flashDetailMax)
+	}
+	return ""
+}
+
+// truncateRunes caps s to n runes, adding an ellipsis when it did not
+// fit. Rune-safe so a multi-byte character does not get cut mid-sequence.
+func truncateRunes(s string, n int) string {
+	runes := []rune(s)
+	if len(runes) <= n {
+		return s
+	}
+	return string(runes[:n]) + "…"
 }
 
 // looksLikePDF is a defensive check the professor sees a nice message

--- a/apps/server/internal/app/web/handler/scans_test.go
+++ b/apps/server/internal/app/web/handler/scans_test.go
@@ -453,8 +453,8 @@ func TestUploadScanRefusedFlashCarriesFirstLineOfDetail(t *testing.T) {
 	f := newControlsFixture(t)
 	controlID := f.createControl(t, "Control 210 upload with detail", 1)
 	f.fake.AnalyzeErr = &controls.AnalyzerRefusedError{
-		Message: "worker answered 400: scan not recognized",
-		Detail:  "ERR: /work/controls/x/scans/0001.pdf scan not recognized\nERR: /work/controls/x/scans/0002.pdf scan not recognized",
+		Status: 400, Message: "scan not recognized",
+		Detail: "ERR: /work/controls/x/scans/0001.pdf scan not recognized\nERR: /work/controls/x/scans/0002.pdf scan not recognized",
 	}
 
 	body, ct := buildScanUpload(t, "batch.pdf", "application/pdf", []byte("%PDF-fake"))
@@ -492,7 +492,7 @@ func TestUploadScanRefusedFlashFallsBackWhenDetailEmpty(t *testing.T) {
 	f := newControlsFixture(t)
 	controlID := f.createControl(t, "Control 210 upload no detail", 1)
 	f.fake.AnalyzeErr = &controls.AnalyzerRefusedError{
-		Message: "worker answered 400: bad request",
+		Status: 400, Message: "bad request",
 	}
 
 	body, ct := buildScanUpload(t, "batch.pdf", "application/pdf", []byte("%PDF-fake"))
@@ -527,8 +527,8 @@ func TestUploadScanRefusedFlashSkipsBlankLinesAndTruncatesLongOnes(t *testing.T)
 	controlID := f.createControl(t, "Control 210 truncation", 1)
 	long := strings.Repeat("A", 800)
 	f.fake.AnalyzeErr = &controls.AnalyzerRefusedError{
-		Message: "worker answered 400",
-		Detail:  "\n\n   \n" + long,
+		Status: 400,
+		Detail: "\n\n   \n" + long,
 	}
 	body, ct := buildScanUpload(t, "batch.pdf", "application/pdf", []byte("%PDF-fake"))
 	req := f.authedRequest(t, http.MethodPost, "/controls/"+controlID+"/scans", nil)
@@ -563,8 +563,8 @@ func TestReanalyzeRefusedFlashCarriesFirstLineOfDetail(t *testing.T) {
 	uploadOnce(t, f, controlID)
 
 	f.fake.ReanalyzeErr = &controls.AnalyzerRefusedError{
-		Message: "worker answered 400: no captures",
-		Detail:  "nothing to re-read on /work/controls/y\nsecond line",
+		Status: 400, Message: "no captures",
+		Detail: "nothing to re-read on /work/controls/y\nsecond line",
 	}
 	values := url.Values{"ticked": {"0.20"}, "unsure": {"0.05"}}
 	req := f.authedRequest(t, http.MethodPost, "/controls/"+controlID+"/reanalyze", values)

--- a/apps/server/internal/app/web/handler/scans_test.go
+++ b/apps/server/internal/app/web/handler/scans_test.go
@@ -444,6 +444,152 @@ func TestReanalyzeRefusesAnInvertedBand(t *testing.T) {
 	}
 }
 
+// Issue #210: when the worker refuses an upload with a detail, the flash
+// includes the first non-empty line of that detail so the professor sees
+// what the reader actually said without an SSH round trip. The hint about
+// print/scan borders covers the paper-size class from the 2026-08-19
+// incident without pretending to name a cause.
+func TestUploadScanRefusedFlashCarriesFirstLineOfDetail(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control 210 upload with detail", 1)
+	f.fake.AnalyzeErr = &controls.AnalyzerRefusedError{
+		Message: "worker answered 400: scan not recognized",
+		Detail:  "ERR: /work/controls/x/scans/0001.pdf scan not recognized\nERR: /work/controls/x/scans/0002.pdf scan not recognized",
+	}
+
+	body, ct := buildScanUpload(t, "batch.pdf", "application/pdf", []byte("%PDF-fake"))
+	req := f.authedRequest(t, http.MethodPost, "/controls/"+controlID+"/scans", nil)
+	req.Body = io.NopCloser(body)
+	req.Header.Set("Content-Type", ct)
+	req.ContentLength = int64(body.Len())
+	req.SetPathValue("id", controlID)
+
+	rec := httptest.NewRecorder()
+	f.handler.UploadScan(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303 (flash + redirect back)", rec.Code)
+	}
+	flash := readFlash(t, rec)
+	if !strings.Contains(flash, "rechazó el escaneo") {
+		t.Errorf("flash %q does not name the refusal", flash)
+	}
+	if !strings.Contains(flash, "ERR: /work/controls/x/scans/0001.pdf scan not recognized") {
+		t.Errorf("flash %q does not include the worker's first stderr line", flash)
+	}
+	if strings.Contains(flash, "0002.pdf") {
+		t.Errorf("flash %q leaks a second line — the flash must show only the first", flash)
+	}
+	if !strings.Contains(flash, "impresión y el escaneo") {
+		t.Errorf("flash %q dropped the print/scan hint", flash)
+	}
+}
+
+// When the worker refuses without carrying a detail (an old worker, a
+// non-envelope 4xx), the flash falls back to the fixed hint. The professor
+// still knows what to do next; the log carries whatever context there is.
+func TestUploadScanRefusedFlashFallsBackWhenDetailEmpty(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control 210 upload no detail", 1)
+	f.fake.AnalyzeErr = &controls.AnalyzerRefusedError{
+		Message: "worker answered 400: bad request",
+	}
+
+	body, ct := buildScanUpload(t, "batch.pdf", "application/pdf", []byte("%PDF-fake"))
+	req := f.authedRequest(t, http.MethodPost, "/controls/"+controlID+"/scans", nil)
+	req.Body = io.NopCloser(body)
+	req.Header.Set("Content-Type", ct)
+	req.ContentLength = int64(body.Len())
+	req.SetPathValue("id", controlID)
+
+	rec := httptest.NewRecorder()
+	f.handler.UploadScan(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303", rec.Code)
+	}
+	flash := readFlash(t, rec)
+	if !strings.Contains(flash, "rechazó el escaneo") {
+		t.Errorf("flash %q does not name the refusal", flash)
+	}
+	if strings.Contains(flash, "Detalle del motor") {
+		t.Errorf("flash %q renders a Detalle clause with no detail available", flash)
+	}
+	if !strings.Contains(flash, "impresión y el escaneo") {
+		t.Errorf("flash %q dropped the print/scan hint", flash)
+	}
+}
+
+// A refusal whose Detail is only blank lines behaves like an empty detail.
+// The truncation of a very long line adds an ellipsis at the 500-char cap.
+func TestUploadScanRefusedFlashSkipsBlankLinesAndTruncatesLongOnes(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control 210 truncation", 1)
+	long := strings.Repeat("A", 800)
+	f.fake.AnalyzeErr = &controls.AnalyzerRefusedError{
+		Message: "worker answered 400",
+		Detail:  "\n\n   \n" + long,
+	}
+	body, ct := buildScanUpload(t, "batch.pdf", "application/pdf", []byte("%PDF-fake"))
+	req := f.authedRequest(t, http.MethodPost, "/controls/"+controlID+"/scans", nil)
+	req.Body = io.NopCloser(body)
+	req.Header.Set("Content-Type", ct)
+	req.ContentLength = int64(body.Len())
+	req.SetPathValue("id", controlID)
+	rec := httptest.NewRecorder()
+	f.handler.UploadScan(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303", rec.Code)
+	}
+	flash := readFlash(t, rec)
+	// 500 As followed by an ellipsis rune, then the rest of the message.
+	if !strings.Contains(flash, strings.Repeat("A", 500)+"…") {
+		t.Errorf("flash %q did not truncate the long line at 500 chars with an ellipsis", flash)
+	}
+	if strings.Contains(flash, strings.Repeat("A", 501)) {
+		t.Errorf("flash %q kept more than 500 As — truncation did not apply", flash)
+	}
+}
+
+// The reanalyze branch mirrors upload: detail flows through, fallback
+// keeps the "no captures yet" hint that was there before #210.
+func TestReanalyzeRefusedFlashCarriesFirstLineOfDetail(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control 210 reanalyze", 1)
+	f.fake.AnalyzeReports = []controls.Report{
+		{Copies: map[string]controls.ReportCopy{"1": okCopy("20100001")}},
+	}
+	uploadOnce(t, f, controlID)
+
+	f.fake.ReanalyzeErr = &controls.AnalyzerRefusedError{
+		Message: "worker answered 400: no captures",
+		Detail:  "nothing to re-read on /work/controls/y\nsecond line",
+	}
+	values := url.Values{"ticked": {"0.20"}, "unsure": {"0.05"}}
+	req := f.authedRequest(t, http.MethodPost, "/controls/"+controlID+"/reanalyze", values)
+	req.SetPathValue("id", controlID)
+	rec := httptest.NewRecorder()
+	f.handler.ReanalyzeScans(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303", rec.Code)
+	}
+	flash := readFlash(t, rec)
+	if !strings.Contains(flash, "rechazó re-leer") {
+		t.Errorf("flash %q does not name the reanalyze refusal", flash)
+	}
+	if !strings.Contains(flash, "nothing to re-read on /work/controls/y") {
+		t.Errorf("flash %q does not include the worker's first stderr line", flash)
+	}
+	if strings.Contains(flash, "second line") {
+		t.Errorf("flash %q leaks a second line", flash)
+	}
+	if !strings.Contains(flash, "escaneos subidos") {
+		t.Errorf("flash %q dropped the no-captures hint", flash)
+	}
+}
+
 // Issue #204: the uploaded batch is downloadable from the control page —
 // the endpoint streams the stored batch-N.pdf with download headers.
 func TestUploadsPDFServesTheStoredBatch(t *testing.T) {

--- a/apps/server/internal/domain/controls/reading.go
+++ b/apps/server/internal/domain/controls/reading.go
@@ -174,6 +174,45 @@ var (
 	ErrAnalyzerUnavailable = errors.New("controls: the AMC worker is unreachable")
 )
 
+// AnalyzerRefusedError carries the fields the worker reported alongside a
+// refused /analyse or /reanalyse. Callers that only need to branch keep
+// using errors.Is(err, ErrAnalyzerRefused); callers that render the
+// failure (log, flash, future UI) use errors.As on this type to reach
+// Message and Detail without re-parsing the error string. Issue #210.
+//
+// Detail carries the worker's raw stderr excerpt (up to 4000 chars per
+// apps/amc-worker/worker.py). Truncation is a rendering concern owned by
+// the caller — the struct keeps the full string so a future consumer
+// (a debug view, a "download the log" flow) can read it whole.
+//
+// The field for the worker's "error" JSON is called Message rather than
+// Error because Go forbids a struct field and a method to share a name,
+// and this type implements the error interface via Error() string.
+type AnalyzerRefusedError struct {
+	// Message is the "error" field from the worker's JSON envelope — a
+	// short human summary the worker chose. May be empty when the worker
+	// answered a non-2xx with a body that did not parse as its error
+	// envelope; the caller then only knows the failure was structural.
+	Message string
+	// Detail is the "detail" field — up to 4000 chars of AMC's stderr,
+	// verbatim. May be empty.
+	Detail string
+}
+
+// Error satisfies the error interface. Format mirrors the pre-#210 wrap
+// (`%w: %s` on ErrAnalyzerRefused and Message) so log lines that captured
+// err.Error() still read the same shape.
+func (e *AnalyzerRefusedError) Error() string {
+	if e == nil || e.Message == "" {
+		return ErrAnalyzerRefused.Error()
+	}
+	return ErrAnalyzerRefused.Error() + ": " + e.Message
+}
+
+// Unwrap returns ErrAnalyzerRefused so errors.Is on the sentinel keeps
+// matching. Callers written before #210 do not have to change.
+func (e *AnalyzerRefusedError) Unwrap() error { return ErrAnalyzerRefused }
+
 // A Reading is one copy's stored state. WP-F persists this beside the
 // existing copia rows; grades are computed on the fly from the answers
 // under any overrides.

--- a/apps/server/internal/domain/controls/reading.go
+++ b/apps/server/internal/domain/controls/reading.go
@@ -3,6 +3,7 @@ package controls
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 )
 
@@ -174,39 +175,60 @@ var (
 	ErrAnalyzerUnavailable = errors.New("controls: the AMC worker is unreachable")
 )
 
-// AnalyzerRefusedError carries the fields the worker reported alongside a
-// refused /analyse or /reanalyse. Callers that only need to branch keep
+// AnalyzerRefusedError carries the fields the analyzer reported alongside
+// a refused /analyse or /reanalyse. Callers that only need to branch keep
 // using errors.Is(err, ErrAnalyzerRefused); callers that render the
 // failure (log, flash, future UI) use errors.As on this type to reach
-// Message and Detail without re-parsing the error string. Issue #210.
+// Status, Message and Detail without re-parsing the error string.
+// Issue #210.
 //
-// Detail carries the worker's raw stderr excerpt (up to 4000 chars per
-// apps/amc-worker/worker.py). Truncation is a rendering concern owned by
-// the caller — the struct keeps the full string so a future consumer
-// (a debug view, a "download the log" flow) can read it whole.
+// The type is engine-neutral by design: Status is the HTTP status the
+// analyzer answered with, Message is the short human summary it chose,
+// and Detail is whatever free-form context it attached — an excerpt of
+// its own stderr in the current AMC-worker implementation. A future
+// non-AMC analyzer (ADR-0031) fills the same fields with whatever
+// equivalents it produces.
 //
-// The field for the worker's "error" JSON is called Message rather than
-// Error because Go forbids a struct field and a method to share a name,
-// and this type implements the error interface via Error() string.
+// The struct keeps Detail whole so a future consumer (a debug view, a
+// "download the analyzer log" flow) can render it in full; truncation
+// for logs and UI is the renderer's concern, not this type's.
+//
+// The field for the analyzer's short summary is called Message rather
+// than Error because Go forbids a struct field and a method to share a
+// name, and this type implements the error interface via Error() string.
 type AnalyzerRefusedError struct {
-	// Message is the "error" field from the worker's JSON envelope — a
-	// short human summary the worker chose. May be empty when the worker
-	// answered a non-2xx with a body that did not parse as its error
-	// envelope; the caller then only knows the failure was structural.
+	// Status is the HTTP status code the analyzer answered with (a 4xx
+	// today), or 0 when the caller did not have one to record. Callers
+	// rendering the failure branch on this to distinguish structural
+	// refusals (400/422) from ones the analyzer may recover from (503).
+	Status int
+	// Message is the short human summary the analyzer chose. May be
+	// empty when the analyzer answered with a body that did not parse
+	// as its error envelope — the caller then only knows the failure
+	// was structural.
 	Message string
-	// Detail is the "detail" field — up to 4000 chars of AMC's stderr,
-	// verbatim. May be empty.
+	// Detail is the free-form context the analyzer attached, kept
+	// whole. May be empty.
 	Detail string
 }
 
-// Error satisfies the error interface. Format mirrors the pre-#210 wrap
-// (`%w: %s` on ErrAnalyzerRefused and Message) so log lines that captured
-// err.Error() still read the same shape.
+// Error satisfies the error interface. Composes Status and Message into
+// the same shape pre-#210 callers logged (`worker answered NNN: msg`) so
+// existing log parsers keep reading the same text.
 func (e *AnalyzerRefusedError) Error() string {
-	if e == nil || e.Message == "" {
+	if e == nil {
 		return ErrAnalyzerRefused.Error()
 	}
-	return ErrAnalyzerRefused.Error() + ": " + e.Message
+	switch {
+	case e.Status != 0 && e.Message != "":
+		return fmt.Sprintf("%s: worker answered %d: %s", ErrAnalyzerRefused, e.Status, e.Message)
+	case e.Status != 0:
+		return fmt.Sprintf("%s: worker answered %d", ErrAnalyzerRefused, e.Status)
+	case e.Message != "":
+		return ErrAnalyzerRefused.Error() + ": " + e.Message
+	default:
+		return ErrAnalyzerRefused.Error()
+	}
 }
 
 // Unwrap returns ErrAnalyzerRefused so errors.Is on the sentinel keeps

--- a/apps/server/internal/domain/controls/reading.go
+++ b/apps/server/internal/domain/controls/reading.go
@@ -209,6 +209,13 @@ type AnalyzerRefusedError struct {
 	Message string
 	// Detail is the free-form context the analyzer attached, kept
 	// whole. May be empty.
+	//
+	// SECURITY: never send Detail to slog. See docs/security-notes.md
+	// §"The control worker is unauthenticated" — AMC's stderr can name
+	// student identifiers verbatim, so this field is for renderers that
+	// surface the failure to a human (flash, debug view), not for logs.
+	// The type's Error() intentionally does not include Detail, so
+	// slog.Warn("...", "error", err) stays clean.
 	Detail string
 }
 

--- a/apps/server/internal/domain/controls/scans.go
+++ b/apps/server/internal/domain/controls/scans.go
@@ -89,8 +89,12 @@ func (s *Service) UploadScan(ctx context.Context, req UploadRequest) (UploadResu
 	if err != nil {
 		return UploadResult{}, err
 	}
-	// Issue #197: refuse a bad pair BEFORE anything touches the disk — the
-	// all-or-nothing promise covers the batch file too.
+	// Issue #197: refuse a bad pair BEFORE writing anything so an invalid
+	// threshold submission never even creates a batch file. Note: unlike
+	// pre-#210, DOWNSTREAM failures do not clean the batch file up — see
+	// the UploadScan docstring above for the batch-survives-failure
+	// contract. This validation happens first, so it is the one branch
+	// where nothing on disk is left behind either way.
 	ticked, unsure := req.Ticked, req.Unsure
 	if ticked == 0 {
 		// The handler always resolves the form (optional fields fall back

--- a/apps/server/internal/domain/controls/scans.go
+++ b/apps/server/internal/domain/controls/scans.go
@@ -64,13 +64,20 @@ type UploadResult struct {
 //
 // Failure modes:
 //   - No such control → ErrControlNotFound.
-//   - Copying the upload to disk failed → wraps the io error.
-//   - /analyse refused or was unreachable → wraps ErrAnalyzer* and rolls
-//     back the batch file so the disk shows no evidence of a failed run.
+//   - Copying the upload to disk failed → wraps the io error (the partial
+//     file, if any, is removed inside writeUpload).
+//   - /analyse refused or was unreachable → wraps ErrAnalyzer*. The
+//     uploaded PDF SURVIVES on disk (issue #210): the batch is the
+//     artefact an operator would inspect, and erasing it on refusal
+//     forced a re-scan when the printed sheets — not the file — were
+//     the problem (2026-08-19 incident). The DB writes still roll back
+//     on any downstream failure via the ReadingStore.
 //
 // All-or-nothing on the DB side: the report either persists or it does
 // not; there is no partial commit, because UpsertReadingsFromReport uses
-// a single transaction.
+// a single transaction. The promise moves from "wipe file on failure"
+// to "wipe DB rows on failure" — the batch on disk records what was
+// attempted regardless.
 func (s *Service) UploadScan(ctx context.Context, req UploadRequest) (UploadResult, error) {
 	control, err := s.Store.ControlByID(ctx, req.ControlID)
 	if err != nil {
@@ -106,11 +113,11 @@ func (s *Service) UploadScan(ctx context.Context, req UploadRequest) (UploadResu
 		return UploadResult{}, fmt.Errorf("controls.UploadScan: %w", err)
 	}
 
-	rollbackFile := func() {
-		if err := os.Remove(batchHostPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-			s.Log.Warn("controls.UploadScan: rollback failed", "path", batchHostPath, "error", err)
-		}
-	}
+	// Issue #210: the batch file survives every downstream failure. The
+	// DB writes below still roll back on their own — the ReadingStore's
+	// UpsertReadingsFromReport is a single transaction — but the artefact
+	// on disk is what an operator inspects and what a re-upload cannot
+	// recreate, so we do not erase it.
 
 	project := filepath.Join(projectPrefix, control.ID)
 	report, err := s.Analyzer.Analyze(ctx, AnalyzeRequest{
@@ -121,21 +128,17 @@ func (s *Service) UploadScan(ctx context.Context, req UploadRequest) (UploadResu
 		Unsure:  unsure,
 	})
 	if err != nil {
-		rollbackFile()
 		return UploadResult{}, err
 	}
 	if err := s.Store.SetControlThresholds(ctx, control.ID, ticked, unsure); err != nil {
-		rollbackFile()
 		return UploadResult{}, fmt.Errorf("controls.UploadScan: persist thresholds: %w", err)
 	}
 
 	now := s.Now()
 	if err := s.Readings.UpsertReadingsFromReport(ctx, control.ID, report, now); err != nil {
-		rollbackFile()
 		return UploadResult{}, fmt.Errorf("controls.UploadScan: persist: %w", err)
 	}
 	if err := s.Readings.MarkMissingAsNotPresent(ctx, control.ID, now); err != nil {
-		rollbackFile()
 		return UploadResult{}, fmt.Errorf("controls.UploadScan: mark missing: %w", err)
 	}
 

--- a/apps/server/internal/domain/controls/scans.go
+++ b/apps/server/internal/domain/controls/scans.go
@@ -70,14 +70,20 @@ type UploadResult struct {
 //     uploaded PDF SURVIVES on disk (issue #210): the batch is the
 //     artefact an operator would inspect, and erasing it on refusal
 //     forced a re-scan when the printed sheets — not the file — were
-//     the problem (2026-08-19 incident). The DB writes still roll back
-//     on any downstream failure via the ReadingStore.
+//     the problem (2026-08-19 incident). The DB is not touched on this
+//     branch — Analyzer.Analyze runs before any store write.
 //
-// All-or-nothing on the DB side: the report either persists or it does
-// not; there is no partial commit, because UpsertReadingsFromReport uses
-// a single transaction. The promise moves from "wipe file on failure"
-// to "wipe DB rows on failure" — the batch on disk records what was
-// attempted regardless.
+// DB-atomicity is scoped: the reading report itself is transactional
+// because UpsertReadingsFromReport opens a single tx around every insert
+// it does. The three post-analyse writes as a sequence are NOT — they go
+// through two different stores (Store.SetControlThresholds first, then
+// two ReadingStore calls) and there is no outer transaction wrapping
+// them. A failure in MarkMissingAsNotPresent (last step) leaves the
+// updated thresholds and the persisted report committed; a failure in
+// UpsertReadingsFromReport leaves the updated thresholds committed. In
+// operation this class of failure is a store outage and the professor
+// retries — a widened transactional shape (single-tx PersistReport) is
+// a follow-up, same as the SaveOverrides note below.
 func (s *Service) UploadScan(ctx context.Context, req UploadRequest) (UploadResult, error) {
 	control, err := s.Store.ControlByID(ctx, req.ControlID)
 	if err != nil {
@@ -113,11 +119,9 @@ func (s *Service) UploadScan(ctx context.Context, req UploadRequest) (UploadResu
 		return UploadResult{}, fmt.Errorf("controls.UploadScan: %w", err)
 	}
 
-	// Issue #210: the batch file survives every downstream failure. The
-	// DB writes below still roll back on their own — the ReadingStore's
-	// UpsertReadingsFromReport is a single transaction — but the artefact
-	// on disk is what an operator inspects and what a re-upload cannot
-	// recreate, so we do not erase it.
+	// Issue #210: the batch file survives every downstream failure —
+	// the artefact on disk is what an operator inspects and what a
+	// re-upload cannot recreate. DB scoping below in the docstring.
 
 	project := filepath.Join(projectPrefix, control.ID)
 	report, err := s.Analyzer.Analyze(ctx, AnalyzeRequest{

--- a/apps/server/internal/domain/controls/service_test.go
+++ b/apps/server/internal/domain/controls/service_test.go
@@ -436,8 +436,8 @@ func TestUploadScanPreservesTheBatchOnWorkerRefusal(t *testing.T) {
 	}
 
 	gen.AnalyzeErr = &controls.AnalyzerRefusedError{
-		Message: "worker answered 400: scan not recognized",
-		Detail:  "ERR: /work/controls/x/scans/0001.pdf scan not recognized",
+		Status: 400, Message: "scan not recognized",
+		Detail: "ERR: /work/controls/x/scans/0001.pdf scan not recognized",
 	}
 	_, err = svc.UploadScan(context.Background(), controls.UploadRequest{
 		ControlID: control.ID,

--- a/apps/server/internal/domain/controls/service_test.go
+++ b/apps/server/internal/domain/controls/service_test.go
@@ -422,6 +422,71 @@ func TestCreatePassesTheCorrectAbsoluteListingPathForCodeQuestions(t *testing.T)
 	}
 }
 
+// Issue #210: a worker refusal used to rollback the uploaded PDF, which
+// erased the artefact an operator would inspect and forced the professor
+// to re-scan. The promise now is "wipe DB rows on failure" only — the
+// batch survives on disk so the professor can download it and an operator
+// can look at what got sent. The next upload advances to batch-(N+1).pdf,
+// as expected of a preserved counter derived from directory listing.
+func TestUploadScanPreservesTheBatchOnWorkerRefusal(t *testing.T) {
+	svc, _, gen, workDir := newService(t)
+	control, err := svc.Create(context.Background(), req(nil))
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	gen.AnalyzeErr = &controls.AnalyzerRefusedError{
+		Message: "worker answered 400: scan not recognized",
+		Detail:  "ERR: /work/controls/x/scans/0001.pdf scan not recognized",
+	}
+	_, err = svc.UploadScan(context.Background(), controls.UploadRequest{
+		ControlID: control.ID,
+		Filename:  "batch.pdf",
+		Content:   io.NopCloser(strings.NewReader("%PDF-fake")),
+		Ticked:    controls.DefaultTicked,
+		Unsure:    controls.DefaultUnsure,
+	})
+	if !errors.Is(err, controls.ErrAnalyzerRefused) {
+		t.Fatalf("UploadScan = %v, want ErrAnalyzerRefused", err)
+	}
+	batch1 := filepath.Join(workDir, "controls", control.ID, "uploads", "batch-1.pdf")
+	if _, statErr := os.Stat(batch1); statErr != nil {
+		t.Fatalf("batch-1.pdf missing after refusal: %v — the failed upload's artefact must survive so the operator can download and inspect it", statErr)
+	}
+
+	// The second upload succeeds. The counter is derived from what is on
+	// disk (nextBatchNumber walks the directory), so the second file must
+	// land at batch-2.pdf, not overwrite batch-1.pdf.
+	gen.AnalyzeErr = nil
+	gen.AnalyzeReports = []controls.Report{{
+		Copies: map[string]controls.ReportCopy{
+			"1": {RUT: "20100001", RUTStatus: controls.RUTStatusOK, Status: controls.CopyStatusOK,
+				ExpectedQuestions: 3, SeenQuestions: 3},
+		},
+	}}
+	result, err := svc.UploadScan(context.Background(), controls.UploadRequest{
+		ControlID: control.ID,
+		Filename:  "batch.pdf",
+		Content:   io.NopCloser(strings.NewReader("%PDF-fake-2")),
+		Ticked:    controls.DefaultTicked,
+		Unsure:    controls.DefaultUnsure,
+	})
+	if err != nil {
+		t.Fatalf("second UploadScan: %v", err)
+	}
+	if result.BatchNumber != 2 {
+		t.Errorf("second BatchNumber = %d, want 2 (batch-1.pdf survived the refusal)", result.BatchNumber)
+	}
+	batch2 := filepath.Join(workDir, "controls", control.ID, "uploads", "batch-2.pdf")
+	if _, statErr := os.Stat(batch2); statErr != nil {
+		t.Errorf("batch-2.pdf missing after second upload: %v", statErr)
+	}
+	// batch-1.pdf still there — the second upload does not shift the first.
+	if _, statErr := os.Stat(batch1); statErr != nil {
+		t.Errorf("batch-1.pdf gone after second upload: %v", statErr)
+	}
+}
+
 // Issue #197: the defense-in-depth pair validation refuses before the
 // analyzer is called and before the batch file touches the disk.
 func TestUploadScanRefusesAnInvalidPair(t *testing.T) {

--- a/apps/server/internal/infra/amcworker/analyze.go
+++ b/apps/server/internal/infra/amcworker/analyze.go
@@ -111,13 +111,24 @@ func (c *Client) postReport(ctx context.Context, path string, body []byte) (cont
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		// Issue #210: hand the caller a typed error carrying both fields
+		// the worker reports. Callers that only branch keep using
+		// errors.Is(err, ErrAnalyzerRefused) — the type unwraps to it;
+		// callers that render the failure (handler flash, log) use
+		// errors.As to reach Detail without re-parsing the message.
 		var payload workerError
 		if jerr := json.Unmarshal(respBody, &payload); jerr == nil && payload.Error != "" {
-			return controls.Report{}, fmt.Errorf("%w: worker answered %d: %s",
-				controls.ErrAnalyzerRefused, resp.StatusCode, payload.Error)
+			return controls.Report{}, &controls.AnalyzerRefusedError{
+				Message: fmt.Sprintf("worker answered %d: %s", resp.StatusCode, payload.Error),
+				Detail:  payload.Detail,
+			}
 		}
-		return controls.Report{}, fmt.Errorf("%w: worker answered %d: %s",
-			controls.ErrAnalyzerRefused, resp.StatusCode, truncateForLog(respBody))
+		// The worker answered non-2xx with something that did not parse
+		// as its error envelope — no fields to surface, so Detail stays
+		// empty and Message carries the truncated body for the log.
+		return controls.Report{}, &controls.AnalyzerRefusedError{
+			Message: fmt.Sprintf("worker answered %d: %s", resp.StatusCode, truncateForLog(respBody)),
+		}
 	}
 
 	var wire reportBody

--- a/apps/server/internal/infra/amcworker/analyze.go
+++ b/apps/server/internal/infra/amcworker/analyze.go
@@ -111,23 +111,27 @@ func (c *Client) postReport(ctx context.Context, path string, body []byte) (cont
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		// Issue #210: hand the caller a typed error carrying both fields
-		// the worker reports. Callers that only branch keep using
-		// errors.Is(err, ErrAnalyzerRefused) — the type unwraps to it;
-		// callers that render the failure (handler flash, log) use
-		// errors.As to reach Detail without re-parsing the message.
+		// Issue #210: hand the caller a typed error carrying the fields
+		// the analyzer reports separately. Callers that only branch keep
+		// using errors.Is(err, ErrAnalyzerRefused) — the type unwraps to
+		// it; callers that render the failure (handler flash, log, a
+		// future debug UI) errors.As it to reach Status, Message and
+		// Detail without re-parsing the error string.
 		var payload workerError
 		if jerr := json.Unmarshal(respBody, &payload); jerr == nil && payload.Error != "" {
 			return controls.Report{}, &controls.AnalyzerRefusedError{
-				Message: fmt.Sprintf("worker answered %d: %s", resp.StatusCode, payload.Error),
+				Status:  resp.StatusCode,
+				Message: payload.Error,
 				Detail:  payload.Detail,
 			}
 		}
 		// The worker answered non-2xx with something that did not parse
-		// as its error envelope — no fields to surface, so Detail stays
-		// empty and Message carries the truncated body for the log.
+		// as its error envelope — no envelope fields to surface, so
+		// Detail stays empty and Message carries the truncated body so
+		// the log line still names what the worker returned.
 		return controls.Report{}, &controls.AnalyzerRefusedError{
-			Message: fmt.Sprintf("worker answered %d: %s", resp.StatusCode, truncateForLog(respBody)),
+			Status:  resp.StatusCode,
+			Message: truncateForLog(respBody),
 		}
 	}
 

--- a/apps/server/internal/infra/amcworker/analyze_test.go
+++ b/apps/server/internal/infra/amcworker/analyze_test.go
@@ -154,11 +154,19 @@ func TestAnalyzeRefusalCarriesWorkerMessageAndDetail(t *testing.T) {
 	if !errors.As(err, &wrapped) {
 		t.Fatalf("Analyze: %v; want *AnalyzerRefusedError via errors.As", err)
 	}
-	if !strings.Contains(wrapped.Message, "scan not recognized") {
-		t.Errorf("Message = %q; must include the worker's error text", wrapped.Message)
+	if wrapped.Status != http.StatusBadRequest {
+		t.Errorf("Status = %d; want %d — a consumer picking recoverable vs structural refusals needs this", wrapped.Status, http.StatusBadRequest)
+	}
+	if wrapped.Message != "scan not recognized" {
+		t.Errorf("Message = %q; want the worker's raw summary without a status prefix", wrapped.Message)
 	}
 	if wrapped.Detail != "ERR: /work/x/scans/a not recognized\nERR: /work/x/scans/b not recognized" {
 		t.Errorf("Detail = %q; want the raw stderr excerpt", wrapped.Detail)
+	}
+	// The Error() composition still names the status and message for the
+	// log line — the shape pre-#210 log parsers were reading.
+	if !strings.Contains(err.Error(), "worker answered 400: scan not recognized") {
+		t.Errorf("err.Error() = %q; must still log status+message", err.Error())
 	}
 }
 

--- a/apps/server/internal/infra/amcworker/analyze_test.go
+++ b/apps/server/internal/infra/amcworker/analyze_test.go
@@ -128,6 +128,64 @@ func TestAnalyzeRefusedOn4xxWrapsErrAnalyzerRefused(t *testing.T) {
 	}
 }
 
+// Issue #210: a refused analyse (or reanalyse) reaches the caller as a
+// typed *AnalyzerRefusedError that carries the worker's Message and Detail
+// verbatim. errors.Is on the sentinel still matches — the type wraps it.
+// Callers rendering the failure (log, flash) read Detail without parsing
+// the error string.
+func TestAnalyzeRefusalCarriesWorkerMessageAndDetail(t *testing.T) {
+	body := `{"error":"scan not recognized","detail":"ERR: /work/x/scans/a not recognized\nERR: /work/x/scans/b not recognized"}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := amcworker.New(amcworker.Config{BaseURL: srv.URL})
+	_, err := client.Analyze(context.Background(), controls.AnalyzeRequest{
+		Project: "controls/x", ScanPDF: "controls/x/s.pdf", Source: "controls/x/s.tex",
+		Ticked: controls.DefaultTicked, Unsure: controls.DefaultUnsure,
+	})
+	if !errors.Is(err, controls.ErrAnalyzerRefused) {
+		t.Fatalf("Analyze: %v; want wrapping ErrAnalyzerRefused", err)
+	}
+	var wrapped *controls.AnalyzerRefusedError
+	if !errors.As(err, &wrapped) {
+		t.Fatalf("Analyze: %v; want *AnalyzerRefusedError via errors.As", err)
+	}
+	if !strings.Contains(wrapped.Message, "scan not recognized") {
+		t.Errorf("Message = %q; must include the worker's error text", wrapped.Message)
+	}
+	if wrapped.Detail != "ERR: /work/x/scans/a not recognized\nERR: /work/x/scans/b not recognized" {
+		t.Errorf("Detail = %q; want the raw stderr excerpt", wrapped.Detail)
+	}
+}
+
+// Reanalyze shares postReport with Analyze, but a future refactor could
+// split them; this pins the guarantee at both entry points.
+func TestReanalyzeRefusalCarriesWorkerMessageAndDetail(t *testing.T) {
+	body := `{"error":"no captures","detail":"nothing to re-read"}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := amcworker.New(amcworker.Config{BaseURL: srv.URL})
+	_, err := client.Reanalyze(context.Background(), controls.ReanalyzeRequest{
+		Project: "controls/x", Ticked: 0.3, Unsure: 0.15,
+	})
+	var wrapped *controls.AnalyzerRefusedError
+	if !errors.As(err, &wrapped) {
+		t.Fatalf("Reanalyze: %v; want *AnalyzerRefusedError via errors.As", err)
+	}
+	if wrapped.Detail != "nothing to re-read" {
+		t.Errorf("Detail = %q; want %q", wrapped.Detail, "nothing to re-read")
+	}
+}
+
 func TestAnalyzeRefusesInvalidRequestBeforeCallingTheWorker(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		t.Fatal("Analyze reached the worker with an invalid request")

--- a/docs/security-notes.md
+++ b/docs/security-notes.md
@@ -522,6 +522,14 @@ for what. Two narrower residuals found in the #138 review and accepted with it:
 - **`detail` in an error response carries up to 4 kB of raw AMC output**, and
   AMC's association output names student identifiers verbatim. `apps/server`
   must surface it to a human in the review queue and must not log it.
+  **Worked case since #210**: `apps/server` carries this through
+  `controls.AnalyzerRefusedError.Detail` (kept whole in the struct) and
+  surfaces its first non-empty line, capped to 500 runes, in the flash a
+  professor sees on refusal (`internal/app/web/handler/scans.go`,
+  `refusedFlash`). `Error()` on the same type intentionally omits Detail
+  so `slog.Warn("...", "error", err)` stays clean. The field's godoc
+  points back here so a future caller does not reach for `wrapped.Detail`
+  from a log line by accident.
 - **`/annotate/copy` writes into AMC's private sqlite layout** (`capture_zone`
   keyed by request data, #190 / ADR-0040). The payload is shape-validated
   before any write (integer copy, existing question names, 8-digit RUT) and

--- a/docs/standards/backend-code-style.md
+++ b/docs/standards/backend-code-style.md
@@ -110,6 +110,18 @@ should shape the method set.
 - **Sentinel errors for conditions a caller branches on**, compared with
   `errors.Is`. Worked case: `config.ErrMissing` distinguishes "the operator has
   not finished configuring this" from "the operator configured it wrongly".
+- **A typed error wrapping a sentinel** when a branched failure must also
+  carry structured fields for a renderer to read. Implement `Unwrap() error`
+  returning the sentinel so `errors.Is` on the sentinel keeps matching, and
+  give the type exported fields the renderer needs — status code, message,
+  detail — so nobody has to regex the error string back out. Worked case
+  (#210): `controls.AnalyzerRefusedError{Status, Message, Detail}` unwraps
+  to `ErrAnalyzerRefused`; the handler's `refusedFlash` reads Detail via
+  `errors.As` to embed the worker's first stderr line in the flash a
+  professor sees, and `Error()` composes Status + Message so
+  `slog.Warn(err)` still reads `worker answered NNN: msg` the way pre-#210
+  log parsers expect. Reach for this shape when a `fmt.Errorf` with a
+  formatted status prefix would force every renderer to re-parse it.
 - **Never `panic` in a request path.** A handler that cannot proceed writes a
   status; `panic` is for a programming error at wiring time and nothing else.
 - **Never discard an error silently.** `_ = f.Close()` in a `defer` is fine and


### PR DESCRIPTION
**Closes #210**

## Summary

Diagnosability debt from the 2026-08-19 scan incident (control
`WNME7QU6SZD26KFM5CBJD3QM4E` on the Jetson): a 44-page batch printed
Letter on an A4 layout came back +0/0/0+ for every page (fiducials
walked off the edge). The worker returned 400 with `detail` naming
`ERR: /work/…/scans/… scan not recognized` × 44 — but the server
dropped `Detail`, deleted the uploaded PDF via rollback, and flashed
"Revisa que sea un escaneo del control correcto". Diagnosis cost 20
minutes via SSH. #206 fixed the root cause (paper size); this WP
fixes the diagnosis.

Three things ship together because they belong to the same failure
mode ("the AMC worker refused this scan"):

- **The worker's `detail` reaches humans.** New
  `controls.AnalyzerRefusedError{Status, Message, Detail}` wraps
  `ErrAnalyzerRefused` (Unwrap → sentinel, so every existing
  `errors.Is` callsite keeps matching). Consumers rendering the
  failure `errors.As` it to read the fields without re-parsing the
  message.
- **The flash is diagnostic.** For both upload and reanalyze, the
  flash carries the first non-empty line of `Detail`, capped to 500
  runes (rune-safe), with a hint tuned to the widest class of causes
  (`"Revisa que la impresión y el escaneo estén completos y no
  cortados en los bordes."`). Fallback keeps verdict+hint alone when
  `Detail` is empty (old worker, non-envelope 4xx).
- **The uploaded batch survives the refusal.** `rollbackFile` and its
  four call sites are gone. The batch on disk is what an operator
  inspects and what a re-upload cannot recreate — erasing it forced a
  re-scan when the printed sheets, not the file, were the problem.

Server-side only. No worker change (apps/amc-worker already returned
`{"error", "detail"}` correctly, `worker.py:781-782`).

## Slices completed

- [x] **S1** (9b2fbba) — `AnalyzerRefusedError{Status, Message, Detail}` in `apps/server/internal/domain/controls/reading.go`; `apps/server/internal/infra/amcworker/analyze.go` returns it on every non-2xx (both parsed-envelope and fallback paths). Tests pin `errors.Is` + `errors.As` + `Error()` shape for both `Analyze` and `Reanalyze`.
- [x] **S2** (5b3b620) — `apps/server/internal/app/web/handler/scans.go` gains `refusedFlash` / `firstDetailLine` / `truncateRunes`. Two handler branches (upload + reanalyze) render the enriched flash. Handler tests cover: with-detail, empty-detail fallback, blank-line-skip + truncation with ellipsis, reanalyze branch.
- [x] **S3** (8def6fe) — `rollbackFile` closure + 4 call sites removed from `apps/server/internal/domain/controls/scans.go`. Domain test `TestUploadScanPreservesTheBatchOnWorkerRefusal` asserts `batch-1.pdf` survives a worker refusal AND the next upload advances to `batch-2.pdf`.

Two review-fix commits followed the pipeline (see "Reviews run" below).

## Acceptance criteria

The eight ACs on issue #210, each with evidence:

1. **AnalyzerRefusedError exposes Message+Detail, both `Analyze` and `Reanalyze` return it.**
   `apps/server/internal/domain/controls/reading.go:189-197` (type), `apps/server/internal/infra/amcworker/analyze.go:118-133` (both paths through `postReport`, which is shared by `Analyze`/`Reanalyze`).
2. **Unit test asserts both fields readable via `errors.As`.**
   `apps/server/internal/infra/amcworker/analyze_test.go:110-158` (`TestAnalyzeRefusalCarriesWorkerMessageAndDetail` + `TestReanalyzeRefusalCarriesWorkerMessageAndDetail`).
3. **Handler flash for `ErrAnalyzerRefused` includes first line of `detail`; falls back when empty. Handler test covers both branches.**
   Flash construction: `apps/server/internal/app/web/handler/scans.go:346-386` (`refusedFlash` / `firstDetailLine`), called from L157-163 (upload) and L228-233 (reanalyze). Tests: `apps/server/internal/app/web/handler/scans_test.go:445-590` (four cases: with-detail, empty-detail, truncation, reanalyze).
4. **`UploadScan` NO LONGER calls `rollbackFile()`. DB-write rollbacks intact.**
   `apps/server/internal/domain/controls/scans.go:112-146` — closure and 4 call sites gone. `UpsertReadingsFromReport` remains transactional (single tx, `internal/infra/storage/controlstore/readings.go:22-83`). Docstring at scans.go:59-85 documents the scoped-atomicity reality (thresholds + upsert + mark-missing are three independent writes — this is honest about what the pre-#210 code also didn't cover).
5. **Domain test: after simulated worker 400, `batch-1.pdf` exists AND `nextBatchNumber` returns 2.**
   `apps/server/internal/domain/controls/service_test.go:427-489` (`TestUploadScanPreservesTheBatchOnWorkerRefusal`).
6. **Per-commit protocol green before every commit; pre-PR complete before publishing.**
   Every slice landed after fmt/vet/build/test-race passed. Pre-PR ran twice (once at end of S3, once after Round B fixes): both green including `govulncheck` and `docker compose up --wait server` + `/health` + `/api/health`.
7. **No changes to apps/amc-worker, content/, or any ADR.**
   `git diff main --stat` touches only `apps/server/**` and `docs/{security-notes.md, standards/backend-code-style.md}`. No ADR file added or edited.
8. **Verified in a real browser at ≥1440px in one theme.**
   → See "Manual verification" below (this is your part per develop-task).

## Tests

- New unit tests: `TestAnalyzeRefusalCarriesWorkerMessageAndDetail`, `TestReanalyzeRefusalCarriesWorkerMessageAndDetail` (both in `analyze_test.go`).
- New handler tests: `TestUploadScanRefusedFlashCarriesFirstLineOfDetail`, `TestUploadScanRefusedFlashFallsBackWhenDetailEmpty`, `TestUploadScanRefusedFlashSkipsBlankLinesAndTruncatesLongOnes`, `TestReanalyzeRefusedFlashCarriesFirstLineOfDetail` (all in `scans_test.go`).
- New domain test: `TestUploadScanPreservesTheBatchOnWorkerRefusal` (`service_test.go`).
- Full suite green: `go test -race -count=1 ./...` in apps/server (25 packages, 0 failures).
- Pre-PR: `gofmt -l` silent, `go vet ./...`, `go build ./...`, `go test -race -count=1 ./...`, `govulncheck ./...` ("No vulnerabilities found"), `docker build`, `docker compose up -d --wait server` (Healthy), `curl /health` `{"process":"up","database":"up"}`, `curl /api/health` same.

## Reviews run

`review-pipeline` in integrated mode over `main...HEAD`. Both rounds ran. All lenses in isolated worktrees per the bindings override.

- **Mechanical gate**: pre-PR protocol — green.
- **Round A panel** (correctness-tests + arch-simplicity + security; performance skipped — no hot paths touched): 1 important (dedup across two lenses) + 3 suggestions + 1 pattern.
  - **MERGED-1** (correctness+arch, important) — S3 docstring overpromised DB atomicity. Verifier **CONFIRMED**. Fix: rewrote the docstring to describe reality (single Upsert is transactional; the three-step sequence is not). Per-fix lens recheck: **resolved**.
  - **COR-3** (suggestion, accepted) — added `Status int` to `AnalyzerRefusedError`; `Message` no longer bakes in the status prefix; `Error()` composes both so log parsers still read `worker answered NNN: msg`.
  - **COR-4** (suggestion, accepted) — `truncateRunes(s, 0)` no longer returns a lone ellipsis; guarded.
  - **ARQ-2** (suggestion, partially accepted) — kept field names `Message`/`Detail` (they mirror the analyzer contract); rephrased the type doc to be engine-neutral (dropped AMC-specific 4000-char reference).
  - **ARQ-3** (suggestion, dismissed) — three well-named handler-local helpers are clearer than one 15-line function.
  - **SEC-1** (pattern, deferred) — unbounded `uploads/` growth once rollback is gone. Legitimate hardening, outside #210 scope; noted below in "Notes".
- **Round B panel** (docs-completeness + docs-accuracy + adr-hunter + agent-readability): 3 important + 3 suggestions.
  - **DCO-1** (docs-completeness, important, accepted) — added SECURITY paragraph to `AnalyzerRefusedError.Detail` godoc pointing to `docs/security-notes.md §"The control worker is unauthenticated"` (Detail can name student RUTs; must never reach slog).
  - **DAC-1** (docs-accuracy, important, accepted) — the in-body comment on the `ThresholdsValid` gate still cited "the all-or-nothing promise covers the batch file too" (false since S3). Rewritten to match reality.
  - **DCO-2** (suggestion, accepted) — worked-case pointer in `docs/security-notes.md` back to `AnalyzerRefusedError.Detail` + `refusedFlash`.
  - **AGR-1** (suggestion, accepted) — added a bullet to `docs/standards/backend-code-style.md §Errors` naming the typed-error-wrapping-a-sentinel pattern with #210 as worked case.
  - **AGR-2** (suggestion, accepted) — added a rule to `apps/server/CLAUDE.md` forbidding re-introduction of `os.Remove(batchHostPath)` on post-copy failures; cites the 2026-08-19 incident.
  - **ADR-1 + ADR-2** (important + suggestion, DEFERRED per WP brief) — hunter recommended an ADR for the "batch survives" policy reversal and one for scoped DB atomicity. User's brief explicitly said "No ADR expected (chore hardening, not architectural)"; the invariants are captured inline (CLAUDE.md rule + `UploadScan` docstring) instead.

Two review-fix commits: `a8dd534` (Round A) and `c4fc8c1` (Round B). Re-gate + per-fix rechecks green after each.

## Manual verification

Your part per the WP-210 §Acceptance criteria (AC-8). Suggested check:

- [ ] Start the app locally (e.g. `docker compose up -d --wait server` from `infra/local/`, then `curl http://127.0.0.1:8081/health`).
- [ ] Sign in, open any control's detail page, upload a batch.
- [ ] To force an `ErrAnalyzerRefused` locally: point the server at an `amc-worker` you've made refuse (easiest: patch `apps/amc-worker/worker.py` `/analyse` handler to return a 400 with `{"error":"scan not recognized","detail":"ERR: /work/x/scans/a scan not recognized\nERR: /work/x/scans/b scan not recognized"}` before rebuilding the worker container; or point `NALANDA_WORKER_URL` at a local `python -m http.server`-style stub that returns that shape).
- [ ] After the upload, verify at ≥1440px in one theme:
  - The red flash reads `"El motor de lectura rechazó el escaneo. Detalle del motor: ERR: /work/x/scans/a scan not recognized. Revisa que la impresión y el escaneo estén completos y no cortados en los bordes."`
  - The batch appears in "Lotes subidos" and is downloadable (link resolves to the stored `batch-N.pdf`).

If the local reproduction is finicky, I can hand you a scripted `httptest`-style stand-in — just say the word.

## Notes

- **Uploaded batches now accumulate under `<project>/uploads/`** — before #210 the file self-erased on any failure; after, it survives. `SEC-1` from the review panel flagged this as unbounded disk growth on an unattended failure loop. Real hardening, but outside #210 scope. Suggested follow-up: cap per-control size or add an admin reaper.
- **A widened single-tx `PersistReport`** is a follow-up mentioned in the `UploadScan` docstring. The three post-analyse writes (`Store.SetControlThresholds`, `Readings.UpsertReadingsFromReport`, `Readings.MarkMissingAsNotPresent`) are not atomic as a sequence; only the middle Upsert is transactional. Pre-#210 code had the same shape — this WP made the docstring honest about it rather than fixing it.
- **Copy for the Spanish flash**: settled on `"El motor de lectura rechazó el escaneo. Detalle del motor: <line>. Revisa que la impresión y el escaneo estén completos y no cortados en los bordes."` (Miguel's proposal, keeping the "no cortados en los bordes" hint that covers the paper-size class without pretending to name it). Reanalyze uses `"El motor rechazó re-leer. Detalle del motor: <line>. Puede que aún no haya escaneos subidos."`.
- **The failed batch shows up in "Lotes subidos" identically to a successful one.** Per WP brief §Non-goals: no UI marker for "this batch failed". The professor knows which one failed because the flash just told them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0137DjbUdyAmB71f2V1AoGAU
