### PR TITLE
fix: unify deck-ground with ground so slide titles adopt accent-pop (#225)

### DIFF
--- a/apps/web/src/presentation/RotateNotice.tsx
+++ b/apps/web/src/presentation/RotateNotice.tsx
@@ -31,10 +31,11 @@ export function RotateNotice({ docId }: Props) {
       className="fixed inset-0 h-[100dvh] z-40 flex flex-col items-center justify-center gap-4 bg-deck-ground px-8 text-center text-ink"
     >
       <RotateCwSquare size={48} aria-hidden="true" className="text-ink-faint" />
-      {/* No `text-accent-pop` here: this panel is `bg-deck-ground`, and on that
-          surface the seed clears only 2.92:1 in light (<3:1). The heading is
-          system UI, not a course-content title — see ADR-0026 addendum §Deck
-          exception and `design-system.md` §Títulos "Two exceptions". */}
+      {/* No `text-accent-pop` here: this heading is system UI (a device-shape
+          signal shown when the reader cannot see the presentation, not a
+          title in a course document). Course content — the deck's own slide
+          titles — paints in `accent-pop` since #225. See design-system.md
+          §Títulos and ADR-0026 addendum §Reversal. */}
       <h1 id="rotate-notice-title" className="text-2xl font-bold tracking-tight">
         Gira el teléfono
       </h1>

--- a/apps/web/src/presentation/SlideDeck.tsx
+++ b/apps/web/src/presentation/SlideDeck.tsx
@@ -247,12 +247,9 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
             className="w-full max-w-4xl"
           >
             {slide.title ? (
-              // No `text-accent-pop` here: on `bg-deck-ground` the seed clears
-              // only 2.92:1 in light (<3:1). Slide titles are `text-ink` on
-              // purpose — see ADR-0026 addendum §Deck exception and
-              // `design-system.md` §Títulos. `.prose` inside the slide is
-              // handled by the deck-override block in `styles/index.css`.
-              <h2 className="mb-10 text-5xl font-bold tracking-tight">{slide.title}</h2>
+              <h2 className="text-accent-pop mb-10 text-5xl font-bold tracking-tight">
+                {slide.title}
+              </h2>
             ) : null}
             <div className="prose prose-xl max-w-none">{slide.content}</div>
           </motion.div>

--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -91,7 +91,7 @@
   --nl-ground: #f8f2ef;
   --nl-surface: #fef9f7;
   --nl-sunk: #ede6e3;
-  --nl-deck-ground: #f5eeea;
+  --nl-deck-ground: #f8f2ef;
   --nl-ink: #2b221d;
   --nl-ink-soft: #493d37;
   --nl-ink-faint: #73645c;
@@ -191,19 +191,6 @@
   --tw-prose-pre-bg: var(--color-sunk);
   --tw-prose-th-borders: var(--color-rule-strong);
   --tw-prose-td-borders: var(--color-rule);
-}
-
-/* Slides run deeper than the book (see ADR-0026 addendum §Deck exception). The
-   reroute above paints prose headings with accent-pop, but on `bg-deck-ground`
-   (`#F5EEEA` in light) accent-pop lands at 2.92:1 — below the 3:1 floor
-   `palette.test.ts` enforces via CHROME_TOKENS. Reset headings back to `ink`
-   whenever prose renders inside a deck-ground container. Unlayered for the same
-   reason the reroute itself is unlayered: a layered override loses to Tailwind's
-   utilities, and every `.prose h1/h2/h3` inside a slide is exactly what this
-   catches. The paint check itself lives in the browser (jsdom cannot see it);
-   documented in ADR-0026 addendum and `design-system.md` §Títulos. */
-.bg-deck-ground .prose {
-  --tw-prose-headings: var(--color-ink);
 }
 
 /* What the page is, declared on the document rather than assumed by a div.

--- a/apps/web/src/styles/palette.test.ts
+++ b/apps/web/src/styles/palette.test.ts
@@ -73,20 +73,20 @@ const UI_TOKENS = ['rule-strong', 'focus'] as const;
 /**
  * Chrome tokens paint on the two page-level surfaces (canvas + cards) at the
  * WCAG "large text / non-text UI" floor of 3:1, and are NOT checked against
- * inset surfaces like `sunk` or `deck-ground`. The real uses of `accent-pop`
- * are: filled buttons (BG `accent-pop` + label on-pop, folded into `PAIRS` via
- * the existing on-keep shape), TEXT on `accent-soft` (chips, covered by
+ * inset surfaces like `sunk`. The real uses of `accent-pop` are: filled
+ * buttons (BG `accent-pop` + label on-pop, folded into `PAIRS` via the
+ * existing on-keep shape), TEXT on `accent-soft` (chips, covered by
  * `[accent, accent-soft]`), and section titles (H1/H2/H3) on `ground` or
- * `surface`. Inside `bg-deck-ground` (slides) the `--tw-prose-headings` reroute
- * is overridden and prose headings paint in `ink` instead — deck ≠ book, see
- * ADR-0026 addendum §Deck exception (the palette-level consequence) and the
- * deck-override block in `styles/index.css`. Testing `accent-pop` against every surface would
- * sacrifice the deck seed's identity (reference `#E86800`, shipped as the
- * nudged `#E66600` — see ADR-0026 addendum §Seed provenance) to a pairing
- * no component
- * paints; if a future component needs `accent-pop` on `sunk`, mint a specific
- * token for that use or promote `accent-pop` into `UI_TOKENS`. Recorded in
- * ADR-0026's addendum, alongside the seed provenance. */
+ * `surface`. Slides paint titles here too since #225 unified
+ * `--nl-deck-ground` with `--nl-ground` — every deck-ground pair collapses
+ * into a `ground` pair this test already verifies. Testing `accent-pop`
+ * against every surface would sacrifice the deck seed's identity (reference
+ * `#E86800`, shipped as the nudged `#E66600` — see ADR-0026 addendum §Seed
+ * provenance) to a pairing no component paints; if a future component needs
+ * `accent-pop` on `sunk`, mint a specific token for that use or promote
+ * `accent-pop` into `UI_TOKENS`. If a future WP re-diverges deck-ground
+ * from ground, revisit `CHROME_SURFACES` alongside the palette nudge — see
+ * ADR-0026 addendum §Reversal for why this coupling is now the shape. */
 const CHROME_TOKENS = ['accent-pop'] as const;
 const CHROME_SURFACES = ['ground', 'surface'] as const;
 

