### PR TITLE
fix(controls-review): show every page of the annotated PDF via <embed>

### DIFF
--- a/apps/server/internal/app/web/handler/review_test.go
+++ b/apps/server/internal/app/web/handler/review_test.go
@@ -49,8 +49,10 @@ func TestReviewPageRendersEditableFormForACopy(t *testing.T) {
 		`type="checkbox"`, // multiple question
 		"Marcar en blanco",
 		// Issue #190: the copy was clean, so the upload annotated it and the
-		// page shows the corrected PDF, not the raw scan.
-		`<iframe`,
+		// page shows the corrected PDF, not the raw scan. The viewer is an
+		// <embed> so the browser's native PDF UI can paginate to every page
+		// (an <iframe> gated by a fixed height cut it to page 1 in Safari).
+		`<embed`,
 		"annotated.pdf",
 	} {
 		if !strings.Contains(body, want) {
@@ -61,7 +63,7 @@ func TestReviewPageRendersEditableFormForACopy(t *testing.T) {
 
 // TestReviewPageFallsBackToRawScanWithoutAnnotated pins the fallback of
 // issue #190: a copy that was never annotated (needs_review, waiting for
-// the professor) shows the raw scan image, not the iframe.
+// the professor) shows the raw scan image, not the PDF <embed>.
 func TestReviewPageFallsBackToRawScanWithoutAnnotated(t *testing.T) {
 	f := newControlsFixture(t)
 	controlID := f.createControl(t, "Control fallback", 1)
@@ -90,8 +92,8 @@ func TestReviewPageFallsBackToRawScanWithoutAnnotated(t *testing.T) {
 		t.Fatalf("status = %d\nbody: %s", rec.Code, rec.Body.String())
 	}
 	body := rec.Body.String()
-	if strings.Contains(body, "<iframe") {
-		t.Errorf("review page shows an iframe for a copy with no annotated PDF\n%s", body)
+	if strings.Contains(body, "<embed") {
+		t.Errorf("review page shows a PDF <embed> for a copy with no annotated PDF\n%s", body)
 	}
 	if !strings.Contains(body, `<img src="/controls/`+controlID+`/copies/1/page/1"`) {
 		t.Errorf("review page missing the raw scan image\n%s", body)
@@ -359,7 +361,7 @@ func TestAnnotatedPDFRefusesARecordPointingOutsideTheWorkDir(t *testing.T) {
 }
 
 // The flag gates the READ too, not only the write: rows produced while
-// the flow was on must not keep rendering the iframe after the operator
+// the flow was on must not keep rendering the PDF <embed> after the operator
 // flips it off — the escape hatch exists precisely for the scenario where
 // the surviving rows are the stale or broken ones (issue #190 review, F5).
 func TestAnnotateDisabledHidesRowsProducedWhileItWasOn(t *testing.T) {
@@ -386,8 +388,8 @@ func TestAnnotateDisabledHidesRowsProducedWhileItWasOn(t *testing.T) {
 		t.Fatalf("status = %d", rec.Code)
 	}
 	body := rec.Body.String()
-	if strings.Contains(body, "<iframe") {
-		t.Errorf("review page shows the iframe with the flow disabled, stale row or not\n%s", body)
+	if strings.Contains(body, "<embed") {
+		t.Errorf("review page shows the PDF <embed> with the flow disabled, stale row or not\n%s", body)
 	}
 	if !strings.Contains(body, `<img src="/controls/`+controlID+`/copies/1/page/1"`) {
 		t.Errorf("review page must serve the raw scan with the flow disabled\n%s", body)

--- a/apps/server/internal/app/web/handler/scans_test.go
+++ b/apps/server/internal/app/web/handler/scans_test.go
@@ -325,8 +325,8 @@ func TestAnnotateDisabledServesRawEverywhere(t *testing.T) {
 		t.Fatalf("status = %d", rec.Code)
 	}
 	body := rec.Body.String()
-	if strings.Contains(body, "<iframe") {
-		t.Errorf("review page shows an iframe with the flow disabled\n%s", body)
+	if strings.Contains(body, "<embed") {
+		t.Errorf("review page shows a PDF <embed> with the flow disabled\n%s", body)
 	}
 	if !strings.Contains(body, `<img src="/controls/`+controlID+`/copies/1/page/1"`) {
 		t.Errorf("review page must serve the raw scan with the flow disabled\n%s", body)

--- a/apps/server/internal/app/web/view/templates/layout.html
+++ b/apps/server/internal/app/web/view/templates/layout.html
@@ -96,11 +96,13 @@
          sheet overflows every viewport. */
       .review-image img { max-width: 100%; height: auto; }
       /* The corrected PDF (issue #190) renders in the browser's own viewer
-         through an iframe; a fixed height keeps the review form's left
-         column from collapsing to the viewer's default 150px sliver. */
-      .review-image iframe {
+         through an <embed>; a fixed height keeps the review form's left
+         column from collapsing to the viewer's default 150px sliver, and
+         letting the viewer own its scroll is what lets it show every page
+         (an <iframe> gated to 70vh cut it to the first page in Safari). */
+      .review-image embed {
         width: 100%;
-        height: 70vh;
+        height: 85vh;
         border: 1px solid var(--border, #ddd);
       }
 

--- a/apps/server/internal/app/web/view/templates/pages/review.html
+++ b/apps/server/internal/app/web/view/templates/pages/review.html
@@ -10,7 +10,7 @@
     <section class="review-image">
       <h2>Escaneo</h2>
       {{ if .HasAnnotated }}
-        <p><iframe src="{{ .AnnotatedURL }}" title="Copia {{ .CopyNumber }} corregida"></iframe></p>
+        <p><embed src="{{ .AnnotatedURL }}#view=FitH&scrollbar=1" type="application/pdf" title="Copia {{ .CopyNumber }} corregida"></p>
         <p><a href="{{ .AnnotatedURL }}">Abrir el PDF corregido en otra pestaña</a></p>
       {{ else }}
         <p><img src="{{ .ImageURL }}" alt="Escaneo de la copia {{ .CopyNumber }}"></p>


### PR DESCRIPTION
## Bug

Reported by Miguel: on the copy-review page, the annotated PDF only shows page 1. Everything past that is invisible — the professor has to click "Abrir en otra pestaña" to see any of the rest.

## Cause

`pages/review.html:13` rendered the annotated PDF through `<iframe src="…">`, and `layout.html:101` gave the container a fixed `70vh`. Safari's PDF plugin (and some Chromium configurations) paint only the first page inside that box, without visible pagination or scroll affordance.

## Fix

- Swap `<iframe>` for `<embed type="application/pdf">` with the `#view=FitH&scrollbar=1` fragment. The `<embed>` viewer paints every page vertically inside its own scroll region and honours the `FitH` hint on Safari.
- Rename `.review-image iframe` → `.review-image embed` in `layout.html:101`, and bump `height` from `70vh` → `85vh` for a bit more visible surface.
- Update three test assertions (`review_test.go:53`, `review_test.go:93`, `review_test.go:391`, `scans_test.go:328`) that were pinned on the literal string `<iframe`. The positive case now asserts `<embed`; the two negative cases (raw-scan fallback and flow-disabled fallback) now forbid `<embed`.

## Scope

Yolo mode per `docs/conventions.md`: 1 template line + 1 CSS selector rename + 3 mechanical test-string updates + 2 comment refreshes. Cero cambios en handlers, cero cambios de lógica.

## Verification

- `go test -count=1 ./...` — green (`internal/app/web/handler` passes with the new assertions).
- Manual browser verification pending on the Jetson after merge — the file is rendered by the browser, so the only real test is opening a real copy in Safari + Chrome + Firefox.

## Notes

Reported alongside 3 other backoffice bugs. Being shipped as a separate PR because the fix is trivial and self-contained; the other three (question order, RUT edit, bank hot-refresh + picker UX) each get their own WP.
