### PR TITLE
fix(controls-review): preserve per-copy print order for questions and alternatives

### DIFF
--- a/apps/amc-worker/README.md
+++ b/apps/amc-worker/README.md
@@ -275,6 +275,18 @@ correct → 4/4; one correct and nothing wrong → 3/4; only a wrong one → 1/4
 **every box ticked → 2/4**; blank → 0/4. Ticking everything does not win, and no
 score comes back negative.
 
+**Each answer says where it printed on THIS copy, and in what order.** AMC
+shuffles the questions per copy (`\shufflegroup`) and the alternatives per
+question, so a paper in hand does not match a review page that renders by
+numeric id or authoring index — the mental alignment breaks even when the
+marks are read correctly (#229). Each answer therefore carries
+`position` (its 1-based slot on this copy's printed sheet) and
+`alternatives` (the authoring-index list in printed order for this copy,
+per question). Both are optional: an empty `alternatives` or `position:
+0` means the analyzer has no layout data, and callers fall back to bank
+order. The full shape stays in the module docstring, which is the
+schema-of-record.
+
 **The report says which threshold those scores were computed at.** AMC's `note`
 scores at its own `--seuil` while `--ticked` is ours and tunable, so a CLI
 re-read of a stored capture at another sensitivity moves the marks and leaves

--- a/apps/amc-worker/read_capture.py
+++ b/apps/amc-worker/read_capture.py
@@ -296,10 +296,41 @@ def read(data_dir, ticked, unsure):
     # every question that *is* present looks fine. A double feed on a duplex
     # batch is the most likely failure with real paper, and it would otherwise
     # give a student zero on half the sheet and tell nobody (#138 review, F-3).
+    #
+    # And in what order it printed them. AMC shuffles questions per copy
+    # (`\shufflegroup`) and alternatives per question, so the layout knows the
+    # physical position of every box on every sheet and no other database
+    # does. Publishing that lets the review page render each copy the way its
+    # student saw it — the numeric-id / authoring-index order the reader used
+    # to iterate in did not match the paper in hand (#229). Order is derived
+    # from the box geometry (page, ymin, xmin): AMC records coordinates, not a
+    # position column.
     expected = {}
-    for student, q in lay.execute("SELECT DISTINCT student, question FROM layout_box"):
-        if not names.get(q, "").startswith("rut["):
-            expected.setdefault(student, set()).add(q)
+    printed_alts = {}   # (student, question) -> [answer_id, ...] in printed order
+    q_anchors = {}      # (student, question) -> (page, ymin, xmin) of first box
+    for student, q, ans, page, ymin, xmin in lay.execute(
+        "SELECT student, question, answer, page, ymin, xmin FROM layout_box"
+    ):
+        if names.get(q, "").startswith("rut["):
+            continue
+        expected.setdefault(student, set()).add(q)
+        key = (student, q)
+        printed_alts.setdefault(key, []).append((page, ymin, xmin, ans))
+        anchor = (page, ymin, xmin)
+        if key not in q_anchors or anchor < q_anchors[key]:
+            q_anchors[key] = anchor
+    for key, boxes in printed_alts.items():
+        boxes.sort()
+        printed_alts[key] = [a for _, _, _, a in boxes]
+
+    q_positions = {}    # (student, question) -> 1-based position on the sheet
+    by_student = {}
+    for (student, q), anchor in q_anchors.items():
+        by_student.setdefault(student, []).append((anchor, q))
+    for student, items in by_student.items():
+        items.sort()
+        for pos, (_, q) in enumerate(items, 1):
+            q_positions[(student, q)] = pos
 
     copies = {}
     for student, q, a, black, total, manual in cap.execute(
@@ -393,6 +424,16 @@ def read(data_dir, ticked, unsure):
                 "status": status,
                 "score": fact["score"],
                 "max": fact["max"],
+                # Where THIS copy printed the question, and in what order it
+                # printed its alternatives. Both come from layout.sqlite and
+                # are per-copy: two students holding the same test see the
+                # same questions in a different order and each question's
+                # alternatives in a different order (#229). The outer answers
+                # list keeps its iteration order for compatibility; a consumer
+                # rendering the paper sorts by `position` and iterates
+                # `alternatives` to pick each box's letter.
+                "position": q_positions.get((student, q), 0),
+                "alternatives": printed_alts.get((student, q), []),
             })
 
         seen = set(c["q"])

--- a/apps/amc-worker/read_capture.py
+++ b/apps/amc-worker/read_capture.py
@@ -20,7 +20,13 @@ Runs INSIDE the worker image. Emits JSON on stdout:
              "marked": [1],                        // confident ticks
              "doubtful": [],                       // [{answer, darkness}]
              "status": "ok",                       // ok|blank|ambiguous|doubtful
-             "score": 1.0, "max": 1.0}             // the caller: score / max
+             "score": 1.0, "max": 1.0,             // the caller: score / max
+             "position": 3,                        // 1-based slot on THIS
+                                                   // copy's printed sheet;
+                                                   // 0 when no layout data
+             "alternatives": [3, 4, 2, 1]}         // authoring indices in
+                                                   // printed order for THIS
+                                                   // copy; [] when unknown
           ],
           "expected_questions": 4,                 // what the layout says printed
           "seen_questions": 4,                     // what the capture holds

--- a/apps/amc-worker/tests/03-read.sh
+++ b/apps/amc-worker/tests/03-read.sh
@@ -177,6 +177,43 @@ check_eq "and the copy that drew none of them says so too" \
   "['simple', 'simple', 'simple', 'simple']" \
   "$(jq '[a["type"] for a in d["copies"]["1"]["answers"]]')"
 
