### PR TITLE
fix(controls): propagate worker Detail on generate refusal (unblock #208 diagnosis)

### DIFF
--- a/apps/server/internal/infra/amcworker/amcworker.go
+++ b/apps/server/internal/infra/amcworker/amcworker.go
@@ -162,8 +162,21 @@ func (c *Client) Generate(ctx context.Context, req controls.GenerateRequest) (co
 		// do not fail closed if it is not JSON: the value here is the
 		// status and the raw body's leading text, both useful for
 		// diagnosis.
+		//
+		// `detail` is the last 4000 chars of AMC's stderr — the LaTeX
+		// error, the missing file, the pdflatex Emergency stop. Without
+		// it "prepare failed (1)" is unactionable (issue #206 §Notes
+		// follow-up: "Worker payload.Detail is not propagated to the
+		// server log — the 44 ERR lines never appeared, forcing manual
+		// reproduction to diagnose"). Capped so the wire-worst case of a
+		// full 4000-char AMC dump still fits one log line.
 		var payload workerError
 		if jerr := json.Unmarshal(respBody, &payload); jerr == nil && payload.Error != "" {
+			if payload.Detail != "" {
+				return controls.Assets{}, fmt.Errorf("%w: %s answered %d: %s (worker detail: %s)",
+					controls.ErrGeneratorRefused, req.Project, resp.StatusCode,
+					payload.Error, truncateDetail(payload.Detail))
+			}
 			return controls.Assets{}, fmt.Errorf("%w: %s answered %d: %s",
 				controls.ErrGeneratorRefused, req.Project, resp.StatusCode, payload.Error)
 		}
@@ -202,6 +215,23 @@ func truncateForLog(b []byte) string {
 		return string(b[:max]) + "…"
 	}
 	return string(b)
+}
+
+// truncateDetail keeps the worker's AMC-stderr detail short enough to fit a
+// single log line. 1200 chars covers a Package Listings Error's file line,
+// an Emergency stop, and the "Fatal error occurred" tail — the three lines
+// that identify what pdflatex actually rejected. The worker itself caps at
+// 4000, so this is a second gate against a runaway log entry.
+func truncateDetail(s string) string {
+	const max = 1200
+	// Newlines interpolated into a slog Errorf line become "\n" that
+	// splits the message across lines — a log aggregator then sees
+	// several unindexable half-messages. Collapse.
+	s = strings.ReplaceAll(s, "\n", " | ")
+	if len(s) > max {
+		return s[:max] + "…"
+	}
+	return s
 }
 
 // Assert the interface at compile time — the storage.Prober shape.

--- a/apps/server/internal/infra/amcworker/amcworker_test.go
+++ b/apps/server/internal/infra/amcworker/amcworker_test.go
@@ -76,12 +76,72 @@ func TestGenerateRefusedOn4xxWrapsErrGeneratorRefused(t *testing.T) {
 		t.Errorf("Generate on 400: %v, want ErrGeneratorRefused", err)
 	}
 	// The worker's `error` string is what the operator will read; the
-	// message must include it. The `detail` field is not part of the
-	// domain-facing text — it can carry student identifiers per the
-	// worker's own security note, and this handler runs BEFORE any
-	// filtering in the caller.
+	// message must include it. `detail` is now included too — it carries
+	// the last 4000 chars of AMC's stderr (Package Listings Error,
+	// Emergency stop, missing file), which is the only diagnosable
+	// signal when pdflatex refuses a source. It was dropped in the
+	// original wire mapping, and "prepare failed (1)" was unactionable
+	// in production (#208 hotfix, mirror of #210's analyze-path fix).
+	// The /generate stderr is LaTeX output, not student data — safe to
+	// log; the analyze path has its own struct because reader stderr
+	// can carry RUT/name fragments.
 	if !strings.Contains(err.Error(), "source path does not exist") {
 		t.Errorf("error %q does not include worker's error message", err.Error())
+	}
+	if !strings.Contains(err.Error(), "no such file: controls/bogus/inputs/source.tex") {
+		t.Errorf("error %q does not include worker's detail — 'prepare failed (1)' alone is unactionable (#208 hotfix)", err.Error())
+	}
+}
+
+// A refusal WITHOUT a detail field falls back to the message-only shape
+// (an older worker version, or a Failed() raised without a stderr tail).
+// The parenthetical "(worker detail: ...)" must not appear in that case,
+// or a reader sees `(worker detail: )` and thinks the stderr was empty
+// when in fact the field was absent.
+func TestGenerateRefusedOmitsDetailClauseWhenDetailAbsent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		respond(w, http.StatusBadRequest, map[string]any{
+			"error": "copies must be at least 1",
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	client := amcworker.New(amcworker.Config{BaseURL: srv.URL})
+	_, err := client.Generate(context.Background(), controls.GenerateRequest{
+		Project: "controls/abc", Source: "controls/abc/inputs/source.tex", Copies: 0,
+	})
+	if !errors.Is(err, controls.ErrGeneratorRefused) {
+		t.Fatalf("Generate on 400: %v, want ErrGeneratorRefused", err)
+	}
+	if strings.Contains(err.Error(), "worker detail:") {
+		t.Errorf("error %q includes an empty 'worker detail:' clause; the parenthetical must be omitted when detail is absent", err.Error())
+	}
+}
+
+// The detail is collapsed to one line so a log aggregator keeps the whole
+// AMC-stderr tail on one entry rather than splitting it across several
+// unindexable half-messages. Newlines become " | ".
+func TestGenerateRefusedCollapsesMultilineDetailIntoOneLine(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		respond(w, http.StatusBadRequest, map[string]any{
+			"error":  "auto-multiple-choice prepare failed (1)",
+			"detail": "line one\nline two\nline three",
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	client := amcworker.New(amcworker.Config{BaseURL: srv.URL})
+	_, err := client.Generate(context.Background(), controls.GenerateRequest{
+		Project: "controls/abc", Source: "controls/abc/inputs/source.tex", Copies: 1,
+	})
+	if err == nil {
+		t.Fatal("Generate: nil error, want ErrGeneratorRefused")
+	}
+	if strings.Contains(err.Error(), "\n") {
+		t.Errorf("error contains a literal newline — the detail was not collapsed; err = %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "line one | line two | line three") {
+		t.Errorf("error %q does not preserve every detail line joined by ' | '", err.Error())
 	}
 }
 


### PR DESCRIPTION
Unblocks diagnosis of the 500 Miguel hit right after #211 landed (control
6P3FFVJQ6FJOTYSU7RDGJJH6IA, 2026-08-20 01:31 UTC). The server logged
\`auto-multiple-choice prepare failed (1)\` with no LaTeX evidence — the
exact follow-up flagged in #206 §Notes.

The worker's response is \`{"error", "detail"}\` where \`detail\` is the
last 4000 chars of AMC's stderr. \`amcworker.Client.Generate\` decoded
both but wrapped only \`error\` into the returned Go error.

## Summary

- Wrap \`detail\` into the error as \`(worker detail: …)\`, capped 1200
  chars, newlines collapsed to \` | \` so a log aggregator keeps the
  whole tail on one entry.
- Three tests pin: refusal WITH detail includes both; refusal WITHOUT
  detail omits the parenthetical; multi-line detail is joined not split.

## Scope

**Generate path only.** The analyzer path got the full treatment in
#210 (AnalyzerRefusedError struct + flash renders Detail + preserves
uploaded PDF). A mirror GeneratorRefusedError is a proper follow-up —
this fix is the minimum to unblock diagnosis. \`/generate\` stderr is
LaTeX output (safe to log), unlike \`/analyse\` which can carry RUT.

## Tests

- \`gofmt -l . / go vet ./... / go test -race -count=1 ./...\` — 25 pkgs.
- New tests in \`amcworker_test.go\`:
  - \`TestGenerateRefusedOn4xxWrapsErrGeneratorRefused\` extended to
    check that \`no such file: controls/bogus/inputs/source.tex\` (the
    detail) is in the wrapped error.
  - \`TestGenerateRefusedOmitsDetailClauseWhenDetailAbsent\`
  - \`TestGenerateRefusedCollapsesMultilineDetailIntoOneLine\`

## Manual verification

- [ ] Merge, wait for server CD, force pull on Jetson (or wait
      Watchtower's 5 min).
- [ ] Miguel reintenta el control fallido.
- [ ] \`docker logs local-server-1 --since 5m | grep "creating a control"\`
      now includes \`(worker detail: …)\` with the real AMC stderr.
- [ ] Con eso en mano, abrimos el fix del bug de fondo (probablemente
      un follow-up del banco de preguntas o el staging del listing).

Refs #208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)