### PR TITLE
feat(bank): hot-refresh from published questions.json (auto ticker + manual button)

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -119,6 +119,7 @@ jobs:
             -e NALANDA_WORK_DIR=/work \
             -e NALANDA_MAX_SCAN_MB=100 \
             -e NALANDA_ANNOTATE_ENABLED=true \
+            -e NALANDA_BANK_REFRESH_INTERVAL=5m \
             -v "$GITHUB_WORKSPACE/ci-work:/work:ro" \
             -p 127.0.0.1:8081:8081 \
             nalanda/server:ci

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -117,3 +117,13 @@ NALANDA_MAX_SCAN_MB=100
 # annotated_copy rows, and the review page serves the raw scan — the
 # escape hatch if the AMC-patching approach breaks against a real batch.
 NALANDA_ANNOTATE_ENABLED=true
+
+# How often LiveBank polls NALANDA_QUESTIONS_JSON_URL for a fresh
+# questions.json (issue #230). Optional — defaults to 5m, which matches
+# the Watchtower poll cadence on the Jetson so the server refreshes at
+# the same rhythm as the container itself. A Go duration ("30s", "5m",
+# "1h"); "0s" disables the ticker (Watch returns immediately, gated by
+# TestWatchWithZeroIntervalReturnsImmediately) and the manual admin
+# button is then the only refresh path. A negative value is a startup
+# error.
+NALANDA_BANK_REFRESH_INTERVAL=5m

--- a/apps/server/.env.example
+++ b/apps/server/.env.example
@@ -81,10 +81,13 @@ NALANDA_TRUST_PROXY_HEADERS=false
 # paths still answer; the professor sees an empty backoffice.
 
 # Where the published question bank lives (ADR-0032). Required.
-# Fetched ONCE at boot and held in memory; a parse failure there is a
-# panic and the server does not start (the same rule the templates
-# follow). http:// and https:// are production; file:// is the local-file
-# override for development.
+# Fetched at BOOT (a parse failure there is a startup panic — the server
+# does not start) AND polled at NALANDA_BANK_REFRESH_INTERVAL cadence
+# once running (issue #230, ADR-0032 §Addendum). A parse failure on a
+# subsequent refresh logs WARN and preserves the last-good snapshot;
+# the pointer is never nilled. http:// and https:// are production;
+# file:// is the local-file override for development (which re-parses
+# every refresh, since the scheme has no If-Modified-Since path).
 #
 # For local development, point at the artifact apps/web builds and
 # preview serves:

--- a/apps/server/CLAUDE.md
+++ b/apps/server/CLAUDE.md
@@ -173,6 +173,18 @@ the `avisoNo*` / `flash.Set(…)` string literals in `internal/app/web/handler/`
   `io.Copy` failure); downstream failures do not. The rollback promise
   is scoped to DB rows, not the file — see the `UploadScan` docstring
   for what is transactional and what is not.
