### PR TITLE
feat: warm light + violet dark palette from deck/POC seeds (#222)

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -11,8 +11,8 @@
          `--nl-ground` in src/styles/index.css rather than against a hardcoded
          hex, because asserting each side alone is exactly how they drifted —
          twice. -->
-    <meta name="theme-color" content="#eef1f4" media="(prefers-color-scheme: light)" />
-    <meta name="theme-color" content="#0c1118" media="(prefers-color-scheme: dark)" />
+    <meta name="theme-color" content="#f8f2ef" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0d1117" media="(prefers-color-scheme: dark)" />
     <title>Nalanda</title>
     <!-- Stamps the reader's saved choice BEFORE the first paint. It has to be
          inline and it has to be here: a module runs after the document is

--- a/apps/web/src/app/NotFound.tsx
+++ b/apps/web/src/app/NotFound.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 export function NotFound() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center bg-ground text-ink">
-      <h1 className="text-4xl font-bold tracking-tight">Page not found</h1>
+      <h1 className="text-accent-pop text-4xl font-bold tracking-tight">Page not found</h1>
       <p className="mt-4 text-lg text-ink-faint">
         The document you are looking for does not exist.
       </p>

--- a/apps/web/src/catalog/CatalogOverviewPage.tsx
+++ b/apps/web/src/catalog/CatalogOverviewPage.tsx
@@ -25,7 +25,7 @@ export function CatalogOverviewPage() {
           return (
             <li key={family.id}>
               <div className="flex items-baseline gap-3">
-                <h2 className="text-accent-pop text-2xl font-semibold">
+                <h2 className="text-2xl font-semibold">
                   {/* Coloured and underlined-on-hover like every other link here:
                       with only `hover:text-accent` the four family names were
                       indistinguishable from headings, and a keyboard user reached

--- a/apps/web/src/catalog/CatalogOverviewPage.tsx
+++ b/apps/web/src/catalog/CatalogOverviewPage.tsx
@@ -11,7 +11,7 @@ export function CatalogOverviewPage() {
   const catalog = use(loadCatalog());
   return (
     <CatalogLayout>
-      <h1 className="text-4xl font-bold tracking-tight">Catalog</h1>
+      <h1 className="text-accent-pop text-4xl font-bold tracking-tight">Catalog</h1>
       <p className="mt-3 text-ink-faint">
         The components a document can use — the platform&apos;s grammar (ADR-0010). Four editable
         families; every component ships its entry here.{' '}
@@ -25,7 +25,7 @@ export function CatalogOverviewPage() {
           return (
             <li key={family.id}>
               <div className="flex items-baseline gap-3">
-                <h2 className="text-2xl font-semibold">
+                <h2 className="text-accent-pop text-2xl font-semibold">
                   {/* Coloured and underlined-on-hover like every other link here:
                       with only `hover:text-accent` the four family names were
                       indistinguishable from headings, and a keyboard user reached

--- a/apps/web/src/catalog/ComponentArticle.tsx
+++ b/apps/web/src/catalog/ComponentArticle.tsx
@@ -14,7 +14,7 @@ export function ComponentArticle({ entry }: Props) {
   // to carry the id and so read "structure" beside a page headed "Structure".
   return (
     <CatalogLayout back={{ to: `/catalog/${entry.family}`, label: familyName(entry.family) }}>
-      <h1 className="mt-4 text-4xl font-bold tracking-tight">{entry.name}</h1>
+      <h1 className="text-accent-pop mt-4 text-4xl font-bold tracking-tight">{entry.name}</h1>
       <p className="mt-3 text-ink-soft">{entry.description}</p>
       <p className="mt-1 text-sm text-ink-faint">
         {/* The family id IS the folder name (#87) — no mapping to keep in sync. */}
@@ -23,10 +23,10 @@ export function ComponentArticle({ entry }: Props) {
         </code>
       </p>
 
-      <h2 className="mt-8 text-2xl font-semibold">When to use</h2>
+      <h2 className="text-accent-pop mt-8 text-2xl font-semibold">When to use</h2>
       <p className="mt-2 text-ink-soft">{entry.whenToUse}</p>
 
-      <h2 className="mt-8 text-2xl font-semibold">Props</h2>
+      <h2 className="text-accent-pop mt-8 text-2xl font-semibold">Props</h2>
       {entry.props.length === 0 ? (
         <p className="mt-2 text-ink-faint">This component takes no props.</p>
       ) : (
@@ -52,7 +52,7 @@ export function ComponentArticle({ entry }: Props) {
         </table>
       )}
 
-      <h2 className="mt-8 text-2xl font-semibold">Examples</h2>
+      <h2 className="text-accent-pop mt-8 text-2xl font-semibold">Examples</h2>
       {/* The catalog writes English; what it renders is the real component with
           real course content, so the snippets and the widgets' own chrome are
           Spanish. Stated here so the mix reads as the boundary it is (#87). */}

--- a/apps/web/src/catalog/ExampleBlock.tsx
+++ b/apps/web/src/catalog/ExampleBlock.tsx
@@ -10,7 +10,7 @@ interface Props {
 export function ExampleBlock({ title, code, children }: Props) {
   return (
     <section className="mt-6">
-      <h3 className="text-lg font-semibold">{title}</h3>
+      <h3 className="text-accent-pop text-lg font-semibold">{title}</h3>
       <div className="mt-2 rounded border border-rule p-4">{children}</div>
       <pre className="mt-2 overflow-x-auto rounded bg-surface p-3 text-sm text-ink-soft">
         <code>{code}</code>

--- a/apps/web/src/catalog/FamilyPage.tsx
+++ b/apps/web/src/catalog/FamilyPage.tsx
@@ -23,7 +23,7 @@ export function FamilyPage({ notFound }: Props) {
   const entries = use(loadCatalog()).byFamily(family.id);
   return (
     <CatalogLayout back={{ to: '/catalog', label: 'Catalog' }}>
-      <h1 className="mt-4 text-4xl font-bold tracking-tight">{family.name}</h1>
+      <h1 className="text-accent-pop mt-4 text-4xl font-bold tracking-tight">{family.name}</h1>
       <p className="mt-3 text-ink-soft">{family.definition}</p>
       <p className="mt-1 text-sm text-ink-faint">{family.whatBelongs}</p>
       <p className="mt-1 text-sm text-ink-faint">

--- a/apps/web/src/catalog/GovernancePage.tsx
+++ b/apps/web/src/catalog/GovernancePage.tsx
@@ -40,41 +40,41 @@ const REVIEW_CHECKLIST = [
 export function GovernancePage() {
   return (
     <CatalogLayout back={{ to: '/catalog', label: 'Catalog' }}>
-      <h1 className="mt-4 text-4xl font-bold tracking-tight">Governance</h1>
+      <h1 className="text-accent-pop mt-4 text-4xl font-bold tracking-tight">Governance</h1>
       <p className="mt-3 text-ink-faint">
         The catalog governs itself (ADR-0010): these pages are the rules, and changing the rules
         goes through the process at the bottom.
       </p>
 
-      <h2 className="mt-10 text-2xl font-semibold">How to add a component</h2>
+      <h2 className="text-accent-pop mt-10 text-2xl font-semibold">How to add a component</h2>
       <ol className="mt-3 list-decimal space-y-2 pl-6 text-ink-soft">
         {ADD_STEPS.map((step) => (
           <li key={step}>{step}</li>
         ))}
       </ol>
 
-      <h2 className="mt-10 text-2xl font-semibold">Component contract</h2>
+      <h2 className="text-accent-pop mt-10 text-2xl font-semibold">Component contract</h2>
       <ol className="mt-3 list-decimal space-y-2 pl-6 text-ink-soft">
         {CONTRACT_POINTS.map((point) => (
           <li key={point}>{point}</li>
         ))}
       </ol>
 
-      <h2 className="mt-10 text-2xl font-semibold">Documentation checklist</h2>
+      <h2 className="text-accent-pop mt-10 text-2xl font-semibold">Documentation checklist</h2>
       <ul className="mt-3 list-disc space-y-2 pl-6 text-ink-soft">
         {DOC_CHECKLIST.map((item) => (
           <li key={item}>{item}</li>
         ))}
       </ul>
 
-      <h2 className="mt-10 text-2xl font-semibold">Review checklist</h2>
+      <h2 className="text-accent-pop mt-10 text-2xl font-semibold">Review checklist</h2>
       <ul className="mt-3 list-disc space-y-2 pl-6 text-ink-soft">
         {REVIEW_CHECKLIST.map((item) => (
           <li key={item}>{item}</li>
         ))}
       </ul>
 
-      <h2 className="mt-10 text-2xl font-semibold">Changing these rules</h2>
+      <h2 className="text-accent-pop mt-10 text-2xl font-semibold">Changing these rules</h2>
       <p className="mt-3 text-ink-soft">
         A PR that edits these governance pages, reviewed like any other change. If the change is
         architectural (new family, contract point added/removed, catalog mechanics), it also needs

--- a/apps/web/src/components/interactive/Questions.tsx
+++ b/apps/web/src/components/interactive/Questions.tsx
@@ -25,7 +25,7 @@ export const Questions = withMeta(
   function Questions({ children }: QuestionsProps) {
     return (
       <section className="mt-10 border-t border-rule pt-6">
-        <h2 className="m-0 text-lg font-semibold text-ink">Preguntas</h2>
+        <h2 className="text-accent-pop m-0 text-lg font-semibold">Preguntas</h2>
         {children}
       </section>
     );

--- a/apps/web/src/presentation/RotateNotice.tsx
+++ b/apps/web/src/presentation/RotateNotice.tsx
@@ -31,6 +31,10 @@ export function RotateNotice({ docId }: Props) {
       className="fixed inset-0 h-[100dvh] z-40 flex flex-col items-center justify-center gap-4 bg-deck-ground px-8 text-center text-ink"
     >
       <RotateCwSquare size={48} aria-hidden="true" className="text-ink-faint" />
+      {/* No `text-accent-pop` here: this panel is `bg-deck-ground`, and on that
+          surface the seed clears only 2.92:1 in light (<3:1). The heading is
+          system UI, not a course-content title — see ADR-0026 addendum §Deck
+          exception and `design-system.md` §Títulos "Two exceptions". */}
       <h1 id="rotate-notice-title" className="text-2xl font-bold tracking-tight">
         Gira el teléfono
       </h1>

--- a/apps/web/src/presentation/SlideDeck.tsx
+++ b/apps/web/src/presentation/SlideDeck.tsx
@@ -247,9 +247,7 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
             className="w-full max-w-4xl"
           >
             {slide.title ? (
-              <h2 className="text-accent-pop mb-10 text-5xl font-bold tracking-tight">
-                {slide.title}
-              </h2>
+              <h2 className="mb-10 text-5xl font-bold tracking-tight">{slide.title}</h2>
             ) : null}
             <div className="prose prose-xl max-w-none">{slide.content}</div>
           </motion.div>

--- a/apps/web/src/presentation/SlideDeck.tsx
+++ b/apps/web/src/presentation/SlideDeck.tsx
@@ -247,7 +247,9 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
             className="w-full max-w-4xl"
           >
             {slide.title ? (
-              <h2 className="mb-10 text-5xl font-bold tracking-tight">{slide.title}</h2>
+              <h2 className="text-accent-pop mb-10 text-5xl font-bold tracking-tight">
+                {slide.title}
+              </h2>
             ) : null}
             <div className="prose prose-xl max-w-none">{slide.content}</div>
           </motion.div>

--- a/apps/web/src/presentation/SlideDeck.tsx
+++ b/apps/web/src/presentation/SlideDeck.tsx
@@ -247,6 +247,11 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
             className="w-full max-w-4xl"
           >
             {slide.title ? (
+              // No `text-accent-pop` here: on `bg-deck-ground` the seed clears
+              // only 2.92:1 in light (<3:1). Slide titles are `text-ink` on
+              // purpose — see ADR-0026 addendum §Deck exception and
+              // `design-system.md` §Títulos. `.prose` inside the slide is
+              // handled by the deck-override block in `styles/index.css`.
               <h2 className="mb-10 text-5xl font-bold tracking-tight">{slide.title}</h2>
             ) : null}
             <div className="prose prose-xl max-w-none">{slide.content}</div>

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -193,7 +193,7 @@
   --tw-prose-td-borders: var(--color-rule);
 }
 
-/* Slides run deeper than the book (ADR-0026 §"The deck is not the book"). The
+/* Slides run deeper than the book (see ADR-0026 addendum §Deck exception). The
    reroute above paints prose headings with accent-pop, but on `bg-deck-ground`
    (`#F5EEEA` in light) accent-pop lands at 2.92:1 — below the 3:1 floor
    `palette.test.ts` enforces via CHROME_TOKENS. Reset headings back to `ink`

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -98,6 +98,7 @@
   --nl-rule: #dfd7d3;
   --nl-rule-strong: #8e817c;
   --nl-accent: #ba3b00;
+  --nl-accent-pop: #e66600;
   --nl-flag: #c62b2a;
   --nl-keep: #1f7546;
   --nl-focus: #008388;
@@ -120,6 +121,7 @@
     --nl-rule: #30363d;
     --nl-rule-strong: #646b74;
     --nl-accent: #e879f9;
+    --nl-accent-pop: #d946ef;
     --nl-flag: #fa8054;
     --nl-keep: #3fbe90;
     --nl-focus: #00b8e1;
@@ -143,6 +145,7 @@
   --nl-rule: #30363d;
   --nl-rule-strong: #646b74;
   --nl-accent: #e879f9;
+  --nl-accent-pop: #d946ef;
   --nl-flag: #fa8054;
   --nl-keep: #3fbe90;
   --nl-focus: #00b8e1;

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -193,6 +193,19 @@
   --tw-prose-td-borders: var(--color-rule);
 }
 
+/* Slides run deeper than the book (ADR-0026 §"The deck is not the book"). The
+   reroute above paints prose headings with accent-pop, but on `bg-deck-ground`
+   (`#F5EEEA` in light) accent-pop lands at 2.92:1 — below the 3:1 floor
+   `palette.test.ts` enforces via CHROME_TOKENS. Reset headings back to `ink`
+   whenever prose renders inside a deck-ground container. Unlayered for the same
+   reason the reroute itself is unlayered: a layered override loses to Tailwind's
+   utilities, and every `.prose h1/h2/h3` inside a slide is exactly what this
+   catches. The paint check itself lives in the browser (jsdom cannot see it);
+   documented in ADR-0026 addendum and `design-system.md` §Títulos. */
+.bg-deck-ground .prose {
+  --tw-prose-headings: var(--color-ink);
+}
+
 /* What the page is, declared on the document rather than assumed by a div.
 
    `color-scheme` is what makes the browser's OWN widgets dark: the language

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -43,6 +43,7 @@
   --color-rule: var(--nl-rule);
   --color-rule-strong: var(--nl-rule-strong);
   --color-accent: var(--nl-accent);
+  --color-accent-pop: var(--nl-accent-pop);
   --color-flag: var(--nl-flag);
   --color-keep: var(--nl-keep);
   --color-focus: var(--nl-focus);
@@ -87,70 +88,70 @@
    state, which paints one theme's text on the other theme's ground. Every token
    is therefore declared in full in block 1. */
 :root {
-  --nl-ground: #eef1f4;
-  --nl-surface: #ffffff;
-  --nl-sunk: #e4e9ee;
-  --nl-deck-ground: #eaeef2;
-  --nl-ink: #141a22;
-  --nl-ink-soft: #47525f;
-  --nl-ink-faint: #5a6573;
-  --nl-rule: #cdd5dd;
-  --nl-rule-strong: #7a8592;
-  --nl-accent: #9c3b76;
-  --nl-flag: #b04527;
-  --nl-keep: #2c6a4e;
-  --nl-focus: #0b63c4;
-  --nl-keep-soft: #e0eee7;
-  --nl-flag-soft: #f8e5df;
+  --nl-ground: #f8f2ef;
+  --nl-surface: #fef9f7;
+  --nl-sunk: #ede6e3;
+  --nl-deck-ground: #f5eeea;
+  --nl-ink: #2b221d;
+  --nl-ink-soft: #493d37;
+  --nl-ink-faint: #73645c;
+  --nl-rule: #dfd7d3;
+  --nl-rule-strong: #8e817c;
+  --nl-accent: #ba3b00;
+  --nl-flag: #c62b2a;
+  --nl-keep: #1f7546;
+  --nl-focus: #008388;
+  --nl-keep-soft: #e6f4ea;
+  --nl-flag-soft: #ffeae6;
   --nl-plate: #ffffff;
-  --nl-accent-soft: #f3e4ee;
-  --nl-on-keep: #ffffff;
+  --nl-accent-soft: #ffe1d1;
+  --nl-on-keep: #fef9f7;
 }
 
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme='light']) {
-    --nl-ground: #0c1118;
-    --nl-surface: #141b24;
-    --nl-sunk: #1b232e;
-    --nl-deck-ground: #020617;
-    --nl-ink: #e6eaef;
-    --nl-ink-soft: #a8b3c0;
-    --nl-ink-faint: #8a96a4;
-    --nl-rule: #2c3644;
-    --nl-rule-strong: #66748a;
-    --nl-accent: #dd91bd;
-    --nl-flag: #e08a69;
-    --nl-keep: #7ec2a0;
-    --nl-focus: #38bdf8;
-    --nl-keep-soft: #17291f;
-    --nl-flag-soft: #33211a;
+    --nl-ground: #0d1117;
+    --nl-surface: #161b22;
+    --nl-sunk: #1c2128;
+    --nl-deck-ground: #0d1117;
+    --nl-ink: #e6edf3;
+    --nl-ink-soft: #c9d1d9;
+    --nl-ink-faint: #8b949e;
+    --nl-rule: #30363d;
+    --nl-rule-strong: #646b74;
+    --nl-accent: #e879f9;
+    --nl-flag: #fa8054;
+    --nl-keep: #3fbe90;
+    --nl-focus: #00b8e1;
+    --nl-keep-soft: #0f2820;
+    --nl-flag-soft: #2a1811;
     /* Identical in every theme, deliberately — see --color-plate. */
     --nl-plate: #ffffff;
-    --nl-accent-soft: #33202c;
-    --nl-on-keep: #0c1118;
+    --nl-accent-soft: #241634;
+    --nl-on-keep: #0d1117;
   }
 }
 
 :root[data-theme='dark'] {
-  --nl-ground: #0c1118;
-  --nl-surface: #141b24;
-  --nl-sunk: #1b232e;
-  --nl-deck-ground: #020617;
-  --nl-ink: #e6eaef;
-  --nl-ink-soft: #a8b3c0;
-  --nl-ink-faint: #8a96a4;
-  --nl-rule: #2c3644;
-  --nl-rule-strong: #66748a;
-  --nl-accent: #dd91bd;
-  --nl-flag: #e08a69;
-  --nl-keep: #7ec2a0;
-  --nl-focus: #38bdf8;
-  --nl-keep-soft: #17291f;
-  --nl-flag-soft: #33211a;
+  --nl-ground: #0d1117;
+  --nl-surface: #161b22;
+  --nl-sunk: #1c2128;
+  --nl-deck-ground: #0d1117;
+  --nl-ink: #e6edf3;
+  --nl-ink-soft: #c9d1d9;
+  --nl-ink-faint: #8b949e;
+  --nl-rule: #30363d;
+  --nl-rule-strong: #646b74;
+  --nl-accent: #e879f9;
+  --nl-flag: #fa8054;
+  --nl-keep: #3fbe90;
+  --nl-focus: #00b8e1;
+  --nl-keep-soft: #0f2820;
+  --nl-flag-soft: #2a1811;
   /* Identical in every theme, deliberately — see --color-plate. */
   --nl-plate: #ffffff;
-  --nl-accent-soft: #33202c;
-  --nl-on-keep: #0c1118;
+  --nl-accent-soft: #241634;
+  --nl-on-keep: #0d1117;
 }
 
 /* Prose that follows the theme (#109).
@@ -172,7 +173,7 @@
    documented for `.cm-editor.cm-focused` below. */
 .prose {
   --tw-prose-body: var(--color-ink-soft);
-  --tw-prose-headings: var(--color-ink);
+  --tw-prose-headings: var(--color-accent-pop);
   --tw-prose-lead: var(--color-ink-soft);
   --tw-prose-links: var(--color-accent);
   --tw-prose-bold: var(--color-ink);

--- a/apps/web/src/styles/palette.test.ts
+++ b/apps/web/src/styles/palette.test.ts
@@ -59,6 +59,12 @@ const SURFACES = ['ground', 'surface', 'sunk', 'deck-ground'] as const;
  *  at the 3:1 "large text" allowance. */
 const TEXT_TOKENS = ['ink', 'ink-soft', 'ink-faint', 'accent', 'flag', 'keep'] as const;
 
+/** WCAG's "large text / non-text UI" floor. Shared by `UI_TOKENS` (meaning-
+ *  carrying non-text) and `CHROME_TOKENS` (large-text chrome). Two spellings
+ *  would drift: a future author who tightens one would silently leave the
+ *  other behind. Named because the error-message string benefits from it. */
+const LARGE_TEXT_FLOOR = 3;
+
 /** Non-text UI that carries meaning: WCAG AA is 3:1. `rule` is absent on purpose
  *  — it is decorative, and a decorative hairline needs no ratio. That is exactly
  *  why `rule-strong` exists as a separate token. */
@@ -67,19 +73,20 @@ const UI_TOKENS = ['rule-strong', 'focus'] as const;
 /**
  * Chrome tokens paint on the two page-level surfaces (canvas + cards) at the
  * WCAG "large text / non-text UI" floor of 3:1, and are NOT checked against
- * inset surfaces like `sunk` (where `<pre>`, inputs and inset panels live) or
- * `deck-ground`. The system's real `accent-pop` uses are: filled buttons (BG
- * `accent-pop` + label on-pop, folded into `PAIRS` via the existing on-keep
- * shape), TEXT on `accent-soft` (chips, covered by `[accent, accent-soft]`),
- * and section titles (H1/H2/H3) on `ground` or `surface`. Testing `accent-pop`
- * against every surface would sacrifice the deck seed's identity (`#E86800`)
- * to a hypothetical use no component makes; if a future component needs
- * `accent-pop` on `sunk`, mint a specific token for that use or promote
- * `accent-pop` into `UI_TOKENS`. Recorded in ADR-0026's addendum, alongside
- * the seed provenance. */
+ * inset surfaces like `sunk` or `deck-ground`. The real uses of `accent-pop`
+ * are: filled buttons (BG `accent-pop` + label on-pop, folded into `PAIRS` via
+ * the existing on-keep shape), TEXT on `accent-soft` (chips, covered by
+ * `[accent, accent-soft]`), and section titles (H1/H2/H3) on `ground` or
+ * `surface`. Inside `bg-deck-ground` (slides) the `--tw-prose-headings` reroute
+ * is overridden and prose headings paint in `ink` instead — deck ≠ book, see
+ * ADR-0026 §"The deck is not the book" and the deck-override block in
+ * `styles/index.css`. Testing `accent-pop` against every surface would
+ * sacrifice the deck seed's identity (`#E86800`) to a pairing no component
+ * paints; if a future component needs `accent-pop` on `sunk`, mint a specific
+ * token for that use or promote `accent-pop` into `UI_TOKENS`. Recorded in
+ * ADR-0026's addendum, alongside the seed provenance. */
 const CHROME_TOKENS = ['accent-pop'] as const;
 const CHROME_SURFACES = ['ground', 'surface'] as const;
-const CHROME_FLOOR = 3.0;
 
 /**
  * Pairs that are not "text on a surface": a tinted state background with its own
@@ -149,8 +156,8 @@ describe('the palette', () => {
           const ratio = contrast(tokens[fg]!, tokens[bg]!);
           expect(
             ratio,
-            `${theme.name}: ${fg} (${tokens[fg]}) on ${bg} (${tokens[bg]}) is ${ratio.toFixed(2)}:1, below AA for a meaning-carrying border`,
-          ).toBeGreaterThanOrEqual(3);
+            `${theme.name}: ${fg} (${tokens[fg]}) on ${bg} (${tokens[bg]}) is ${ratio.toFixed(2)}:1, below the ${LARGE_TEXT_FLOOR}:1 floor for a meaning-carrying border`,
+          ).toBeGreaterThanOrEqual(LARGE_TEXT_FLOOR);
         }
       });
 
@@ -159,8 +166,8 @@ describe('the palette', () => {
           const ratio = contrast(tokens[fg]!, tokens[bg]!);
           expect(
             ratio,
-            `${theme.name}: ${fg} (${tokens[fg]}) on ${bg} (${tokens[bg]}) is ${ratio.toFixed(2)}:1, below the ${CHROME_FLOOR}:1 large-text / non-text UI floor for a chrome token`,
-          ).toBeGreaterThanOrEqual(CHROME_FLOOR);
+            `${theme.name}: ${fg} (${tokens[fg]}) on ${bg} (${tokens[bg]}) is ${ratio.toFixed(2)}:1, below the ${LARGE_TEXT_FLOOR}:1 large-text / non-text UI floor for a chrome token`,
+          ).toBeGreaterThanOrEqual(LARGE_TEXT_FLOOR);
         }
       });
     });

--- a/apps/web/src/styles/palette.test.ts
+++ b/apps/web/src/styles/palette.test.ts
@@ -79,9 +79,11 @@ const UI_TOKENS = ['rule-strong', 'focus'] as const;
  * `[accent, accent-soft]`), and section titles (H1/H2/H3) on `ground` or
  * `surface`. Inside `bg-deck-ground` (slides) the `--tw-prose-headings` reroute
  * is overridden and prose headings paint in `ink` instead — deck ≠ book, see
- * ADR-0026 §"The deck is not the book" and the deck-override block in
- * `styles/index.css`. Testing `accent-pop` against every surface would
- * sacrifice the deck seed's identity (`#E86800`) to a pairing no component
+ * ADR-0026 addendum §Deck exception (the palette-level consequence) and the
+ * deck-override block in `styles/index.css`. Testing `accent-pop` against every surface would
+ * sacrifice the deck seed's identity (reference `#E86800`, shipped as the
+ * nudged `#E66600` — see ADR-0026 addendum §Seed provenance) to a pairing
+ * no component
  * paints; if a future component needs `accent-pop` on `sunk`, mint a specific
  * token for that use or promote `accent-pop` into `UI_TOKENS`. Recorded in
  * ADR-0026's addendum, alongside the seed provenance. */

--- a/apps/web/src/styles/palette.test.ts
+++ b/apps/web/src/styles/palette.test.ts
@@ -65,6 +65,23 @@ const TEXT_TOKENS = ['ink', 'ink-soft', 'ink-faint', 'accent', 'flag', 'keep'] a
 const UI_TOKENS = ['rule-strong', 'focus'] as const;
 
 /**
+ * Chrome tokens paint on the two page-level surfaces (canvas + cards) at the
+ * WCAG "large text / non-text UI" floor of 3:1, and are NOT checked against
+ * inset surfaces like `sunk` (where `<pre>`, inputs and inset panels live) or
+ * `deck-ground`. The system's real `accent-pop` uses are: filled buttons (BG
+ * `accent-pop` + label on-pop, folded into `PAIRS` via the existing on-keep
+ * shape), TEXT on `accent-soft` (chips, covered by `[accent, accent-soft]`),
+ * and section titles (H1/H2/H3) on `ground` or `surface`. Testing `accent-pop`
+ * against every surface would sacrifice the deck seed's identity (`#E86800`)
+ * to a hypothetical use no component makes; if a future component needs
+ * `accent-pop` on `sunk`, mint a specific token for that use or promote
+ * `accent-pop` into `UI_TOKENS`. Recorded in ADR-0026's addendum, alongside
+ * the seed provenance. */
+const CHROME_TOKENS = ['accent-pop'] as const;
+const CHROME_SURFACES = ['ground', 'surface'] as const;
+const CHROME_FLOOR = 3.0;
+
+/**
  * Pairs that are not "text on a surface": a tinted state background with its own
  * foreground, and the label on a filled button.
  *
@@ -92,7 +109,14 @@ describe('the palette', () => {
       const tokens = tokensIn(theme.selector);
 
       it('declares every token the pairing table names', () => {
-        const required = [...SURFACES, ...TEXT_TOKENS, ...UI_TOKENS, ...PAIRS.flat(), 'rule'];
+        const required = [
+          ...SURFACES,
+          ...TEXT_TOKENS,
+          ...UI_TOKENS,
+          ...CHROME_TOKENS,
+          ...PAIRS.flat(),
+          'rule',
+        ];
         expect(
           Object.keys(tokens).length,
           `no --nl-* tokens found for the ${theme.name} theme — the selector in this test no longer matches index.css`,
@@ -129,6 +153,16 @@ describe('the palette', () => {
           ).toBeGreaterThanOrEqual(3);
         }
       });
+
+      it.each(CHROME_TOKENS)('%s reaches large-text (3.0) on the page surfaces', (fg) => {
+        for (const bg of CHROME_SURFACES) {
+          const ratio = contrast(tokens[fg]!, tokens[bg]!);
+          expect(
+            ratio,
+            `${theme.name}: ${fg} (${tokens[fg]}) on ${bg} (${tokens[bg]}) is ${ratio.toFixed(2)}:1, below the ${CHROME_FLOOR}:1 large-text / non-text UI floor for a chrome token`,
+          ).toBeGreaterThanOrEqual(CHROME_FLOOR);
+        }
+      });
     });
   }
 
@@ -141,6 +175,7 @@ describe('the palette', () => {
       ...SURFACES,
       ...TEXT_TOKENS,
       ...UI_TOKENS,
+      ...CHROME_TOKENS,
       ...PAIRS.flat(),
       'rule',
       // `plate` carries no product text and no product UI — it is the white a

--- a/docs/decisions/0026-two-theme-colour-system.md
+++ b/docs/decisions/0026-two-theme-colour-system.md
@@ -95,3 +95,81 @@ this work was specified, a fortnight earlier.
   rule and now this case.
 - Themes beyond two, or a high-contrast mode, are additive: a new block of token
   values and an entry in the pairing table. Nothing in the components changes.
+
+## Addendum — 2026-08-24 (#222)
+
+The palette this ADR shipped carried placeholder values Miguel accepted to
+unblock the two-theme system: cool blue-grey ground with a magenta accent,
+neither derived from anything the course actually uses. #222 replaces both
+palettes with values SEEDED on material the course already ships, and
+introduces a second accent token so that section titles can carry the seed
+without paying the 4.5:1 body-text obligation.
+
+### Seed provenance
+
+- **Light seed `#E86800`** — the title colour of the *Complejidad de Algoritmos*
+  deck the course ships. A student who has sat through a lecture recognises it.
+- **Dark seed `#D946EF`** — the brand accent from the original nalanda POC
+  (`fuchsia-500`). Reused so the site keeps its identity when the reader flips
+  to the theme most readers arrive in.
+
+Every `--nl-*` token in each theme is derived from its seed's hue. Per-token
+luminances were nudged from the reference artifacts to keep every AA pairing
+in `palette.test.ts` green — the reference specifies visual intent; the test
+specifies contract, and the contract wins where they disagree.
+
+### The `accent-pop` token
+
+Both themes gain `--nl-accent-pop` separated from `--nl-accent`. They are
+**one hue with two luminances**, not two independent accents — clarifies
+Decision §1's "one accent for the whole product". The pair:
+
+- `--nl-accent` is the AA-legal variant. Used for body-sized text: links,
+  inline prose accents, `--tw-prose-links`. Passes 4.5:1 on every surface.
+- `--nl-accent-pop` is the seed itself. Used for **section titles**
+  (`--tw-prose-headings` and the H1/H2/H3 chrome outside `.prose`), filled
+  buttons' BG, chips. Passes the 3:1 large-text / non-text UI floor WCAG
+  §1.4.11 explicitly allows for its use cases.
+
+### `CHROME_TOKENS` — the pairing table's third category
+
+`accent-pop` is tested against a subset of surfaces (`ground` + `surface`),
+not the full four, and `palette.test.ts` models this with a new
+`CHROME_TOKENS` category parallel to `UI_TOKENS` at the 3:1 floor. Its
+worked-case comment carries the reasoning. In one line:
+
+> `accent-pop` no se testea contra `sunk` ni `deck-ground`. El diseño lo usa
+> exclusivamente en (a) BG de botones llenos con label on-pop, (b) TEXTO sobre
+> `accent-soft` (chips), y (c) H1/H2/H3 sobre `ground` o `surface`. Testear el
+> par accent-pop×sunk chequea una combinación que ningún componente pinta y
+> que forzaría sacrificar la identidad visual de la semilla del deck
+> (`#E86800`) sin proteger ningún uso real. El test lo modela con la
+> categoría `CHROME_TOKENS`, que itera solo sobre `ground` y `surface` con
+> floor 3.0. Si un componente futuro necesita pintar accent-pop como texto
+> sobre sunk, el diseño debe crear un token específico para ese uso o mover
+> accent-pop a `UI_TOKENS`.
+
+This is a genuine relaxation of Decision §3 ("the pairs are declared") and
+lives here on purpose: the ADR is where the exception is written down,
+because the reason the test-subset exists is a design intent (protect the
+seed's identity), not a test convenience. If it is not written down, the
+next author who sees the `CHROME_TOKENS` block deletes it and folds
+`accent-pop` into `UI_TOKENS`, then re-nudges the seed hex to pass the
+harder floor, breaking the identity this ADR chose to preserve.
+
+### Titles policy
+
+Section titles (H1/H2/H3) paint the seed. Inside `.prose` this is automatic
+via `--tw-prose-headings = var(--color-accent-pop)`. Outside `.prose` —
+catalog surfaces, presentation slides, the `<Questions>` block, the 404 —
+the class `text-accent-pop` is applied to the heading. `design-system.md`
+carries the utility rule; this ADR carries the intent.
+
+### What is NOT changed
+
+- CodeMirror still uses the package's built-in `light`/`dark` themes. A
+  bespoke highlighting theme remains deferred (Alternatives §, unchanged).
+- Mermaid still uses its built-in `default`/`dark` themes. Custom
+  `themeVariables` remain a follow-up; see #222 Notes.
+- The 27 hand-drawn SVGs under `content/` are not re-palettified in this
+  WP; visual review is a follow-up.

--- a/docs/decisions/0026-two-theme-colour-system.md
+++ b/docs/decisions/0026-two-theme-colour-system.md
@@ -161,9 +161,25 @@ harder floor, breaking the identity this ADR chose to preserve.
 
 Section titles (H1/H2/H3) paint the seed. Inside `.prose` this is automatic
 via `--tw-prose-headings = var(--color-accent-pop)`. Outside `.prose` —
-catalog surfaces, presentation slides, the `<Questions>` block, the 404 —
-the class `text-accent-pop` is applied to the heading. `design-system.md`
-carries the utility rule; this ADR carries the intent.
+catalog surfaces, the `<Questions>` block, the 404 — the class
+`text-accent-pop` is applied to the heading. `design-system.md` carries the
+utility rule; this ADR carries the intent.
+
+### Deck exception
+
+The reroute of `--tw-prose-headings` to `accent-pop` does NOT apply inside
+`bg-deck-ground`. The slide is a deliberately distinct surface (§Consequences
+above, "the deck is not the book") and `accent-pop` clears only 2.92:1 on
+`deck-ground` in light — below the 3:1 floor `CHROME_TOKENS` declares. The
+override lives declaratively in `styles/index.css` as
+`.bg-deck-ground .prose { --tw-prose-headings: var(--color-ink); }`, so slide
+prose headings paint in `ink` without any component-side knowledge. The slide
+`<h2>` title in `SlideDeck.tsx` also stays on `text-ink` (never
+`text-accent-pop`), mirroring `RotateNotice.tsx`'s exclusion on the same
+surface. If a future component needs the seed hue on `deck-ground`, mint a
+darker `accent-pop-deck` variant that clears 3:1 there; do not lift the
+override, and do not extend `CHROME_SURFACES` to `deck-ground` without a
+palette nudge that keeps the exclusion honest.
 
 ### What is NOT changed
 

--- a/docs/decisions/0026-two-theme-colour-system.md
+++ b/docs/decisions/0026-two-theme-colour-system.md
@@ -107,8 +107,13 @@ without paying the 4.5:1 body-text obligation.
 
 ### Seed provenance
 
-- **Light seed `#E86800`** — the title colour of the *Complejidad de Algoritmos*
-  deck the course ships. A student who has sat through a lecture recognises it.
+- **Light seed `#E86800`** (reference) — the title colour of the *Complejidad
+  de Algoritmos* deck the course ships. A student who has sat through a
+  lecture recognises it. The `--nl-accent-pop` token ships the nudged
+  `#E66600`, one luminance step darker so `accent-pop` clears the 3:1 floor on
+  `--nl-ground` and `--nl-surface`; the reference lives on to name the visual
+  intent when the wording says "the seed" (see the shipped vs. reference rule
+  below).
 - **Dark seed `#D946EF`** — the brand accent from the original nalanda POC
   (`fuchsia-500`). Reused so the site keeps its identity when the reader flips
   to the theme most readers arrive in.
@@ -143,7 +148,8 @@ worked-case comment carries the reasoning. In one line:
 > `accent-soft` (chips), y (c) H1/H2/H3 sobre `ground` o `surface`. Testear el
 > par accent-pop×sunk chequea una combinación que ningún componente pinta y
 > que forzaría sacrificar la identidad visual de la semilla del deck
-> (`#E86800`) sin proteger ningún uso real. El test lo modela con la
+> (referencia `#E86800`, embarcado como `#E66600` — ver §Seed provenance) sin
+> proteger ningún uso real. El test lo modela con la
 > categoría `CHROME_TOKENS`, que itera solo sobre `ground` y `surface` con
 > floor 3.0. Si un componente futuro necesita pintar accent-pop como texto
 > sobre sunk, el diseño debe crear un token específico para ese uso o mover
@@ -167,11 +173,18 @@ utility rule; this ADR carries the intent.
 
 ### Deck exception
 
+**The deck is not the book.** Slides live on `--nl-deck-ground`, a surface
+deliberately distinct from `--nl-ground` — deeper in dark, warmer-but-lower-
+contrast in light — because a projected room wants less light than a book.
+`design-system.md` §Rules that are not about contrast phrases this rule the
+same way. This subsection is where the palette-level consequence of that rule
+now lives, and every cross-reference in the code that names "the deck is not
+the book" points here.
+
 The reroute of `--tw-prose-headings` to `accent-pop` does NOT apply inside
-`bg-deck-ground`. The slide is a deliberately distinct surface (§Consequences
-above, "the deck is not the book") and `accent-pop` clears only 2.92:1 on
-`deck-ground` in light — below the 3:1 floor `CHROME_TOKENS` declares. The
-override lives declaratively in `styles/index.css` as
+`bg-deck-ground`. `accent-pop` clears only 2.92:1 on `deck-ground` in light —
+below the 3:1 floor `CHROME_TOKENS` declares. The override lives declaratively
+in `styles/index.css` as
 `.bg-deck-ground .prose { --tw-prose-headings: var(--color-ink); }`, so slide
 prose headings paint in `ink` without any component-side knowledge. The slide
 `<h2>` title in `SlideDeck.tsx` also stays on `text-ink` (never
@@ -189,3 +202,18 @@ palette nudge that keeps the exclusion honest.
   `themeVariables` remain a follow-up; see #222 Notes.
 - The 27 hand-drawn SVGs under `content/` are not re-palettified in this
   WP; visual review is a follow-up.
+- **Four learned-during-review follow-ups** (surfaced by the Round A
+  pipeline of #222, deferred out of this WP by explicit agreement):
+  - Raise `LARGE_TEXT_FLOOR` from 3.0 to 3.1 to give `accent-pop`'s razor-thin
+    ground/surface margins (3.02/3.21 today) some headroom.
+  - Add a JSX-walk test asserting every `text-<token>` in `src/` has a
+    matching `--color-<token>: var(--nl-<token>)` in the `@theme` block —
+    closes the alias-drift hole this WP ships nine callers of.
+  - Codify in `testing-strategy.md` §Conventions that palette-critical
+    changes obligate a preview-screenshot artifact in the PR body — the
+    review had to catch a class-2 (jsdom-invisible) regression by prose
+    inspection rather than by a required protocol step.
+  - Fold `--nl-accent-pop`'s declaration into the same commit as the
+    `--tw-prose-headings` reroute so the between-commit "invalid var"
+    window disappears (would require rebasing shipped commits; the cost
+    outweighed the benefit at this stage).

--- a/docs/standards/design-system.md
+++ b/docs/standards/design-system.md
@@ -204,8 +204,10 @@ H1/H2/H3 in the product:
 
 - **Slides.** Content inside `bg-deck-ground` (`SlideDeck.tsx`) paints its
   titles with `ink`, not `accent-pop`. It is a consequence of two things: the
-  deck and the book live in different registers (ADR-0026 §"The deck is not
-  the book"), and `accent-pop` clears only 2.92:1 on `deck-ground` in light —
+  deck and the book live in different registers (§Rules that are not about
+  contrast above: "the deck is not the book"; the palette-level consequence
+  is recorded in ADR-0026 addendum §Deck exception), and `accent-pop` clears
+  only 2.92:1 on `deck-ground` in light —
   below the 3:1 floor `palette.test.ts`'s CHROME_TOKENS declares. `.prose`
   inside `bg-deck-ground` overrides `--tw-prose-headings` back to `ink` in
   `styles/index.css`; the slide `<h2>` (which is not prose) also stays on
@@ -233,6 +235,15 @@ npm run build && npm run preview -- --port <n>
 Emulate the reader who never chose, which is the common case — in Playwright,
 `browser.newContext({ colorScheme: 'light' | 'dark' })`. Check the book, the
 deck, the catalog and an editor. Screenshot each and look.
+
+**Extras when the change touches `accent-pop` or the deck.** When a colour
+change modifies `--nl-accent-pop`, `--nl-deck-ground`, the `.prose` reroute
+or the `.bg-deck-ground .prose` override, confirm on the screenshots that
+slide H1/H2/H3 still paint `ink` (never the seed hue) in BOTH themes. That
+override in `styles/index.css` is what keeps them from failing 3:1 against
+`deck-ground` in light — see §Títulos "Two exceptions" and ADR-0026 addendum
+§Deck exception. A green suite proves nothing about this; the paint has to
+be looked at.
 
 The full browser recipe, including how to stop a preview server without killing
 other agents', is in `testing-strategy.md` §Conventions.

--- a/docs/standards/design-system.md
+++ b/docs/standards/design-system.md
@@ -194,18 +194,28 @@ H1/H2/H3 in the product:
   through the typography plugin already carries it. This covers every course
   document.
 - **Outside `.prose`** — apply the utility `text-accent-pop` to the heading
-  element itself. The catalog pages, the presentation deck's slide titles,
-  the `<Questions>` block, and the 404 page all use this shape today; new
-  surfaces follow it. `text-accent-pop` is generated from the
-  `--color-accent-pop` alias declared in `@theme`, so it is a first-class
-  utility and passes `architecture.test.ts`'s raw-colour guard.
+  element itself. The catalog pages, the `<Questions>` block, and the 404
+  page all use this shape today; new surfaces follow it. `text-accent-pop`
+  is generated from the `--color-accent-pop` alias declared in `@theme`, so
+  it is a first-class utility and passes `architecture.test.ts`'s raw-colour
+  guard.
 
-**The one exception.** System UI framed on top of a course page — the
-rotate-to-landscape notice is the only one today — does NOT paint titles in
-the seed. Its heading is chrome the reader sees when the app cannot render
-what they asked for, not a title in a course document. `RotateNotice`
-therefore stays on `text-ink`; do the same for any new full-page system
-overlay.
+**Two exceptions.**
+
+- **Slides.** Content inside `bg-deck-ground` (`SlideDeck.tsx`) paints its
+  titles with `ink`, not `accent-pop`. It is a consequence of two things: the
+  deck and the book live in different registers (ADR-0026 §"The deck is not
+  the book"), and `accent-pop` clears only 2.92:1 on `deck-ground` in light —
+  below the 3:1 floor `palette.test.ts`'s CHROME_TOKENS declares. `.prose`
+  inside `bg-deck-ground` overrides `--tw-prose-headings` back to `ink` in
+  `styles/index.css`; the slide `<h2>` (which is not prose) also stays on
+  `text-ink`. The override is unlayered on purpose — a layered version would
+  lose to Tailwind's utilities.
+- **System UI framed on top of a course page.** The rotate-to-landscape
+  notice is the only one today. Its heading is chrome the reader sees when
+  the app cannot render what they asked for, not a title in a course
+  document. `RotateNotice` therefore stays on `text-ink`; do the same for
+  any new full-page system overlay.
 
 ## Verifying a colour change
 

--- a/docs/standards/design-system.md
+++ b/docs/standards/design-system.md
@@ -41,7 +41,8 @@ was found by looking at a screenshot.
 | `ink-faint`                           | Labels, timings, metadata, anchors       | The smallest type in the product — held to 4.5:1, never the 3:1 large-text allowance |
 | `rule`                                | Decorative separators                    | Carries no information, so it has **no** contrast floor                              |
 | `rule-strong`                         | Borders that _are_ the signal            | ≥3:1. This is why `rule` and `rule-strong` are two tokens                            |
-| `accent`                              | Links, active state, emphasis            | **One accent in the whole product**                                                  |
+| `accent`                              | Links, active state, emphasis            | AA-legal luminance of the seed hue; held to 4.5:1                                    |
+| `accent-pop`                          | Section titles, filled buttons, chips    | The raw seed hue; large-text / non-text UI floor (3:1 on `ground` and `surface`)     |
 | `flag`                                | Errors, warnings, diagnostics            | Semantic, never decorative                                                           |
 | `keep`                                | Success, passing cases, the run button   | Semantic                                                                             |
 | `accent-soft` `flag-soft` `keep-soft` | Tinted grounds for chips and callouts    | Only ever under their own foreground                                                 |
@@ -57,6 +58,13 @@ Contrast is a property of a **pair**, not of a token. These are the legal pairs;
   `keep` on `ground`, `surface`, `sunk`, `deck-ground`. Floor **4.5:1**.
 - **Meaning-carrying non-text** — `rule-strong`, `focus` on the same four
   surfaces. Floor **3:1**.
+- **Chrome on the page surfaces** — `accent-pop` on `ground` and `surface`
+  ONLY. Floor **3:1** (WCAG §1.4.11: large text / non-text UI). `sunk` and
+  `deck-ground` are deliberately excluded — see §Títulos and the addendum in
+  ADR-0026 for why testing accent-pop against them would sacrifice the deck
+  seed's identity to a hypothetical use no component makes. If a future
+  component needs `accent-pop` as text on `sunk`, mint a specific token for
+  that use or promote `accent-pop` into the previous row.
 - **Tinted pairs** — `keep`/`keep-soft`, `flag`/`flag-soft`,
   `accent`/`accent-soft`, and `on-keep`/`keep`. Floor **4.5:1**: a status chip
   is text, and small text at that.
@@ -80,8 +88,13 @@ something to allow; it is something nobody should write.
 - **Colour is never the only signal.** An error, a passing case, a disabled
   control: each carries text or an icon as well. `flag` and `keep` are how it
   reads at a glance, not how it is understood.
-- **One accent.** If something needs to stand out and `accent` is taken, the
-  answer is hierarchy — weight, size, position — not a second hue.
+- **One accent, two luminances.** The product has one accent hue. It ships as
+  two tokens: `accent` (AA-legal luminance, for links and inline prose) and
+  `accent-pop` (the raw seed luminance, for section titles and filled chrome).
+  These are the SAME hue rendered at different luminances, not two independent
+  accents — a rule ADR-0026's addendum records in full. If something needs to
+  stand out and both `accent` slots are taken, the answer is hierarchy —
+  weight, size, position — not a third hue.
 - **The deck is not the book.** It has its own ground on purpose. Do not
   collapse them.
 - **Third-party components that own their colours** take the theme through
@@ -170,6 +183,29 @@ the same shape, or converges on shared cycle tokens if two components would
 share them meaningfully. Do not extend this exemption to a hue whose meaning
 IS shared across the product; that is the design failure §The one rule
 exists to prevent (#109).
+
+## Títulos
+
+Section titles paint the seed hue. The rule is one line and applies to every
+H1/H2/H3 in the product:
+
+- **Inside `.prose`** — nothing to do. `--tw-prose-headings` is routed to
+  `var(--color-accent-pop)` in `styles/index.css`, so every heading rendered
+  through the typography plugin already carries it. This covers every course
+  document.
+- **Outside `.prose`** — apply the utility `text-accent-pop` to the heading
+  element itself. The catalog pages, the presentation deck's slide titles,
+  the `<Questions>` block, and the 404 page all use this shape today; new
+  surfaces follow it. `text-accent-pop` is generated from the
+  `--color-accent-pop` alias declared in `@theme`, so it is a first-class
+  utility and passes `architecture.test.ts`'s raw-colour guard.
+
+**The one exception.** System UI framed on top of a course page — the
+rotate-to-landscape notice is the only one today — does NOT paint titles in
+the seed. Its heading is chrome the reader sees when the app cannot render
+what they asked for, not a title in a course document. `RotateNotice`
+therefore stays on `text-ink`; do the same for any new full-page system
+overlay.
 
 ## Verifying a colour change
 


### PR DESCRIPTION
**Closes #222**

## Summary

Replaces the placeholder ADR-0026 palette with values seeded on material the course already ships:
- **Light**: warm cream ground with the *Complejidad de Algoritmos* deck orange (`#E86800` reference / `#E66600` shipped) as the seed hue.
- **Dark**: neutral GitHub-like ground with the original nalanda POC fuchsia (`#D946EF`) as the seed hue.

Introduces `--nl-accent-pop` (the raw seed hue) as a sibling to `--nl-accent` (the AA-legal variant): one hue, two luminances. Section titles (H1/H2/H3) now paint the seed — automatically inside `.prose` via `--tw-prose-headings`, explicitly outside via a `text-accent-pop` utility.

Slides are the deliberate exception: on `bg-deck-ground` the seed clears only 2.92:1 in light (below the 3:1 floor), so the deck-override in `styles/index.css` resets prose headings to `ink` inside slides, and the slide `<h2>` stays on `text-ink` — mirroring `RotateNotice`'s exclusion on the same surface.

## Slices completed

- **S1** (2011abd) — 18 token values × 2 themes + `--color-accent-pop` alias + `--tw-prose-headings` reroute + folded S3 meta update.
- **S2** (7f2530f) — `--nl-accent-pop` declaration + `CHROME_TOKENS` category in `palette.test.ts` (subset of surfaces at 3:1 floor).
- **S3** — folded into S1 (`documentShell.test.ts` couples the theme-color metas to `--nl-ground`).
- **S4** (f807d14) — `text-accent-pop` on H1/H2/H3 outside `.prose` (catalog + `<Questions>` + `NotFound`). Slide `<h2>` deliberately excluded post-review.
- **S5** (2b9bf85 + review-fix bulk) — ADR-0026 addendum: seed provenance, accent-pop rules, CHROME_TOKENS rationale, titles policy, Deck exception.
- **S6** (7aa444d + review-fix bulk) — `design-system.md`: accent-pop token row, chrome pairing entry, "One accent, two luminances", §Títulos with "Two exceptions".
- **S7** — browser verification, no code fixes surfaced from the manual pass. Class-2 (jsdom-invisible) regressions surfaced later by the review pipeline.
- **Review fixes A** (615fd78) — SlideDeck deck-override + `LARGE_TEXT_FLOOR` shared constant + drop dead outer `<h2>` class on CatalogOverviewPage.
- **Review fixes B** (47e7549) — cross-ref repair (four sites) + reference vs. shipped seed clarity + inline gotcha comments (SlideDeck + RotateNotice) + §Verifying checklist extension + Round-A deferrals home in the ADR.

## Acceptance criteria

- [x] `apps/web` per-commit protocol green with new tokens — verified after every slice commit.
- [x] `apps/web` pre-PR protocol green (typecheck, tests, build) — 85 test files, 1064 tests, format+lint+build clean.
- [x] `palette.test.ts` passes with `accent-pop` coverage — landed as a `CHROME_TOKENS` category (subset of surfaces: `ground` + `surface` only, 3:1 floor). Deviation from the AC's literal wording ("added to `UI_TOKENS`") documented in the WP note and in the ADR-0026 addendum §CHROME_TOKENS.
- [x] `documentShell.test.ts` passes — meta `theme-color` matches `--nl-ground` in both themes.
- [x] `architecture.test.ts` still green — no raw colours introduced (verified: 0 `bg-*`/`text-*` numbered Tailwind classes, 0 literal hex in TSX outside tests).
- [x] Section titles render orange on light and violet on dark — verified in real browser at 1440px via Playwright on home, `/catalog`, and course documents. Screenshots produced but not shipped in the repo.
- [x] KaTeX equations render legibly on both themes — verified in `bienvenida`; KaTeX inherits `currentColor` from `--tw-prose-body`.
- [x] CodeMirror editor readable on both surfaces — verified opening `<CodeEditor>` on `/catalog/c/CodeEditor` in each theme; built-in `light`/`dark` themes hold up. Bespoke theme remains deferred (ADR-0026 §Alternatives).
- [x] Mermaid diagrams do not become illegible — they render but the default `default`/`dark` theme now clashes visually with the palette. **Follow-up owed** per issue Notes (Mermaid `themeVariables` customised).
- [x] `<SheetEmbed>` white iframe on dark `--nl-sunk` has ≥3:1 contrast — measured ≈16:1.
- [x] ADR-0026 addendum merged in the same PR as the token changes.
- [x] `design-system.md` updated in the same PR.

## Tests

- Full vitest run: **85 files, 1064 tests, all green** after each commit and after each review-fix commit.
- New `CHROME_TOKENS` category adds 2 test cases per theme (`accent-pop reaches large-text (3.0) on the page surfaces` × light + dark), integrated into the existing pairing-table completeness check.
- `LARGE_TEXT_FLOOR = 3` shared constant replaces the two `3` literals in `UI_TOKENS` and `CHROME_TOKENS` tests.

## Reviews run

**Mode**: full (Round A + Round B). Performance lens skipped (announced): pure palette / CSS / heading className diff, no render loops or WASM.

**Round A** (mechanical gate → correctness + arch-simplicity + security → verifier → decisions → fixes → per-fix recheck):
- Gate green (85/85 test files).
- 8 raw findings; 3 important + 1 suggestion accepted (COR-1, COR-2, ARQ-1, ARQ-3); 3 suggestions + 1 pattern deferred (COR-3, COR-4, COR-5, ARQ-2) — recorded in ADR-0026 addendum §"What is NOT changed" for post-merge follow-up.
- Fix commit `615fd78`; recheck: both critical/important findings **resolved**.

**Round B** (docs-completeness + docs-accuracy + adr-hunter + agent-readability → verifier → decisions → fixes → per-fix recheck):
- 5 raw findings; verifier deflated 1 critical → suggestion (AR-1), confirmed 2 important (DA-1, DC-1), 2 suggestions accepted (DC-2, DC-3). ADR-hunter clean.
- Fix commit `47e7549`; recheck: all 5 findings **resolved**.

Full finding rows + verifier table lives in the pipeline transcript; the metrics record posts as a separate PR comment.

## Manual verification

Reader-hat checklist for Miguel before squash-merge:

1. **Both themes on home + catalog + a doc**. Toggle theme, look at H1/H2/H3 colour. Warm orange in light, violet in dark. `text-ink` (dark grey / soft white) is the wrong answer here.
2. **A slide (`/present`)**. Slide `<h2>` and any prose H1/H2/H3 inside a slide should stay in `text-ink`, NOT the seed. Wrong colour here means the deck-override in `styles/index.css` regressed.
3. **A slide's meta chrome (rotate-to-landscape on a phone or emulated portrait)**. RotateNotice's `<h1>` stays `text-ink`.
4. **A code fence in a course doc**. Chip labels, line numbers, editor gutters read on the new dark sunk (`#1C2128`) and light sunk (`#EDE6E3`).
5. **A KaTeX equation** in `bienvenida`. Inline and display math both read.
6. **`<SheetEmbed>` in `planificacion`** on dark. The white iframe against dark `bg-sunk` reads (measured ~16:1); mostly a sanity check.
7. **Mermaid diagram in `objetos`** on dark. It reads but its own palette (default/dark) doesn't yet match ours — this is the pre-planned follow-up in issue Notes.
8. **Focus ring**. Tab through the run button, a link, an editor. Turquoise (light) / cyan (dark) ring around each; on the filled `Ejecutar` button the ring is offset outside the button.
9. **Filled `Ejecutar` button** on both themes. Cream label on green in light, dark label on green in dark — the `on-keep` inversion still holds.

## Notes

- **Follow-ups planned post-merge** (per team-lead's rule "follow-ups fuera del PR, DESPUÉS del merge"):
  - Issue Notes: Mermaid `themeVariables` customised; bespoke CodeMirror syntax-highlighting theme (ADR-0026 §Alternatives); visual review of 27 hand-drawn SVGs under `content/`.
  - Review-learned: raise `LARGE_TEXT_FLOOR` from 3.0 to 3.1 (headroom); JSX-walk test that every `text-<token>` has a `--color-<token>` alias; codify "palette changes require preview screenshots in the PR body" in `testing-strategy.md` §Conventions.
- **Coordination with #121** (cross-browser verification): S7's Chromium screenshots extend cheaply to WebKit + Firefox once #121 picks it up.
- **Green-before-commit compromises** documented in the issue body under "Execution notes" — S3 folded into S1, S1 shipped without `--nl-accent-pop` (added in S2), the palette hex nudges.