--- a/apps/web/src/styles/palette.test.ts
+++ b/apps/web/src/styles/palette.test.ts
@@ -48,10 +48,13 @@ function contrast(a: string, b: string): number {
  * token lands here or it is not covered — see the completeness case below, which
  * is what makes that true rather than aspirational.
  */
-// `deck-ground` is a surface like the others and is checked like the others. It
-// is separate from `ground` because a projected room wants less light, so the
-// deck runs deeper than the book in dark and lighter-but-not-white in light —
-// but "it is the deck" is not a licence to be less readable.
+// `deck-ground` is retained in SURFACES so the completeness case still names it
+// and every TEXT_TOKENS/UI_TOKENS pair keeps a gate against it. Since #225 both
+// themes have `--nl-deck-ground === --nl-ground` (see ADR-0026 addendum
+// §Reversal), so every pair collapses to a `ground` pair this file already
+// verifies — the alias is kept as a semantic anchor for the slide surface,
+// not because the value is expected to diverge again. A re-divergence is
+// guarded by the "deck-ground stays coupled to ground" case below.
 const SURFACES = ['ground', 'surface', 'sunk', 'deck-ground'] as const;
 
 /** Text: WCAG AA is 4.5:1. `ink-faint` is deliberately included — it carries the
@@ -209,6 +212,34 @@ describe('the palette', () => {
       Object.keys(tokensIn(':root')).sort(),
     );
   });
+
+  // The guard against silently re-diverging `deck-ground` from `ground` — the
+  // failure mode ADR-0026 addendum §Reversal calls out by name. #222 shipped
+  // `--nl-deck-ground: #F5EEEA` in light and paid for it with a 2.92:1 pair
+  // that only came out in review. #225 collapsed the value, and every real
+  // component gate today assumes the collapse: `CHROME_SURFACES` excludes
+  // `deck-ground` because the pair is already tested via `ground`. If a future
+  // author reintroduces a distinct `deck-ground` without adding it to
+  // `CHROME_SURFACES` too, `accent-pop` becomes ungated on the surface the
+  // slide actually paints, and the failure mode of #222 reappears green.
+  //
+  // The case is not "deck-ground equals ground" (that would foreclose a
+  // legitimate future re-divergence). It is "if you re-diverge, own the
+  // consequence" — either move `deck-ground` into `CHROME_SURFACES` and
+  // re-verify the palette, or mint a specific token for the deeper deck ground
+  // and leave this alias alone.
+  it.each(THEMES)(
+    '$name: if deck-ground diverges from ground, CHROME_SURFACES must catch up',
+    (theme) => {
+      const tokens = tokensIn(theme.selector);
+      if (tokens['deck-ground'] !== tokens['ground']) {
+        expect(
+          CHROME_SURFACES,
+          `${theme.name}: --nl-deck-ground (${tokens['deck-ground']}) diverges from --nl-ground (${tokens['ground']}), but CHROME_SURFACES does not include 'deck-ground'. That is the silent-pass ADR-0026 addendum §Reversal warns about — accent-pop is ungated on the surface the slide paints. Add 'deck-ground' to CHROME_SURFACES and re-verify contrast, or mint a specific darker/warmer deck token instead of re-diverging this alias.`,
+        ).toContain('deck-ground');
+      }
+    },
+  );
 
   /**
    * The tokens whose whole point is NOT following the theme, and which therefore

--- a/docs/decisions/0026-two-theme-colour-system.md
+++ b/docs/decisions/0026-two-theme-colour-system.md
@@ -200,8 +200,8 @@ palette nudge that keeps the exclusion honest.
 
 ### Reversal — 2026-08-24 (#225)
 
-Miguel opened the merged #223 build in presentation mode and rejected the
-ink-titled slides. The doctrine loss ("the deck is not the book" narrowing
+Miguel opened the merged #222 build (PR #223) in presentation mode and
+rejected the ink-titled slides. The doctrine loss ("the deck is not the book" narrowing
 to layout only) is preferable to the identity loss (slide titles muted while
 every other document surface carries the seed).
 
@@ -219,6 +219,14 @@ the pair no longer exists. Consequences:
   comment there is refreshed to reflect the new reasoning.
 - `CHROME_TOKENS` continues to check `ground` + `surface` only; that pair
   now includes what used to be `deck-ground`, so coverage is unchanged.
+- `--nl-deck-ground` is kept as a pure alias of `--nl-ground`, not retired.
+  The alias is the marker that says "slide surface", so a future
+  re-divergence has to touch the palette (one file, one line per theme)
+  rather than every callsite (`bg-deck-ground` in `SlideDeck.tsx` and
+  `RotateNotice.tsx`, the token binding in `@theme`, the token-table row
+  in `design-system.md`). The `palette.test.ts` coupling guard
+  ("deck-ground stays coupled to ground until CHROME_SURFACES catches up")
+  is what makes the alias safe — a silent re-divergence fails there.
 - The "deck is not the book" clause in `design-system.md` §Rules that are
   not about contrast narrows to **layout, motion, and typography scale**.
   It no longer implies a separate surface.

--- a/docs/decisions/0026-two-theme-colour-system.md
+++ b/docs/decisions/0026-two-theme-colour-system.md
@@ -5,6 +5,7 @@
 **Decision-makers:** Miguel Rodriguez
 **Source:** Issue #109. Extends ADR-0004 (frontend stack) and ADR-0010 (component
 contract); the usage rules live in `docs/standards/design-system.md`.
+**Amended by:** #222 (2026-08-24) — Seed provenance + accent-pop token + CHROME_TOKENS category + deck exception (§Addendum below); #225 (2026-08-24) — Deck exception reversed, `--nl-deck-ground` unified with `--nl-ground` (§Reversal below).
 
 ## Context
 
@@ -143,17 +144,21 @@ not the full four, and `palette.test.ts` models this with a new
 `CHROME_TOKENS` category parallel to `UI_TOKENS` at the 3:1 floor. Its
 worked-case comment carries the reasoning. In one line:
 
-> `accent-pop` no se testea contra `sunk` ni `deck-ground`. El diseño lo usa
-> exclusivamente en (a) BG de botones llenos con label on-pop, (b) TEXTO sobre
-> `accent-soft` (chips), y (c) H1/H2/H3 sobre `ground` o `surface`. Testear el
+> `accent-pop` no se testea contra `sunk`. El diseño lo usa exclusivamente en
+> (a) BG de botones llenos con label on-pop, (b) TEXTO sobre `accent-soft`
+> (chips), y (c) H1/H2/H3 sobre `ground` o `surface` — y en (d) slides desde
+> #225 (§Reversal más abajo), superficie que ahora aliasa `ground`. Testear el
 > par accent-pop×sunk chequea una combinación que ningún componente pinta y
-> que forzaría sacrificar la identidad visual de la semilla del deck
-> (referencia `#E86800`, embarcado como `#E66600` — ver §Seed provenance) sin
-> proteger ningún uso real. El test lo modela con la
-> categoría `CHROME_TOKENS`, que itera solo sobre `ground` y `surface` con
-> floor 3.0. Si un componente futuro necesita pintar accent-pop como texto
-> sobre sunk, el diseño debe crear un token específico para ese uso o mover
-> accent-pop a `UI_TOKENS`.
+> forzaría sacrificar la identidad visual de la semilla del deck (referencia
+> `#E86800`, embarcado como `#E66600` — ver §Seed provenance) sin proteger
+> ningún uso real. `deck-ground` estaba en esta lista bajo #222 con la misma
+> justificación; #225 lo cubre transitivamente vía `ground`, y el guardián de
+> `palette.test.ts` fuerza a re-evaluar `CHROME_SURFACES` si un futuro WP
+> re-diverge el alias. El test modela `sunk`-exclusion con la categoría
+> `CHROME_TOKENS`, que itera solo sobre `ground` y `surface` con floor 3.0.
+> Si un componente futuro necesita pintar accent-pop como texto sobre sunk,
+> el diseño debe crear un token específico para ese uso o mover accent-pop a
+> `UI_TOKENS`.
 
 This is a genuine relaxation of Decision §3 ("the pairs are declared") and
 lives here on purpose: the ADR is where the exception is written down,
@@ -172,12 +177,14 @@ slide `<h2>` in `SlideDeck.tsx` — the class `text-accent-pop` is applied
 to the heading. `design-system.md` carries the utility rule; this ADR
 carries the intent.
 
-### Deck exception (superseded — see §Reversal below)
+### Deck exception (reversed — see §Reversal below)
 
 > ⚠️ **This subsection describes what #222 shipped and #225 reversed.** It is
 > kept as the historical record of the trade-off that got the palette merged
 > in the first place. The rule it declares does NOT govern the current code —
-> read §Reversal for what does.
+> read §Reversal for what does. (`"superseded"` in ADR vocabulary is a
+> file-level status transition that spins off a new ADR file; this is an
+> intra-addendum reversal, so it lives inline.)
 
 **The deck is not the book.** Slides live on `--nl-deck-ground`, a surface
 deliberately distinct from `--nl-ground` — deeper in dark, warmer-but-lower-

--- a/docs/decisions/0026-two-theme-colour-system.md
+++ b/docs/decisions/0026-two-theme-colour-system.md
@@ -167,19 +167,23 @@ harder floor, breaking the identity this ADR chose to preserve.
 
 Section titles (H1/H2/H3) paint the seed. Inside `.prose` this is automatic
 via `--tw-prose-headings = var(--color-accent-pop)`. Outside `.prose` —
-catalog surfaces, the `<Questions>` block, the 404 — the class
-`text-accent-pop` is applied to the heading. `design-system.md` carries the
-utility rule; this ADR carries the intent.
+catalog surfaces, the `<Questions>` block, the 404, and (since #225) the
+slide `<h2>` in `SlideDeck.tsx` — the class `text-accent-pop` is applied
+to the heading. `design-system.md` carries the utility rule; this ADR
+carries the intent.
 
-### Deck exception
+### Deck exception (superseded — see §Reversal below)
+
+> ⚠️ **This subsection describes what #222 shipped and #225 reversed.** It is
+> kept as the historical record of the trade-off that got the palette merged
+> in the first place. The rule it declares does NOT govern the current code —
+> read §Reversal for what does.
 
 **The deck is not the book.** Slides live on `--nl-deck-ground`, a surface
 deliberately distinct from `--nl-ground` — deeper in dark, warmer-but-lower-
 contrast in light — because a projected room wants less light than a book.
 `design-system.md` §Rules that are not about contrast phrases this rule the
-same way. This subsection is where the palette-level consequence of that rule
-now lives, and every cross-reference in the code that names "the deck is not
-the book" points here.
+same way.
 
 The reroute of `--tw-prose-headings` to `accent-pop` does NOT apply inside
 `bg-deck-ground`. `accent-pop` clears only 2.92:1 on `deck-ground` in light —
@@ -193,6 +197,45 @@ surface. If a future component needs the seed hue on `deck-ground`, mint a
 darker `accent-pop-deck` variant that clears 3:1 there; do not lift the
 override, and do not extend `CHROME_SURFACES` to `deck-ground` without a
 palette nudge that keeps the exclusion honest.
+
+### Reversal — 2026-08-24 (#225)
+
+Miguel opened the merged #223 build in presentation mode and rejected the
+ink-titled slides. The doctrine loss ("the deck is not the book" narrowing
+to layout only) is preferable to the identity loss (slide titles muted while
+every other document surface carries the seed).
+
+**Decision.** `--nl-deck-ground` is unified with `--nl-ground` in both
+themes — light drops from `#F5EEEA` to `#F8F2EF` (dark was already `#0D1117`
+in both). Every `deck-ground` pair collapses to a `ground` pair
+`palette.test.ts` already verifies; the 2.92:1 concern dissolves because
+the pair no longer exists. Consequences:
+
+- `.bg-deck-ground .prose { --tw-prose-headings: var(--color-ink) }`
+  deleted. Slide prose headings inherit the normal `accent-pop` reroute.
+- `SlideDeck.tsx`'s slide `<h2>` restores `text-accent-pop`.
+- `RotateNotice.tsx`'s H1 stays on `text-ink`, but for a different reason —
+  it's system UI (a device-shape signal), not a course-content title. The
+  comment there is refreshed to reflect the new reasoning.
+- `CHROME_TOKENS` continues to check `ground` + `surface` only; that pair
+  now includes what used to be `deck-ground`, so coverage is unchanged.
+- The "deck is not the book" clause in `design-system.md` §Rules that are
+  not about contrast narrows to **layout, motion, and typography scale**.
+  It no longer implies a separate surface.
+
+This is a two-line palette change with a large doctrinal footprint. The
+addendum keeps §Deck exception above as the record of the trade-off that
+got #222 out the door — deleting it would erase the reasoning a future
+reviewer needs to understand why the two-value split ever existed.
+
+If a future WP wants a projected-room-specific ground back (deeper dark,
+warmer light), reopen this decision explicitly: rename `--nl-deck-ground`
+to something like `--nl-deck-projection` so its use is intentional, add it
+to `CHROME_SURFACES` with a palette nudge, and update `design-system.md`
+§Títulos accordingly. Do NOT silently re-diverge `deck-ground` from
+`ground`; the CHROME_TOKENS test will pass and the slide titles will still
+land on the accent, but the doctrine will be back to the same broken
+shape #222 → #225 fixed.
 
 ### What is NOT changed
 

--- a/docs/standards/design-system.md
+++ b/docs/standards/design-system.md
@@ -200,24 +200,23 @@ H1/H2/H3 in the product:
   it is a first-class utility and passes `architecture.test.ts`'s raw-colour
   guard.
 
-**Two exceptions.**
+**One exception.**
 
-- **Slides.** Content inside `bg-deck-ground` (`SlideDeck.tsx`) paints its
-  titles with `ink`, not `accent-pop`. It is a consequence of two things: the
-  deck and the book live in different registers (§Rules that are not about
-  contrast above: "the deck is not the book"; the palette-level consequence
-  is recorded in ADR-0026 addendum §Deck exception), and `accent-pop` clears
-  only 2.92:1 on `deck-ground` in light —
-  below the 3:1 floor `palette.test.ts`'s CHROME_TOKENS declares. `.prose`
-  inside `bg-deck-ground` overrides `--tw-prose-headings` back to `ink` in
-  `styles/index.css`; the slide `<h2>` (which is not prose) also stays on
-  `text-ink`. The override is unlayered on purpose — a layered version would
-  lose to Tailwind's utilities.
 - **System UI framed on top of a course page.** The rotate-to-landscape
   notice is the only one today. Its heading is chrome the reader sees when
   the app cannot render what they asked for, not a title in a course
   document. `RotateNotice` therefore stays on `text-ink`; do the same for
   any new full-page system overlay.
+
+**Slides are NOT an exception.** Slide titles paint `text-accent-pop` like
+every other H1/H2/H3, because `--nl-deck-ground` collapses to the same
+value as `--nl-ground` in both themes (see §Rules that are not about
+contrast: "the deck is not the book" — narrowed since #225 to layout,
+motion, and typography scale, not surface). This was different in #222,
+which shipped `deck-ground` as a distinct surface and reset slide prose
+headings back to `ink` because `accent-pop` failed 3:1 there. #225 unified
+the two surfaces so the failing pair no longer exists — full history in
+ADR-0026 addendum §Deck exception (now superseded) and §Reversal.
 
 ## Verifying a colour change
 
@@ -237,13 +236,13 @@ Emulate the reader who never chose, which is the common case — in Playwright,
 deck, the catalog and an editor. Screenshot each and look.
 
 **Extras when the change touches `accent-pop` or the deck.** When a colour
-change modifies `--nl-accent-pop`, `--nl-deck-ground`, the `.prose` reroute
-or the `.bg-deck-ground .prose` override, confirm on the screenshots that
-slide H1/H2/H3 still paint `ink` (never the seed hue) in BOTH themes. That
-override in `styles/index.css` is what keeps them from failing 3:1 against
-`deck-ground` in light — see §Títulos "Two exceptions" and ADR-0026 addendum
-§Deck exception. A green suite proves nothing about this; the paint has to
-be looked at.
+change modifies `--nl-accent-pop`, `--nl-deck-ground`, or the `.prose`
+reroute, confirm on the screenshots that slide H1/H2/H3 paint the seed
+hue in BOTH themes (matching every other document H1/H2/H3). If a change
+re-diverges `--nl-deck-ground` from `--nl-ground`, the accent-pop pair
+against the new value has to clear 3:1 or a fresh mitigation is required —
+that history is in ADR-0026 addendum §Deck exception and §Reversal. A
+green suite proves nothing about this; the paint has to be looked at.
 
 The full browser recipe, including how to stop a preview server without killing
 other agents', is in `testing-strategy.md` §Conventions.

--- a/docs/standards/design-system.md
+++ b/docs/standards/design-system.md
@@ -35,7 +35,7 @@ was found by looking at a screenshot.
 | `ground`                              | The page background                      | Painted on `html`, not on a div                                                      |
 | `surface`                             | Panels, cards, the editor shell          | Sits on `ground`                                                                     |
 | `sunk`                                | Table heads, inputs, chips, hover states | **The worst-case surface** — contrast is measured against it                         |
-| `deck-ground`                         | The slide deck only                      | Deliberately deeper than `ground` in dark: a projected room wants less light         |
+| `deck-ground`                         | The slide deck only                      | Currently aliases `ground` in both themes; kept as a semantic anchor for the slide deck — see ADR-0026 addendum §Reversal |
 | `ink`                                 | Primary text, headings                   | AAA on every surface                                                                 |
 | `ink-soft`                            | Body prose, secondary text               |                                                                                      |
 | `ink-faint`                           | Labels, timings, metadata, anchors       | The smallest type in the product — held to 4.5:1, never the 3:1 large-text allowance |
@@ -59,12 +59,15 @@ Contrast is a property of a **pair**, not of a token. These are the legal pairs;
 - **Meaning-carrying non-text** — `rule-strong`, `focus` on the same four
   surfaces. Floor **3:1**.
 - **Chrome on the page surfaces** — `accent-pop` on `ground` and `surface`
-  ONLY. Floor **3:1** (WCAG §1.4.11: large text / non-text UI). `sunk` and
-  `deck-ground` are deliberately excluded — see §Títulos and the addendum in
-  ADR-0026 for why testing accent-pop against them would sacrifice the deck
-  seed's identity to a hypothetical use no component makes. If a future
-  component needs `accent-pop` as text on `sunk`, mint a specific token for
-  that use or promote `accent-pop` into the previous row.
+  ONLY. Floor **3:1** (WCAG §1.4.11: large text / non-text UI). `sunk` is
+  deliberately excluded to protect the deck seed's identity from a chip-on-
+  inset pairing no component makes (see ADR-0026 addendum §CHROME_TOKENS).
+  `deck-ground` currently aliases `ground` — since #225 the pair is already
+  tested via `ground`, and the palette test carries a guard that fires if a
+  future author re-diverges without adding `deck-ground` back to this row
+  (see ADR-0026 addendum §Reversal). If a future component needs `accent-pop`
+  as text on `sunk`, mint a specific token for that use or promote
+  `accent-pop` into the previous row.
 - **Tinted pairs** — `keep`/`keep-soft`, `flag`/`flag-soft`,
   `accent`/`accent-soft`, and `on-keep`/`keep`. Floor **4.5:1**: a status chip
   is text, and small text at that.
@@ -95,8 +98,11 @@ something to allow; it is something nobody should write.
   accents — a rule ADR-0026's addendum records in full. If something needs to
   stand out and both `accent` slots are taken, the answer is hierarchy —
   weight, size, position — not a third hue.
-- **The deck is not the book.** It has its own ground on purpose. Do not
-  collapse them.
+- **The deck is not the book — in layout, motion, and typography scale.** The
+  ground itself IS shared: `--nl-deck-ground` aliases `--nl-ground` in both
+  themes since #225 (see ADR-0026 addendum §Reversal). Do not add a
+  projected-room-specific ground back without reopening that decision — the
+  palette test carries a guard against silent re-divergence.
 - **Third-party components that own their colours** take the theme through
   `lib/useResolvedTheme.ts`. That hook exists for CodeMirror and should stay
   rare: anything we style ourselves takes tokens and needs no hook.


### PR DESCRIPTION
**Closes #225**

## Summary

Reverses the mitigation shipped in #222 for the `accent-pop × deck-ground` contrast fail. Miguel opened the merged #223 build (`00cb877`) in presentation mode and rejected the ink-titled slides — the identity loss reads worse than the "deck is not the book" doctrine loss.

Two coupled changes make the reversal safe without renegotiating any palette value:

- Light `--nl-deck-ground` drops from `#F5EEEA` → `#F8F2EF`, unifying with `--nl-ground` (dark was already `#0D1117` = `--nl-ground`).
- `.bg-deck-ground .prose { --tw-prose-headings: var(--color-ink) }` deleted; slide prose headings inherit the normal `accent-pop` reroute. Slide `<h2>` restored to `text-accent-pop`.

Every `deck-ground`-relative contrast pair now collapses to a `ground` pair `palette.test.ts` already verifies. The "deck is not the book" doctrine narrows to **layout, motion, and typography scale** — not surface.

## Slices completed

- **S1** (`a76e037`) — `index.css` (deck-ground unified + reset deleted), `SlideDeck.tsx` (`text-accent-pop` restored), `RotateNotice.tsx` (comment refresh).
- **S2** (`0c558c6`) — ADR-0026 addendum (§Deck exception preserved as historical + new §Reversal) + `design-system.md` §Títulos rewrite + `palette.test.ts` CHROME_TOKENS block comment refresh.
- **S3** — browser verification, no code fixes surfaced from the manual pass; class-2 (jsdom-invisible) drift caught later by the pipeline.
- **Round A fixes** (`4af6ef0`) — added the `palette.test.ts` coupling guard against silent re-divergence + rewrote the stale SURFACES block-comment.
- **Round A docs fixes** (`92df077`) — applied the doctrine narrowing everywhere in `design-system.md` (§Rules bullet, §The tokens table, §Chrome pairing bullet); fixed a `#223` → `#222` typo in ADR §Reversal; added a Consequences bullet explaining the alias-vs-retire trade-off.
- **Round B fixes** (`68f82e9`) — added the missing `Amended by:` header line to ADR-0026 (retroactive for #222 too); relabelled `(superseded — see §Reversal below)` → `(reversed …)` with a vocabulary-distinction callout; rewrote the CHROME_TOKENS Spanish blockquote so it no longer bundles deck-ground with sunk.

## Acceptance criteria

- [x] Slide titles render orange in the light theme and violet in the dark theme when viewing `/nalanda/d/<id>/present` — screenshots at `.claude/screenshots-225/{light,dark}/slide-bienvenida-first.png` and `slide-java-first.png`.
- [x] `apps/web` per-commit + pre-PR protocols green after every commit.
- [x] `palette.test.ts` 34/34 (was 32; +2 for the new "if deck-ground diverges, CHROME_SURFACES must catch up" case × light + dark).
- [x] `documentShell.test.ts` green (unchanged; reads `--nl-ground`, not `--nl-deck-ground`).
- [x] Real-browser screenshots at 1440px of one slide deck × two themes: kept in `.claude/screenshots-225/{light,dark}/` on the worktree (untracked, viewable locally). Six PNGs total: two slide decks + one book control × two themes.
- [x] ADR-0026 addendum records the reversal explicitly — new §Reversal subsection, §Deck exception preserved with a `(reversed — see §Reversal below)` marker + callout.
- [x] `design-system.md` §Títulos updated (Slides moved from "exception" to "NOT an exception"), plus §Rules that are not about contrast + §The tokens + §The pairing table all consistent with the reversal.

## Tests

- Full vitest run: **85 files, 1066 tests** — was 1064 before this WP; +2 for the new `it.each(THEMES)` coupling guard in `palette.test.ts` that reads *"if deck-ground diverges from ground, CHROME_SURFACES must catch up"*.
- Failure message on the guard names the theme + both hex values + points at ADR-0026 addendum §Reversal, matching the ADR's own warning against silent re-divergence.
- Static-traced by the correctness-lens recheck: a future author setting `--nl-deck-ground: #F5EEEA` in light triggers the assertion `expected [ 'ground', 'surface' ] to contain 'deck-ground'`.

## Reviews run

**Mode**: full (Round A + Round B). Performance lens **skipped** (announced): pure palette / comment / doc changes.

**Round A** (mechanical gate → correctness + arch-simplicity + security → verifier → decisions → fixes → per-fix recheck):
- Gate green (85/85 test files, format+lint+build).
- Raw: correctness 3 (2 imp, 1 sug); arch 5 (2 CRITICAL, 2 imp, 1 sug); security clean. Dedup merged COR-1 with ARQ-2 (same stale SURFACES comment) — net 7 unique.
- 6 accepted (ARQ-1, ARQ-2, ARQ-3, ARQ-4, ARQ-5, COR-2, COR-3); 0 deferred. Verifier confirmed all 5 verified findings.
- Fix commits `4af6ef0` (code) + `92df077` (docs). Rechecks: all findings **resolved** (correctness + arch lenses re-run over the fix commits).

**Round B** (docs-completeness + docs-accuracy + adr-hunter + agent-readability → verifier → decisions → fixes → per-fix recheck):
- Raw: 5 findings (1 sug DC-1, 0 accuracy, 3 adr-hunter of which 1 imp + 1 sug + 1 pre-existing pattern, 0 readability).
- 3 accepted (ADR-1, ADR-2, DC-1); 1 pre-existing pattern (ADR-3, ADR numbering collisions on `main`) declared out of scope.
- Fix commit `68f82e9`. Rechecks: ADR-1 + ADR-2 **resolved** via adr-hunter recheck; DC-1 spot-verified inline (prose swap).

## Manual verification

Reader-hat checklist for Miguel before squash-merge:

1. **Presentation mode on both themes**. `/nalanda/d/bienvenida/present` and `/nalanda/d/java-desde-cpp/present`. Slide titles paint **orange in light** and **violet in dark**, matching every other H1 in the product. Anything muted / ink-coloured means the reset was reintroduced or the classname was dropped again.
2. **RotateNotice** on emulated portrait. Its H1 stays in `text-ink` — this is deliberate (system UI signal, not course content), and the inline comment now says so.
3. **Book control**. `/nalanda/d/bienvenida` — no regression. H1/H2/H3 still the seed, prose body still readable, code fences still on `bg-sunk`.
4. **Focus ring + Ejecutar button**. Turquoise (light) / cyan (dark) ring; button label stays crema-on-green / dark-on-green per theme.
5. **A slide with prose content**. Any slide whose body renders through `.prose` (most of them). Its H1/H2/H3 now paint the seed too, since the `.bg-deck-ground .prose` reset is gone.
6. **Try the guard**. Optional but instructive: edit `apps/web/src/styles/index.css` to set `--nl-deck-ground: #F5EEEA;` in the light `:root` block, run `npm test -- src/styles/palette.test.ts`. You should see the new case fail with a message naming both hex values and pointing at ADR-0026 §Reversal. Revert.

## Notes

- **Pre-existing follow-ups** documented in ADR-0026 addendum §"What is NOT changed" — unchanged by this WP (Mermaid themeVariables, bespoke CodeMirror theme, 27-SVG palette review, and the four learned-during-review deferrals from #222).
- **ADR-3 out-of-scope observation**: the ADR-hunter lens surfaced that `main` already carries duplicated ADR numbers (0040 × 2, 0043 × 2). This is not a #225 regression — it predates this WP — but any future WP that spins off ADR-0044 should `git branch -a`-scan for numbering before assigning. Not fixed here; flagged for post-merge follow-up if Miguel wants a renumbering WP.
- **Coordinates with #222** (merged as PR #223, commit `00cb877`) — this is the follow-up Miguel opened after opening the merged build in presentation mode.