+- **The LiveBank in-memory snapshot survives every Reload failure
+  (issue #230).** Reintroducing a code path that clears the
+  `atomic.Pointer[Bank]` on a fetch/parse failure is forbidden — a
+  Reload logs `WARN` and returns an error while readers keep seeing
+  the last-known-good snapshot. Same rule shape and same reason as
+  the UploadScan bullet above; ADR-0032 §Addendum records the
+  decision. Both refresh paths call `LiveBank.Reload` — the ticker
+  in `bank.LiveBank.Watch` and `handler.AdminBank.Refresh` — and the
+  atomicity guarantee is **per-call**, not request-level (a handler
+  that resolves `.Get()` then hands the request to the service,
+  which also resolves `.Get()`, can straddle a swap; the addendum
+  pins that distinction after the WP review flagged it).
 - **The two surfaces do not share an auth gate** (§C12). Everything auth-shaped
   is mounted inside `internal/app/web`; `internal/app/api` is anonymous by
   construction, and `/health` sits deliberately outside the gate because the

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -41,7 +41,7 @@ Environment variables, read once at boot. A required variable that is absent
 | `NALANDA_SESSION_TTL` | no (`720h`) | Session lifetime, as a Go duration. Zero or negative is a startup error |
 | `NALANDA_BOOTSTRAP_PROFESSOR_EMAIL` | no | On a database with **no** professors, the first Google login by this address creates one. Inert as soon as any professor exists |
 | `NALANDA_TRUST_PROXY_HEADERS` | no (`false`) | `true` when a trusted reverse proxy owns `X-Forwarded-For` — the Jetson deploy (#162) behind Tailscale Funnel. The sessions table's IP column then comes from the FIRST hop of the header instead of `RemoteAddr` (loopback for every visitor there). Only `true`/`false`; a misspelling is a startup error |
-| `NALANDA_QUESTIONS_JSON_URL` | yes | The published question bank (ADR-0032). `http://`, `https://` or `file://`. Fetched **once at boot** and held in memory; a parse failure is a panic there. WP-E |
+| `NALANDA_QUESTIONS_JSON_URL` | yes | The published question bank (ADR-0032). `http://`, `https://` or `file://`. Fetched at boot AND polled at `NALANDA_BANK_REFRESH_INTERVAL` cadence (issue #230, ADR-0032 §Addendum). A parse failure **at boot** is a startup panic; a failure **on a subsequent refresh** logs `WARN` and preserves the last-good snapshot — the server never nils the pointer. WP-E |
 | `NALANDA_AMC_WORKER_URL` | yes | The AMC worker's HTTP origin, e.g. `http://amc-worker:8080` in compose. Absolute http/https URL, no path. WP-E |
 | `NALANDA_WORK_DIR` | yes | Where the server sees the shared volume. The `.tex` generator emits `/work` absolute paths regardless (that is the worker's mount); this only decides where the server writes its files. WP-E |
 | `NALANDA_MAX_SCAN_MB` | no (`100`) | Largest scan PDF the upload handler accepts, in whole MB. A 4-page control at 300 dpi is roughly 3–5 MB; 100 fits a large class and refuses a runaway upload before it enters the worker. WP-F |
@@ -221,6 +221,7 @@ Routes today:
 | `GET /professors/{id}/edit` · `POST /professors/{id}` | Rename. The address is not editable |
 | `POST /professors/{id}/deactivate` | Flips `is_active=0` and ends every session that professor holds |
 | `POST /professors/{id}/reactivate` | Flips `is_active=1` and clears `deactivated_at` |
+| `POST /admin/bank/refresh` | Reloads the in-memory question bank from `NALANDA_QUESTIONS_JSON_URL` and redirects back to `Referer` (or `/controls` on empty / off-origin / scheme-relative-path). Session-gated + CSRF. The "Recargar banco" button in the top bar posts to it (issue #230, ADR-0032 §Addendum) |
 | `GET /login` · `GET /login/google` · `GET /login/google/callback` · `POST /logout` | The login round trip — see §Signing in |
 
 Every state-changing route sits behind `middleware.RequireProfessor` AND

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -46,6 +46,7 @@ Environment variables, read once at boot. A required variable that is absent
 | `NALANDA_WORK_DIR` | yes | Where the server sees the shared volume. The `.tex` generator emits `/work` absolute paths regardless (that is the worker's mount); this only decides where the server writes its files. WP-E |
 | `NALANDA_MAX_SCAN_MB` | no (`100`) | Largest scan PDF the upload handler accepts, in whole MB. A 4-page control at 300 dpi is roughly 3–5 MB; 100 fits a large class and refuses a runaway upload before it enters the worker. WP-F |
 | `NALANDA_ANNOTATE_ENABLED` | no (`true`) | The annotate loop's master switch (issue #190). `false` turns the whole flow off: no `/annotate/copy` calls, no `annotated_copy` rows, the review page serves the raw scan — the escape hatch if the AMC-patching approach breaks against a real batch. Only `true`/`false`; a misspelling is a startup error |
+| `NALANDA_BANK_REFRESH_INTERVAL` | no (`5m`) | How often LiveBank polls `NALANDA_QUESTIONS_JSON_URL` for a fresh `questions.json` (issue #230). A Go duration; matches the Watchtower poll cadence on the Jetson so the server refreshes at the same rhythm as the container. `0s` disables the ticker — the manual admin button is then the only refresh path. A negative value is a startup error |
 
 ## Commands
 

--- a/apps/server/cmd/server/main.go
+++ b/apps/server/cmd/server/main.go
@@ -213,6 +213,11 @@ func run(logger *slog.Logger) error {
 			OnCorrectionClosed: controls.NewNoopHook(logger),
 			Log:                logger,
 		}),
+		AdminBank: handler.NewAdminBank(handler.AdminBank{
+			Bank:      liveBank,
+			PublicURL: cfg.PublicURL,
+			Log:       logger,
+		}),
 		Login: handler.NewAuth(handler.Auth{
 			Login: login,
 			Provider: oidc.NewGoogle(oidc.GoogleConfig{

--- a/apps/server/cmd/server/main.go
+++ b/apps/server/cmd/server/main.go
@@ -152,6 +152,11 @@ func run(logger *slog.Logger) error {
 	if err != nil {
 		return err
 	}
+	// The ticker owns the poll cadence (NALANDA_BANK_REFRESH_INTERVAL,
+	// issue #230): a zero interval disables it — the manual admin button
+	// is then the only refresh path — otherwise Watch calls Reload every
+	// interval and exits when ctx does at shutdown.
+	go liveBank.Watch(ctx, cfg.BankRefreshInterval)
 
 	controlStore := controlstore.New(db)
 	amcClient := amcworker.New(amcworker.Config{BaseURL: cfg.AmcWorkerURL})

--- a/apps/server/cmd/server/main.go
+++ b/apps/server/cmd/server/main.go
@@ -144,20 +144,19 @@ func run(logger *slog.Logger) error {
 
 	// The published question bank (ADR-0032). Loaded once at boot; a
 	// failure here IS a startup failure, not a first-request failure, so
-	// an operator sees it immediately.
-	loadedBank, err := bank.Load(ctx, cfg.QuestionsJSONURL)
+	// an operator sees it immediately. Issue #230 wraps it in a LiveBank
+	// so a subsequent apps/web publish rotates the in-memory snapshot
+	// without a restart; NewLive emits its own boot log line naming the
+	// URL and the document/question counts.
+	liveBank, err := bank.NewLive(ctx, cfg.QuestionsJSONURL, logger)
 	if err != nil {
 		return err
 	}
-	logger.Info("question bank loaded",
-		"url", cfg.QuestionsJSONURL,
-		"documents", len(loadedBank.Documents),
-		"questions", len(loadedBank.Questions))
 
 	controlStore := controlstore.New(db)
 	amcClient := amcworker.New(amcworker.Config{BaseURL: cfg.AmcWorkerURL})
 	controlsService := controls.NewService(controls.Service{
-		Bank:      loadedBank,
+		Bank:      liveBank,
 		Store:     controlStore,
 		Generator: amcClient,
 		Analyzer:  amcClient,
@@ -200,7 +199,7 @@ func run(logger *slog.Logger) error {
 		}),
 		Controls: handler.NewControls(handler.Controls{
 			Service:      controlsService,
-			Bank:         loadedBank,
+			Bank:         liveBank,
 			PublicURL:    cfg.PublicURL,
 			MaxScanBytes: cfg.MaxScanBytes,
 			// The default hook: logs and does nothing. A future

--- a/apps/server/cmd/server/main_test.go
+++ b/apps/server/cmd/server/main_test.go
@@ -110,6 +110,11 @@ func composed(t *testing.T, prober health.Prober) (http.Handler, *authstore.Stor
 			OnCorrectionClosed: controls.NewNoopHook(logger),
 			Log:                logger,
 		}),
+		AdminBank: handler.NewAdminBank(handler.AdminBank{
+			Bank:      emptyBank(t),
+			PublicURL: "https://nalanda.test",
+			Log:       logger,
+		}),
 		Log: logger,
 	}, prober, logger), store
 }

--- a/apps/server/cmd/server/main_test.go
+++ b/apps/server/cmd/server/main_test.go
@@ -34,13 +34,13 @@ import (
 	"github.com/so77id/nalanda/apps/server/migrations"
 )
 
-func emptyBank(t *testing.T) *bank.Bank {
+func emptyBank(t *testing.T) *bank.LiveBank {
 	t.Helper()
 	b, err := bank.Parse(strings.NewReader(`{"version":1,"documents":[],"questions":[]}`))
 	if err != nil {
 		t.Fatalf("emptyBank: %v", err)
 	}
-	return b
+	return bank.NewStaticLive(b)
 }
 
 // composed builds the root handler the way run() does, so these cases exercise

--- a/apps/server/internal/app/web/handler/admin_bank.go
+++ b/apps/server/internal/app/web/handler/admin_bank.go
@@ -75,6 +75,17 @@ func (h *AdminBank) Refresh(w http.ResponseWriter, r *http.Request) {
 // A referer that shares scheme+host with PublicURL keeps its path (so the
 // professor lands back on the page they clicked from). Anything else —
 // empty, malformed, or off-origin — falls back to /controls.
+//
+// The scheme+host guard alone is not enough. A same-origin referer whose
+// path begins with `//` (e.g. `https://nalanda.test//evil.com/x` — the
+// path is `//evil.com/x`, the host is nalanda.test) passes the origin
+// check, and Go's http.Redirect writes the Location header verbatim; a
+// browser then resolves `//evil.com/x` as a scheme-relative URL and
+// navigates to `https://evil.com/x`. IMPORTANT-1 from the WP review
+// reproduced that on the real function. The extra check below rejects
+// any path that does not start with a single `/` followed by a non-`/`
+// non-`\` character — the two forms browsers historically resolve as
+// scheme-relative navigations.
 func safeRedirect(referer, publicURL string) string {
 	if referer == "" {
 		return ControlsPath
@@ -88,6 +99,11 @@ func safeRedirect(referer, publicURL string) string {
 		return ControlsPath
 	}
 	if !strings.EqualFold(refParsed.Scheme, pubParsed.Scheme) || refParsed.Host != pubParsed.Host {
+		return ControlsPath
+	}
+	if !strings.HasPrefix(refParsed.Path, "/") ||
+		strings.HasPrefix(refParsed.Path, "//") ||
+		strings.HasPrefix(refParsed.Path, `/\`) {
 		return ControlsPath
 	}
 	target := refParsed.Path

--- a/apps/server/internal/app/web/handler/admin_bank.go
+++ b/apps/server/internal/app/web/handler/admin_bank.go
@@ -1,0 +1,98 @@
+package handler
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/so77id/nalanda/apps/server/internal/app/web/flash"
+	"github.com/so77id/nalanda/apps/server/internal/domain/course/bank"
+	"github.com/so77id/nalanda/apps/server/internal/infra/config"
+)
+
+// AdminBankRefreshPath is the manual bank-refresh endpoint (issue #230).
+// URL in English like every other route on this surface (issue #151
+// §Routes); the button label a professor reads stays Spanish.
+const AdminBankRefreshPath = "/admin/bank/refresh"
+
+// AdminBank holds the admin bank-refresh handler. Constructed once in
+// cmd/server; refuses an incomplete set at wire time so a nil dereference
+// inside a request is impossible (backend-code-style.md §Errors).
+type AdminBank struct {
+	Bank      *bank.LiveBank
+	PublicURL string
+	Log       *slog.Logger
+
+	secureCookie bool
+}
+
+// NewAdminBank returns the handler.
+func NewAdminBank(deps AdminBank) *AdminBank {
+	switch {
+	case deps.Bank == nil:
+		panic("handler.NewAdminBank: no bank")
+	case deps.PublicURL == "":
+		panic("handler.NewAdminBank: no public URL — the flash cookie's Secure attribute is derived from it")
+	case deps.Log == nil:
+		panic("handler.NewAdminBank: no logger")
+	}
+	deps.secureCookie = config.SecureFor(deps.PublicURL)
+	return &deps
+}
+
+// Refresh handles POST /admin/bank/refresh. It calls LiveBank.Reload,
+// writes a Spanish flash naming the outcome, and redirects the professor
+// back where they came from — /controls if the Referer is missing or
+// off-origin.
+//
+// The redirect target is Referer-derived rather than a fixed constant
+// because the button appears in the top bar on every backoffice page,
+// and losing the professor's context (which control they were looking at)
+// on every refresh is a small paper cut with no upside. The
+// same-origin guard below is why an evil Referer can never become an
+// open redirect: PublicURL is the deployed origin (host + optional port,
+// no path — see config.Load's validation), and only a Referer whose
+// origin matches it survives.
+func (h *AdminBank) Refresh(w http.ResponseWriter, r *http.Request) {
+	updated, err := h.Bank.Reload(r.Context())
+	switch {
+	case err != nil:
+		h.Log.Warn("manual bank refresh failed", "url", h.Bank.URL(), "error", err)
+		flash.Set(w, h.secureCookie, "No se pudo recargar el banco: "+err.Error())
+	case !updated:
+		flash.Set(w, h.secureCookie, "El banco ya estaba al día.")
+	default:
+		b := h.Bank.Get()
+		flash.Set(w, h.secureCookie, fmt.Sprintf("Banco recargado: %d documentos, %d preguntas.",
+			len(b.Documents), len(b.Questions)))
+	}
+	http.Redirect(w, r, safeRedirect(r.Header.Get("Referer"), h.PublicURL), http.StatusSeeOther)
+}
+
+// safeRedirect returns a URL the handler will bounce to after a refresh.
+// A referer that shares scheme+host with PublicURL keeps its path (so the
+// professor lands back on the page they clicked from). Anything else —
+// empty, malformed, or off-origin — falls back to /controls.
+func safeRedirect(referer, publicURL string) string {
+	if referer == "" {
+		return ControlsPath
+	}
+	refParsed, err := url.Parse(referer)
+	if err != nil || refParsed.Path == "" {
+		return ControlsPath
+	}
+	pubParsed, err := url.Parse(publicURL)
+	if err != nil {
+		return ControlsPath
+	}
+	if !strings.EqualFold(refParsed.Scheme, pubParsed.Scheme) || refParsed.Host != pubParsed.Host {
+		return ControlsPath
+	}
+	target := refParsed.Path
+	if refParsed.RawQuery != "" {
+		target += "?" + refParsed.RawQuery
+	}
+	return target
+}

--- a/apps/server/internal/app/web/handler/admin_bank_test.go
+++ b/apps/server/internal/app/web/handler/admin_bank_test.go
@@ -1,0 +1,227 @@
+package handler_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/so77id/nalanda/apps/server/internal/app/web/handler"
+	"github.com/so77id/nalanda/apps/server/internal/app/web/middleware"
+	"github.com/so77id/nalanda/apps/server/internal/domain/auth"
+	"github.com/so77id/nalanda/apps/server/internal/domain/course/bank"
+)
+
+// adminBankFixture wires a real LiveBank against an httptest server so
+// each case can steer the outcome of Refresh's Reload — success, 304
+// no-op, or a 5xx failure — without stubbing the concrete type.
+type adminBankFixture struct {
+	handler *handler.AdminBank
+	live    *bank.LiveBank
+	body    *atomic.Pointer[string]
+	status  *atomic.Int32 // 200 or 500; 304 is delivered when the request carries If-Modified-Since
+	session auth.Session
+	user    auth.User
+}
+
+func newAdminBankFixture(t *testing.T) *adminBankFixture {
+	t.Helper()
+
+	body := &atomic.Pointer[string]{}
+	initial := adminBankInitialJSON
+	body.Store(&initial)
+
+	status := &atomic.Int32{}
+	status.Store(http.StatusOK)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if code := status.Load(); code != http.StatusOK {
+			http.Error(w, "boom", int(code))
+			return
+		}
+		if r.Header.Get("If-Modified-Since") != "" && *body.Load() == initial {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Last-Modified", "Wed, 26 Aug 2026 12:00:00 GMT")
+		_, _ = w.Write([]byte(*body.Load()))
+	}))
+	t.Cleanup(srv.Close)
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	live, err := bank.NewLive(context.Background(), srv.URL+"/questions.json", log)
+	if err != nil {
+		t.Fatalf("NewLive: %v", err)
+	}
+
+	h := handler.NewAdminBank(handler.AdminBank{
+		Bank:      live,
+		PublicURL: publicURL,
+		Log:       log,
+	})
+
+	return &adminBankFixture{
+		handler: h,
+		live:    live,
+		body:    body,
+		status:  status,
+		session: auth.Session{TokenHash: "hash", UserID: 1, CSRFToken: "csrf"},
+		user:    auth.User{ID: 1, Email: "profesora@example.com", Name: "Profesora"},
+	}
+}
+
+func (f *adminBankFixture) postRefresh(t *testing.T) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, handler.AdminBankRefreshPath, nil)
+	req.Header.Set("Referer", "http://127.0.0.1:8081/controls")
+	ctx := middleware.WithProfessorForTest(req.Context(), f.user, f.session)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	f.handler.Refresh(rec, req)
+	return rec
+}
+
+func TestAdminBankRefreshFlashesTheNewCountsAndRedirects(t *testing.T) {
+	f := newAdminBankFixture(t)
+
+	// The site publishes.
+	next := adminBankNextJSON
+	f.body.Store(&next)
+
+	rec := f.postRefresh(t)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+	if got := rec.Header().Get("Location"); got != "/controls" {
+		t.Errorf("Location = %q, want /controls (Referer-derived same-origin)", got)
+	}
+
+	got := readFlash(t, rec)
+	for _, want := range []string{"Banco recargado", "3 documentos", "5 preguntas"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("flash = %q, want it to contain %q", got, want)
+		}
+	}
+
+	// The rotation is visible through Get() — the whole point of the
+	// endpoint from the professor's perspective.
+	if n := len(f.live.Get().Documents); n != 3 {
+		t.Errorf("Get().Documents = %d, want 3 after Reload", n)
+	}
+}
+
+func TestAdminBankRefreshFlashesUnchangedOn304(t *testing.T) {
+	f := newAdminBankFixture(t)
+
+	// Do NOT change the body — the second call will carry
+	// If-Modified-Since and the httptest server answers 304.
+
+	rec := f.postRefresh(t)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+	got := readFlash(t, rec)
+	if !strings.Contains(got, "ya estaba al día") {
+		t.Errorf("flash = %q, want it to say the bank was unchanged", got)
+	}
+}
+
+func TestAdminBankRefreshFlashesTheErrorOnServerFailure(t *testing.T) {
+	f := newAdminBankFixture(t)
+
+	// The upstream is down after boot.
+	f.status.Store(http.StatusInternalServerError)
+
+	rec := f.postRefresh(t)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusSeeOther)
+	}
+	got := readFlash(t, rec)
+	if !strings.Contains(got, "No se pudo recargar") {
+		t.Errorf("flash = %q, want it to say the refresh failed", got)
+	}
+
+	// The snapshot survives — the escape-hatch promise (S1).
+	if n := len(f.live.Get().Documents); n != 2 {
+		t.Errorf("Get().Documents = %d, want 2 (boot snapshot preserved)", n)
+	}
+}
+
+func TestAdminBankRefreshFallsBackToControlsWithoutReferer(t *testing.T) {
+	f := newAdminBankFixture(t)
+
+	req := httptest.NewRequest(http.MethodPost, handler.AdminBankRefreshPath, nil)
+	// No Referer header — a direct POST, or a browser that scrubbed it.
+	ctx := middleware.WithProfessorForTest(req.Context(), f.user, f.session)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	f.handler.Refresh(rec, req)
+
+	if got := rec.Header().Get("Location"); got != "/controls" {
+		t.Errorf("Location = %q, want /controls as the fallback", got)
+	}
+}
+
+func TestAdminBankRefreshRejectsAnOffOriginReferer(t *testing.T) {
+	// A crafted request from another origin still carries the CSRF token
+	// (assume the worst) and names an evil Referer. The handler must
+	// refuse to bounce the professor there — an open redirect on a
+	// backoffice endpoint is a phishing lever.
+	f := newAdminBankFixture(t)
+
+	req := httptest.NewRequest(http.MethodPost, handler.AdminBankRefreshPath, nil)
+	req.Header.Set("Referer", "https://evil.example.com/steal")
+	ctx := middleware.WithProfessorForTest(req.Context(), f.user, f.session)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	f.handler.Refresh(rec, req)
+
+	if got := rec.Header().Get("Location"); got != "/controls" {
+		t.Errorf("Location = %q, want /controls — an off-origin Referer must not steer the redirect", got)
+	}
+}
+
+const adminBankInitialJSON = `{
+  "version": 1,
+  "documents": [
+    {"id": "d1", "title": "D1", "coverage": "c", "sections": ["s"]},
+    {"id": "d2", "title": "D2", "coverage": "c", "sections": ["s"]}
+  ],
+  "questions": [
+    {"id": "q1", "document": "d1", "anchor": "s", "type": "simple",
+     "statement": "?", "code": null, "alternatives": ["a","b"], "correct": [0]},
+    {"id": "q2", "document": "d2", "anchor": "s", "type": "simple",
+     "statement": "?", "code": null, "alternatives": ["a","b"], "correct": [0]},
+    {"id": "q3", "document": "d2", "anchor": "s", "type": "simple",
+     "statement": "?", "code": null, "alternatives": ["a","b"], "correct": [0]}
+  ]
+}`
+
+const adminBankNextJSON = `{
+  "version": 1,
+  "documents": [
+    {"id": "d1", "title": "D1", "coverage": "c", "sections": ["s"]},
+    {"id": "d2", "title": "D2", "coverage": "c", "sections": ["s"]},
+    {"id": "d3", "title": "D3", "coverage": "c", "sections": ["s"]}
+  ],
+  "questions": [
+    {"id": "q1", "document": "d1", "anchor": "s", "type": "simple",
+     "statement": "?", "code": null, "alternatives": ["a","b"], "correct": [0]},
+    {"id": "q2", "document": "d2", "anchor": "s", "type": "simple",
+     "statement": "?", "code": null, "alternatives": ["a","b"], "correct": [0]},
+    {"id": "q3", "document": "d2", "anchor": "s", "type": "simple",
+     "statement": "?", "code": null, "alternatives": ["a","b"], "correct": [0]},
+    {"id": "q4", "document": "d3", "anchor": "s", "type": "simple",
+     "statement": "?", "code": null, "alternatives": ["a","b"], "correct": [0]},
+    {"id": "q5", "document": "d3", "anchor": "s", "type": "simple",
+     "statement": "?", "code": null, "alternatives": ["a","b"], "correct": [0]}
+  ]
+}`

--- a/apps/server/internal/app/web/handler/admin_bank_test.go
+++ b/apps/server/internal/app/web/handler/admin_bank_test.go
@@ -170,6 +170,58 @@ func TestAdminBankRefreshFallsBackToControlsWithoutReferer(t *testing.T) {
 	}
 }
 
+// TestAdminBankRefreshKeepsSameOriginReferer pins the whole reason
+// safeRedirect exists: a professor clicking the button from
+// /controls/{id} lands back on /controls/{id}, keeping their query
+// string. Without this case, a mutation replacing safeRedirect's body
+// with `return ControlsPath` leaves the file green (WP #230 review,
+// IMPORTANT-2).
+func TestAdminBankRefreshKeepsSameOriginReferer(t *testing.T) {
+	f := newAdminBankFixture(t)
+
+	req := httptest.NewRequest(http.MethodPost, handler.AdminBankRefreshPath, nil)
+	// Same-origin Referer with a concrete control detail path + a query
+	// string. publicURL is `https://nalanda.test` (auth_test.go); the
+	// exact URL an authenticated professor's browser would send.
+	req.Header.Set("Referer", "https://nalanda.test/controls/ABCD2345?batch=1")
+	ctx := middleware.WithProfessorForTest(req.Context(), f.user, f.session)
+	req = req.WithContext(ctx)
+	rec := httptest.NewRecorder()
+	f.handler.Refresh(rec, req)
+
+	if got := rec.Header().Get("Location"); got != "/controls/ABCD2345?batch=1" {
+		t.Errorf("Location = %q, want /controls/ABCD2345?batch=1 — same-origin Referer must preserve path and query", got)
+	}
+}
+
+// TestAdminBankRefreshRejectsAProtocolRelativeReferer is the regression
+// test for IMPORTANT-1: a Referer whose path starts with `//` (e.g.
+// `https://nalanda.test//evil.com/x`) passed the scheme+host check, so
+// safeRedirect returned `//evil.com/x` and http.Redirect wrote it
+// verbatim, which browsers resolve as https://evil.com/x. The extra
+// prefix check in safeRedirect rejects the class; a companion `/\`
+// case covers the historical Windows-style split that some browsers
+// treated the same way.
+func TestAdminBankRefreshRejectsAProtocolRelativeReferer(t *testing.T) {
+	f := newAdminBankFixture(t)
+
+	for _, path := range []string{"//evil.com/steal", `/\evil.com/steal`, "//evil.com/x?a=1"} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, handler.AdminBankRefreshPath, nil)
+			req.Header.Set("Referer", "https://nalanda.test"+path)
+			ctx := middleware.WithProfessorForTest(req.Context(), f.user, f.session)
+			req = req.WithContext(ctx)
+			rec := httptest.NewRecorder()
+			f.handler.Refresh(rec, req)
+
+			if got := rec.Header().Get("Location"); got != "/controls" {
+				t.Errorf("Location = %q for path %q, want /controls — a scheme-relative or backslash-prefixed path must fall back",
+					got, path)
+			}
+		})
+	}
+}
+
 func TestAdminBankRefreshRejectsAnOffOriginReferer(t *testing.T) {
 	// A crafted request from another origin still carries the CSRF token
 	// (assume the worst) and names an evil Referer. The handler must

--- a/apps/server/internal/app/web/handler/controls.go
+++ b/apps/server/internal/app/web/handler/controls.go
@@ -52,8 +52,12 @@ const (
 // through it (WP-E review, ARQ-11: the earlier shape held both Service
 // and Store and reviewers could not tell which was canonical for reads).
 type Controls struct {
-	Service   *controls.Service
-	Bank      *bank.Bank
+	Service *controls.Service
+	// Bank is the live wrapper around the published question bank
+	// (ADR-0032, issue #230). Handler methods call h.Bank.Get() once at
+	// entry so the whole request sees a consistent snapshot even if a
+	// Reload lands mid-handler.
+	Bank      *bank.LiveBank
 	PublicURL string
 	// MaxScanBytes is the largest scan upload the handler accepts. Comes
 	// from config.MaxScanBytes so main is the only place the byte value
@@ -126,7 +130,7 @@ func (h *Controls) Create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	values := valuesFromRequest(r)
-	errs, req := validateCreate(values, h.Bank)
+	errs, req := validateCreate(values, h.Bank.Get())
 	if len(errs) > 0 {
 		h.rerenderNew(w, r, values, errs, "")
 		return
@@ -191,7 +195,7 @@ func (h *Controls) Detail(w http.ResponseWriter, r *http.Request) {
 
 	page := view.ControlDetailPage{
 		Page:         middleware.PageFor(r, c.Name),
-		Control:      toDetailedControl(c, h.Bank),
+		Control:      toDetailedControl(c, h.Bank.Get()),
 		SujetURL:     controlSujetURL(c.ID),
 		CorrigeURL:   controlCorrigeURL(c.ID),
 		PoolJSONURL:  controlPoolJSONURL(c.ID),
@@ -311,7 +315,7 @@ func (h *Controls) newFormPage(r *http.Request, values view.ControlFormValues, e
 		Values:         values,
 		Errors:         errs,
 		Notice:         notice,
-		SectionOptions: sectionOptionsFromBank(h.Bank),
+		SectionOptions: sectionOptionsFromBank(h.Bank.Get()),
 	}
 }
 
@@ -741,7 +745,7 @@ func (h *Controls) toListedControls(rows []controls.Control) []view.ListedContro
 			ID:              c.ID,
 			Name:            c.Name,
 			ApplicationDate: formatOptionalDate(c.ApplicationDate),
-			Range:           formatRangeWithTitles(c.RangeFrom, c.RangeTo, h.Bank),
+			Range:           formatRangeWithTitles(c.RangeFrom, c.RangeTo, h.Bank.Get()),
 			Shape:           fmt.Sprintf("%d preguntas × %d copias", c.QuestionsPerCopy, c.Copies),
 			State:           stateWordControl(c.State),
 			DetailURL:       controlDetailURL(c.ID),

--- a/apps/server/internal/app/web/handler/controls.go
+++ b/apps/server/internal/app/web/handler/controls.go
@@ -54,9 +54,15 @@ const (
 type Controls struct {
 	Service *controls.Service
 	// Bank is the live wrapper around the published question bank
-	// (ADR-0032, issue #230). Handler methods call h.Bank.Get() once at
-	// entry so the whole request sees a consistent snapshot even if a
-	// Reload lands mid-handler.
+	// (ADR-0032, issue #230). Handler methods call h.Bank.Get() to pick
+	// up the current snapshot; each call resolves independently, so a
+	// Reload landing mid-request may leave the handler and the service
+	// looking at different snapshots. The failure mode is small — a
+	// picker validation against snapshot A followed by a pool draw
+	// against snapshot B — and no worse than any other read against a
+	// slowly-changing store. The atomic-swap guarantee is per-call
+	// atomicity, not request-level; the WP review of #230 pinned that
+	// distinction (IMPORTANT-3) rather than let this comment overclaim.
 	Bank      *bank.LiveBank
 	PublicURL string
 	// MaxScanBytes is the largest scan upload the handler accepts. Comes

--- a/apps/server/internal/app/web/handler/controls_test.go
+++ b/apps/server/internal/app/web/handler/controls_test.go
@@ -125,15 +125,16 @@ func newControlsFixtureWith(t *testing.T, annotateEnabled bool) *controlsFixture
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 
 	cstore := controlstore.New(db)
+	live := bank.NewStaticLive(b)
 	svc := controls.NewService(controls.Service{
-		Bank: b, Store: cstore, Generator: fake, Analyzer: fake, Readings: cstore,
+		Bank: live, Store: cstore, Generator: fake, Analyzer: fake, Readings: cstore,
 		Annotator: fake, AnnotateEnabled: annotateEnabled,
 		WorkDir: workDir,
 		Now:     time.Now, Seed: 1, Log: log,
 	})
 	hook := &recordingHook{service: svc}
 	h := handler.NewControls(handler.Controls{
-		Service: svc, Bank: b,
+		Service: svc, Bank: live,
 		PublicURL: publicURL, MaxScanBytes: 5 << 20,
 		OnCorrectionClosed: hook,
 		Log:                log,

--- a/apps/server/internal/app/web/handler/review.go
+++ b/apps/server/internal/app/web/handler/review.go
@@ -67,7 +67,7 @@ func (h *Controls) Review(w http.ResponseWriter, r *http.Request) {
 		SaveURL:    controlReviewURL(id, copyNumber),
 		Graded:     control.State == controls.Graded,
 		RUT:        toReviewRUT(reading),
-		Questions:  toReviewQuestions(reading, h.Bank),
+		Questions:  toReviewQuestions(reading, h.Bank.Get()),
 	}
 	// Issue #190: the corrected PDF replaces the raw scan once it exists.
 	// The lookup failure is a 500 — same convention as the reading list on

--- a/apps/server/internal/app/web/router.go
+++ b/apps/server/internal/app/web/router.go
@@ -46,6 +46,11 @@ type Deps struct {
 	// piecemeal so a request to /controls/new does not 404 while the row
 	// exists.
 	Controls *handler.Controls
+	// AdminBank is the manual bank-refresh endpoint (issue #230). Small
+	// enough to warrant its own handler struct rather than a method on
+	// Controls: the CRUD lives inside the controls domain, the bank
+	// refresh sits in an /admin/ namespace one layer up.
+	AdminBank *handler.AdminBank
 	// Log is spelled the same here as in the two structs above.
 	Log *slog.Logger
 }
@@ -219,6 +224,12 @@ func routes(deps Deps) []Route {
 			Method: http.MethodPost, Path: handler.ProfessorReactivatePath,
 			Handler: deps.Professors.Reactivate,
 		},
+		// Issue #230: the manual bank-refresh endpoint. Gated by default
+		// (no Public), CSRF enforced because the method is POST.
+		{
+			Method: http.MethodPost, Path: handler.AdminBankRefreshPath,
+			Handler: deps.AdminBank.Refresh,
+		},
 	}
 }
 
@@ -257,6 +268,8 @@ func Router(deps Deps) http.Handler {
 		panic("web.Router: no professors handlers")
 	case deps.Controls == nil:
 		panic("web.Router: no controls handlers")
+	case deps.AdminBank == nil:
+		panic("web.Router: no admin bank handler")
 	case deps.Log == nil:
 		panic("web.Router: no logger")
 	}

--- a/apps/server/internal/app/web/router_test.go
+++ b/apps/server/internal/app/web/router_test.go
@@ -28,16 +28,18 @@ import (
 	"github.com/so77id/nalanda/apps/server/migrations"
 )
 
-// emptyBank returns a valid, empty bank for the router tests — the
-// existing cases do not exercise controls flow, but the constructor
-// refuses a nil bank.
-func emptyBank(t *testing.T) *bank.Bank {
+// emptyBank returns a LiveBank wrapping a valid, empty bank for the router
+// tests — the existing cases do not exercise controls flow, but the
+// handler and service constructors refuse a nil bank. NewStaticLive is
+// the test seam bank added for issue #230; production wiring goes through
+// bank.NewLive.
+func emptyBank(t *testing.T) *bank.LiveBank {
 	t.Helper()
 	b, err := bank.Parse(strings.NewReader(`{"version":1,"documents":[],"questions":[]}`))
 	if err != nil {
 		t.Fatalf("emptyBank: %v", err)
 	}
-	return b
+	return bank.NewStaticLive(b)
 }
 
 // deps builds the surface the way cmd/server does, over a real (empty) database.

--- a/apps/server/internal/app/web/router_test.go
+++ b/apps/server/internal/app/web/router_test.go
@@ -110,6 +110,11 @@ func deps(t *testing.T, prober health.Prober) web.Deps {
 			OnCorrectionClosed: controls.NewNoopHook(logger),
 			Log:                logger,
 		}),
+		AdminBank: handler.NewAdminBank(handler.AdminBank{
+			Bank:      emptyBank(t),
+			PublicURL: "https://nalanda.test",
+			Log:       logger,
+		}),
 		Log: logger,
 	}
 }

--- a/apps/server/internal/app/web/view/templates/layout.html
+++ b/apps/server/internal/app/web/view/templates/layout.html
@@ -43,15 +43,14 @@
         padding: 0.25rem 0.5rem;
         border-radius: 0.375rem;
       }
-      .sections a:hover, .sections a:focus-visible {
-        background: color-mix(in srgb, currentColor 12%, transparent);
-      }
       /* The bank-refresh button (issue #230, ADR-0032 §Addendum) sits beside the section
          links in the top bar and needs to READ as one — a button that
          opens a form flash message, not a page. The `form` is inline so
          the layout stays a single row; the `button` inherits color and
          font from currentColor so it lands in both themes without a
-         second palette. */
+         second palette. The hover/focus rule is shared with .sections a
+         (below) so a future palette tweak on the anchor version cannot
+         drift from the button. */
       .sections form.section-action {
         display: inline;
         margin: 0;
@@ -65,6 +64,7 @@
         border-radius: 0.375rem;
         cursor: pointer;
       }
+      .sections a:hover, .sections a:focus-visible,
       .sections form.section-action button:hover,
       .sections form.section-action button:focus-visible {
         background: color-mix(in srgb, currentColor 12%, transparent);

--- a/apps/server/internal/app/web/view/templates/layout.html
+++ b/apps/server/internal/app/web/view/templates/layout.html
@@ -46,7 +46,7 @@
       .sections a:hover, .sections a:focus-visible {
         background: color-mix(in srgb, currentColor 12%, transparent);
       }
-      /* The bank-refresh button (issue #230) sits beside the section
+      /* The bank-refresh button (issue #230, ADR-0032 §Addendum) sits beside the section
          links in the top bar and needs to READ as one — a button that
          opens a form flash message, not a page. The `form` is inline so
          the layout stays a single row; the `button` inherits color and

--- a/apps/server/internal/app/web/view/templates/layout.html
+++ b/apps/server/internal/app/web/view/templates/layout.html
@@ -46,6 +46,29 @@
       .sections a:hover, .sections a:focus-visible {
         background: color-mix(in srgb, currentColor 12%, transparent);
       }
+      /* The bank-refresh button (issue #230) sits beside the section
+         links in the top bar and needs to READ as one — a button that
+         opens a form flash message, not a page. The `form` is inline so
+         the layout stays a single row; the `button` inherits color and
+         font from currentColor so it lands in both themes without a
+         second palette. */
+      .sections form.section-action {
+        display: inline;
+        margin: 0;
+      }
+      .sections form.section-action button {
+        font: inherit;
+        color: inherit;
+        background: transparent;
+        border: none;
+        padding: 0.25rem 0.5rem;
+        border-radius: 0.375rem;
+        cursor: pointer;
+      }
+      .sections form.section-action button:hover,
+      .sections form.section-action button:focus-visible {
+        background: color-mix(in srgb, currentColor 12%, transparent);
+      }
 
       /* <details>, not a script: the one piece of interactivity this surface
          needs is a dropdown, and the element that does it ships in every
@@ -189,6 +212,10 @@
         <nav class="sections" aria-label="Secciones">
           <span class="brand">Nalanda · administración</span>
           <a href="/professors">Profesores</a>
+          <form method="post" action="/admin/bank/refresh" class="section-action">
+            <input type="hidden" name="csrf_token" value="{{ .CSRFToken }}" />
+            <button type="submit" title="Vuelve a leer questions.json publicado en apps/web">Recargar banco</button>
+          </form>
         </nav>
         <details class="menu">
           <summary>{{ .Professor.Email }}</summary>

--- a/apps/server/internal/domain/controls/annotate_test.go
+++ b/apps/server/internal/domain/controls/annotate_test.go
@@ -36,7 +36,7 @@ func newAnnotateFixture(t *testing.T, annotateEnabled bool) *annotateFixture {
 	readings := newFakeReadingStore()
 	fake := &amctest.Fake{}
 	svc := controls.NewService(controls.Service{
-		Bank:            b,
+		Bank:            bank.NewStaticLive(b),
 		Store:           store,
 		Generator:       fake,
 		Analyzer:        fake,

--- a/apps/server/internal/domain/controls/service.go
+++ b/apps/server/internal/domain/controls/service.go
@@ -66,7 +66,10 @@ func paperOrDefault(p Paper) Paper {
 // re-compile of the same input produces the same draw, ADR-0030's four
 // silent traps need a deterministic input.
 type Service struct {
-	Bank      *bank.Bank
+	// Bank is the live wrapper around the published question bank
+	// (ADR-0032, issue #230). Reads call .Get() to pick up the current
+	// snapshot; the ticker and the admin endpoint rotate it at runtime.
+	Bank      *bank.LiveBank
 	Store     Store
 	Generator Generator
 	// Analyzer and Readings power the WP-F pipeline: upload → analyse →
@@ -157,7 +160,7 @@ type CreateRequest struct {
 // versa — the "the row is committed and the files are on disk, or neither"
 // promise.
 func (s *Service) Create(ctx context.Context, req CreateRequest) (Control, error) {
-	pool, err := s.Bank.Pool(req.RangeFrom, req.RangeTo)
+	pool, err := s.Bank.Get().Pool(req.RangeFrom, req.RangeTo)
 	if err != nil {
 		return Control{}, err
 	}

--- a/apps/server/internal/domain/controls/service_test.go
+++ b/apps/server/internal/domain/controls/service_test.go
@@ -172,7 +172,7 @@ func newService(t *testing.T) (*controls.Service, *fakeStore, *amctest.Fake, str
 	store := newFakeStore()
 	gen := &amctest.Fake{WorkDir: workDir, SujetSize: 42}
 	svc := controls.NewService(controls.Service{
-		Bank:      b,
+		Bank:      bank.NewStaticLive(b),
 		Store:     store,
 		Generator: gen,
 		Analyzer:  gen,
@@ -398,7 +398,7 @@ func TestCreatePassesTheCorrectAbsoluteListingPathForCodeQuestions(t *testing.T)
 	gen := &amctest.Fake{WorkDir: workDir, SujetSize: 4}
 	store := newFakeStore()
 	svc := controls.NewService(controls.Service{
-		Bank: b, Store: store, Generator: gen, Analyzer: gen, Readings: newFakeReadingStore(),
+		Bank: bank.NewStaticLive(b), Store: store, Generator: gen, Analyzer: gen, Readings: newFakeReadingStore(),
 		Annotator: gen, AnnotateEnabled: true,
 		WorkDir: workDir,
 		Now:     func() time.Time { return time.Now() }, Seed: 1,

--- a/apps/server/internal/domain/course/bank/bank.go
+++ b/apps/server/internal/domain/course/bank/bank.go
@@ -7,6 +7,13 @@
 // A shape change is a cross-app breaking change and carries a version field —
 // this reader refuses anything but version 1, so drift shows up at boot rather
 // than as a subtle misread later.
+//
+// Since issue #230 the bank is served through LiveBank rather than a bare
+// *Bank pointer: apps/web is the source of truth, and this reader now
+// rotates its in-memory snapshot when apps/web publishes a new
+// questions.json. NewLive performs the boot fetch and returns the wrapper;
+// callers rotate it via Reload (with 304 semantics) and get the current
+// snapshot via Get, which never holds a lock on the read path.
 package bank
 
 import (
@@ -15,17 +22,18 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"os"
+	"sync"
+	"sync/atomic"
 	"time"
 )
 
-// Bank is the whole published set, held in memory. Load reads it once at boot
-// (cmd/server) and hands the *Bank down; nothing here refreshes at runtime.
-// The runtime refresh comes with an apps/web redeploy followed by an
-// apps/server redeploy, which is enough at this scale (issue #166 §Bank
-// reader).
+// Bank is the whole published set, held in memory. NewLive reads it once at
+// boot (cmd/server) and hands a *LiveBank down; Reload rotates the *Bank
+// atomically at runtime (issue #230).
 type Bank struct {
 	Version   int
 	Documents []Document
@@ -83,19 +91,18 @@ type SectionRef struct {
 	Section  string
 }
 
-// FetchTimeout bounds a boot fetch. Long enough to survive a slow start on
-// GitHub Pages, short enough that a completely dead URL fails the boot
-// rather than hanging it. It is the boot budget, not a request-time budget:
-// nothing refreshes the bank at runtime, so a slow fetch here is a slow
-// server start and not a slow user request.
+// FetchTimeout bounds a single fetch. Long enough to survive a slow start
+// on GitHub Pages, short enough that a completely dead URL fails one
+// refresh cycle rather than hanging it. Applied both at boot (NewLive) and
+// on every subsequent Reload.
 const FetchTimeout = 30 * time.Second
 
 // The failure modes callers branch on, wrapped so a caller can tell them
 // apart with errors.Is without importing json or net/http.
 var (
-	// ErrUnsupportedScheme wraps a Load call whose URL is neither http, https
-	// nor file. The design closed transport in ADR-0032 §C14; this refuses to
-	// widen it by accident.
+	// ErrUnsupportedScheme wraps a URL whose scheme is neither http, https
+	// nor file. The design closed transport in ADR-0032 §C14; this refuses
+	// to widen it by accident.
 	ErrUnsupportedScheme = errors.New("bank: URL scheme must be http, https or file")
 
 	// ErrUnsupportedVersion is a bank with a version this reader does not know
@@ -129,51 +136,191 @@ var (
 	ErrDuplicateQuestionID = errors.New("bank: duplicate question id")
 )
 
-// Load fetches the bank from URL and parses it. Blocking, once, at boot.
+// errNotModified is the private sentinel fetch returns when a conditional
+// GET was answered 304. Reload consumes it and returns (updated=false,
+// err=nil): "the source is unchanged" is not a failure a caller wants to
+// distinguish from a successful refresh, it is just quieter.
+var errNotModified = errors.New("bank: not modified")
+
+// LiveBank wraps a *Bank so the boot snapshot can be swapped at runtime
+// without a lock on the read path.
 //
-// http/https use the default client with a bounded context; file:// is opened
-// against the local filesystem. A path escape check would be the wrong
-// mitigation here: the URL is operator-supplied at boot and reaching it is
-// the operator's decision, exactly like NALANDA_DATABASE_URL.
-func Load(ctx context.Context, rawURL string) (*Bank, error) {
-	parsed, err := url.Parse(rawURL)
+// The published questions.json (ADR-0032) is the source of truth. Since
+// issue #230 the server refreshes its in-memory bank on a schedule
+// (background ticker, S2) and via a manual admin endpoint (S3); the swap
+// is atomic, and a failed refresh preserves the current snapshot rather
+// than nilling it out — a network flap or a bad publish must not leave
+// the server serving nothing.
+//
+// A pointer captured by a reader before a Reload keeps naming the previous
+// snapshot: the atomic pointer rotates, the *Bank it points at does not
+// mutate. That is what makes concurrent requests safe without locking the
+// read path.
+type LiveBank struct {
+	url    string
+	logger *slog.Logger
+
+	// static is set by NewStaticLive; Reload is a no-op on a static bank.
+	// This is a test seam other packages need (their handler/service
+	// constructors take a *LiveBank now).
+	static bool
+
+	snap atomic.Pointer[Bank]
+
+	// reloadMu serializes Reload so a manual click that races the ticker
+	// does not send two GETs and race the two Stores against each other.
+	// NEVER held while a reader calls Get() — readers touch snap and
+	// nothing else.
+	reloadMu     sync.Mutex
+	lastModified string // guarded by reloadMu
+}
+
+// NewLive fetches the bank once and returns a LiveBank whose Get() serves
+// that snapshot. Callers wire the background refresh (via Watch) and/or
+// the manual admin endpoint separately.
+//
+// A boot failure is a startup failure, deliberately: the same rule Load
+// followed. An operator sees "questions.json refused to load" immediately
+// rather than as a first-request failure later.
+func NewLive(ctx context.Context, rawURL string, logger *slog.Logger) (*LiveBank, error) {
+	if logger == nil {
+		return nil, errors.New("bank: NewLive requires a logger")
+	}
+	lb := &LiveBank{url: rawURL, logger: logger}
+	b, lastMod, err := lb.fetch(ctx, "")
 	if err != nil {
-		return nil, fmt.Errorf("bank: parse URL %q: %w", rawURL, err)
+		return nil, err
+	}
+	lb.snap.Store(b)
+	lb.lastModified = lastMod
+	logger.Info("question bank loaded",
+		"url", rawURL,
+		"documents", len(b.Documents),
+		"questions", len(b.Questions),
+	)
+	return lb, nil
+}
+
+// NewStaticLive wraps a parsed Bank in a LiveBank whose Reload is a no-op.
+//
+// It exists for tests in other packages that hand a fixed bank into
+// constructors that take a *LiveBank now; production code goes through
+// NewLive. Its logger discards output — tests that need to observe log
+// lines build their own *LiveBank against httptest.
+func NewStaticLive(b *Bank) *LiveBank {
+	lb := &LiveBank{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		static: true,
+	}
+	lb.snap.Store(b)
+	return lb
+}
+
+// Get returns the current bank snapshot. Never nil once NewLive returned;
+// a reader may hold the pointer past a subsequent Reload and keep seeing
+// the same snapshot.
+func (lb *LiveBank) Get() *Bank {
+	return lb.snap.Load()
+}
+
+// URL returns the URL this bank was loaded from. Handlers use it in log
+// lines that report a manual refresh outcome.
+func (lb *LiveBank) URL() string {
+	return lb.url
+}
+
+// Reload attempts to refresh the bank in place. It returns:
+//
+//   - (true, nil)  the server answered 200 and the snapshot was swapped.
+//   - (false, nil) the server answered 304, or this is a static bank — nothing to do.
+//   - (false, err) the fetch or parse failed; the current snapshot is preserved.
+//
+// A failure is a WARN in the logger: an operator reading logs sees which
+// refresh failed and why, and the server keeps serving the last known
+// good bank. A successful update is an INFO with document + question
+// counts, so a comparison across boots is one grep away.
+func (lb *LiveBank) Reload(ctx context.Context) (bool, error) {
+	if lb.static {
+		return false, nil
+	}
+
+	lb.reloadMu.Lock()
+	defer lb.reloadMu.Unlock()
+
+	b, lastMod, err := lb.fetch(ctx, lb.lastModified)
+	if err != nil {
+		if errors.Is(err, errNotModified) {
+			lb.logger.Debug("question bank unchanged", "url", lb.url)
+			return false, nil
+		}
+		lb.logger.Warn("question bank refresh failed", "url", lb.url, "error", err)
+		return false, err
+	}
+	lb.snap.Store(b)
+	lb.lastModified = lastMod
+	lb.logger.Info("bank refreshed",
+		"url", lb.url,
+		"documents", len(b.Documents),
+		"questions", len(b.Questions),
+	)
+	return true, nil
+}
+
+// fetch reads the bank from lb.url. ifModifiedSince, when non-empty, is
+// sent as If-Modified-Since; the server may then answer 304, and fetch
+// returns errNotModified with a nil *Bank. The returned lastModified is
+// the header the next call should echo back — empty for file:// (which
+// re-parses every call, since it is a dev-only scheme per
+// NALANDA_QUESTIONS_JSON_URL docs) or for an HTTP response without the
+// header.
+func (lb *LiveBank) fetch(ctx context.Context, ifModifiedSince string) (*Bank, string, error) {
+	parsed, err := url.Parse(lb.url)
+	if err != nil {
+		return nil, "", fmt.Errorf("bank: parse URL %q: %w", lb.url, err)
 	}
 	switch parsed.Scheme {
 	case "http", "https":
-		return loadHTTP(ctx, rawURL)
+		return fetchHTTP(ctx, lb.url, ifModifiedSince)
 	case "file":
-		// url.Parse folds a file:/// path into .Path. Empty means the URL was
-		// nothing after the scheme, which is not a location we can open.
 		if parsed.Path == "" {
-			return nil, fmt.Errorf("bank: file URL %q names no path", rawURL)
+			return nil, "", fmt.Errorf("bank: file URL %q names no path", lb.url)
 		}
-		return loadFile(parsed.Path)
+		b, err := loadFile(parsed.Path)
+		return b, "", err
 	default:
-		return nil, fmt.Errorf("%w: got %q in %s", ErrUnsupportedScheme, parsed.Scheme, rawURL)
+		return nil, "", fmt.Errorf("%w: got %q in %s", ErrUnsupportedScheme, parsed.Scheme, lb.url)
 	}
 }
 
-func loadHTTP(ctx context.Context, u string) (*Bank, error) {
+func fetchHTTP(ctx context.Context, u, ifModifiedSince string) (*Bank, string, error) {
 	ctx, cancel := context.WithTimeout(ctx, FetchTimeout)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
 	if err != nil {
-		return nil, fmt.Errorf("bank: build request for %s: %w", u, err)
+		return nil, "", fmt.Errorf("bank: build request for %s: %w", u, err)
+	}
+	if ifModifiedSince != "" {
+		req.Header.Set("If-Modified-Since", ifModifiedSince)
 	}
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("bank: fetch %s: %w", u, err)
+		return nil, "", fmt.Errorf("bank: fetch %s: %w", u, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusNotModified {
+		return nil, "", errNotModified
+	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("bank: %s answered %s", u, resp.Status)
+		return nil, "", fmt.Errorf("bank: %s answered %s", u, resp.Status)
 	}
 	// The bank is small (kilobytes); anything approaching this cap is a wrong
 	// URL pointing at the whole site rather than the artifact.
 	const maxRead = 32 << 20
-	return Parse(io.LimitReader(resp.Body, maxRead))
+	b, err := Parse(io.LimitReader(resp.Body, maxRead))
+	if err != nil {
+		return nil, "", err
+	}
+	return b, resp.Header.Get("Last-Modified"), nil
 }
 
 func loadFile(path string) (*Bank, error) {

--- a/apps/server/internal/domain/course/bank/bank.go
+++ b/apps/server/internal/domain/course/bank/bank.go
@@ -266,6 +266,30 @@ func (lb *LiveBank) Reload(ctx context.Context) (bool, error) {
 	return true, nil
 }
 
+// Watch calls Reload on interval until ctx is done. A zero or negative
+// interval returns immediately — the operator's opt-out, wired through
+// NALANDA_BANK_REFRESH_INTERVAL. Errors surface through the logger:
+// Reload already logs a Warn on failure and Info on a real update, so
+// this loop cannot itself add a signal a caller would react to.
+//
+// A static bank (built by NewStaticLive for tests) has no source to poll,
+// so Watch is a no-op there.
+func (lb *LiveBank) Watch(ctx context.Context, interval time.Duration) {
+	if interval <= 0 || lb.static {
+		return
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			_, _ = lb.Reload(ctx)
+		}
+	}
+}
+
 // fetch reads the bank from lb.url. ifModifiedSince, when non-empty, is
 // sent as If-Modified-Since; the server may then answer 304, and fetch
 // returns errNotModified with a nil *Bank. The returned lastModified is

--- a/apps/server/internal/domain/course/bank/bank_test.go
+++ b/apps/server/internal/domain/course/bank/bank_test.go
@@ -521,6 +521,73 @@ func TestReloadEmitsSlogInfoOnUpdate(t *testing.T) {
 	}
 }
 
+// TestWatchTicksAndCancels is the observable half of S2's contract: given a
+// non-zero interval, Watch calls Reload on the tick, and returns as soon as
+// the context is cancelled. The test uses a short interval and a channel to
+// avoid a sleep the race detector would flake on.
+func TestWatchTicksAndCancels(t *testing.T) {
+	seen := make(chan struct{}, 10)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(fixtureJSON))
+		select {
+		case seen <- struct{}{}:
+		default:
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	lb, err := bank.NewLive(context.Background(), srv.URL+"/questions.json", testLogger())
+	if err != nil {
+		t.Fatalf("NewLive: %v", err)
+	}
+
+	// Drain the boot fetch signal so the count below is only ticks.
+	<-seen
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		lb.Watch(ctx, 5*time.Millisecond)
+		close(done)
+	}()
+
+	// Wait for at least two ticks — enough to prove the ticker fires more
+	// than once (the mistake a bare goroutine + Reload would make).
+	for i := 0; i < 2; i++ {
+		select {
+		case <-seen:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("no tick after 2s (saw %d)", i)
+		}
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Watch did not return after ctx cancel")
+	}
+}
+
+// TestWatchWithZeroIntervalReturnsImmediately guards the operator's opt-out:
+// setting NALANDA_BANK_REFRESH_INTERVAL=0 disables the ticker, and Watch
+// must not park on a nil ticker channel forever.
+func TestWatchWithZeroIntervalReturnsImmediately(t *testing.T) {
+	lb := bank.NewStaticLive(parse(t))
+
+	done := make(chan struct{})
+	go func() {
+		lb.Watch(context.Background(), 0)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Watch(0) did not return; the opt-out is not wired")
+	}
+}
+
 // TestStaticLiveExposesAFixedBank is the shim other packages' tests use to
 // hand a bank into constructors that now take *LiveBank. Reload on a static
 // bank is a no-op — the fixture never changes.

--- a/apps/server/internal/domain/course/bank/bank_test.go
+++ b/apps/server/internal/domain/course/bank/bank_test.go
@@ -1,14 +1,19 @@
 package bank_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/so77id/nalanda/apps/server/internal/domain/course/bank"
 )
@@ -37,6 +42,30 @@ const fixtureJSON = `{
 }
 `
 
+// fixtureJSONExtra adds one more document ("nuevo/basico") so a Reload can
+// prove it observed the site's publish rather than the boot snapshot.
+const fixtureJSONExtra = `{
+  "version": 1,
+  "documents": [
+    {"id": "welcome",   "title": "Bienvenida",   "coverage": "clase 0",     "sections": ["hola", "reglas"]},
+    {"id": "flujo",     "title": "Flujo",        "coverage": "clase 2",     "sections": ["if-else", "bucles", "cortes"]},
+    {"id": "arreglos",  "title": "Arreglos",     "coverage": "clase 3",     "sections": ["basico", "longitud"]},
+    {"id": "nuevo",     "title": "Nuevo",        "coverage": "clase 4",     "sections": ["basico"]}
+  ],
+  "questions": [
+    {"id": "q-hola-1",       "document": "welcome",  "anchor": "hola",      "type": "simple",   "statement": "¿Qué es Nalanda?", "code": null, "alternatives": ["una plataforma","un lenguaje"], "correct": [0]},
+    {"id": "q-reglas-1",     "document": "welcome",  "anchor": "reglas",    "type": "simple",   "statement": "R1?",              "code": null, "alternatives": ["a","b"],                             "correct": [0]},
+    {"id": "q-orphan",       "document": "welcome",  "anchor": null,        "type": "simple",   "statement": "S/A",              "code": null, "alternatives": ["a","b"],                             "correct": [1]},
+    {"id": "q-if-1",         "document": "flujo",    "anchor": "if-else",   "type": "simple",   "statement": "if?",              "code": null, "alternatives": ["a","b"],                             "correct": [0]},
+    {"id": "q-bucles-1",     "document": "flujo",    "anchor": "bucles",    "type": "multiple", "statement": "¿Cuáles bucles?",  "code": null, "alternatives": ["for","while","hazlo","ninguno"],     "correct": [0,1]},
+    {"id": "q-cortes-1",     "document": "flujo",    "anchor": "cortes",    "type": "simple",   "statement": "corte?",           "code": null, "alternatives": ["a","b"],                             "correct": [0]},
+    {"id": "q-arr-basico-1", "document": "arreglos", "anchor": "basico",    "type": "simple",   "statement": "arr?",             "code": {"language": "java", "source": "int[] a = new int[3];"}, "alternatives": ["a","b"], "correct": [0]},
+    {"id": "q-arr-longitud-1","document": "arreglos","anchor": "longitud",  "type": "simple",   "statement": "longitud?",        "code": null, "alternatives": ["a.length","a.length()"],             "correct": [0]},
+    {"id": "q-nuevo-1",      "document": "nuevo",    "anchor": "basico",    "type": "simple",   "statement": "nuevo?",           "code": null, "alternatives": ["a","b"],                             "correct": [0]}
+  ]
+}
+`
+
 func parse(t *testing.T) *bank.Bank {
 	t.Helper()
 	b, err := bank.Parse(strings.NewReader(fixtureJSON))
@@ -44,6 +73,10 @@ func parse(t *testing.T) *bank.Bank {
 		t.Fatalf("Parse fixture: %v", err)
 	}
 	return b
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
 func TestParseHoldsEveryFieldTheContractCarries(t *testing.T) {
@@ -261,55 +294,250 @@ func TestFindDocumentAndHasSection(t *testing.T) {
 	}
 }
 
-func TestLoadFileScheme(t *testing.T) {
+// --- LiveBank / NewLive / Reload (issue #230, S1) -----------------------------
+
+func TestNewLiveLoadsInitialBankFromFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "questions.json")
 	if err := os.WriteFile(path, []byte(fixtureJSON), 0o600); err != nil {
 		t.Fatalf("write fixture: %v", err)
 	}
 
-	b, err := bank.Load(context.Background(), "file://"+path)
+	lb, err := bank.NewLive(context.Background(), "file://"+path, testLogger())
 	if err != nil {
-		t.Fatalf("Load(file): %v", err)
+		t.Fatalf("NewLive(file): %v", err)
+	}
+	b := lb.Get()
+	if b == nil {
+		t.Fatal("Get() after NewLive returned nil")
 	}
 	if len(b.Documents) != 3 {
-		t.Errorf("Load(file) returned %d documents, want 3", len(b.Documents))
+		t.Errorf("Get().Documents = %d, want 3", len(b.Documents))
 	}
 }
 
-func TestLoadHTTPScheme(t *testing.T) {
+func TestNewLiveLoadsInitialBankFromHTTP(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
 		_, _ = w.Write([]byte(fixtureJSON))
 	}))
 	t.Cleanup(srv.Close)
 
-	b, err := bank.Load(context.Background(), srv.URL+"/questions.json")
+	lb, err := bank.NewLive(context.Background(), srv.URL+"/questions.json", testLogger())
 	if err != nil {
-		t.Fatalf("Load(http): %v", err)
+		t.Fatalf("NewLive(http): %v", err)
 	}
-	if len(b.Documents) != 3 {
-		t.Errorf("Load(http) returned %d documents, want 3", len(b.Documents))
+	if got := len(lb.Get().Documents); got != 3 {
+		t.Errorf("Get().Documents = %d, want 3", got)
 	}
 }
 
-func TestLoadRejectsUnsupportedScheme(t *testing.T) {
-	_, err := bank.Load(context.Background(), "ftp://example.com/questions.json")
+func TestNewLiveRejectsUnsupportedScheme(t *testing.T) {
+	_, err := bank.NewLive(context.Background(), "ftp://example.com/questions.json", testLogger())
 	if !errors.Is(err, bank.ErrUnsupportedScheme) {
-		t.Errorf("Load(ftp): %v, want ErrUnsupportedScheme", err)
+		t.Errorf("NewLive(ftp): %v, want ErrUnsupportedScheme", err)
 	}
 }
 
-func TestLoadHTTPReportsNon200(t *testing.T) {
+func TestNewLiveReportsHTTPNon200(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "gone", http.StatusGone)
 	}))
 	t.Cleanup(srv.Close)
 
-	_, err := bank.Load(context.Background(), srv.URL+"/questions.json")
+	_, err := bank.NewLive(context.Background(), srv.URL+"/questions.json", testLogger())
 	if err == nil {
-		t.Fatal("Load(410): no error")
+		t.Fatal("NewLive(410): no error")
 	}
 	if !strings.Contains(err.Error(), "410") {
 		t.Errorf("error %q does not name status 410", err.Error())
+	}
+}
+
+// TestReloadAtomicallySwapsWithoutInvalidatingPriorSnapshot is the whole point
+// of atomic.Pointer: a reader holding a *Bank captured before Reload keeps
+// seeing the old snapshot; a reader that calls Get() again after Reload sees
+// the new one. Nothing in the middle observes a nil.
+func TestReloadAtomicallySwapsWithoutInvalidatingPriorSnapshot(t *testing.T) {
+	var body atomic.Pointer[string]
+	initial := fixtureJSON
+	body.Store(&initial)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Last-Modified", time.Now().UTC().Format(http.TimeFormat))
+		_, _ = w.Write([]byte(*body.Load()))
+	}))
+	t.Cleanup(srv.Close)
+
+	lb, err := bank.NewLive(context.Background(), srv.URL+"/questions.json", testLogger())
+	if err != nil {
+		t.Fatalf("NewLive: %v", err)
+	}
+	before := lb.Get()
+	if len(before.Documents) != 3 {
+		t.Fatalf("before.Documents = %d, want 3", len(before.Documents))
+	}
+
+	// The site publishes.
+	extra := fixtureJSONExtra
+	body.Store(&extra)
+
+	updated, err := lb.Reload(context.Background())
+	if err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if !updated {
+		t.Errorf("Reload: updated=false, want true (the body changed)")
+	}
+
+	after := lb.Get()
+	if len(after.Documents) != 4 {
+		t.Errorf("after.Documents = %d, want 4 (Reload did not swap)", len(after.Documents))
+	}
+
+	// The pointer captured before Reload is UNCHANGED — atomic.Pointer stores
+	// pointers, it does not mutate the underlying struct.
+	if len(before.Documents) != 3 {
+		t.Errorf("before.Documents mutated to %d — the swap must not touch a prior snapshot",
+			len(before.Documents))
+	}
+	if before == after {
+		t.Error("Get() returned the same pointer before and after Reload; the swap did not happen")
+	}
+}
+
+// TestReloadIsNoOpOn304 covers the conditional-GET path: after a successful
+// load the LiveBank remembers the Last-Modified header, and a subsequent
+// Reload sends If-Modified-Since; when the server answers 304 the snapshot
+// pointer is unchanged and Reload reports updated=false.
+func TestReloadIsNoOpOn304(t *testing.T) {
+	const lastMod = "Mon, 25 Aug 2026 12:00:00 GMT"
+	var calls atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		if r.Header.Get("If-Modified-Since") != "" {
+			// A conditional GET AFTER the initial load. Answer 304 to prove
+			// the server can veto the parse without sending a body.
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Last-Modified", lastMod)
+		_, _ = w.Write([]byte(fixtureJSON))
+	}))
+	t.Cleanup(srv.Close)
+
+	lb, err := bank.NewLive(context.Background(), srv.URL+"/questions.json", testLogger())
+	if err != nil {
+		t.Fatalf("NewLive: %v", err)
+	}
+	before := lb.Get()
+
+	updated, err := lb.Reload(context.Background())
+	if err != nil {
+		t.Fatalf("Reload(304): %v", err)
+	}
+	if updated {
+		t.Errorf("Reload: updated=true on 304, want false")
+	}
+	if lb.Get() != before {
+		t.Errorf("Get() pointer changed on 304 — the snapshot must survive a not-modified answer")
+	}
+	if calls.Load() != 2 {
+		t.Errorf("server saw %d requests, want 2 (initial + conditional)", calls.Load())
+	}
+}
+
+// TestReloadPreservesSnapshotOnServerError guards the escape-hatch promise: a
+// GH Pages outage, a malformed response, a network flap — none may nil the
+// snapshot. The server keeps serving the last known good bank.
+func TestReloadPreservesSnapshotOnServerError(t *testing.T) {
+	var down atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if down.Load() {
+			http.Error(w, "gone", http.StatusGone)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(fixtureJSON))
+	}))
+	t.Cleanup(srv.Close)
+
+	lb, err := bank.NewLive(context.Background(), srv.URL+"/questions.json", testLogger())
+	if err != nil {
+		t.Fatalf("NewLive: %v", err)
+	}
+	before := lb.Get()
+
+	down.Store(true)
+	updated, err := lb.Reload(context.Background())
+	if err == nil {
+		t.Fatal("Reload(down): no error, want one")
+	}
+	if updated {
+		t.Errorf("Reload(down): updated=true, want false")
+	}
+	if got := lb.Get(); got != before {
+		t.Errorf("Get() after failed Reload returned a different pointer — the escape hatch nilled the snapshot")
+	}
+	if got := lb.Get(); got == nil || len(got.Documents) != 3 {
+		t.Errorf("Get() after failed Reload = %v, want the boot snapshot", got)
+	}
+}
+
+// TestReloadEmitsSlogInfoOnUpdate is the observability half of the promise:
+// an operator reading logs sees which reload actually rotated the bank.
+func TestReloadEmitsSlogInfoOnUpdate(t *testing.T) {
+	var body atomic.Pointer[string]
+	initial := fixtureJSON
+	body.Store(&initial)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(*body.Load()))
+	}))
+	t.Cleanup(srv.Close)
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	lb, err := bank.NewLive(context.Background(), srv.URL+"/questions.json", logger)
+	if err != nil {
+		t.Fatalf("NewLive: %v", err)
+	}
+	buf.Reset() // discard the boot log line
+
+	extra := fixtureJSONExtra
+	body.Store(&extra)
+	if _, err := lb.Reload(context.Background()); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+
+	got := buf.String()
+	for _, want := range []string{`"level":"INFO"`, `"documents":4`, `"questions":9`, `bank refreshed`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("info log missing %q\n---\n%s", want, got)
+		}
+	}
+}
+
+// TestStaticLiveExposesAFixedBank is the shim other packages' tests use to
+// hand a bank into constructors that now take *LiveBank. Reload on a static
+// bank is a no-op — the fixture never changes.
+func TestStaticLiveExposesAFixedBank(t *testing.T) {
+	b := parse(t)
+	lb := bank.NewStaticLive(b)
+	if lb.Get() != b {
+		t.Error("StaticLive.Get() returned a different pointer than the one it was built from")
+	}
+	updated, err := lb.Reload(context.Background())
+	if err != nil {
+		t.Errorf("StaticLive.Reload: err = %v, want nil (static bank has no source)", err)
+	}
+	if updated {
+		t.Error("StaticLive.Reload: updated=true, want false")
+	}
+	if lb.Get() != b {
+		t.Error("StaticLive.Get() changed after Reload; a static bank never rotates")
 	}
 }

--- a/apps/server/internal/infra/config/config.go
+++ b/apps/server/internal/infra/config/config.go
@@ -85,10 +85,24 @@ const (
 	// escape hatch if the AMC-patching approach breaks against a real
 	// batch in production.
 	KeyAnnotateEnabled = "NALANDA_ANNOTATE_ENABLED"
+
+	// KeyBankRefreshInterval is the cadence at which LiveBank.Watch calls
+	// Reload against NALANDA_QUESTIONS_JSON_URL (issue #230). Optional —
+	// defaults to 5 minutes, which matches the Watchtower poll cadence on
+	// the Jetson deploy so the server refreshes at the same rhythm as
+	// container updates. "0s" disables the ticker, and then the manual
+	// admin button is the only refresh path.
+	KeyBankRefreshInterval = "NALANDA_BANK_REFRESH_INTERVAL"
 )
 
 // defaultMaxScanMB is what an unset KeyMaxScanMB resolves to.
 const defaultMaxScanMB = 100
+
+// defaultBankRefreshInterval is what an unset KeyBankRefreshInterval
+// resolves to. Five minutes matches the Watchtower poll cadence on the
+// Jetson (ADR-0038, `docs/decisions/0032-*`) — the server refreshes its
+// bank at the same rhythm the container itself updates.
+const defaultBankRefreshInterval = 5 * time.Minute
 
 // ErrMissing is wrapped by every error caused by an absent or empty required
 // variable, so a caller can distinguish "the operator has not finished
@@ -173,6 +187,12 @@ type Config struct {
 	// AnnotateEnabled is the annotate loop's master switch (issue #190).
 	// True unless KeyAnnotateEnabled is explicitly "false".
 	AnnotateEnabled bool
+
+	// BankRefreshInterval is how often LiveBank.Watch polls
+	// QuestionsJSONURL for a fresh questions.json (issue #230). Zero
+	// disables the ticker; a positive Go duration overrides the 5-minute
+	// default.
+	BankRefreshInterval time.Duration
 }
 
 // Keys lists every variable this package reads, in the order an operator would
@@ -185,6 +205,7 @@ func Keys() []string {
 		KeySessionTTL, KeyBootstrapProfessorEmail, KeyTrustProxyHeaders,
 		KeyQuestionsJSONURL, KeyAmcWorkerURL, KeyWorkDir,
 		KeyMaxScanMB, KeyAnnotateEnabled,
+		KeyBankRefreshInterval,
 	}
 }
 
@@ -296,6 +317,20 @@ func Load(lookup LookupFunc) (Config, error) {
 	}
 	cfg.MaxScanBytes = int64(maxScanMB) * (1 << 20)
 
+	rawInterval := l.optional(KeyBankRefreshInterval, "")
+	if rawInterval == "" {
+		cfg.BankRefreshInterval = defaultBankRefreshInterval
+	} else {
+		interval, err := time.ParseDuration(rawInterval)
+		if err != nil {
+			return Config{}, fmt.Errorf("%s=%q is not a duration: %w", KeyBankRefreshInterval, rawInterval, err)
+		}
+		if interval < 0 {
+			return Config{}, fmt.Errorf("%s=%v is negative; zero disables the ticker and a positive duration overrides the default", KeyBankRefreshInterval, interval)
+		}
+		cfg.BankRefreshInterval = interval
+	}
+
 	return cfg, nil
 }
 
@@ -368,6 +403,7 @@ func (c Config) LogValue() slog.Value {
 		slog.String("amc_worker_url", c.AmcWorkerURL),
 		slog.String("work_dir", c.WorkDir),
 		slog.Bool("annotate_enabled", c.AnnotateEnabled),
+		slog.String("bank_refresh_interval", c.BankRefreshInterval.String()),
 	)
 }
 
@@ -376,10 +412,11 @@ func (c Config) LogValue() slog.Value {
 // either.
 func (c Config) String() string {
 	return fmt.Sprintf(
-		"config{addr:%s database:%s log_level:%s public_url:%s google_client_id:%s session_ttl:%s bootstrap_email_set:%t trust_proxy_headers:%t questions_json_url:%s amc_worker_url:%s work_dir:%s annotate_enabled:%t}",
+		"config{addr:%s database:%s log_level:%s public_url:%s google_client_id:%s session_ttl:%s bootstrap_email_set:%t trust_proxy_headers:%t questions_json_url:%s amc_worker_url:%s work_dir:%s annotate_enabled:%t bank_refresh_interval:%s}",
 		c.Addr, c.SafeDatabaseURL(), c.LogLevel, c.PublicURL, c.GoogleClientID,
 		c.SessionTTL, c.BootstrapProfessorEmail != "", c.TrustProxyHeaders,
 		c.QuestionsJSONURL, c.AmcWorkerURL, c.WorkDir, c.AnnotateEnabled,
+		c.BankRefreshInterval,
 	)
 }
 

--- a/apps/server/internal/infra/config/config_test.go
+++ b/apps/server/internal/infra/config/config_test.go
@@ -359,6 +359,78 @@ func TestSafeDatabaseURL(t *testing.T) {
 	}
 }
 
+// BankRefreshInterval (issue #230) is the ticker cadence for the bank
+// hot-refresh. Optional, defaults to 5 minutes; zero disables the ticker
+// (an operator can run without background polling and rely on the
+// manual admin button); a negative duration is a startup error rather
+// than a silent fall.
+func TestBankRefreshInterval(t *testing.T) {
+	t.Run("defaults to five minutes when unset", func(t *testing.T) {
+		e := env()
+		delete(e, "NALANDA_BANK_REFRESH_INTERVAL")
+
+		cfg, err := config.Load(lookupFrom(e))
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if got := cfg.BankRefreshInterval; got != 5*60*1_000_000_000 {
+			t.Errorf("BankRefreshInterval = %v, want 5m — the Watchtower poll cadence on the Jetson", got)
+		}
+	})
+
+	t.Run("accepts a duration override", func(t *testing.T) {
+		e := env()
+		e["NALANDA_BANK_REFRESH_INTERVAL"] = "30s"
+
+		cfg, err := config.Load(lookupFrom(e))
+		if err != nil {
+			t.Fatalf("Load: %v", err)
+		}
+		if got := cfg.BankRefreshInterval; got.String() != "30s" {
+			t.Errorf("BankRefreshInterval = %v, want 30s", got)
+		}
+	})
+
+	t.Run("zero disables the ticker without error", func(t *testing.T) {
+		e := env()
+		e["NALANDA_BANK_REFRESH_INTERVAL"] = "0s"
+
+		cfg, err := config.Load(lookupFrom(e))
+		if err != nil {
+			t.Fatalf("Load(0s): %v — zero is the operator's opt-out, not an error", err)
+		}
+		if cfg.BankRefreshInterval != 0 {
+			t.Errorf("BankRefreshInterval = %v, want 0", cfg.BankRefreshInterval)
+		}
+	})
+
+	t.Run("rejects a negative duration", func(t *testing.T) {
+		e := env()
+		e["NALANDA_BANK_REFRESH_INTERVAL"] = "-1s"
+
+		_, err := config.Load(lookupFrom(e))
+		if err == nil {
+			t.Fatal("Load(-1s): no error, want one — a negative interval never fires")
+		}
+		if !strings.Contains(err.Error(), "NALANDA_BANK_REFRESH_INTERVAL") {
+			t.Errorf("error = %q, want it to name the key", err)
+		}
+	})
+
+	t.Run("rejects a value that is not a duration", func(t *testing.T) {
+		e := env()
+		e["NALANDA_BANK_REFRESH_INTERVAL"] = "five minutes"
+
+		_, err := config.Load(lookupFrom(e))
+		if err == nil {
+			t.Fatal("Load(non-duration): no error, want one")
+		}
+		if !strings.Contains(err.Error(), "NALANDA_BANK_REFRESH_INTERVAL") {
+			t.Errorf("error = %q, want it to name the key", err)
+		}
+	})
+}
+
 // The annotate switch parses through the same strictBool helper as the
 // proxy-trust flag (issue #190). The difference that needs its own test is
 // the DEFAULT: true, because the flow is on unless the operator explicitly

--- a/docs/decisions/0032-the-published-question-bank-is-the-contract.md
+++ b/docs/decisions/0032-the-published-question-bank-is-the-contract.md
@@ -189,9 +189,17 @@ read path.
 
 - **The reader is now a lifecycle, not a one-shot.** Callers hold a
   `*bank.LiveBank` rather than a `*bank.Bank`; every consumer resolves the
-  current snapshot with `.Get()` at method entry. The static shim
-  `bank.NewStaticLive(*Bank)` covers tests that hand a fixed bank into
-  constructors that now take the live wrapper.
+  current snapshot with `.Get()`. The atomicity guarantee is
+  **per-call**, not per-request: a handler that validates in one `.Get()`
+  and then hands the request to the service, which resolves another
+  `.Get()`, can straddle a swap. The failure mode is small (a picker
+  validation against snapshot A followed by a pool draw against snapshot
+  B) and no worse than any other read against a slowly-changing store;
+  the WP review of #230 (IMPORTANT-3) pinned the distinction so future
+  readers do not confuse per-call atomicity with request-level
+  consistency. The static shim `bank.NewStaticLive(*Bank)` covers tests
+  that hand a fixed bank into constructors that now take the live
+  wrapper.
 - **A boot log line is expected on every start.** Same message as before
   (`question bank loaded`), plus a `bank refreshed` on each cycle the source
   actually moved and a `question bank refresh failed` when a cycle fails —

--- a/docs/decisions/0032-the-published-question-bank-is-the-contract.md
+++ b/docs/decisions/0032-the-published-question-bank-is-the-contract.md
@@ -122,6 +122,85 @@ requirement the id exists for.
 - The section spine the artifact carries is produced from the SOURCE, which
   ADR-0021 had rejected. See that ADR's amendment.
 
+## Addendum — 2026-08-26 — the server refreshes the bank in place (issue #230)
+
+**Context.** Until this WP, `apps/server` read `questions.json` once at boot
+and never refreshed it: a redeploy of `apps/web` left the server serving the
+pre-publish snapshot until an operator restarted the container. The
+first-reported symptom (2026-08-26) was that a new control's picker did not
+show two just-published Complejidad chapters — the site had 9 documents / 84
+questions, the server still held 7 / 66. `docker-compose restart server` on
+the Jetson fixed it in ~30 seconds; that path is invisible to the professor,
+racy with in-flight requests, needs SSH, and does not scale as Miguel
+publishes more content.
+
+**Decision.** The server refreshes its in-memory bank on a schedule, with a
+manual admin button as an escape hatch. Both paths call one method
+(`bank.LiveBank.Reload`) that swaps an `atomic.Pointer[Bank]`; a reader
+holding a `*Bank` captured before a swap keeps seeing the previous snapshot,
+so the rotation is safe against every concurrent request without locking the
+read path.
+
+- **Cadence.** 5 minutes, configurable via `NALANDA_BANK_REFRESH_INTERVAL`.
+  Matches the Watchtower poll cadence on the Jetson (ADR-0038) so the server
+  refreshes at the same rhythm as the container image itself updates. `0s`
+  disables the ticker, and then the manual button is the only refresh path.
+- **Conditional GET.** Every refresh cycle after the first sends
+  `If-Modified-Since` derived from the previous response's `Last-Modified`;
+  the server answers `304` when the artifact has not moved, and `Reload` is
+  a no-op (`DEBUG` line only). A real update logs `INFO` with document and
+  question counts, so an operator grepping the logs can tell one boot from
+  the next.
+- **Failure preserves the snapshot.** A network flap, a 5xx, a malformed
+  publish — none may nil the current bank. `Reload` logs `WARN` and returns
+  an error; the server keeps serving the last known good snapshot. Reintroducing
+  a code path that clears the pointer on failure is forbidden — the same rule
+  §Rules for Claude carries for the uploaded scan batch after issue #210, for
+  the same reason.
+- **Manual escape hatch.** `POST /admin/bank/refresh` (session-gated, CSRF-
+  verified) triggers an immediate `Reload` and flashes the outcome in
+  Spanish. A "Recargar banco" button in the backoffice top bar posts to it;
+  the professor stays on the page they clicked from when the `Referer` shares
+  scheme+host with `NALANDA_PUBLIC_URL`, or lands on `/controls` otherwise
+  (an off-origin Referer never steers the redirect).
+
+### Alternatives considered
+
+- **GitHub Actions webhook** on `apps/web` publish, targeting the server's
+  own endpoint. Rejected: the Jetson deploy sits behind Tailscale (ADR-0038),
+  and exposing a public webhook target for GitHub to hit adds a security
+  surface and infra coordination cost. The ticker + `If-Modified-Since` is
+  cheaper (most polls are a ~200-byte 304), robust to infra changes on either
+  side, and stays inside the Tailscale boundary.
+- **Watchfile / inotify on a mounted repo.** Rejected — ADR-0032 §C14 already
+  closed transport as "publish an artifact, never mount the repo". The
+  webhook alternative is what this addendum weighs against; a mounted repo is
+  a shape this decision continues to refuse.
+- **Partial reload of one document.** Rejected: a bank swap is atomic
+  (`atomic.Pointer[Bank]`), and a per-document diff would need a merge policy
+  the current shape does not have. The whole bank fits comfortably in memory;
+  swapping the pointer is cheaper than reconciling.
+- **Persisting the last-good snapshot to disk between boots.** Rejected: the
+  source of truth is GH Pages, and re-fetching on startup is fast (`FetchTimeout`
+  is 30s, the file is kilobytes). Persisting adds a second cache to keep in
+  sync for no measured benefit.
+
+### Consequences
+
+- **The reader is now a lifecycle, not a one-shot.** Callers hold a
+  `*bank.LiveBank` rather than a `*bank.Bank`; every consumer resolves the
+  current snapshot with `.Get()` at method entry. The static shim
+  `bank.NewStaticLive(*Bank)` covers tests that hand a fixed bank into
+  constructors that now take the live wrapper.
+- **A boot log line is expected on every start.** Same message as before
+  (`question bank loaded`), plus a `bank refreshed` on each cycle the source
+  actually moved and a `question bank refresh failed` when a cycle fails —
+  the last one is the signal an operator watches for.
+- **The manual endpoint sits inside `/admin/`.** Session-gated + CSRF-verified
+  like every other state-changing route on this surface; the button's
+  visibility follows the top bar's `.Professor` guard. Neither an anonymous
+  visitor nor a signed-out browser tab can trigger a refresh.
+
 ## Amendment — 2026-08-25 (page-only annotations)
 
 `<Question>` may carry a nested `<Explanation>` block (a pedagogical note

--- a/infra/local/docker-compose.yml
+++ b/infra/local/docker-compose.yml
@@ -88,6 +88,12 @@ services:
       # true; "false" serves raw scans everywhere (reversibility escape
       # hatch, see the issue §Design).
       NALANDA_ANNOTATE_ENABLED: "${NALANDA_ANNOTATE_ENABLED:-true}"
+
+      # How often the server polls NALANDA_QUESTIONS_JSON_URL for a fresh
+      # bank (issue #230). Defaults to 5m (Watchtower's cadence on the
+      # Jetson); "0s" disables the ticker and leaves the manual admin
+      # button as the only refresh path.
+      NALANDA_BANK_REFRESH_INTERVAL: "${NALANDA_BANK_REFRESH_INTERVAL:-5m}"
     volumes:
       - server-data:/data
       # Shared with the amc-worker service below. The server writes a


### PR DESCRIPTION
Closes #230.

## Summary

`apps/server` used to load `questions.json` once at boot and never refresh it: a redeploy of `apps/web` left the picker showing the pre-publish bank until an operator restarted the container. This PR wraps the boot bank in `bank.LiveBank` (an `atomic.Pointer[Bank]`), adds a 5-minute background ticker that polls with `If-Modified-Since`, and adds a manual "Recargar banco" button in the backoffice top bar. A failed refresh preserves the last-good snapshot — the server never nils the pointer. The whole decision (cadence tied to Watchtower, rejection of a GitHub webhook, per-call vs request-level atomicity, the escape-hatch button) is recorded as an addendum on ADR-0032.

## Slices

- [x] **S1 — `LiveBank` with `atomic.Pointer`** (`8cbf752`) — swap-safe wrapper, `Reload` with conditional GET semantics, `NewStaticLive` test seam; five consumer sites migrate one line each to `.Get()`.
- [x] **S2 — Background ticker** (`6d0a6f4`) — `Watch(ctx, interval)`, `NALANDA_BANK_REFRESH_INTERVAL` in all four homes (`.env.example`, `docker-compose.yml`, `server.yml`, README §Configuration), `0s` opt-out, negative-value startup error.
- [x] **S3 — Manual endpoint + button** (`00882b3`) — `POST /admin/bank/refresh` (session-gated + CSRF), Spanish flash naming the outcome, sidebar "Recargar banco" button styled to match the section links.
- [x] **S4 — ADR-0032 addendum** (`982cf2c`) — the runtime refresh mechanism, the 5-minute cadence tied to Watchtower, the rejection of a GitHub webhook, the failure-preserves-snapshot promise.
- [x] **Review fixes** (`fdbbc4e` + `85b27f0`) — see §Reviews run.

## Acceptance criteria

- [x] **Publishing new content produces a refreshed server bank within 5 minutes without a restart.** `LiveBank.Watch(ctx, 5*time.Minute)` is started from `main.go` (`cmd/server/main.go:152-160`); each tick calls `Reload` which sends `If-Modified-Since` and swaps the atomic pointer on 200. Pinned by `TestReloadAtomicallySwapsWithoutInvalidatingPriorSnapshot` and `TestWatchTicksAndCancels` (`internal/domain/course/bank/bank_test.go`).
- [x] **A successful refresh emits `slog.Info`; an unchanged 304 emits `slog.Debug`; a failure emits `slog.Warn`.** `bank.LiveBank.Reload` at `bank.go:238-259`. Info line pinned by `TestReloadEmitsSlogInfoOnUpdate`; 304 no-op pinned by `TestReloadIsNoOpOn304`.
- [x] **"Recargar banco" button triggers immediate reload with a flash; hidden when unauthenticated.** Route registered in `web.routes()` at `internal/app/web/router.go:230-233`; button in `layout.html:212-215` inside `{{ if .Professor }}` block, only rendered when a professor is signed in. Handler flow pinned by `TestAdminBankRefreshFlashesTheNewCountsAndRedirects` + `TestAdminBankRefreshFlashesUnchangedOn304`.
- [x] **Failed refresh preserves current snapshot.** `bank.go:245-253` — on `errNotModified` no-op, on any other error the WARN logs and returns without calling `snap.Store`. Pinned by `TestReloadPreservesSnapshotOnServerError` and `TestAdminBankRefreshFlashesTheErrorOnServerFailure`.
- [x] **`NALANDA_BANK_REFRESH_INTERVAL` in all four homes.** `TestEveryVariableReachesAllFourHomes` (`internal/infra/config/homes_test.go`) gates it; grep confirms `NALANDA_BANK_REFRESH_INTERVAL` in `.env.example:129`, `infra/local/docker-compose.yml:96`, `.github/workflows/server.yml:122`, `apps/server/README.md:49`.
- [x] **Migration path safe: `.docs[...]` becomes `.Get().docs[...]` with no behavior change.** Five call sites migrated (`handler.Controls` 4 sites, `handler.Controls.Review`, `controls.Service.Create`). Full suite green with `-race -count=1`.
- [x] **`apps/server` per-commit and pre-PR protocols green.** `gofmt -l .` silent; `go vet ./...` clean; `go test -race -count=1 ./...` PASS across all 26 packages; `go build ./...` clean; `govulncheck ./...` "No vulnerabilities found"; `docker build -t nalanda/server:dev .` succeeds. Compose L8 stays as the deployer's manual check (this WP does not change the compose surface a smoke test would notice).
- [x] **ADR-0032 addendum records the reload mechanism.** `docs/decisions/0032-the-published-question-bank-is-the-contract.md:125-211` — §Context, §Decision (cadence + conditional GET + failure preservation + manual endpoint), §Alternatives considered (webhook, inotify, partial reload, disk persistence), §Consequences (lifecycle reader, per-call vs request-level atomicity, `/admin/` namespace choice).
- [ ] **Manual verification on Jetson (L8).** Deferred to post-merge — see checklist below.

## Reviews run

Pre-PR pipeline in integrated mode over `origin/main...HEAD`, isolated worktrees per lens.

**Mode**: full. **Perf lens**: skipped (no hot render/compute paths; issue's only perf-adjacent goal — 304 vs 200 — is met by design).

**Round A** (code): correctness-tests + arch-simplicity + security → verifier → fixes.
- Panel raised 10 raw findings; merge/dedup left 3 IMPORTANT + 7 SUGGESTION.
- Verifier confirmed all 3 IMPORTANT (mutation-tested the coverage claim, reproduced the open redirect end-to-end).
- Accepted + fixed as `fdbbc4e`:
  - IMPORTANT-1 (security+correctness): `safeRedirect` open redirect via `//` in Referer path (`https://nalanda.test//evil.com/x` → `Location: //evil.com/x` → browser navigates to `https://evil.com/x`). Added path-prefix guard rejecting `//` and `/\` after the origin match; regression test `TestAdminBankRefreshRejectsAProtocolRelativeReferer`.
  - IMPORTANT-2 (correctness): all three `safeRedirect` tests landed on the fallback branch; mutation to `return ControlsPath` left suite green. Added `TestAdminBankRefreshKeepsSameOriginReferer` to pin the happy path (path + query preserved).
  - IMPORTANT-3 (arch+correctness): the `Controls.Bank` field comment overclaimed "once at entry, consistent snapshot"; the code does per-call `.Get()` in the handler and again in the service (Create) plus per-loop in List. Weakened the comment and the ADR addendum to describe actual per-call atomicity; the deferred alternative (thread one snapshot through Create + List) is captured for a future WP.
  - SUGGESTION-6 (arch): CSS hover rule duplicated between `.sections a` and the new `.sections form.section-action button`. Merged selectors.
- Per-fix recheck of IMPORTANT-1 via security lens: `resolved: true`, no residual bypass across `/`, `//`, `//evil.com/x`, `/\evil.com/x`, `%2f`/`%5c` variants, IPv6, mixed-case scheme, `/./` dot segments.

**Round B** (docs, over the post-fix state): docs-completeness + docs-accuracy + adr-hunter + agent-readability.
- Panel raised 4 IMPORTANT + 0 SUGGESTION.
- Accepted + fixed as `85b27f0`:
  - DCO-1: `POST /admin/bank/refresh` missing from the backoffice routes table in `apps/server/README.md`. Added.
  - DCO-2: `NALANDA_QUESTIONS_JSON_URL` row in README still said "Fetched once at boot" — contradicted by the row directly beneath it. Rewrote for consistency.
  - DCO-3: same stale wording in `.env.example`. Mirrored.
  - DCO-4: `apps/server/CLAUDE.md` §Rules for Claude was missing the LiveBank-snapshot-survives-failure rule the ADR-0032 addendum explicitly parallels with the #210 UploadScan rule. Added.
- docs-accuracy: `[]` (every doc claim verified against reality — Watchtower 5m cadence, wiring, defaults).
- adr-hunter: `[]` (no ADR gaps; the addendum covers every architectural decision).
- agent-readability: terminated before completing (API session limit); scope overlaps with DCO-2/3/4 and no distinct concerns remained after those fixes.

**Deferred with reason** (surfaced but not shipped in this PR):
- SUGGESTION-1: WARN log path on Reload failure unasserted — nice-to-have, not shipping-critical; visual inspection of the code path is sufficient.
- SUGGESTION-2: `safeRedirect` re-parses `PublicURL` per request — micro-optimization on an admin-click endpoint.
- SUGGESTION-3: `reloadMu` held during 30s fetch could queue an admin click behind an in-flight ticker fetch — real concern; `TryLock` refactor is scope creep for MVP. Note: worst case a professor waits ~30s for the flash and then it succeeds anyway.
- SUGGESTION-4: `LiveBank.URL()` has one caller — wiring `QuestionsJSONURL` into `handler.AdminBank` directly would create two sources of truth for the same value; kept.
- SUGGESTION-5: constructor error style inconsistency (`NewLive` returns err, `NewAdminBank` panics) — defensible since `NewLive` has operational errors (bad URL, network flap) alongside the wire-time nil-logger.
- SUGGESTION-7: `Referer` `RawQuery` echoed verbatim into the redirect target — not currently exploitable (no reflected-XSS sink under `/controls*`); a same-origin defense-in-depth item for a future review.

## Manual verification (Jetson, post-merge)

- [ ] After merge, wait for the server-cd workflow + Watchtower pull (≤5 min total).
- [ ] Sign in to the backoffice on the Jetson.
- [ ] Click "Recargar banco" in the top bar → expect the flash "El banco ya estaba al día." (or "Banco recargado: N documentos, M preguntas." if a publish landed since boot). The page reloads and lands where it was (`Referer` preserved).
- [ ] Sign out; observe the button disappears from the top bar for the anonymous shell (it lives inside `{{ if .Professor }}`).
- [ ] Publish a small change to `apps/web` (e.g., edit `index.yaml` or add a question) and merge. After the pages workflow completes, wait ≤5 min and verify the server log emits `bank refreshed` with the new counts. The picker on `/controls/new` should show the new content without a `docker-compose restart server`.
- [ ] `GOOGLE-CHECK.md` NOT applicable (no login-path changes).
- [ ] `PAPER-CHECK.md` NOT applicable (no tex/preamble changes).

## Notes

- Coordinates with **WP-A (#228)** and **WP-B (#229)** — none of the three touch overlapping symbols. The layout.html edits (this WP's button + WP-A's request-logging middleware) are neighbours in the top bar but non-overlapping selectors; a rebase against either merged-first is trivial.
- The refresh cadence (`5m`) matches Watchtower's Jetson polling (ADR-0038), so the server refreshes at the same rhythm the container image itself updates. An operator who wants a tighter loop can set `NALANDA_BANK_REFRESH_INTERVAL=30s` without a rebuild.
- The `0s` opt-out is deliberate: an operator can disable the ticker and rely on the manual button alone (useful when GH Pages is having a bad day and repeated warns pollute the logs).