+# --- per-copy printed order: questions and alternatives (issue #229) ----------
+#
+# AMC shuffles both the questions per copy (\shufflegroup) and the alternatives
+# per question. Reading them back in numeric-id / authored-index order made the
+# professor's review page render the sheet in a different order from the paper
+# in hand — nothing was mismarked, but the mental alignment broke. The reader
+# now publishes each answer's 1-based `position` on the printed sheet and the
+# question's full `alternatives` list (authoring indices, in printed order),
+# so the server can lay both out the way the student saw them.
+#
+# Numbers here are pinned against layout.sqlite for seed 1242, 5 copies. The
+# outer answers list keeps its old (question-id) order for compatibility; the
+# server sorts by `position` when it renders.
+
+check_eq "each answer carries its 1-based position on the printed sheet" \
+  "[3, 1, 2, 4]" "$(jq '[a["position"] for a in d["copies"]["2"]["answers"]]')"
+
+check_eq "copy 2's questions in printed order match the paper" \
+  "['comparar-cadenas', 'arreglo-largo', 'suma-arreglo', 'indice']" \
+  "$(jq '[a["name"] for a in sorted(d["copies"]["2"]["answers"], key=lambda x: x["position"])]')"
+
+check_eq "copy 3's questions in printed order match ITS paper (differs from copy 2)" \
+  "['comparar-cadenas', 'suma-arreglo', 'tipo-primitivo', 'requisito']" \
+  "$(jq '[a["name"] for a in sorted(d["copies"]["3"]["answers"], key=lambda x: x["position"])]')"
+
+# Alternatives are shuffled per copy too. `descarte` prints [3, 4, 2, 1] on
+# copy 1 and [1, 2, 4, 3] on copy 5 — same question, different paper.
+check_eq "copy 1 alternatives for descarte are in printed order [3,4,2,1]" \
+  "[3, 4, 2, 1]" \
+  "$(jq '[a["alternatives"] for a in d["copies"]["1"]["answers"] if a["name"]=="descarte"][0]')"
+check_eq "and copy 5's printing of the same question is [1,2,4,3]" \
+  "[1, 2, 4, 3]" \
+  "$(jq '[a["alternatives"] for a in d["copies"]["5"]["answers"] if a["name"]=="descarte"][0]')"
+check_eq "the multiple-answer question, `comparar-cadenas`, is shuffled too" \
+  "[1, 3, 2, 4]" \
+  "$(jq '[a["alternatives"] for a in d["copies"]["3"]["answers"] if a["name"]=="comparar-cadenas"][0]')"
+
 # THE defect this WP exists for: two ticks on a multiple-answer question are the
 # ANSWER, and the old reader called every second tick an ambiguity — so a
 # student who answered correctly was sent to the manual review queue, and the

--- a/apps/server/internal/app/web/handler/alternatives_for_test.go
+++ b/apps/server/internal/app/web/handler/alternatives_for_test.go
@@ -104,6 +104,45 @@ func TestAlternativesForRendersGenericLabelsInPrintedOrderWithoutBank(t *testing
 	}
 }
 
