### PR TITLE
fix(content): tune three Control 2 distractors — drop CheerpJ, drop bad C++ analogies

### DIFF
--- a/content/courses/sample-course/09-arrays-y-funciones.mdx
+++ b/content/courses/sample-course/09-arrays-y-funciones.mdx
@@ -904,7 +904,7 @@ El documento sugiere probar `fib(40)` en vivo con el recursivo y desaconseja
 subir mucho más allá de `fib(45)`. ¿Por qué?
 
 - [x] Porque cada `+5` en `n` multiplica el tiempo por diez y no hay botón de cancelar
-- [ ] Porque CheerpJ no soporta números tan grandes como `fib(45)`
+- [ ] Porque el navegador mata la pestaña si un cálculo tarda más de un umbral fijo
 - [ ] Porque el resultado de `fib(45)` no cabe en un `int` ni en un `long`
 - [ ] Es una limitación arbitraria; con permisos elevados se puede correr
 

--- a/content/courses/sample-course/10-objetos.mdx
+++ b/content/courses/sample-course/10-objetos.mdx
@@ -878,7 +878,7 @@ En Java, `this` dentro de un método de instancia es:
 - [x] Una referencia al objeto sobre el que se llamó el método
 - [ ] Un puntero al objeto (con aritmética permitida)
 - [ ] Un alias de una variable local del método
-- [ ] La clase, no el objeto — como `Clase::` en C++
+- [ ] Un objeto especial que representa a la clase misma (equivalente a `Persona.class`)
 
 </Question>
 
@@ -925,7 +925,7 @@ sobrescriben?
 - [x] Porque el compilador verifica que sobrescriben algo: un typo pasa a ser error de build
 - [ ] Porque acelera la ejecución del método en runtime
 - [ ] Porque es obligatorio para que la sobrescritura funcione
-- [ ] Porque marca el método como `virtual`, que en Java es opt-in
+- [ ] Porque `@Override` hace la llamada más rápida al saltarse la búsqueda dinámica
 
 </Question>
 


### PR DESCRIPTION
## Summary

Revisión pedagógica del banco de preguntas de Control 2 (pool `PGPYYVW73SRQCMJXCVVVZSFV4A`, 36 preguntas). Todas las respuestas correctas verifican correctas, todas las anclas coinciden. Se acordó cambiar **3 distractores** que rompían coherencia con la audiencia o plantaban modelos mentales que después había que desenseñar:

- **`cap-del-n`** (`09-arrays-y-funciones.mdx`) — fuera la mención a `CheerpJ`. Los alumnos de EDA no deben saber qué runtime Java corre en el navegador; además `CheerpJ` es interino (memoria: `project_java_backend_direction`). Reemplazado por un distractor de "el navegador mata pestañas por umbral fijo" — plausible, falsable en clase, y sigue apuntando al hueco real (no hay botón de cancelar).
- **`this-en-java`** (`10-objetos.mdx`) — fuera el distractor `Clase::` en C++: mezcla `this` con el operador de resolución de ámbito, y en C++ **también** existe `this` con el mismo significado. Reemplazado por "un objeto que representa a la clase misma (`Persona.class`)" — falsable, refuerza el delta entre instancia y `Class` object.
- **`anotacion-override-protege`** (`10-objetos.mdx`) — fuera "`virtual` en Java es opt-in": es doctrina errada justo en la audiencia que viene de C++, donde `virtual` sí es opt-in. Reemplazado por una afirmación de rendimiento (falsable, no plantea mala doctrina).

Cambio yolo-shape (3 líneas de contenido, sin lógica), aprobado en revisión previa con el usuario.

## Test plan

- [x] `npm run format:check` verde
- [x] `npm run lint` verde
- [x] `npm run build` verde (tipo + integridad de content/ + unicidad de question ids)
- [x] `npm run test` verde — 1061/1061
- [ ] Después del merge y deploy, borrar Control 2 en la UI y regenerar; verificar que el nuevo pool.json trae los tres distractores actualizados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RbVJsq2WVVQsjkVTxE7UKC