+// TestAlternativesForFallsBackWhenAlternativesLengthMismatchesMax covers a
+// malformed analyzer emit: a wrong-length Alternatives (short, over-long,
+// or a lone bad index) triggers the bank-order fallback, so a "[99]" from
+// a buggy analyzer no longer renders one option instead of four (review
+// COR-1). Nothing panics; index bounds stay inside labels.
+func TestAlternativesForFallsBackWhenAlternativesLengthMismatchesMax(t *testing.T) {
+	q := bank.Question{
+		ID:           "tipo-primitivo",
+		Alternatives: []string{"int", "String", "Integer", "Object"},
+	}
+	for _, tc := range []struct {
+		name string
+		alts []int
+	}{
+		{"single bad index", []int{99}},
+		{"short list", []int{1, 2}},
+		{"over-long list", []int{1, 2, 3, 4, 5}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := controls.Answer{
+				QuestionRef:  "tipo-primitivo",
+				QuestionType: controls.QuestionSimple,
+				Max:          4,
+				Alternatives: tc.alts,
+			}
+			got := alternativesFor(a, q, true)
+			want := []view.ReviewAlternative{
+				{Index: 1, Label: "int"},
+				{Index: 2, Label: "String"},
+				{Index: 3, Label: "Integer"},
+				{Index: 4, Label: "Object"},
+			}
+			if !equalAlternatives(got, want) {
+				t.Errorf("alternativesFor mismatch\ngot  %+v\nwant %+v", got, want)
+			}
+		})
+	}
+}
+
 func equalAlternatives(a, b []view.ReviewAlternative) bool {
 	if len(a) != len(b) {
 		return false

--- a/apps/server/internal/app/web/handler/alternatives_for_test.go
+++ b/apps/server/internal/app/web/handler/alternatives_for_test.go
@@ -1,0 +1,117 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/so77id/nalanda/apps/server/internal/app/web/view"
+	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+	"github.com/so77id/nalanda/apps/server/internal/domain/course/bank"
+)
+
+// The review page renders alternatives in the order the student saw them
+// on THIS copy (issue #229). alternativesFor uses Answer.Alternatives —
+// the authoring-index list in printed order — to line up the bank's
+// labels with the paper. When the list is empty (an answer stored before
+// #229), it falls back to bank order — the pre-change behaviour.
+
+func TestAlternativesForRendersLabelsInPrintedOrder(t *testing.T) {
+	q := bank.Question{
+		ID: "tipo-primitivo",
+		Alternatives: []string{
+			"int",     // authoring index 1
+			"String",  // authoring index 2
+			"Integer", // authoring index 3
+			"Object",  // authoring index 4
+		},
+	}
+	a := controls.Answer{
+		QuestionRef:  "tipo-primitivo",
+		QuestionType: controls.QuestionSimple,
+		Max:          4,
+		Alternatives: []int{3, 1, 4, 2},
+	}
+
+	got := alternativesFor(a, q, true)
+
+	want := []view.ReviewAlternative{
+		{Index: 3, Label: "Integer"},
+		{Index: 1, Label: "int"},
+		{Index: 4, Label: "Object"},
+		{Index: 2, Label: "String"},
+	}
+	if !equalAlternatives(got, want) {
+		t.Errorf("alternativesFor mismatch\ngot  %+v\nwant %+v", got, want)
+	}
+}
+
+func TestAlternativesForFallsBackToBankOrderWhenLegacy(t *testing.T) {
+	q := bank.Question{
+		ID: "tipo-primitivo",
+		Alternatives: []string{
+			"int",     // 1
+			"String",  // 2
+			"Integer", // 3
+			"Object",  // 4
+		},
+	}
+	// No Alternatives — a reading written before #229's storage change.
+	a := controls.Answer{
+		QuestionRef:  "tipo-primitivo",
+		QuestionType: controls.QuestionSimple,
+		Max:          4,
+	}
+
+	got := alternativesFor(a, q, true)
+
+	// Bank order, 1..N — indistinguishable from the pre-change behaviour.
+	want := []view.ReviewAlternative{
+		{Index: 1, Label: "int"},
+		{Index: 2, Label: "String"},
+		{Index: 3, Label: "Integer"},
+		{Index: 4, Label: "Object"},
+	}
+	if !equalAlternatives(got, want) {
+		t.Errorf("alternativesFor mismatch\ngot  %+v\nwant %+v", got, want)
+	}
+}
+
+// TestAlternativesForFallsBackToBankOrderWithoutBankLabels covers the
+// path where the bank does not resolve — a professor wiped a question
+// but a reading still references it. Pre-#229 the labels went generic
+// (`Opción 1..N`) in bank order; the layout order must not break that.
+func TestAlternativesForRendersGenericLabelsInPrintedOrderWithoutBank(t *testing.T) {
+	a := controls.Answer{
+		QuestionRef:  "gone-from-bank",
+		QuestionType: controls.QuestionSimple,
+		Max:          4,
+		Alternatives: []int{2, 4, 1, 3},
+	}
+
+	got := alternativesFor(a, bank.Question{}, false)
+
+	// Labels are the fallback `Opción N`; N is the AUTHORING index (the
+	// number the store persisted as `marked`), not the printed slot —
+	// otherwise the professor's tick on "Opción 2" would send a different
+	// integer to save_review.
+	want := []view.ReviewAlternative{
+		{Index: 2, Label: "Opción 2"},
+		{Index: 4, Label: "Opción 4"},
+		{Index: 1, Label: "Opción 1"},
+		{Index: 3, Label: "Opción 3"},
+	}
+	if !equalAlternatives(got, want) {
+		t.Errorf("alternativesFor mismatch\ngot  %+v\nwant %+v", got, want)
+	}
+}
+
+func equalAlternatives(a, b []view.ReviewAlternative) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/apps/server/internal/app/web/handler/review.go
+++ b/apps/server/internal/app/web/handler/review.go
@@ -481,13 +481,31 @@ func alternativesFor(a controls.Answer, q bank.Question, has bool) []view.Review
 	if max == 0 {
 		max = 4 // sensible default; a professor can still edit
 	}
-	out := make([]view.ReviewAlternative, max)
-	for i := 0; i < max; i++ {
-		label := fmt.Sprintf("Opción %d", i+1)
-		if i < len(labels) {
+	// #229: `a.Alternatives` is the authoring-index list in the physical
+	// printed order for this copy. When it is set, iterate it — the
+	// professor's review page then renders alternatives in the same order
+	// as the paper. When it is empty (a reading written before #229, or
+	// an analyzer that predates S1), iterate 1..max in bank order —
+	// indistinguishable from the pre-change behaviour.
+	//
+	// Index remains the AUTHORING index in both branches: it is what the
+	// store persisted as `marked`, what the save-review form sends back,
+	// and what the bank's Correct list is keyed by. Only the position in
+	// the returned slice changes.
+	order := a.Alternatives
+	if len(order) == 0 {
+		order = make([]int, max)
+		for i := range order {
+			order[i] = i + 1
+		}
+	}
+	out := make([]view.ReviewAlternative, 0, len(order))
+	for _, idx := range order {
+		label := fmt.Sprintf("Opción %d", idx)
+		if i := idx - 1; i >= 0 && i < len(labels) {
 			label = labels[i]
 		}
-		out[i] = view.ReviewAlternative{Index: i + 1, Label: label}
+		out = append(out, view.ReviewAlternative{Index: idx, Label: label})
 	}
 	return out
 }

--- a/apps/server/internal/app/web/handler/review.go
+++ b/apps/server/internal/app/web/handler/review.go
@@ -482,18 +482,21 @@ func alternativesFor(a controls.Answer, q bank.Question, has bool) []view.Review
 		max = 4 // sensible default; a professor can still edit
 	}
 	// #229: `a.Alternatives` is the authoring-index list in the physical
-	// printed order for this copy. When it is set, iterate it — the
-	// professor's review page then renders alternatives in the same order
-	// as the paper. When it is empty (a reading written before #229, or
-	// an analyzer that predates S1), iterate 1..max in bank order —
-	// indistinguishable from the pre-change behaviour.
+	// printed order for this copy. When it is set AND its length matches
+	// the question's alternative count, iterate it — the professor's
+	// review page then renders alternatives in the same order as the
+	// paper. Otherwise (empty for a pre-#229 reading, or unexpected
+	// length from a malformed analyzer emit), iterate 1..max in bank
+	// order — indistinguishable from the pre-change behaviour, and
+	// enough to prevent the "only one option shown" regression a stray
+	// `[99]` from a buggy analyzer would produce (review COR-1).
 	//
 	// Index remains the AUTHORING index in both branches: it is what the
 	// store persisted as `marked`, what the save-review form sends back,
 	// and what the bank's Correct list is keyed by. Only the position in
 	// the returned slice changes.
 	order := a.Alternatives
-	if len(order) == 0 {
+	if len(order) != max {
 		order = make([]int, max)
 		for i := range order {
 			order[i] = i + 1

--- a/apps/server/internal/domain/controls/reading.go
+++ b/apps/server/internal/domain/controls/reading.go
@@ -87,6 +87,14 @@ type ReportAnswer struct {
 	Status   AnswerStatus
 	Score    float64 // engine per-question score
 	Max      float64 // 1 for simple; alternative count for multiple
+	// Position is this question's 1-based slot on the printed sheet, per
+	// copy. Zero means the analyzer did not report one — the review UI
+	// falls back to iteration order. Issue #229.
+	Position int
+	// Alternatives is the authoring-index list in the physical printed
+	// order for THIS copy. Empty when the analyzer did not report the
+	// layout — the review UI falls back to bank order. Issue #229.
+	Alternatives []int
 }
 
 // ReportCopy is one copy's reading.
@@ -275,6 +283,14 @@ type Answer struct {
 	Score        float64
 	Max          float64
 	Override     *AnswerOverride
+	// Position is this question's 1-based slot on the printed sheet for
+	// this reading's copy. Zero means the answer row was written before
+	// #229 and no positional data is stored — callers rendering the paper
+	// fall back to iteration order or question_ref.
+	Position int
+	// Alternatives is the authoring-index list in the physical printed
+	// order for this reading's copy. Nil for a legacy row (#229).
+	Alternatives []int
 }
 
 // AnswerOverride sits BESIDE Answer rather than replacing it, so the UI

--- a/apps/server/internal/infra/amcworker/analyze.go
+++ b/apps/server/internal/infra/amcworker/analyze.go
@@ -195,6 +195,12 @@ type answerBody struct {
 	Status   string         `json:"status"`
 	Score    float64        `json:"score"`
 	Max      float64        `json:"max"`
+	// Per-copy physical layout (issue #229). Absent from workers that
+	// predate the field; a zero Position and nil Alternatives then reach
+	// the store as "no positional data", which the review page falls
+	// back for.
+	Position     int   `json:"position"`
+	Alternatives []int `json:"alternatives"`
 }
 
 type doubtfulBody struct {
@@ -241,14 +247,16 @@ func toAnswers(in []answerBody) []controls.ReportAnswer {
 			doubtful[j] = controls.Doubtful{Answer: d.Answer, Darkness: d.Darkness}
 		}
 		out[i] = controls.ReportAnswer{
-			Question: a.Question,
-			Name:     a.Name,
-			Type:     controls.QuestionType(a.Type),
-			Marked:   append([]int(nil), a.Marked...),
-			Doubtful: doubtful,
-			Status:   controls.AnswerStatus(a.Status),
-			Score:    a.Score,
-			Max:      a.Max,
+			Question:     a.Question,
+			Name:         a.Name,
+			Type:         controls.QuestionType(a.Type),
+			Marked:       append([]int(nil), a.Marked...),
+			Doubtful:     doubtful,
+			Status:       controls.AnswerStatus(a.Status),
+			Score:        a.Score,
+			Max:          a.Max,
+			Position:     a.Position,
+			Alternatives: append([]int(nil), a.Alternatives...),
 		}
 	}
 	return out

--- a/apps/server/internal/infra/storage/controlstore/readings.go
+++ b/apps/server/internal/infra/storage/controlstore/readings.go
@@ -63,13 +63,33 @@ func (s *Store) UpsertReadingsFromReport(ctx context.Context, controlID string, 
 				return fmt.Errorf("controlstore.UpsertReadingsFromReport: copy %d question %d has empty layout name — the wrapper cannot resolve it against the pool",
 					copyNumber, ans.Question)
 			}
+			// #229: position is NULL when the analyzer sent 0 (no data)
+			// and alternatives_json is NULL for a nil list. A NULL
+			// position triggers loadAnswers' legacy ORDER BY fallback,
+			// so a mixed-shape report cannot silently reorder rows that
+			// had no position to begin with.
+			var (
+				positionVal     any
+				alternativesVal any
+			)
+			if ans.Position > 0 {
+				positionVal = ans.Position
+			}
+			if ans.Alternatives != nil {
+				b, err := json.Marshal(ans.Alternatives)
+				if err != nil {
+					return fmt.Errorf("controlstore.UpsertReadingsFromReport: encode alternatives: %w", err)
+				}
+				alternativesVal = string(b)
+			}
 			if _, err := tx.ExecContext(ctx,
 				`INSERT INTO answer
-                    (reading_id, question_ref, question_type, marked_json, doubtful_json, status, score, max)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+                    (reading_id, question_ref, question_type, marked_json, doubtful_json, status, score, max, position, alternatives_json)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 				readingID, ans.Name, string(ans.Type),
 				string(markedJSON), string(doubtfulJSON),
 				string(ans.Status), ans.Score, ans.Max,
+				positionVal, alternativesVal,
 			); err != nil {
 				return fmt.Errorf("controlstore.UpsertReadingsFromReport: insert answer copy %d %s: %w",
 					copyNumber, ans.Name, err)
@@ -203,13 +223,20 @@ func (s *Store) attachAnswersAndOverrides(ctx context.Context, readings []contro
 }
 
 func (s *Store) loadAnswers(ctx context.Context, r *controls.Reading) error {
+	// #229: order by position when it is set, and fall back to
+	// question_ref for legacy rows written before the position column
+	// existed. `position IS NULL` sorts new rows (has position) first
+	// under SQLite's default (false < true = 0 < 1). Answers with a
+	// position come out in the order the student saw them on the paper;
+	// answers without one keep the pre-#229 alphabetical order.
 	rows, err := s.db.QueryContext(ctx, `
         SELECT a.question_ref, a.question_type, a.marked_json, a.doubtful_json, a.status, a.score, a.max,
+               a.position, a.alternatives_json,
                o.marked_json, o.status, o.edited_at
         FROM answer a
         LEFT JOIN answer_override o ON o.reading_id = a.reading_id AND o.question_ref = a.question_ref
         WHERE a.reading_id = ?
-        ORDER BY a.question_ref ASC`, r.ID)
+        ORDER BY a.position IS NULL, a.position ASC, a.question_ref ASC`, r.ID)
 	if err != nil {
 		return fmt.Errorf("controlstore.loadAnswers: reading %d: %w", r.ID, err)
 	}
@@ -218,17 +245,20 @@ func (s *Store) loadAnswers(ctx context.Context, r *controls.Reading) error {
 	r.Answers = nil
 	for rows.Next() {
 		var (
-			a             controls.Answer
-			qtype         string
-			markedJSON    string
-			doubtfulJSON  string
-			status        string
-			ovMarkedJSON  sql.NullString
-			ovStatus      sql.NullString
-			ovEditedAtRaw sql.NullInt64
+			a                controls.Answer
+			qtype            string
+			markedJSON       string
+			doubtfulJSON     string
+			status           string
+			positionRaw      sql.NullInt64
+			alternativesJSON sql.NullString
+			ovMarkedJSON     sql.NullString
+			ovStatus         sql.NullString
+			ovEditedAtRaw    sql.NullInt64
 		)
 		if err := rows.Scan(
 			&a.QuestionRef, &qtype, &markedJSON, &doubtfulJSON, &status, &a.Score, &a.Max,
+			&positionRaw, &alternativesJSON,
 			&ovMarkedJSON, &ovStatus, &ovEditedAtRaw,
 		); err != nil {
 			return fmt.Errorf("controlstore.loadAnswers: scan: %w", err)
@@ -240,6 +270,14 @@ func (s *Store) loadAnswers(ctx context.Context, r *controls.Reading) error {
 		}
 		if err := json.Unmarshal([]byte(doubtfulJSON), &a.Doubtful); err != nil {
 			return fmt.Errorf("controlstore.loadAnswers: decode doubtful: %w", err)
+		}
+		if positionRaw.Valid {
+			a.Position = int(positionRaw.Int64)
+		}
+		if alternativesJSON.Valid {
+			if err := json.Unmarshal([]byte(alternativesJSON.String), &a.Alternatives); err != nil {
+				return fmt.Errorf("controlstore.loadAnswers: decode alternatives: %w", err)
+			}
 		}
 		if ovMarkedJSON.Valid {
 			ov := controls.AnswerOverride{

--- a/apps/server/internal/infra/storage/controlstore/readings_test.go
+++ b/apps/server/internal/infra/storage/controlstore/readings_test.go
@@ -73,7 +73,10 @@ func TestUpsertReadingsFromReportInsertsThenUpdatesOnASecondCall(t *testing.T) {
 		t.Errorf("Reading(1) RUT = %+v (%v)", r.RUTRead, r.RUTStatus)
 	}
 	if len(r.Answers) != 2 || r.Answers[0].QuestionRef != "q-bucles-1" || r.Answers[1].QuestionRef != "q-if-1" {
-		// ORDER BY question_ref ASC — bucles < if lexicographically.
+		// Both answers have Position=0 → NULL, so ORDER BY falls back to
+		// question_ref ASC — bucles < if lexicographically. The
+		// primary printed-order path is covered by
+		// TestUpsertReadingsFromReportPersistsPerCopyPrintedOrder.
 		t.Errorf("Reading(1) answers = %+v", r.Answers)
 	}
 	multi := r.Answers[0]

--- a/apps/server/internal/infra/storage/controlstore/readings_test.go
+++ b/apps/server/internal/infra/storage/controlstore/readings_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"slices"
 	"testing"
 	"time"
 
@@ -189,6 +190,118 @@ func TestMarkMissingAsNotPresentAddsAReadingPerMissingCopy(t *testing.T) {
 		default:
 			t.Errorf("unexpected copy_number %d", r.CopyNumber)
 		}
+	}
+}
+
+// TestUpsertReadingsFromReportPersistsPerCopyPrintedOrder pins issue #229's
+// storage contract: the position of each question on the printed sheet and
+// the alternatives in printed order both travel from report to database and
+// back. loadAnswers orders by position (falling back to question_ref for
+// legacy rows without one), so answers come out in the same order the
+// student saw them.
+func TestUpsertReadingsFromReportPersistsPerCopyPrintedOrder(t *testing.T) {
+	ctx, db := migrated(t)
+	seedControl(t, ctx, db, "CTRL0130ORDER00000000000AA", 2)
+	store := controlstore.New(db)
+
+	now := time.Unix(1_755_700_000, 0).UTC()
+	// q-bucles-1 prints SECOND on copy 1 (position 2). q-if-1 prints FIRST.
+	// Alphabetically bucles < if, so the pre-#229 order (question_ref ASC)
+	// would put bucles first — this test proves the store now respects
+	// `position` instead.
+	report := controls.Report{
+		Copies: map[string]controls.ReportCopy{
+			"1": {
+				RUT: "20123456", RUTStatus: controls.RUTStatusOK,
+				ExpectedQuestions: 2, SeenQuestions: 2, Status: controls.CopyStatusOK,
+				Answers: []controls.ReportAnswer{
+					{Question: 9, Name: "q-if-1", Type: controls.QuestionSimple,
+						Marked: []int{1}, Status: controls.AnswerStatusOK,
+						Score: 1.0, Max: 1.0,
+						Position: 1, Alternatives: []int{3, 1, 4, 2}},
+					{Question: 10, Name: "q-bucles-1", Type: controls.QuestionSimple,
+						Marked: []int{2}, Status: controls.AnswerStatusOK,
+						Score: 1.0, Max: 1.0,
+						Position: 2, Alternatives: []int{2, 4, 1, 3}},
+				},
+			},
+		},
+	}
+	if err := store.UpsertReadingsFromReport(ctx, "CTRL0130ORDER00000000000AA", report, now); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	r, err := store.ReadingByCopy(ctx, "CTRL0130ORDER00000000000AA", 1)
+	if err != nil {
+		t.Fatalf("ReadingByCopy: %v", err)
+	}
+	if len(r.Answers) != 2 {
+		t.Fatalf("want 2 answers, got %d", len(r.Answers))
+	}
+	if r.Answers[0].QuestionRef != "q-if-1" || r.Answers[0].Position != 1 {
+		t.Errorf("answers[0] = %+v, want q-if-1 at position 1", r.Answers[0])
+	}
+	if !slices.Equal(r.Answers[0].Alternatives, []int{3, 1, 4, 2}) {
+		t.Errorf("answers[0].Alternatives = %v, want [3 1 4 2]", r.Answers[0].Alternatives)
+	}
+	if r.Answers[1].QuestionRef != "q-bucles-1" || r.Answers[1].Position != 2 {
+		t.Errorf("answers[1] = %+v, want q-bucles-1 at position 2", r.Answers[1])
+	}
+	if !slices.Equal(r.Answers[1].Alternatives, []int{2, 4, 1, 3}) {
+		t.Errorf("answers[1].Alternatives = %v, want [2 4 1 3]", r.Answers[1].Alternatives)
+	}
+}
+
+// TestLegacyAnswerRowsWithoutPositionFallBackToRefOrder pins the migration
+// contract: an answer row written before #229 has NULL position and NULL
+// alternatives; loadAnswers must still return it, ordered by question_ref
+// as before the change. Backfilling a made-up position would be the same
+// silent-wrong shape ADR-0031 exists to forbid — the fallback is the
+// design.
+func TestLegacyAnswerRowsWithoutPositionFallBackToRefOrder(t *testing.T) {
+	ctx, db := migrated(t)
+	seedControl(t, ctx, db, "CTRL0131LEGACY0000000000AA", 1)
+	store := controlstore.New(db)
+
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO reading (control_id, copy_number, rut_read, rut_status, copy_status, read_at)
+         VALUES (?, 1, '20123456', 'ok', 'ok', ?)`,
+		"CTRL0131LEGACY0000000000AA", time.Now().Unix()); err != nil {
+		t.Fatalf("insert reading: %v", err)
+	}
+	var readingID int64
+	if err := db.QueryRowContext(ctx,
+		`SELECT id FROM reading WHERE control_id = ? AND copy_number = 1`,
+		"CTRL0131LEGACY0000000000AA").Scan(&readingID); err != nil {
+		t.Fatalf("lookup reading: %v", err)
+	}
+	// Two answers, inserted in a deliberately non-alphabetical order so the
+	// fallback ORDER BY question_ref is what determines the read order, not
+	// insertion time.
+	for _, name := range []string{"q-if-1", "q-bucles-1"} {
+		if _, err := db.ExecContext(ctx,
+			`INSERT INTO answer
+                 (reading_id, question_ref, question_type, marked_json, doubtful_json, status, score, max)
+             VALUES (?, ?, 'simple', '[1]', '[]', 'ok', 1.0, 1.0)`,
+			readingID, name); err != nil {
+			t.Fatalf("insert answer %s: %v", name, err)
+		}
+	}
+
+	r, err := store.ReadingByCopy(ctx, "CTRL0131LEGACY0000000000AA", 1)
+	if err != nil {
+		t.Fatalf("ReadingByCopy: %v", err)
+	}
+	if len(r.Answers) != 2 ||
+		r.Answers[0].QuestionRef != "q-bucles-1" ||
+		r.Answers[1].QuestionRef != "q-if-1" {
+		t.Errorf("legacy fallback order = %+v, want [q-bucles-1, q-if-1]", r.Answers)
+	}
+	if r.Answers[0].Position != 0 {
+		t.Errorf("legacy Position = %d, want 0 (unset)", r.Answers[0].Position)
+	}
+	if r.Answers[0].Alternatives != nil {
+		t.Errorf("legacy Alternatives = %v, want nil", r.Answers[0].Alternatives)
 	}
 }
 

--- a/apps/server/migrations/00010_answer_layout_position.sql
+++ b/apps/server/migrations/00010_answer_layout_position.sql
@@ -17,9 +17,10 @@
 --
 -- Two columns on `answer` rather than a child answer_alternative_position
 -- table, for the same reason marked_json and doubtful_json sit here
--- (00005 §JSON arrays): the natural read shape is "here is the whole list
--- at once", and a normalised table would answer every render with an
--- extra query per question.
+-- (00005_readings.sql, the `answer` table's inline comment on those two
+-- columns): the natural read shape is "here is the whole list at once",
+-- and a normalised table would answer every render with an extra query
+-- per question.
 
 -- +goose Up
 ALTER TABLE answer ADD COLUMN position INTEGER;

--- a/apps/server/migrations/00010_answer_layout_position.sql
+++ b/apps/server/migrations/00010_answer_layout_position.sql
@@ -1,0 +1,30 @@
+-- Issue #229: preserve per-copy printed order on the review page.
+--
+-- AMC shuffles both the questions per copy (\shufflegroup) and the
+-- alternatives per question. read_capture now publishes those two orders on
+-- the wire per answer (`position` + `alternatives`), and this column pair
+-- records them so the review page can render each copy the way its student
+-- saw it. Without them the professor's paper in hand did not match the
+-- order on screen — the marks were read correctly, but the mental
+-- alignment broke.
+--
+-- Nullable, no backfill. Readings landed before this migration have no
+-- positional data and stay legible via loadAnswers' fallback ORDER BY
+-- (position IS NULL first, then question_ref) — which is what they were
+-- rendered by before this change. Backfilling a made-up position would be
+-- the silent-wrong shape ADR-0031 exists to forbid: no answer was ever
+-- printed at some "position that happens to be its rowid".
+--
+-- Two columns on `answer` rather than a child answer_alternative_position
+-- table, for the same reason marked_json and doubtful_json sit here
+-- (00005 §JSON arrays): the natural read shape is "here is the whole list
+-- at once", and a normalised table would answer every render with an
+-- extra query per question.
+
+-- +goose Up
+ALTER TABLE answer ADD COLUMN position INTEGER;
+ALTER TABLE answer ADD COLUMN alternatives_json TEXT;
+
+-- +goose Down
+ALTER TABLE answer DROP COLUMN alternatives_json;
+ALTER TABLE answer DROP COLUMN position;

--- a/docs/decisions/0031-the-reading-report-is-the-contract.md
+++ b/docs/decisions/0031-the-reading-report-is-the-contract.md
@@ -6,6 +6,8 @@
 **Source:** #138 review (round B) — split out of ADR-0030
 **Amended by:** #147 (2026-08-16) — multiple-answer questions, per-question
 weight, and the threshold the scores were computed at
+**Amended by:** #229 (2026-08-26) — per-copy printed order of questions and
+alternatives
 
 ## Context
 
@@ -133,6 +135,32 @@ partial-credit setting awards **full marks for ticking every box** — the hole
 this design exists to close. Reporting the engine's numbers and owning the
 arithmetic keeps the decision ours and survives an engine swap, which is the
 whole point of this ADR.
+
+### Each answer says where it printed on THIS copy, and in what order
+
+The engine shuffles both the questions per copy (a random draw plus
+`\shufflegroup`) and the alternatives per question. A reader that iterated
+by numeric question id and by authoring alternative index produced a review
+page whose questions and options were rendered in a different order than
+the paper the professor held (#229): nothing was mismarked, but the mental
+alignment broke.
+
+So each answer carries `position` (its 1-based slot on THIS copy's printed
+sheet) and `alternatives` (the authoring-index list in printed order for
+THIS copy, per question). The natural key for the reader is still the
+authoring alternative index — it is what `marked` names, what the review
+form posts back, and what the bank's Correct list is keyed by — so
+`alternatives` is a permutation OF those indices, not a replacement for
+them. `position` and `alternatives` are engine-independent by
+construction: any engine that can print a shuffled paper knows this order
+and can publish it; the AMC-fallback reversal test still holds.
+
+Both fields are **optional**. A missing `position` (0) and an empty
+`alternatives` mean "the analyzer has no layout data" — a reading written
+before this amendment, or an analyzer that predates it. Callers rendering
+the paper fall back to their pre-amendment ordering (iteration order for
+the outer answers list, bank order for the alternatives) rather than
+refusing the report, so historical readings stay legible.
 
 ### The report says which threshold its scores were computed at
 


### PR DESCRIPTION
Closes #229.

## Summary

The backoffice review page rendered questions and their alternatives in a different order from the paper the professor was holding: nothing was mismarked, but the mental alignment broke and the page could not do its job. Two independent shuffles cause the mismatch — `\shufflegroup` for questions per copy, AMC's `\shuffle` for alternatives per question — and the pipeline dropped both:

1. `read_capture.py` sorted answers by numeric question id (`for q in sorted(c["q"])`), discarding the physical layout.
2. `controlstore.ListAnswers` re-ordered by `question_ref ASC` on read, undoing any hint.
3. `alternativesFor` read the bank's authoring order, not the layout printed on the specific copy.

The fix carries per-copy printed order end-to-end. Order is derived from `layout_box` geometry `(page, ymin, xmin)` — AMC records coordinates, not a position column. The outer answers list keeps its old iteration order for compatibility; `position` is the authoritative render axis.

## Slices

- **S1 — Worker**: `read_capture.py` publishes `position` (1-based sheet slot) and `alternatives` (authoring indices in printed order) per answer. `03-read.sh` pins seed 1242 order for copies 1, 2, 3 and 5 — including copy 2's `[comparar-cadenas, arreglo-largo, suma-arreglo, indice]` which is NOT numeric order (falsifies any "sort by id" implementation).
- **S2 — Server storage**: migration 00010 adds `answer.position` and `answer.alternatives_json` (both nullable, no backfill). Domain `ReportAnswer` + `Answer` extended. Wire decoder in `amcworker/analyze.go`. `SaveReading` writes both; `loadAnswers` orders by `position IS NULL, position ASC, question_ref ASC` — new rows in printed order, legacy rows in the pre-change alphabetical order.
- **S3 — Server render**: `alternativesFor` iterates `a.Alternatives` in printed order when set. `Index` remains the AUTHORING index in both branches: it is what the store persisted as `marked`, what the save-review form posts back, and what the bank's `Correct` list is keyed by — only the position in the returned slice changes. A length-guard fallback (added in review) catches malformed analyzer emits.
- **S4 — E2E manual verification** (Jetson): **PENDING MIGUEL** — imprimir → escanear → abrir el review → comparar dos copias.
- **S5 — Pre-PR + PR**: this one.

## Deviations from the issue's design

**Two nullable columns on `answer` (`position`, `alternatives_json`) instead of a child table `answer_alternative_position`.** Precedent: `00005_readings.sql` keeps `marked_json` and `doubtful_json` as columns on the same table with the same rationale — "here is the whole list at once", and a normalised child table would answer every render with an extra query per question. Full rationale in the migration comment.

**No backfill.** The issue sketched `UPDATE answer SET position = ROWID` for existing rows. Rejected: backfilling a made-up position is the silent-wrong shape ADR-0031 exists to forbid — no answer was ever printed at "the position that happens to be its rowid". The nullable-position ORDER BY fallback keeps legacy rows in their pre-change alphabetical order, which is more honest and matches historical rendering.

## Merge and deploy order (READ BEFORE MERGE)

`fix(controls-review)` crosses two CD workflows: `server-cd.yml` on `apps/server/**` and `amc-worker-cd.yml` on `apps/amc-worker/**`. **The server MUST reach the Jetson before the worker.** The server accepts both shapes (with and without position/alternatives). If the worker's new-shape emit arrives while the old server binary is still running, Watchtower would pull the new worker image and the server wouldn't persist the positional data — readings would go into the DB with NULL positions and the review would show alphabetical order until the server catches up.

Concretely, the safest merge sequence is a single squash-merge from `main` (both workflows fire), and either:

- The server workflow finishes and Watchtower pulls the server first (usual case — server is much faster to build than the worker's texlive layer under QEMU); or
- If the worker somehow lands first, the effect is temporary — the server pull happens within ~5 min and the next `/analyse` writes the positional data. No data loss.

## Acceptance criteria + evidence

| AC | Evidence |
| --- | --- |
| Two scanned copies render questions in per-paper order | `TestUpsertReadingsFromReportPersistsPerCopyPrintedOrder` (readings_test.go); `03-read.sh` seed 1242 copies 2 and 3 differ from numeric order |
| Alternatives render per-paper order | `TestAlternativesForRendersLabelsInPrintedOrder` (handler); `03-read.sh` `descarte` copy 1 `[3,4,2,1]` vs copy 5 `[1,2,4,3]` |
| Legacy readings stay alphabetical | `TestLegacyAnswerRowsWithoutPositionFallBackToRefOrder` — inserts a pre-migration row, returns `q-bucles-1` before `q-if-1` |
| Migration 00010 applies cleanly | Applied by `migrated(t)` in every controlstore test; Jetson application blocks on S4 |
| apps/server per-commit + pre-PR protocols green | gofmt ✓ vet ✓ `go test -race -count=1 ./...` all 26 packages ✓ build ✓ `govulncheck` no vulnerabilities ✓ `docker build` ✓ `docker compose up -d --build --wait server` healthy ✓ `curl /health` + `curl /api/health` both `{"process":"up","database":"up"}` ✓ |
| apps/amc-worker protocol green | `make verify` full six-script battery green |
| Manual E2E on Jetson | **PENDING** — S4, requires you |

## Tests added

- `apps/amc-worker/tests/03-read.sh`: six new assertions on `position` and `alternatives` fields against seed 1242.
- `apps/server/internal/infra/storage/controlstore/readings_test.go`: `TestUpsertReadingsFromReportPersistsPerCopyPrintedOrder` (round-trip) + `TestLegacyAnswerRowsWithoutPositionFallBackToRefOrder` (legacy fallback).
- `apps/server/internal/app/web/handler/alternatives_for_test.go`: three cases — printed-order with bank labels, legacy fallback, generic `Opción N` labels stay authoring-indexed without a bank; plus a table-driven test for the length-guard fallback added during review.

## Reviews run

- Round A (code): mechanical gate green (`gofmt`, `vet`, `test -race -count=1`, `build`, `govulncheck`, `docker build`, compose `/health`); `lens-correctness-tests`, `lens-arch-simplicity`, `lens-security` in parallel isolated worktrees; `lens-performance` skipped (announced — no hot path touched). 4 suggestions total, 2 acted (COR-1 length-guard, COR-2 stale test comment) as `fix(issue-229): review fixes`, 2 dismissed. Per-fix recheck by the correctness lens: both resolved.
- Round B (docs): `lens-docs-completeness`, `lens-docs-accuracy`, `lens-adr-hunter`, `lens-agent-readability` in parallel isolated worktrees. 10 findings across 4 unique concerns; 4 acted as `docs(issue-229): amend reader contract for per-copy printed order` (read_capture.py docstring, ADR-0031 amendment, amc-worker README paragraph, migration comment fix), 2 deferred as patterns for a later standards-growth sweep, 1 dismissed. Per-fix recheck by the completeness lens: all three critical/important findings resolved.

## Manual verification (blocking on you)

Once both images reach the Jetson (Watchtower ≤ 5 min after squash-merge — check `docker compose ps` for the timestamps of `nalanda-amc-worker` and `nalanda-server`):

1. `ssh jetson` → `cd /opt/nalanda/repo/infra/local` → confirm both containers were restarted recently.
2. Generate + print a small control (2-4 copies) from the backoffice.
3. Mark a couple of copies BY HAND on the printed paper (not synthetic fill — the whole point of this AC is to see the real cycle).
4. Scan the pile.
5. Upload the scan; wait for `/analyse` to finish (see `sistema.log` for a `writeReading` for each copy).
6. Open the review for copy 1, THEN for copy 2 (or whichever two you have on paper).
7. **Verify**: on each copy the order of questions on the screen matches the paper in your hand, AND the letters (A/B/C/D) beside each alternative match the boxes in the printed order.

If it doesn't line up, capture: which copy, which question, what the paper shows, what the screen shows — I'll debug from the `answer.position` and `answer.alternatives_json` rows for that reading.
