### PR TITLE
fix(controls-review): RUT edit feedback + two-level section picker + request logging

### DIFF
--- a/apps/server/GOOGLE-CHECK.md
+++ b/apps/server/GOOGLE-CHECK.md
@@ -184,6 +184,13 @@ the raw log lines (they carry the professor id and, on a refusal, the email), th
 database file, or a screenshot of the signed-in page. `nalanda.db*` and `.env`
 are gitignored; that stops a commit, not a paste.
 
+Since #228 a per-request line lands on the callback fetch too
+(`msg=request path=/login/google/callback method=GET status=302 …`) — the
+query string (`?code=…&state=…`) is stripped by `middleware.loggedPath`
+because those are one-shot credentials RFC 6749 §10.3 warns against
+persisting to logs. That line is safe to summarise (status, duration) but
+not to paste in full while other identifying lines sit around it.
+
 ---
 
 ## What this check has NOT verified

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -34,7 +34,7 @@ Environment variables, read once at boot. A required variable that is absent
 |---|---|---|
 | `NALANDA_ADDR` | yes | Bind address, `host:port` |
 | `NALANDA_DATABASE_URL` | yes | Path to the SQLite file |
-| `NALANDA_LOG_LEVEL` | no (`info`) | `debug`, `info`, `warn` or `error` |
+| `NALANDA_LOG_LEVEL` | no (`info`) | `debug`, `info`, `warn` or `error`. Since #228 every HTTP request is logged at INFO across both surfaces (backoffice + api), one line with method, path, status and duration_ms; `/health` is at DEBUG on purpose so the container healthcheck stays out of the operator's view. The OAuth callback path is logged without its `code`/`state` query — those are one-shot credentials (RFC 6749 §10.3). Middleware: `internal/app/web/middleware/requestlog.go` |
 | `NALANDA_PUBLIC_URL` | yes | Base URL the server is reached at — scheme, host, optional port, and **no path**. The OAuth redirect URI is built from it and its scheme decides the cookie's `Secure` flag; a base carrying a path would build a redirect URI these routes do not serve, so it is refused at boot |
 | `NALANDA_GOOGLE_CLIENT_ID` | yes | The Google OAuth client (ADR-0009) |
 | `NALANDA_GOOGLE_CLIENT_SECRET` | yes | Its secret. Never printed: `config.Config` redacts it for both `fmt` and `slog` |
@@ -113,7 +113,7 @@ internal/domain/   business types and the interfaces they need — PURE
   auth/            professors, identities, sessions, and who may log in
 internal/app/web/  the professor's backoffice
   handler/         the login round trip and the professor CRUD
-  middleware/      cookie → professor, the gate, CSRF
+  middleware/      cookie → professor, the gate, CSRF, and the surface-agnostic request log
   oauthstate/      the single-use state nonces of the OAuth flow
   flash/           the one-shot POST/redirect/GET message cookie
   view/            html/template, embedded — shell + pages

--- a/apps/server/cmd/server/main.go
+++ b/apps/server/cmd/server/main.go
@@ -88,7 +88,11 @@ func rootHandler(backoffice web.Deps, prober health.Prober, logger *slog.Logger)
 	// belongs to the backoffice and is mounted there, on the line above.
 	// TestTheApiSurfaceIsReachableWithoutASession asserts it stayed that way.
 	mux.Handle("/api/", api.Router(prober, logger))
-	return mux
+	// Request logging is outermost and covers BOTH surfaces: the gate above
+	// records who is asking, this records what was asked (issue #228 S1). It
+	// wraps the composition rather than each router individually so a route
+	// added on either side is logged by construction.
+	return middleware.RequestLog(logger, mux)
 }
 
 // run holds everything main would otherwise do, so the only thing outside it is

--- a/apps/server/internal/app/web/handler/controls_test.go
+++ b/apps/server/internal/app/web/handler/controls_test.go
@@ -423,6 +423,39 @@ func TestNewRendersTheFormWithBankSections(t *testing.T) {
 	}
 }
 
+// TestNewFormCarriesTheCascadePickerMarkers pins the S4 progressive
+// enhancement: the flat select is annotated with the data-cascade attribute
+// (so the inline script finds it) and the script itself is inlined on the
+// page. The flat <select> still carries every (doc, section) option — the
+// case above asserts that, and it is what continues to submit when JS is
+// off.
+//
+// A tighter DOM test (asserting the cascade renders and cascades correctly)
+// belongs in a browser, not here: this file is a Go test and cannot execute
+// the script. The DOM behavior is verified by the manual check.
+func TestNewFormCarriesTheCascadePickerMarkers(t *testing.T) {
+	f := newControlsFixture(t)
+	rec := httptest.NewRecorder()
+	f.handler.New(rec, f.authedRequest(t, http.MethodGet, handler.ControlsNewPath, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, needle := range []string{
+		`id="from" name="from" required` + "\n" + `              data-cascade`,
+		`id="to" name="to" required` + "\n" + `              data-cascade`,
+		// The script that builds the cascade. Asserted by a stable-looking
+		// substring rather than the whole block so an added comment does
+		// not break the case.
+		`select[data-cascade]`,
+		`data-cascade-doc-label`,
+	} {
+		if !strings.Contains(body, needle) {
+			t.Errorf("form is missing cascade marker %q", needle)
+		}
+	}
+}
+
 func TestCreateWritesAControlAndRedirectsToItsDetail(t *testing.T) {
 	f := newControlsFixture(t)
 	rec := httptest.NewRecorder()

--- a/apps/server/internal/app/web/handler/controls_test.go
+++ b/apps/server/internal/app/web/handler/controls_test.go
@@ -441,14 +441,21 @@ func TestNewFormCarriesTheCascadePickerMarkers(t *testing.T) {
 		t.Fatalf("status = %d, want 200", rec.Code)
 	}
 	body := rec.Body.String()
+	// Each check is one intent; the whitespace of the template is NOT
+	// part of the assertion, so a reformat of the HTML leaves the case
+	// green (S3 review ARQ-4). The initial revision baked the 14-space
+	// indent of the `data-cascade` line into the substring and would have
+	// broken on any indent change.
 	for _, needle := range []string{
-		`id="from" name="from" required` + "\n" + `              data-cascade`,
-		`id="to" name="to" required` + "\n" + `              data-cascade`,
-		// The script that builds the cascade. Asserted by a stable-looking
-		// substring rather than the whole block so an added comment does
-		// not break the case.
-		`select[data-cascade]`,
+		`id="from"`,
+		`id="to"`,
+		`name="from"`,
+		`name="to"`,
+		`data-cascade`,
 		`data-cascade-doc-label`,
+		// The script that builds the cascade — a stable-looking selector
+		// substring, not a whole-block match.
+		`select[data-cascade]`,
 	} {
 		if !strings.Contains(body, needle) {
 			t.Errorf("form is missing cascade marker %q", needle)

--- a/apps/server/internal/app/web/handler/review.go
+++ b/apps/server/internal/app/web/handler/review.go
@@ -216,10 +216,13 @@ func (h *Controls) SaveReview(w http.ResponseWriter, r *http.Request) {
 	// something to search for.
 	//
 	// The RUT values are masked to the last 4 digits (S3 review SEC-2):
-	// the full RUT is personal data under Ley 19.628 and would otherwise
-	// sit in the docker log rotation. `rut_action` already carries the
-	// diagnostic value — the last 4 digits are enough to correlate two
-	// log lines about the same student without persisting the full ID.
+	// the full RUT is personal data under Ley 21.719 (Chile's 2024
+	// data-protection law, which supersedes Ley 19.628) and would
+	// otherwise sit in the docker log rotation. `rut_action` already
+	// carries the diagnostic value — the last 4 digits are enough to
+	// correlate two log lines about the same student without persisting
+	// the full ID. See `docs/security-notes.md` §"Logs and personal
+	// data" for the surface-wide masking rule (Round B ADR-1).
 	h.Log.Info("save review",
 		"control", id,
 		"copy", copyNumber,

--- a/apps/server/internal/app/web/handler/review.go
+++ b/apps/server/internal/app/web/handler/review.go
@@ -128,6 +128,7 @@ func (h *Controls) SaveReview(w http.ResponseWriter, r *http.Request) {
 	}
 
 	rut := strings.TrimSpace(r.PostFormValue("rut"))
+	blank := r.PostFormValue("blank") // "" or one question_ref
 	// SEC-1: the template's pattern="[0-9]{8}" is client-side; the
 	// professor's form goes to the RUT override table verbatim, so an
 	// arbitrary string would persist. Reject anything that is not eight
@@ -139,17 +140,32 @@ func (h *Controls) SaveReview(w http.ResponseWriter, r *http.Request) {
 	// behaviour silently ignored empty submissions in the domain, so the
 	// professor got the generic "Cambios guardados." flash even though the
 	// RUT field they had cleared was not persisted. Refusing here surfaces
-	// the mistake instead. The rule applies to every submission the form
-	// can produce, including the "Marcar en blanco" question button — the
-	// RUT field is always in the form and is always submitted with it,
-	// prefilled with the current effective value; clearing it on any
-	// submission is what the professor said, and the refusal names it.
-	switch {
-	case rut == "":
-		flash.Set(w, h.secureCookie, "El RUT no puede quedar vacío.")
-		http.Redirect(w, r, controlReviewURL(id, copyNumber), http.StatusSeeOther)
-		return
-	case !isValidRUT(rut):
+	// the mistake instead.
+	//
+	// The rule is scoped to the main Guardar submission (S3 review COR-3):
+	// the "Marcar en blanco" question button is orthogonal to the RUT
+	// edit, and on a copy where AMC never read the RUT the input renders
+	// with `value=""`; refusing every blank click on such a copy would
+	// silently drop the professor's actual intent (mark this answer
+	// blank). When `blank != ""`, the empty-RUT case falls through to
+	// SaveOverrides, which the domain rejects too — we return a specific
+	// flash there so the professor still learns what happened.
+	if blank == "" {
+		switch {
+		case rut == "":
+			flash.Set(w, h.secureCookie, "El RUT no puede quedar vacío.")
+			http.Redirect(w, r, controlReviewURL(id, copyNumber), http.StatusSeeOther)
+			return
+		case !isValidRUT(rut):
+			flash.Set(w, h.secureCookie, "El RUT debe tener 8 dígitos.")
+			http.Redirect(w, r, controlReviewURL(id, copyNumber), http.StatusSeeOther)
+			return
+		}
+	} else if rut != "" && !isValidRUT(rut) {
+		// Blank click AND the RUT field carries invalid non-empty text —
+		// still refuse (same SEC-1 reasoning). Empty on a blank click
+		// falls through as documented above; the domain treats it as a
+		// no-op on the RUT half.
 		flash.Set(w, h.secureCookie, "El RUT debe tener 8 dígitos.")
 		http.Redirect(w, r, controlReviewURL(id, copyNumber), http.StatusSeeOther)
 		return
@@ -160,7 +176,6 @@ func (h *Controls) SaveReview(w http.ResponseWriter, r *http.Request) {
 		CopyNumber: copyNumber,
 		RUT:        rut,
 	}
-	blank := r.PostFormValue("blank") // "" or one question_ref
 	for _, a := range reading.Answers {
 		edit := controls.AnswerEdit{QuestionRef: a.QuestionRef}
 		if a.QuestionRef == blank {
@@ -199,11 +214,17 @@ func (h *Controls) SaveReview(w http.ResponseWriter, r *http.Request) {
 	// closes here. The line names the concrete outcome (what the RUT
 	// action was, how many answers moved) so a future diagnosis has
 	// something to search for.
+	//
+	// The RUT values are masked to the last 4 digits (S3 review SEC-2):
+	// the full RUT is personal data under Ley 19.628 and would otherwise
+	// sit in the docker log rotation. `rut_action` already carries the
+	// diagnostic value — the last 4 digits are enough to correlate two
+	// log lines about the same student without persisting the full ID.
 	h.Log.Info("save review",
 		"control", id,
 		"copy", copyNumber,
-		"rut_from", result.RUTFrom,
-		"rut_to", result.RUTTo,
+		"rut_from", maskRUT(result.RUTFrom),
+		"rut_to", maskRUT(result.RUTTo),
 		"rut_action", string(result.RUTAction),
 		"answers_changed", result.AnswersChanged)
 	// Issue #190, ruta B: the save just changed what this copy means, so
@@ -224,7 +245,11 @@ func (h *Controls) SaveReview(w http.ResponseWriter, r *http.Request) {
 //
 // The "Marcar en blanco" question button submits with `blank=<ref>` and
 // gets its own dedicated line, because the professor was clicking that
-// specific button and the confirmation belongs beside its intent.
+// specific button and the confirmation belongs beside its intent. When
+// the same submission also moved OTHER answers (a mid-edit blank click
+// carries every field on the page), the count line still fires with
+// those other moves subtracted from `AnswersChanged` — the blank click
+// is already counted there (S3 review COR-5).
 func buildSaveReviewFlash(result controls.SaveOverridesResult, blank string) string {
 	lines := []string{}
 	switch result.RUTAction {
@@ -233,19 +258,35 @@ func buildSaveReviewFlash(result controls.SaveOverridesResult, blank string) str
 	case controls.RUTActionMatchedRead:
 		lines = append(lines, "RUT vuelto al valor leído por AMC.")
 	}
+	otherAnswers := result.AnswersChanged
 	if blank != "" {
 		lines = append(lines, fmt.Sprintf("Pregunta %s marcada en blanco.", blank))
-	} else if result.AnswersChanged > 0 {
-		if result.AnswersChanged == 1 {
+		otherAnswers-- // the blank click itself is counted in AnswersChanged.
+	}
+	if otherAnswers > 0 {
+		if otherAnswers == 1 {
 			lines = append(lines, "Cambios en 1 respuesta.")
 		} else {
-			lines = append(lines, fmt.Sprintf("Cambios en %d respuestas.", result.AnswersChanged))
+			lines = append(lines, fmt.Sprintf("Cambios en %d respuestas.", otherAnswers))
 		}
 	}
 	if len(lines) == 0 {
 		return "Sin cambios."
 	}
 	return strings.Join(lines, "\n")
+}
+
+// maskRUT returns the last four digits of a RUT, prefixed with an
+// ellipsis, for logging. Empty stays empty. Anything shorter than four
+// characters is returned verbatim — the RUT is validated to eight
+// digits before reaching the domain, so a shorter string is either the
+// "never had a RUT" case (empty) or a test fixture; either way it is
+// not personal data.
+func maskRUT(rut string) string {
+	if len(rut) < 4 {
+		return rut
+	}
+	return "…" + rut[len(rut)-4:]
 }
 
 // parseAnswerValues turns form values ("1", "3") into an int slice,

--- a/apps/server/internal/app/web/handler/review.go
+++ b/apps/server/internal/app/web/handler/review.go
@@ -89,8 +89,16 @@ func (h *Controls) Review(w http.ResponseWriter, r *http.Request) {
 }
 
 // SaveReview handles POST /controls/:id/copies/:copy/review. Reads the
-// form values, hands them to the Service, and flashes back to the detail
+// form values, hands them to the Service, and flashes back to the review
 // page.
+//
+// Since issue #228 S3 the redirect target is the review page itself, not
+// the control detail: the professor was losing the RUT edit's "(editado
+// por ti)" marker AND the flash by being sent away from the page they
+// just submitted. Empty RUT is refused here rather than silently dropped
+// by the domain (S2 diagnosis H1), and the success flash is per-action
+// rather than a generic "Cambios guardados." so a ClearRUTOverride does
+// not look identical to a real update.
 func (h *Controls) SaveReview(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	copyNumber, ok := parseCopyPathValue(r.PathValue("copy"))
@@ -126,7 +134,22 @@ func (h *Controls) SaveReview(w http.ResponseWriter, r *http.Request) {
 	// digits — the review handler is authenticated but a defensive server
 	// check is cheap and stops the field from carrying garbage the rest
 	// of the surface treats as an 8-digit id.
-	if rut != "" && !isValidRUT(rut) {
+	//
+	// Empty is refused for its own reason (issue #228 S3): the previous
+	// behaviour silently ignored empty submissions in the domain, so the
+	// professor got the generic "Cambios guardados." flash even though the
+	// RUT field they had cleared was not persisted. Refusing here surfaces
+	// the mistake instead. The rule applies to every submission the form
+	// can produce, including the "Marcar en blanco" question button — the
+	// RUT field is always in the form and is always submitted with it,
+	// prefilled with the current effective value; clearing it on any
+	// submission is what the professor said, and the refusal names it.
+	switch {
+	case rut == "":
+		flash.Set(w, h.secureCookie, "El RUT no puede quedar vacío.")
+		http.Redirect(w, r, controlReviewURL(id, copyNumber), http.StatusSeeOther)
+		return
+	case !isValidRUT(rut):
 		flash.Set(w, h.secureCookie, "El RUT debe tener 8 dígitos.")
 		http.Redirect(w, r, controlReviewURL(id, copyNumber), http.StatusSeeOther)
 		return
@@ -165,12 +188,24 @@ func (h *Controls) SaveReview(w http.ResponseWriter, r *http.Request) {
 		req.Answers = append(req.Answers, edit)
 	}
 
-	if err := h.Service.SaveOverrides(r.Context(), req); err != nil {
+	result, err := h.Service.SaveOverrides(r.Context(), req)
+	if err != nil {
 		h.Log.Error("save review", "error", err, "id", id, "copy", copyNumber)
 		middleware.WriteError(w, r, http.StatusInternalServerError,
 			"El servidor no pudo guardar los cambios. Vuelve a intentarlo.")
 		return
 	}
+	// Issue #228 S3: the observability gap that made Bug 3 invisible
+	// closes here. The line names the concrete outcome (what the RUT
+	// action was, how many answers moved) so a future diagnosis has
+	// something to search for.
+	h.Log.Info("save review",
+		"control", id,
+		"copy", copyNumber,
+		"rut_from", result.RUTFrom,
+		"rut_to", result.RUTTo,
+		"rut_action", string(result.RUTAction),
+		"answers_changed", result.AnswersChanged)
 	// Issue #190, ruta B: the save just changed what this copy means, so
 	// the annotated PDF must follow — synchronously, inside the request
 	// (the issue accepts the seconds-class block). A failure here does not
@@ -179,12 +214,38 @@ func (h *Controls) SaveReview(w http.ResponseWriter, r *http.Request) {
 	if _, err := h.Service.Annotate(r.Context(), id, copyNumber); err != nil {
 		h.Log.Warn("save review: annotate failed", "control", id, "copy", copyNumber, "error", err)
 	}
-	if blank != "" {
-		flash.Set(w, h.secureCookie, fmt.Sprintf("Pregunta %s marcada en blanco.", blank))
-	} else {
-		flash.Set(w, h.secureCookie, "Cambios guardados.")
+	flash.Set(w, h.secureCookie, buildSaveReviewFlash(result, blank))
+	http.Redirect(w, r, controlReviewURL(id, copyNumber), http.StatusSeeOther)
+}
+
+// buildSaveReviewFlash turns a save result into the professor-visible
+// flash. Multi-line output is separated by "\n" — the layout template
+// splits and renders `<li>` items when there is more than one line.
+//
+// The "Marcar en blanco" question button submits with `blank=<ref>` and
+// gets its own dedicated line, because the professor was clicking that
+// specific button and the confirmation belongs beside its intent.
+func buildSaveReviewFlash(result controls.SaveOverridesResult, blank string) string {
+	lines := []string{}
+	switch result.RUTAction {
+	case controls.RUTActionUpdated:
+		lines = append(lines, fmt.Sprintf("RUT actualizado a %s.", result.RUTTo))
+	case controls.RUTActionMatchedRead:
+		lines = append(lines, "RUT vuelto al valor leído por AMC.")
 	}
-	http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
+	if blank != "" {
+		lines = append(lines, fmt.Sprintf("Pregunta %s marcada en blanco.", blank))
+	} else if result.AnswersChanged > 0 {
+		if result.AnswersChanged == 1 {
+			lines = append(lines, "Cambios en 1 respuesta.")
+		} else {
+			lines = append(lines, fmt.Sprintf("Cambios en %d respuestas.", result.AnswersChanged))
+		}
+	}
+	if len(lines) == 0 {
+		return "Sin cambios."
+	}
+	return strings.Join(lines, "\n")
 }
 
 // parseAnswerValues turns form values ("1", "3") into an int slice,

--- a/apps/server/internal/app/web/handler/save_review_test.go
+++ b/apps/server/internal/app/web/handler/save_review_test.go
@@ -393,3 +393,79 @@ func TestSaveReviewFlashesBothRUTAndAnswersOnOneSubmit(t *testing.T) {
 		t.Errorf("flash = %q, want %q — S3 joins per-action lines with \\n", got, want)
 	}
 }
+
+// TestSaveReviewBlankButtonAcceptsEmptyRUT pins COR-3 (S3 review): on a
+// copy where AMC never read the RUT, the input renders with `value=""`;
+// clicking the "Marcar en blanco" question button submits `rut=""`, and
+// the previous revision refused with `El RUT no puede quedar vacío`,
+// silently dropping the blanking. The blank click is orthogonal to the
+// RUT edit — the button's purpose is to blank one answer, not to force a
+// RUT. Now the submission is accepted, the answer is blanked, and the
+// flash names the blank.
+func TestSaveReviewBlankButtonAcceptsEmptyRUT(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control blank empty RUT", 1)
+	// A copy AMC could not read the RUT for — RUTStatus=NotPresent, no
+	// RUTRead, no override. This is the state where `toReviewRUT`
+	// renders the input with value="".
+	f.fake.AnalyzeReports = []controls.Report{
+		{Copies: map[string]controls.ReportCopy{
+			"1": {RUT: "", RUTStatus: controls.RUTStatusNotPresent, Status: controls.CopyStatusNeedsReview,
+				ExpectedQuestions: 2, SeenQuestions: 2,
+				Answers: []controls.ReportAnswer{
+					{Question: 1, Name: "q3", Type: controls.QuestionSimple, Marked: []int{1},
+						Status: controls.AnswerStatusOK, Score: 1, Max: 1},
+					{Question: 2, Name: "q4", Type: controls.QuestionMultiple, Marked: []int{1},
+						Status: controls.AnswerStatusOK, Score: 4, Max: 4},
+				}},
+		}},
+	}
+	uploadOnce(t, f, controlID)
+
+	values := url.Values{}
+	values.Set("rut", "") // the case: no RUT typed, blank button clicked
+	values.Set("qq3", "1")
+	values.Set("qq4", "1")
+	values.Set("blank", "q3")
+
+	rec := postSaveReview(t, f, controlID, 1, values)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d\nbody: %s", rec.Code, rec.Body.String())
+	}
+	// The blanking landed — q3 has a blank override.
+	reading, _ := f.service.ReadingFor(context.Background(), controlID, 1)
+	var q3 *controls.Answer
+	for i := range reading.Answers {
+		if reading.Answers[i].QuestionRef == "q3" {
+			q3 = &reading.Answers[i]
+		}
+	}
+	if q3 == nil || q3.Override == nil || q3.Override.Status != controls.AnswerStatusBlank {
+		t.Fatalf("q3 was not blanked: %+v", q3)
+	}
+	// Flash names the blank, not a RUT rejection.
+	if got, want := flashFromResponse(t, rec), "Pregunta q3 marcada en blanco."; got != want {
+		t.Errorf("flash = %q, want %q — COR-3: blank click must not be refused for empty RUT", got, want)
+	}
+}
+
+// TestSaveReviewBlankButtonAlsoReportsOtherMovedAnswers pins COR-5: when
+// the professor mid-edits other radios and then clicks the blank button,
+// the count of OTHER moves is not swallowed by the blank line.
+func TestSaveReviewBlankButtonAlsoReportsOtherMovedAnswers(t *testing.T) {
+	f, controlID := saveReviewFixture(t)
+	values := url.Values{}
+	values.Set("rut", "20111111") // == AMC-read
+	values.Set("qq3", "1")        // == AMC-read (no move)
+	values.Set("qq4", "2")        // was 1 → moves
+	values.Set("blank", "q3")     // ALSO blanks q3 → 2 answers touched total
+
+	rec := postSaveReview(t, f, controlID, 1, values)
+
+	got := flashFromResponse(t, rec)
+	want := "Pregunta q3 marcada en blanco.\nCambios en 1 respuesta."
+	if got != want {
+		t.Errorf("flash = %q, want %q — COR-5: the mid-blank submission must still report the other move", got, want)
+	}
+}

--- a/apps/server/internal/app/web/handler/save_review_test.go
+++ b/apps/server/internal/app/web/handler/save_review_test.go
@@ -2,6 +2,7 @@ package handler_test
 
 import (
 	"context"
+	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -9,8 +10,68 @@ import (
 	"testing"
 	"time"
 
+	"github.com/so77id/nalanda/apps/server/internal/app/web/flash"
 	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
 )
+
+// flashFromResponse decodes the flash cookie the handler set on rec.
+// Returns empty when there is none. The cookie is base64url-encoded per
+// flash.Set — the raw string can carry "\n" for a multi-line flash.
+func flashFromResponse(t *testing.T, rec *httptest.ResponseRecorder) string {
+	t.Helper()
+	for _, c := range rec.Result().Cookies() {
+		if c.Name != flash.CookieName || c.Value == "" || c.MaxAge < 0 {
+			continue
+		}
+		b, err := base64.URLEncoding.DecodeString(c.Value)
+		if err != nil {
+			t.Fatalf("flash cookie decode: %v", err)
+		}
+		return string(b)
+	}
+	return ""
+}
+
+// saveReviewFixture returns a fixture already set up with one uploaded
+// scan reporting RUT 20111111 and two OK answers on copy 1 — the shape
+// the RUT flash cases in this file build on.
+func saveReviewFixture(t *testing.T) (*controlsFixture, string) {
+	t.Helper()
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control S3", 1)
+	f.fake.AnalyzeReports = []controls.Report{
+		{Copies: map[string]controls.ReportCopy{
+			"1": {RUT: "20111111", RUTStatus: controls.RUTStatusOK, Status: controls.CopyStatusNeedsReview,
+				ExpectedQuestions: 2, SeenQuestions: 2,
+				Answers: []controls.ReportAnswer{
+					{Question: 1, Name: "q3", Type: controls.QuestionSimple, Marked: []int{1},
+						Status: controls.AnswerStatusOK, Score: 1, Max: 1},
+					{Question: 2, Name: "q4", Type: controls.QuestionMultiple, Marked: []int{1},
+						Status: controls.AnswerStatusOK, Score: 4, Max: 4},
+				}},
+		}},
+	}
+	uploadOnce(t, f, controlID)
+	return f, controlID
+}
+
+// postSaveReview POSTs the given form values against SaveReview for the
+// given control/copy and returns the recorder. Marshalled so a case body
+// reads at the level of intent ("post rut, keep answers as read") rather
+// than mux plumbing.
+func postSaveReview(t *testing.T, f *controlsFixture, controlID string, copy int, values url.Values) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost,
+		"/controls/"+controlID+"/copies/1/review",
+		strings.NewReader(values.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetPathValue("id", controlID)
+	req.SetPathValue("copy", "1")
+	req = req.WithContext(f.authedRequest(t, http.MethodPost, "/", nil).Context())
+	rec := httptest.NewRecorder()
+	f.handler.SaveReview(rec, req)
+	return rec
+}
 
 func TestSaveReviewOverridesLandAndFlashConfirms(t *testing.T) {
 	f := newControlsFixture(t)
@@ -140,5 +201,195 @@ func TestSaveReviewBlankButtonClearsAnswer(t *testing.T) {
 				t.Errorf("q3 not blanked: %+v", a.Override)
 			}
 		}
+	}
+}
+
+// The S3 cases below cover issue #228's RUT feedback + redirect + flash
+// granularity work. See handler/review.go:buildSaveReviewFlash.
+
+// TestSaveReviewRedirectsToTheReviewPageNotDetail pins the redirect
+// target change (S3): the professor stays on the page they just
+// submitted, so the RUT `(editado por ti)` marker AND the flash are
+// visible together. Every S3 case below inherits this expectation.
+func TestSaveReviewRedirectsToTheReviewPageNotDetail(t *testing.T) {
+	f, controlID := saveReviewFixture(t)
+	values := url.Values{}
+	values.Set("rut", "20111111")
+	values.Set("qq3", "1")
+	values.Set("qq4", "1")
+	values.Set("save", "1")
+
+	rec := postSaveReview(t, f, controlID, 1, values)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d\nbody: %s", rec.Code, rec.Body.String())
+	}
+	want := "/controls/" + controlID + "/copies/1/review"
+	if got := rec.Header().Get("Location"); got != want {
+		t.Errorf("Location = %q, want %q — the S3 fix keeps the professor on the review page", got, want)
+	}
+}
+
+// TestSaveReviewRefusesEmptyRUTWithFlash pins the S3 rejection of an
+// empty RUT: the domain used to silently ignore it and flash
+// "Cambios guardados." anyway (S2 diagnosis, empty branch of the
+// SaveOverrides switch). Refusing here surfaces the mistake.
+func TestSaveReviewRefusesEmptyRUTWithFlash(t *testing.T) {
+	f, controlID := saveReviewFixture(t)
+	values := url.Values{}
+	values.Set("rut", "") // the case
+	values.Set("qq3", "1")
+	values.Set("qq4", "1")
+	values.Set("save", "1")
+
+	rec := postSaveReview(t, f, controlID, 1, values)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if got, want := flashFromResponse(t, rec), "El RUT no puede quedar vacío."; got != want {
+		t.Errorf("flash = %q, want %q", got, want)
+	}
+	// No override was written — the request was refused before the domain
+	// call, so the reading stays exactly as AMC read it.
+	reading, _ := f.service.ReadingFor(context.Background(), controlID, 1)
+	if reading.RUTOverride != nil {
+		t.Errorf("RUT override = %+v, want none — the empty submission was refused", reading.RUTOverride)
+	}
+}
+
+// TestSaveReviewRefusesInvalidRUTWithFlash pins the existing
+// eight-digit-only refusal (SEC-1) still flashes.
+func TestSaveReviewRefusesInvalidRUTWithFlash(t *testing.T) {
+	f, controlID := saveReviewFixture(t)
+	values := url.Values{}
+	values.Set("rut", "1234") // too short
+	values.Set("qq3", "1")
+	values.Set("qq4", "1")
+	values.Set("save", "1")
+
+	rec := postSaveReview(t, f, controlID, 1, values)
+
+	if got, want := flashFromResponse(t, rec), "El RUT debe tener 8 dígitos."; got != want {
+		t.Errorf("flash = %q, want %q", got, want)
+	}
+}
+
+// TestSaveReviewFlashesRUTUpdatedWhenTheValueChanges pins the flash for
+// a new override that differs from what AMC read. This is the branch
+// that actually changed something Miguel typed.
+func TestSaveReviewFlashesRUTUpdatedWhenTheValueChanges(t *testing.T) {
+	f, controlID := saveReviewFixture(t)
+	values := url.Values{}
+	values.Set("rut", "20222222") // differs from the AMC-read 20111111
+	values.Set("qq3", "1")
+	values.Set("qq4", "1")
+	values.Set("save", "1")
+
+	rec := postSaveReview(t, f, controlID, 1, values)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if got, want := flashFromResponse(t, rec), "RUT actualizado a 20222222."; got != want {
+		t.Errorf("flash = %q, want %q", got, want)
+	}
+	// The override landed. Reading it back confirms the persist.
+	reading, _ := f.service.ReadingFor(context.Background(), controlID, 1)
+	if reading.RUTOverride == nil || reading.RUTOverride.RUT != "20222222" {
+		t.Errorf("RUT override = %+v, want the new value", reading.RUTOverride)
+	}
+}
+
+// TestSaveReviewFlashesRUTMatchedReadWhenClearingOverride pins the H1
+// bug from the S2 diagnosis. Setup: an override exists that differs
+// from AMC's read. The professor types the AMC-read value back → the
+// override is CLEARED. Before S3, the flash said "Cambios guardados."
+// and the review page came back looking untouched; the professor read
+// that as "nothing persisted". After S3 the flash names the branch.
+func TestSaveReviewFlashesRUTMatchedReadWhenClearingOverride(t *testing.T) {
+	f, controlID := saveReviewFixture(t)
+	// First save: write an override that differs from AMC. That is the
+	// state Miguel would have arrived at from a prior edit.
+	values := url.Values{}
+	values.Set("rut", "20999999")
+	values.Set("qq3", "1")
+	values.Set("qq4", "1")
+	values.Set("save", "1")
+	_ = postSaveReview(t, f, controlID, 1, values)
+
+	// Second save: the professor types the AMC value back. The domain
+	// clears the override (ClearRUTOverride branch, scans.go). The
+	// flash must name what happened rather than saying "Cambios
+	// guardados."
+	values.Set("rut", "20111111") // == AMC-read
+	rec := postSaveReview(t, f, controlID, 1, values)
+
+	if got, want := flashFromResponse(t, rec), "RUT vuelto al valor leído por AMC."; got != want {
+		t.Errorf("flash = %q, want %q — S3 makes the ClearRUTOverride branch visible", got, want)
+	}
+	// The override is gone: only the AMC-read value survives.
+	reading, _ := f.service.ReadingFor(context.Background(), controlID, 1)
+	if reading.RUTOverride != nil {
+		t.Errorf("RUT override = %+v, want none — the ClearRUTOverride branch fires when the submission matches AMC", reading.RUTOverride)
+	}
+}
+
+// TestSaveReviewFlashesSinCambiosWhenNothingMoved pins the "no-op save"
+// case: the professor clicked Guardar without changing anything. Before
+// S3 it flashed "Cambios guardados." and hid the fact that no override
+// was written; now the flash names the outcome so a professor does not
+// mis-read it as a persist.
+func TestSaveReviewFlashesSinCambiosWhenNothingMoved(t *testing.T) {
+	f, controlID := saveReviewFixture(t)
+	values := url.Values{}
+	values.Set("rut", "20111111") // == AMC-read, no override existed
+	values.Set("qq3", "1")        // == AMC-read
+	values.Set("qq4", "1")        // == AMC-read
+	values.Set("save", "1")
+
+	rec := postSaveReview(t, f, controlID, 1, values)
+
+	if got, want := flashFromResponse(t, rec), "Sin cambios."; got != want {
+		t.Errorf("flash = %q, want %q", got, want)
+	}
+}
+
+// TestSaveReviewFlashesAnswerCountWhenOnlyAnswersMove pins the answer-
+// only flash. The RUT is left as read, one answer is changed, the flash
+// names the count.
+func TestSaveReviewFlashesAnswerCountWhenOnlyAnswersMove(t *testing.T) {
+	f, controlID := saveReviewFixture(t)
+	values := url.Values{}
+	values.Set("rut", "20111111") // == AMC-read
+	values.Set("qq3", "1")        // == AMC-read
+	values.Set("qq4", "2")        // was 1 (q4 is multiple, Max=4 so 2 is valid)
+	values.Set("save", "1")
+
+	rec := postSaveReview(t, f, controlID, 1, values)
+
+	if got, want := flashFromResponse(t, rec), "Cambios en 1 respuesta."; got != want {
+		t.Errorf("flash = %q, want %q", got, want)
+	}
+}
+
+// TestSaveReviewFlashesBothRUTAndAnswersOnOneSubmit pins the multi-line
+// flash: two actions in one submit produce two lines joined by "\n",
+// which the layout template renders as a `<ul>` in a single
+// `.flash` container.
+func TestSaveReviewFlashesBothRUTAndAnswersOnOneSubmit(t *testing.T) {
+	f, controlID := saveReviewFixture(t)
+	values := url.Values{}
+	values.Set("rut", "20222222") // updated
+	values.Set("qq3", "1")        // unchanged
+	values.Set("qq4", "2")        // was 1 → answer moves
+	values.Set("save", "1")
+
+	rec := postSaveReview(t, f, controlID, 1, values)
+
+	got := flashFromResponse(t, rec)
+	want := "RUT actualizado a 20222222.\nCambios en 1 respuesta."
+	if got != want {
+		t.Errorf("flash = %q, want %q — S3 joins per-action lines with \\n", got, want)
 	}
 }

--- a/apps/server/internal/app/web/middleware/middleware.go
+++ b/apps/server/internal/app/web/middleware/middleware.go
@@ -1,21 +1,27 @@
-// Package middleware turns a cookie into a professor, gates what needs one, and
-// refuses a state-changing request that cannot prove it was intended.
+// Package middleware turns a cookie into a professor, gates what needs one,
+// refuses a state-changing request that cannot prove it was intended, and
+// records what each request was.
 //
-// It lives under internal/app/web and nowhere else, which is the seam §C12 of
-// the design draws: the backoffice serves an authenticated professor and the API
-// surface serves anonymous students who join with a room code. Same process,
-// opposite auth models. Mounting any of this on internal/app/api would put a
-// login gate in front of the students, and the composition test in cmd/server
-// asserts that it has not happened.
+// The three AUTH middlewares live under internal/app/web and nowhere else,
+// which is the seam §C12 of the design draws: the backoffice serves an
+// authenticated professor and the API surface serves anonymous students who
+// join with a room code. Same process, opposite auth models. Mounting any of
+// them on internal/app/api would put a login gate in front of the students,
+// and the composition test in cmd/server asserts that it has not happened.
 //
-// The three middlewares are separate on purpose:
+// The four middlewares are separate on purpose:
 //
 //	Resolve          runs on everything — it only ANSWERS who is asking.
 //	RequireProfessor gates — it decides that an answer was required.
 //	VerifyCSRF       refuses a state-changing request without the session's token.
+//	RequestLog       records one slog line per HTTP request (surface-agnostic).
 //
-// Collapsing them would make /health and /login require a session, which is how
-// a container healthcheck starts failing for reasons nobody can see.
+// Collapsing the auth trio would make /health and /login require a session,
+// which is how a container healthcheck starts failing for reasons nobody can
+// see. RequestLog is deliberately outside that trio — it wraps the composed
+// mux in `cmd/server/main.go`'s rootHandler so both the backoffice AND the
+// api surface log their requests, and it never inspects the session (issue
+// #228 S1 + S3 review ARQ-1).
 package middleware
 
 import (

--- a/apps/server/internal/app/web/middleware/requestlog.go
+++ b/apps/server/internal/app/web/middleware/requestlog.go
@@ -1,0 +1,69 @@
+package middleware
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// RequestLog wraps next and writes one slog line per HTTP request with
+// method, path, status, bytes written and duration.
+//
+// The gate below records "who is asking" (Resolve) and the CSRF middleware
+// records refusals, but nothing records the request itself: on 2026-08-26 a
+// backoffice RUT edit reported silent failure and `docker-compose logs server`
+// showed only startup lines. This middleware exists so the next round of
+// diagnosis is not blind (issue #228 S1).
+//
+// A container healthcheck polls /health every few seconds; that line would
+// dominate the log without carrying any diagnostic value, so it drops to DEBUG
+// rather than INFO. Everything else is INFO — an operator reading the log
+// wants to see one line per request. The path is logged raw (query string
+// preserved) because a bug report ("editar RUT no persiste") is often
+// identified by the query params the browser sent.
+func RequestLog(logger *slog.Logger, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(rec, r)
+		level := slog.LevelInfo
+		if r.URL.Path == "/health" {
+			level = slog.LevelDebug
+		}
+		logger.LogAttrs(r.Context(), level, "request",
+			slog.String("method", r.Method),
+			slog.String("path", r.URL.RequestURI()),
+			slog.Int("status", rec.status),
+			slog.Int64("bytes", rec.bytes),
+			slog.Int64("duration_ms", time.Since(start).Milliseconds()),
+		)
+	})
+}
+
+// statusRecorder wraps a ResponseWriter to capture the final status and the
+// number of bytes written. A handler that writes to the body without calling
+// WriteHeader still counts as 200 — the same rule net/http applies internally.
+type statusRecorder struct {
+	http.ResponseWriter
+	status      int
+	bytes       int64
+	wroteHeader bool
+}
+
+func (r *statusRecorder) WriteHeader(status int) {
+	if r.wroteHeader {
+		return
+	}
+	r.status = status
+	r.wroteHeader = true
+	r.ResponseWriter.WriteHeader(status)
+}
+
+func (r *statusRecorder) Write(b []byte) (int, error) {
+	if !r.wroteHeader {
+		r.wroteHeader = true
+	}
+	n, err := r.ResponseWriter.Write(b)
+	r.bytes += int64(n)
+	return n, err
+}

--- a/apps/server/internal/app/web/middleware/requestlog.go
+++ b/apps/server/internal/app/web/middleware/requestlog.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"log/slog"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -18,31 +19,66 @@ import (
 // A container healthcheck polls /health every few seconds; that line would
 // dominate the log without carrying any diagnostic value, so it drops to DEBUG
 // rather than INFO. Everything else is INFO — an operator reading the log
-// wants to see one line per request. The path is logged raw (query string
-// preserved) because a bug report ("editar RUT no persiste") is often
-// identified by the query params the browser sent.
+// wants to see one line per request. The path is logged with its query string
+// EXCEPT on the OAuth callback, where `?code=...&state=...` are one-shot
+// credentials that RFC 6749 §10.3 warns against persisting to logs; there we
+// keep the bare path (S3 review, SEC-1).
+//
+// The log line is emitted from a `defer` so a panic in the wrapped handler
+// still produces a request line — the exact "silent failure, docker logs
+// shows nothing" symptom that motivated S1 recurs on panic without the
+// defer (S3 review, COR-1).
 func RequestLog(logger *slog.Logger, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		rec := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		defer func() {
+			level := slog.LevelInfo
+			if r.URL.Path == "/health" {
+				level = slog.LevelDebug
+			}
+			logger.LogAttrs(r.Context(), level, "request",
+				slog.String("method", r.Method),
+				slog.String("path", loggedPath(r.URL)),
+				slog.Int("status", rec.status),
+				slog.Int64("bytes", rec.bytes),
+				slog.Int64("duration_ms", time.Since(start).Milliseconds()),
+			)
+		}()
 		next.ServeHTTP(rec, r)
-		level := slog.LevelInfo
-		if r.URL.Path == "/health" {
-			level = slog.LevelDebug
-		}
-		logger.LogAttrs(r.Context(), level, "request",
-			slog.String("method", r.Method),
-			slog.String("path", r.URL.RequestURI()),
-			slog.Int("status", rec.status),
-			slog.Int64("bytes", rec.bytes),
-			slog.Int64("duration_ms", time.Since(start).Milliseconds()),
-		)
 	})
+}
+
+// loggedPath is the URL a request line names. Everything except the OAuth
+// callback keeps its query string; the callback drops it, because the
+// `code` and `state` params are one-shot credentials that must not sit in
+// the docker log rotation (S3 review, SEC-1).
+//
+// The callback path is spelled here as a literal string rather than
+// imported from `handler.LoginCallbackPath`: `middleware` sits below
+// `handler` in the dependency graph, and adding an upward import to name
+// one string would invert the layering the package doc pins.
+func loggedPath(u *url.URL) string {
+	if u.Path == "/login/google/callback" {
+		return u.Path
+	}
+	return u.RequestURI()
 }
 
 // statusRecorder wraps a ResponseWriter to capture the final status and the
 // number of bytes written. A handler that writes to the body without calling
 // WriteHeader still counts as 200 — the same rule net/http applies internally.
+//
+// TODO(streaming): this wrapper embeds only `http.ResponseWriter` and does
+// NOT re-implement `http.Hijacker`, `http.Flusher` or `http.Pusher`. Nothing
+// in the tree upgrades today (no SSE, no WebSocket, no HTTP/2 push), so a
+// naive wrap is proportionate; but this middleware is now the outermost
+// wrap over BOTH surfaces (`cmd/server/main.go` `rootHandler`), so the
+// first streaming handler added on either surface will silently fail its
+// `w.(http.Flusher)` and `w.(http.Hijacker)` upgrades. Fix path: delegate
+// each of the three via a type assertion on the embedded writer. Spec:
+// `net/http` documents each interface; the classic pattern is described
+// in the `httpsnoop` project's README (github.com/felixge/httpsnoop).
 type statusRecorder struct {
 	http.ResponseWriter
 	status      int

--- a/apps/server/internal/app/web/middleware/requestlog_test.go
+++ b/apps/server/internal/app/web/middleware/requestlog_test.go
@@ -1,0 +1,178 @@
+package middleware_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/so77id/nalanda/apps/server/internal/app/web/middleware"
+)
+
+// captureLogs returns a JSON slog handler writing into buf, at DEBUG level so a
+// /health line is visible when the case asserts it was demoted.
+func captureLogs(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+// TestRequestLogEmitsOneLinePerRequest is the happy path: a 200 leaves one INFO
+// line carrying method, path, status, bytes and a non-negative duration_ms.
+func TestRequestLogEmitsOneLinePerRequest(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := captureLogs(buf)
+	wrapped := middleware.RequestLog(logger, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("hola"))
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/controls", nil)
+	wrapped.ServeHTTP(httptest.NewRecorder(), req)
+
+	line := decodeOneLine(t, buf)
+	if got, want := line["level"], "INFO"; got != want {
+		t.Errorf("level: got %q, want %q", got, want)
+	}
+	if got, want := line["msg"], "request"; got != want {
+		t.Errorf("msg: got %q, want %q", got, want)
+	}
+	if got, want := line["method"], http.MethodGet; got != want {
+		t.Errorf("method: got %q, want %q", got, want)
+	}
+	if got, want := line["path"], "/controls"; got != want {
+		t.Errorf("path: got %q, want %q", got, want)
+	}
+	if got, want := jsonNumberInt(t, line["status"]), 200; got != want {
+		t.Errorf("status: got %d, want %d", got, want)
+	}
+	if got, want := jsonNumberInt(t, line["bytes"]), 4; got != want {
+		t.Errorf("bytes: got %d, want %d", got, want)
+	}
+	if _, ok := line["duration_ms"]; !ok {
+		t.Errorf("duration_ms: missing")
+	}
+}
+
+// TestRequestLogCapturesStatusFromWriteHeader pins that a 500 the handler chose
+// reaches the log, so a bug report of "no persisted / no flash" can be matched
+// to the actual status the server sent.
+func TestRequestLogCapturesStatusFromWriteHeader(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := captureLogs(buf)
+	wrapped := middleware.RequestLog(logger, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+
+	wrapped.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/controls/1/copies/2/review", nil))
+
+	line := decodeOneLine(t, buf)
+	if got, want := jsonNumberInt(t, line["status"]), http.StatusInternalServerError; got != want {
+		t.Errorf("status: got %d, want %d", got, want)
+	}
+}
+
+// TestRequestLogCapturesStatusFromRedirect pins a 302: the login redirect is
+// the single most common non-200 in production, and losing it in the log would
+// mean every anonymous request looked like a served page.
+func TestRequestLogCapturesStatusFromRedirect(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := captureLogs(buf)
+	wrapped := middleware.RequestLog(logger, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/login", http.StatusSeeOther)
+	}))
+
+	wrapped.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/controls", nil))
+
+	line := decodeOneLine(t, buf)
+	if got, want := jsonNumberInt(t, line["status"]), http.StatusSeeOther; got != want {
+		t.Errorf("status: got %d, want %d", got, want)
+	}
+}
+
+// TestRequestLogPreservesQueryString pins that ?copy=2 stays in the log — the
+// backoffice's review page is /controls/{id}/copies/{copy}/review AND takes
+// query params, and a bug report often points at exactly one of them.
+func TestRequestLogPreservesQueryString(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := captureLogs(buf)
+	wrapped := middleware.RequestLog(logger, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	wrapped.ServeHTTP(httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodGet, "/controls/1/copies/2/review?page=3", nil))
+
+	line := decodeOneLine(t, buf)
+	if got, want := line["path"], "/controls/1/copies/2/review?page=3"; got != want {
+		t.Errorf("path: got %q, want %q", got, want)
+	}
+}
+
+// TestRequestLogDemotesHealthToDebug pins that /health goes to DEBUG rather
+// than INFO: the container healthcheck polls it every few seconds and would
+// bury every other line.
+func TestRequestLogDemotesHealthToDebug(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := captureLogs(buf)
+	wrapped := middleware.RequestLog(logger, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	wrapped.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/health", nil))
+
+	line := decodeOneLine(t, buf)
+	if got, want := line["level"], "DEBUG"; got != want {
+		t.Errorf("level: got %q, want %q — /health should not compete with real traffic at INFO", got, want)
+	}
+	if got, want := line["path"], "/health"; got != want {
+		t.Errorf("path: got %q, want %q", got, want)
+	}
+}
+
+// TestRequestLogHealthAtDebugIsFilteredAtInfo pins the practical consequence
+// of demoting /health: an INFO-level operator log carries zero /health lines.
+// Without this the demotion is only a label change.
+func TestRequestLogHealthAtDebugIsFilteredAtInfo(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	wrapped := middleware.RequestLog(logger, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	wrapped.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/health", nil))
+
+	if buf.Len() != 0 {
+		t.Errorf("INFO-level log wrote %d bytes for /health; want none", buf.Len())
+	}
+}
+
+// decodeOneLine parses buf as exactly one JSON slog line. More than one line
+// means the middleware wrote where nothing else should have; zero lines means
+// it wrote nowhere.
+func decodeOneLine(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	trimmed := strings.TrimRight(buf.String(), "\n")
+	if trimmed == "" {
+		t.Fatalf("no log line")
+	}
+	if strings.Contains(trimmed, "\n") {
+		t.Fatalf("more than one log line:\n%s", trimmed)
+	}
+	var line map[string]any
+	if err := json.Unmarshal([]byte(trimmed), &line); err != nil {
+		t.Fatalf("json: %v — line %q", err, trimmed)
+	}
+	return line
+}
+
+// jsonNumberInt turns a slog-encoded number into an int; encoding/json decodes
+// numeric JSON into float64 by default, so a bare cast would panic on any int.
+func jsonNumberInt(t *testing.T, v any) int {
+	t.Helper()
+	f, ok := v.(float64)
+	if !ok {
+		t.Fatalf("not a number: %T (%v)", v, v)
+	}
+	return int(f)
+}

--- a/apps/server/internal/app/web/middleware/requestlog_test.go
+++ b/apps/server/internal/app/web/middleware/requestlog_test.go
@@ -72,9 +72,9 @@ func TestRequestLogCapturesStatusFromWriteHeader(t *testing.T) {
 	}
 }
 
-// TestRequestLogCapturesStatusFromRedirect pins a 302: the login redirect is
-// the single most common non-200 in production, and losing it in the log would
-// mean every anonymous request looked like a served page.
+// TestRequestLogCapturesStatusFromRedirect pins a 303 (See Other): the
+// login-redirect is the single most common non-200 in production, and losing
+// it in the log would mean every anonymous request looked like a served page.
 func TestRequestLogCapturesStatusFromRedirect(t *testing.T) {
 	buf := &bytes.Buffer{}
 	logger := captureLogs(buf)
@@ -127,6 +127,59 @@ func TestRequestLogDemotesHealthToDebug(t *testing.T) {
 	}
 	if got, want := line["path"], "/health"; got != want {
 		t.Errorf("path: got %q, want %q", got, want)
+	}
+}
+
+// TestRequestLogEmitsALineEvenWhenTheHandlerPanics pins COR-1 (S3 review):
+// the middleware's whole purpose is one line per request; a panic in the
+// wrapped handler used to skip the log call entirely, recurring the exact
+// "silent failure, docker logs shows nothing" symptom the middleware exists
+// to prevent. The fix moves LogAttrs into a defer.
+func TestRequestLogEmitsALineEvenWhenTheHandlerPanics(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := captureLogs(buf)
+	wrapped := middleware.RequestLog(logger, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("boom")
+	}))
+
+	// The panic is expected — swallow it here so the defer in RequestLog
+	// runs and the case can assert the log was written.
+	func() {
+		defer func() { _ = recover() }()
+		wrapped.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/controls", nil))
+	}()
+
+	line := decodeOneLine(t, buf)
+	if got, want := line["path"], "/controls"; got != want {
+		t.Errorf("path: got %q, want %q — the log line must survive the handler panic", got, want)
+	}
+}
+
+// TestRequestLogDropsQueryOnOAuthCallback pins SEC-1 (S3 review): the
+// OAuth callback receives `?code=...&state=...` from Google. Both are
+// one-shot credentials that must not sit in the docker log rotation
+// (RFC 6749 §10.3). The middleware drops the query on this one path only.
+func TestRequestLogDropsQueryOnOAuthCallback(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := captureLogs(buf)
+	wrapped := middleware.RequestLog(logger, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusSeeOther)
+	}))
+
+	wrapped.ServeHTTP(httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodGet, "/login/google/callback?state=abc123&code=secret-oauth-code", nil))
+
+	line := decodeOneLine(t, buf)
+	if got, want := line["path"], "/login/google/callback"; got != want {
+		t.Errorf("path: got %q, want %q — the OAuth callback must never persist code/state to logs", got, want)
+	}
+	// Belt-and-suspenders: nothing in the serialised line carries the
+	// tokens under any key.
+	raw := buf.String()
+	for _, needle := range []string{"secret-oauth-code", "state=abc123", "abc123"} {
+		if strings.Contains(raw, needle) {
+			t.Errorf("log line leaks %q — the query must be stripped for the callback", needle)
+		}
 	}
 }
 

--- a/apps/server/internal/app/web/view/templates/layout.html
+++ b/apps/server/internal/app/web/view/templates/layout.html
@@ -205,7 +205,16 @@
 
     <main{{ if not .Professor }} class="centered"{{ end }}>
       {{ if .Flash }}
-        <p class="flash">{{ .Flash }}</p>
+        {{ $lines := splitLines .Flash }}
+        {{ if gt (len $lines) 1 }}
+          <div class="flash">
+            <ul>
+              {{ range $lines }}<li>{{ . }}</li>{{ end }}
+            </ul>
+          </div>
+        {{ else }}
+          <p class="flash">{{ .Flash }}</p>
+        {{ end }}
       {{ end }}
       {{ template "content" . }}
     </main>

--- a/apps/server/internal/app/web/view/templates/pages/controls_form.html
+++ b/apps/server/internal/app/web/view/templates/pages/controls_form.html
@@ -28,7 +28,12 @@
 
     <p class="field">
       <label for="from">Desde</label>
-      <select id="from" name="from" required>
+      <select id="from" name="from" required
+              data-cascade
+              data-cascade-doc-label="Documento"
+              data-cascade-section-label="Sección"
+              data-cascade-doc-placeholder="— elige un documento —"
+              data-cascade-section-placeholder="— elige una sección —">
         <option value="">— elige un inicio —</option>
         {{ $from := printf "%s:%s" .Values.FromDocument .Values.FromSection }}
         {{ range .SectionOptions }}
@@ -46,7 +51,12 @@
 
     <p class="field">
       <label for="to">Hasta</label>
-      <select id="to" name="to" required>
+      <select id="to" name="to" required
+              data-cascade
+              data-cascade-doc-label="Documento"
+              data-cascade-section-label="Sección"
+              data-cascade-doc-placeholder="— elige un documento —"
+              data-cascade-section-placeholder="— elige una sección —">
         <option value="">— elige un fin —</option>
         {{ $to := printf "%s:%s" .Values.ToDocument .Values.ToSection }}
         {{ range .SectionOptions }}
@@ -117,4 +127,127 @@
     <p><button type="submit">{{ .Submit }}</button>
        <a href="/controls" class="boton">Cancelar</a></p>
   </form>
+
+  <script>
+    // Progressive enhancement: for each <select data-cascade>, build a
+    // two-level picker (document → section) beside it and hide the flat
+    // select. The flat select stays part of the form so the value it holds
+    // is still what POSTs; without JS the flat select is the whole UI.
+    //
+    // Issue #228 S4: with 9+ documents and several sections each, the flat
+    // grouped <select> is a scroll of ~30 options that hides section names
+    // behind the currently-selected group. The cascade shows one document
+    // list and one section list.
+    (function () {
+      for (const flat of document.querySelectorAll('select[data-cascade]')) {
+        buildCascade(flat);
+      }
+
+      function buildCascade(flat) {
+        // Read the doc → sections map from the flat select's <optgroup>s
+        // — no separate JSON payload, one source of truth.
+        const groups = [];
+        for (const og of flat.querySelectorAll('optgroup')) {
+          const options = [];
+          for (const opt of og.querySelectorAll('option')) {
+            const [docId, sectionId] = opt.value.split(':', 2);
+            options.push({ value: opt.value, docId, sectionId, label: opt.textContent });
+          }
+          if (options.length) {
+            groups.push({ docId: options[0].docId, title: og.label, options });
+          }
+        }
+        if (!groups.length) return;
+
+        const docLabel = flat.dataset.cascadeDocLabel || 'Documento';
+        const sectionLabel = flat.dataset.cascadeSectionLabel || 'Sección';
+        const docPlaceholder = flat.dataset.cascadeDocPlaceholder || '— documento —';
+        const sectionPlaceholder = flat.dataset.cascadeSectionPlaceholder || '— sección —';
+        const fieldId = flat.id;
+
+        const wrap = document.createElement('span');
+        wrap.className = 'cascade';
+        wrap.dataset.cascadeFor = fieldId;
+
+        const docSel = document.createElement('select');
+        docSel.id = fieldId + '-doc';
+        const docLbl = document.createElement('label');
+        docLbl.htmlFor = docSel.id;
+        docLbl.textContent = docLabel + ': ';
+
+        docSel.appendChild(new Option(docPlaceholder, ''));
+        for (const g of groups) {
+          docSel.appendChild(new Option(g.title, g.docId));
+        }
+
+        const secSel = document.createElement('select');
+        secSel.id = fieldId + '-section';
+        secSel.disabled = true;
+        secSel.setAttribute('aria-live', 'polite');
+        const secLbl = document.createElement('label');
+        secLbl.htmlFor = secSel.id;
+        secLbl.textContent = ' ' + sectionLabel + ': ';
+        secSel.appendChild(new Option(sectionPlaceholder, ''));
+
+        wrap.appendChild(docLbl);
+        wrap.appendChild(docSel);
+        wrap.appendChild(secLbl);
+        wrap.appendChild(secSel);
+        flat.parentNode.insertBefore(wrap, flat);
+
+        // Hide the flat select but keep it in the form so its value posts.
+        flat.hidden = true;
+        // Remove `required` from the flat control — the browser refuses to
+        // focus a `hidden` invalid element and the form silently fails to
+        // submit. The cascade validates by having both selects `required`.
+        flat.removeAttribute('required');
+        docSel.required = true;
+        secSel.required = true;
+
+        docSel.addEventListener('change', () => {
+          fillSections(secSel, groups, docSel.value, sectionPlaceholder);
+          syncFlat(flat, docSel.value, secSel.value);
+        });
+        secSel.addEventListener('change', () => {
+          syncFlat(flat, docSel.value, secSel.value);
+        });
+
+        // Initialise from whatever the server pre-selected. On a fresh GET
+        // both are empty; after a validation refusal the flat select holds
+        // "doc:section" and both cascades should pre-select accordingly.
+        const initial = (flat.value || '').split(':', 2);
+        if (initial.length === 2 && initial[0]) {
+          docSel.value = initial[0];
+          fillSections(secSel, groups, initial[0], sectionPlaceholder);
+          secSel.value = initial[0] + ':' + initial[1];
+        }
+      }
+
+      function fillSections(secSel, groups, docId, placeholder) {
+        while (secSel.firstChild) secSel.removeChild(secSel.firstChild);
+        secSel.appendChild(new Option(placeholder, ''));
+        const g = groups.find(g => g.docId === docId);
+        if (!g) {
+          secSel.disabled = true;
+          return;
+        }
+        for (const opt of g.options) {
+          secSel.appendChild(new Option(opt.label, opt.value));
+        }
+        secSel.disabled = false;
+      }
+
+      function syncFlat(flat, docId, sectionValue) {
+        // The flat select's value carries the composite "doc:section" the
+        // handler expects (valuesFromRequest splits on ':' — controls.go).
+        // Empty when either half is unselected — the server refuses that
+        // as a validation error and re-renders the form.
+        if (!docId || !sectionValue) {
+          flat.value = '';
+          return;
+        }
+        flat.value = sectionValue;
+      }
+    })();
+  </script>
 {{ end }}

--- a/apps/server/internal/app/web/view/view.go
+++ b/apps/server/internal/app/web/view/view.go
@@ -388,8 +388,18 @@ type ErrorPage struct {
 	Message string
 }
 
+// templateFuncs is registered on every parsed template.
+//
+// splitLines turns a multi-line flash into a []string the layout can range
+// over: a save review flash carries one line per action ("RUT actualizado
+// a X", "Cambios en 3 respuestas") joined by "\n" — see
+// handler.buildSaveReviewFlash (issue #228 S3).
+var templateFuncs = template.FuncMap{
+	"splitLines": func(s string) []string { return strings.Split(s, "\n") },
+}
+
 func mustParsePages() map[string]*template.Template {
-	layout, err := template.ParseFS(files, "templates/layout.html")
+	layout, err := template.New("layout.html").Funcs(templateFuncs).ParseFS(files, "templates/layout.html")
 	if err != nil {
 		panic("view: parse layout: " + err.Error())
 	}

--- a/apps/server/internal/domain/controls/scans.go
+++ b/apps/server/internal/domain/controls/scans.go
@@ -302,11 +302,17 @@ type SaveOverridesResult struct {
 }
 
 // SaveOverrides applies a professor's edits to a single reading. The
-// request carries the RUT (empty is refused — the handler validates and
-// rejects before calling this, issue #228 S3) and one entry per question
-// in the reading's pool with the new marked set. A submitted set that
-// MATCHES what AMC read for that question clears any prior override;
-// anything else upserts one. The RUT logic is symmetric.
+// request carries the RUT and one entry per question in the reading's
+// pool with the new marked set. A submitted set that MATCHES what AMC
+// read for that question clears any prior override; anything else
+// upserts one. The RUT logic is symmetric.
+//
+// Empty RUT is a no-op on the RUT half (RUTAction stays Unchanged): the
+// main Guardar submission is refused by the handler before calling here,
+// but the "Marcar en blanco" question button IS allowed through with an
+// empty RUT — the copy may not have had a RUT read yet, and the button's
+// purpose is to blank a single answer, not to force a RUT edit
+// (issue #228 S3 review COR-3).
 //
 // Returns a SaveOverridesResult that names the actual outcome (was the
 // RUT set anew, cleared to AMC's read, or unchanged; how many answers
@@ -326,9 +332,11 @@ func (s *Service) SaveOverrides(ctx context.Context, req SaveOverridesRequest) (
 
 	// RUT — the override is what shows up beside the AMC read on the
 	// review page; setting it back to what AMC read clears the override.
-	// Empty submissions are refused by the handler before reaching here.
 	rutMatchesRead := reading.RUTRead != nil && *reading.RUTRead == req.RUT
 	switch {
+	case req.RUT == "":
+		// No RUT half to apply; see the docstring for when this branch
+		// is reachable.
 	case rutMatchesRead && reading.RUTStatus == RUTStatusOK:
 		if err := s.Readings.ClearRUTOverride(ctx, reading.ID); err != nil {
 			return result, err
@@ -397,20 +405,7 @@ func effectiveRUT(r Reading) string {
 // professor-visible state. EditedAt is ignored — the timestamp is
 // bookkeeping, not something the professor edited.
 func sameOverride(a, b AnswerOverride) bool {
-	if a.Status != b.Status || len(a.Marked) != len(b.Marked) {
-		return false
-	}
-	seen := make(map[int]int, len(a.Marked))
-	for _, m := range a.Marked {
-		seen[m]++
-	}
-	for _, m := range b.Marked {
-		if seen[m] == 0 {
-			return false
-		}
-		seen[m]--
-	}
-	return true
+	return sameMarksAndStatus(a.Status, a.Marked, b.Status, b.Marked)
 }
 
 // CloseCorrection moves a control to Graded, refusing when the gate is
@@ -492,17 +487,22 @@ func findAnswer(r Reading, ref string) (Answer, bool) {
 // matchesRead reports whether an edit brings the answer back to what AMC
 // originally read (same marks in any order, same status).
 func matchesRead(a Answer, edit AnswerEdit) bool {
-	if a.Status != edit.Status {
+	return sameMarksAndStatus(a.Status, a.Marked, edit.Status, edit.Marked)
+}
+
+// sameMarksAndStatus reports whether two (status, marks) pairs represent
+// the same professor-visible answer. Marks are compared as multisets
+// (order-independent, duplicates counted). Extracted from `sameOverride`
+// and `matchesRead`, which were near-identical (S3 review ARQ-2).
+func sameMarksAndStatus(s1 AnswerStatus, m1 []int, s2 AnswerStatus, m2 []int) bool {
+	if s1 != s2 || len(m1) != len(m2) {
 		return false
 	}
-	if len(a.Marked) != len(edit.Marked) {
-		return false
-	}
-	seen := make(map[int]int, len(a.Marked))
-	for _, m := range a.Marked {
+	seen := make(map[int]int, len(m1))
+	for _, m := range m1 {
 		seen[m]++
 	}
-	for _, m := range edit.Marked {
+	for _, m := range m2 {
 		if seen[m] == 0 {
 			return false
 		}

--- a/apps/server/internal/domain/controls/scans.go
+++ b/apps/server/internal/domain/controls/scans.go
@@ -267,33 +267,83 @@ func (s *Service) AnnotatedFor(ctx context.Context, controlID string, copyNumber
 	return s.Store.AnnotatedByCopy(ctx, controlID, copyNumber)
 }
 
+// RUTAction reports what happened to the RUT during SaveOverrides — the
+// distinction that lets the surface build a professor-facing flash without
+// re-deriving state (issue #228 S3). Empty submissions are refused by the
+// handler, so the empty case is not represented here.
+type RUTAction string
+
+const (
+	// RUTActionUpdated: an override was written and the effective RUT
+	// changed (either it is a new override, or the override's value
+	// differs from what was there before).
+	RUTActionUpdated RUTAction = "updated"
+	// RUTActionMatchedRead: the submission equalled what AMC originally
+	// read, so any prior override was cleared. This is the branch that
+	// looked like "nothing persisted" to Miguel in the 2026-08-26 report
+	// (issue #228 S2 diagnosis H1) — the flash now names it explicitly.
+	RUTActionMatchedRead RUTAction = "matched_read"
+	// RUTActionUnchanged: the submitted value matched what was already
+	// effective (either an override matching itself, or a bare AMC read
+	// with no override — the ClearRUTOverride call was a no-op).
+	RUTActionUnchanged RUTAction = "unchanged"
+)
+
+// SaveOverridesResult reports what SaveOverrides did, so the surface can
+// build a flash that names the actual outcome. See RUTAction for the RUT
+// half; AnswersChanged counts answers whose Override state moved (either a
+// clear that removed a prior override, or an upsert that stored a value
+// different from what was already stored).
+type SaveOverridesResult struct {
+	RUTAction      RUTAction
+	RUTFrom        string // effective RUT the reading had before the save.
+	RUTTo          string // effective RUT the reading has after the save.
+	AnswersChanged int
+}
+
 // SaveOverrides applies a professor's edits to a single reading. The
-// request carries the RUT (empty means "no change" — the review handler
-// enforces its own precondition) and one entry per question in the
-// reading's pool with the new marked set. A submitted set that MATCHES
-// what AMC read for that question clears any prior override; anything
-// else upserts one. The RUT logic is symmetric.
-func (s *Service) SaveOverrides(ctx context.Context, req SaveOverridesRequest) error {
+// request carries the RUT (empty is refused — the handler validates and
+// rejects before calling this, issue #228 S3) and one entry per question
+// in the reading's pool with the new marked set. A submitted set that
+// MATCHES what AMC read for that question clears any prior override;
+// anything else upserts one. The RUT logic is symmetric.
+//
+// Returns a SaveOverridesResult that names the actual outcome (was the
+// RUT set anew, cleared to AMC's read, or unchanged; how many answers
+// moved), so the surface can render a flash the professor can trust.
+func (s *Service) SaveOverrides(ctx context.Context, req SaveOverridesRequest) (SaveOverridesResult, error) {
 	reading, err := s.Readings.ReadingByCopy(ctx, req.ControlID, req.CopyNumber)
 	if err != nil {
-		return err
+		return SaveOverridesResult{}, err
 	}
 	now := s.Now()
 
+	result := SaveOverridesResult{
+		RUTAction: RUTActionUnchanged,
+		RUTFrom:   effectiveRUT(reading),
+		RUTTo:     effectiveRUT(reading),
+	}
+
 	// RUT — the override is what shows up beside the AMC read on the
 	// review page; setting it back to what AMC read clears the override.
+	// Empty submissions are refused by the handler before reaching here.
 	rutMatchesRead := reading.RUTRead != nil && *reading.RUTRead == req.RUT
 	switch {
-	case req.RUT == "":
-		// Empty submission is ignored — the review form always sends the
-		// current visible RUT (either the read value or the override).
 	case rutMatchesRead && reading.RUTStatus == RUTStatusOK:
 		if err := s.Readings.ClearRUTOverride(ctx, reading.ID); err != nil {
-			return err
+			return result, err
+		}
+		if reading.RUTOverride != nil {
+			result.RUTAction = RUTActionMatchedRead
+			result.RUTTo = *reading.RUTRead
 		}
 	default:
 		if err := s.Readings.SetRUTOverride(ctx, reading.ID, req.RUT, now); err != nil {
-			return err
+			return result, err
+		}
+		if reading.RUTOverride == nil || reading.RUTOverride.RUT != req.RUT {
+			result.RUTAction = RUTActionUpdated
+			result.RUTTo = req.RUT
 		}
 	}
 
@@ -309,7 +359,10 @@ func (s *Service) SaveOverrides(ctx context.Context, req SaveOverridesRequest) e
 		}
 		if matchesRead(ans, edit) {
 			if err := s.Readings.ClearAnswerOverride(ctx, reading.ID, edit.QuestionRef); err != nil {
-				return err
+				return result, err
+			}
+			if ans.Override != nil {
+				result.AnswersChanged++
 			}
 			continue
 		}
@@ -319,10 +372,45 @@ func (s *Service) SaveOverrides(ctx context.Context, req SaveOverridesRequest) e
 			EditedAt: now,
 		}
 		if err := s.Readings.SetAnswerOverride(ctx, reading.ID, edit.QuestionRef, override); err != nil {
-			return err
+			return result, err
+		}
+		if ans.Override == nil || !sameOverride(*ans.Override, override) {
+			result.AnswersChanged++
 		}
 	}
-	return nil
+	return result, nil
+}
+
+// effectiveRUT is what the review page would display for the reading:
+// the override if any, else what AMC read, else empty.
+func effectiveRUT(r Reading) string {
+	if r.RUTOverride != nil {
+		return r.RUTOverride.RUT
+	}
+	if r.RUTRead != nil {
+		return *r.RUTRead
+	}
+	return ""
+}
+
+// sameOverride reports whether two answer overrides carry the same
+// professor-visible state. EditedAt is ignored — the timestamp is
+// bookkeeping, not something the professor edited.
+func sameOverride(a, b AnswerOverride) bool {
+	if a.Status != b.Status || len(a.Marked) != len(b.Marked) {
+		return false
+	}
+	seen := make(map[int]int, len(a.Marked))
+	for _, m := range a.Marked {
+		seen[m]++
+	}
+	for _, m := range b.Marked {
+		if seen[m] == 0 {
+			return false
+		}
+		seen[m]--
+	}
+	return true
 }
 
 // CloseCorrection moves a control to Graded, refusing when the gate is

--- a/docs/security-notes.md
+++ b/docs/security-notes.md
@@ -927,3 +927,36 @@ the flag, every read and write goes through them, and two literal-string tests
 pin the two names (`__Host-nalanda_session` / `nalanda_session`). The split
 between dev and prod is real, and the class of defect that used to come with it
 is closed by the tests rather than by refusing the prefix.
+
+### Logs and personal data — RUT is masked to the last four digits (recorded 2026-08-26, #228)
+
+Personal data under **Ley 21.719** (Chile's 2024 data-protection law, which
+supersedes Ley 19.628 — either statute number may appear in older comments and
+tickets, they refer to the same class of obligation on the same fields) reaches
+the server through the review flow: a professor edits a copy's RUT, and both
+the previous and the corrected value briefly exist in the request handler.
+Since #228 the `slog.Info("save review", …)` line in
+`internal/app/web/handler/review.go` masks both `rut_from` and `rut_to` to the
+last four digits (`"…" + rut[len(rut)-4:]`) via the `maskRUT` helper. The
+`rut_action` (`updated` / `matched_read` / `unchanged`) and `answers_changed`
+fields carry the diagnostic value the log was added for; the last four digits
+are enough to correlate two lines about the same student without persisting
+the full identifier to the docker log rotation on the Jetson.
+
+**Rule for new slog callers**: any log line that would touch a RUT or another
+Ley 21.719 field goes through `maskRUT` (or an equivalent masking helper for
+its field). Log the `_action` and `_changed`-style fields freely — they are
+the diagnostic value; keep the identifier itself out.
+
+**Request path (SEC-1, #228)**: `middleware.RequestLog` logs the full
+`RequestURI()` on every request, EXCEPT on `/login/google/callback`, where
+the query string is stripped — `?code=…&state=…` are one-shot OAuth
+credentials that RFC 6749 §10.3 warns against persisting to logs. Any future
+route that carries a credential-like value in its query string needs the same
+scoping added to `middleware.loggedPath` (`internal/app/web/middleware/requestlog.go`).
+
+**Residual, accepted**: the flash cookie the professor sees on save still
+carries the full RUT (`"RUT actualizado a XXXXXXXX."`) — that is intended
+feedback to the same authenticated user who typed it, not a log or third-
+party sink; `flash.Set` scopes it to the session and it is cleared on the
+next render.

--- a/docs/standards/backend-code-style.md
+++ b/docs/standards/backend-code-style.md
@@ -190,6 +190,16 @@ Environment variables only, read **once at boot** into a struct, through
   seam. Review triggers: `docs/security-notes.md` §"The login's state cookie
   is a double-submit cookie" and §"The session cookie has no `Secure` flag
   in development".
+- **Middleware placement**: the three AUTH middlewares
+  (`Resolve` / `RequireProfessor` / `VerifyCSRF`) live under
+  `internal/app/web/middleware` — mounting any of them on the API surface
+  would put a login gate in front of anonymous students (§C12). A
+  SURFACE-AGNOSTIC middleware (the request log added in #228, a rate
+  limiter later) also lives there — same package, but wraps the composed
+  mux in `cmd/server/main.go`'s `rootHandler` so both surfaces trace their
+  own requests. The package doc names both tenants; a new middleware
+  chooses its layer by asking whether it inspects the session (auth →
+  wraps `web.Router`; surface-agnostic → wraps `rootHandler`).
 - **Every server-side timeout is set explicitly — all five.** `ReadTimeout`,
   `ReadHeaderTimeout`, `WriteTimeout`, `IdleTimeout` and `MaxHeaderBytes`. Each
   defaults to zero and zero means *no limit*, so what they prevent is a slow
@@ -282,6 +292,29 @@ is public and has no session to hang a flash on.
 branches on it with `errors.Is`, sets the Spanish message and redirects to
 the list. `auth.ErrCannotDeactivateSelf` and
 `auth.ErrCannotDeactivateLastActive` are the worked cases.
+
+**A flash with multiple bullet-worthy lines is one string joined by
+`"\n"`** — the layout renders a single line as `<p class="flash">` and
+more than one as `<div class="flash"><ul><li>…</li></ul></div>` via the
+`splitLines` template FuncMap in `internal/app/web/view/view.go`. Worked
+case: `handler.buildSaveReviewFlash` (issue #228) emits one line per
+action ("RUT actualizado a X", "Cambios en N respuestas"). Do NOT set
+several flash cookies in one response — the second overwrites the first.
+
+### Client-side JS in a server template
+
+The backoffice serves no static assets today (no `/static/` mount), and a
+one-page progressive enhancement is inline in the template that needs it.
+Worked case: the two-level cascade picker in `controls_form.html` (issue
+#228 S4) inlines ~110 lines of vanilla JS at the end of the form. The
+enhancement reads the flat `<select>`'s own `<optgroup>` structure — one
+source of truth — and hides the flat control while keeping it in the form
+so its value is what POSTs. Without JS the flat select is the whole UI;
+the handler contract is unchanged.
+
+A SECOND page adopting client-side behavior tips the balance: introduce a
+`/static/` mount under `internal/app/web` and move both scripts to files
+with SRI or an immutable path, rather than inlining a second block.
 
 ### Error pages — 404 / 403 / 500
 

--- a/docs/standards/testing-strategy.md
+++ b/docs/standards/testing-strategy.md
@@ -306,6 +306,19 @@ pass over `<input checked value="a4" name="paper">` and
 `checked` on any other input on the page then satisfies it. Anchor the
 regex on `name=` + `value=` + `checked` together.
 
+**Flash assertions decode the flash cookie, not the response body.** A
+save handler sets its message with `flash.Set(w, secure, msg)`, which
+base64url-encodes into the cookie named `flash.CookieName`; the redirected
+GET then renders the message through the shell — as `<p class="flash">`
+for one line or as `<ul><li>…</li></ul>` for a `"\n"`-separated multi-line
+flash (`backend-code-style.md` §Flash). A body-scrape assertion is
+therefore coupled to the layout markup that renders the flash and would
+break on `<p>` ↔ `<ul>` transitions; decoding the cookie tests the
+handler's actual output. Worked helper: `flashFromResponse` in
+`internal/app/web/handler/save_review_test.go` (#228). Use it whenever the
+pinning matters — a substring-in-body check is fine as a smoke test,
+never as a per-line assertion.
+
 ## Conventions (all apps)
 
 These were learned in one app and apply to every one. They sit above the


### PR DESCRIPTION
Closes #228

## Summary

Fix three UX bugs in the `apps/server` backoffice review flow, install the request logging middleware that made the S2 diagnosis possible in the first place, and record the standards growth this WP surfaced.

- **Request logging middleware** (S1) — `middleware.RequestLog` wraps the composed handler in `rootHandler`. One `slog` line per HTTP request across both surfaces, `/health` demoted to DEBUG, OAuth callback query stripped (RFC 6749 §10.3), log line emitted from a `defer` so a handler panic still leaves a trace.
- **RUT edit feedback rewrite** (S3) — the domain returns a `SaveOverridesResult` naming the actual outcome. The handler refuses empty RUT with a specific flash, redirects to the review page (was: control detail — losing the `(editado por ti)` marker), and builds a per-action multi-line flash (`"RUT actualizado a X"` / `"RUT vuelto al valor leído por AMC"` / `"Cambios en N respuestas"` / `"Sin cambios."`). A new `slog.Info("save review", …)` line closes the observability gap; RUT values masked to last-4 (Ley 21.719).
- **Two-level cascade picker** (S4) — `controls_form.html` gets a progressive-enhancement cascade beside each flat `<select>`. Flat select stays as the noscript fallback and the field that POSTs; JS reads the flat select's own `<optgroup>` structure — one source of truth.

## Slices

- [x] **S1** — Request logging middleware — `e58e34e`
- [x] **S2** — Diagnosis checkpoint (static analysis, log excerpt would follow ship-to-Jetson) — [issue comment](https://github.com/so77id/nalanda/issues/228#issuecomment-5420832178)
- [x] **S3** — RUT edit feedback + save-time slog + review-page redirect — `ba6005e`
- [x] **S4** — Two-level section picker — `2f53914`
- [x] **S5** — Pre-PR + PR

Two extra bundled commits from the review pipeline:
- `ca48be9` — Round A review fixes (10 findings)
- `54d3166` — Round B review fixes (3 important — README drifts + statute reference)
- `32f7983` — Round B patterns (backend-code-style.md + testing-strategy.md)

## Acceptance criteria + evidence

| # | AC | Evidence |
|---|---|---|
| 1 | `docker-compose logs server` shows one line per HTTP request | `middleware.RequestLog` (`internal/app/web/middleware/requestlog.go`), wired in `cmd/server/main.go:95`. Tests: `TestRequestLogEmitsOneLinePerRequest`, `TestRequestLogCapturesStatusFromWriteHeader`, `TestRequestLogCapturesStatusFromRedirect`, `TestRequestLogPreservesQueryString`, `TestRequestLogDemotesHealthToDebug`, `TestRequestLogHealthAtDebugIsFilteredAtInfo`, `TestRequestLogEmitsALineEvenWhenTheHandlerPanics`, `TestRequestLogDropsQueryOnOAuthCallback`. |
| 2 | RUT edit with 8 digits persists, re-renders, shows success flash | `TestSaveReviewFlashesRUTUpdatedWhenTheValueChanges`, `TestSaveReviewRedirectsToTheReviewPageNotDetail` in `save_review_test.go`. Handler at `review.go:206` calls `SaveOverrides`, redirects to `controlReviewURL(id, copyNumber)`. |
| 3 | Empty RUT submission has an explicit path (refuse with flash — Miguel's call at S2 review) | `review.go:153` refuses `rut == ""` with flash `"El RUT no puede quedar vacío."`, but only when `blank == ""` — the "Marcar en blanco" question button is orthogonal (COR-3 review). Tests: `TestSaveReviewRefusesEmptyRUTWithFlash`, `TestSaveReviewBlankButtonAcceptsEmptyRUT`. |
| 4 | Invalid RUT (server-side rejection) shows a flash message | `review.go:158` refuses with `"El RUT debe tener 8 dígitos."` Test: `TestSaveReviewRefusesInvalidRUTWithFlash`. |
| 5 | Picker for "desde" and "hasta" is two cascading selects; noscript fallback renders the flat select | `controls_form.html` adds `data-cascade` markers + an inline `<script>` that builds the cascade beside each flat select. Flat select stays as the noscript fallback and the field that POSTs. Test: `TestNewFormCarriesTheCascadePickerMarkers`. |
| 6 | `go test -count=1 ./...` green in `apps/server` | Ran locally green pre-push. |
| 7 | Pre-PR protocol green | Ran locally: `gofmt -l` empty; `go vet ./...` clean; `go test -race -count=1 ./...` all packages OK; `go build ./...` clean; `govulncheck` "No vulnerabilities found." |
| 8 | Manual browser verification on the Jetson | See manual checklist below — for Miguel, post-merge. |

## Manual verification (Miguel, post-merge on Jetson)

- [ ] **Request log visible.** `ssh jetson 'docker-compose logs -f server'` while browsing the backoffice. Every navigation produces one `msg=request …` line at INFO with method, path, status, duration_ms. `/health` produces no INFO line (poll every few seconds is at DEBUG).
- [ ] **OAuth callback query redacted.** After a fresh login round-trip, the `path=/login/google/callback` line has no `code=` or `state=` in it — bare path only.
- [ ] **RUT edit — 8 digits, differs from AMC read.** Open a copy's review, type an 8-digit RUT that differs from AMC's read, click **Guardar cambios**. Land back on the review page. Flash reads `"RUT actualizado a XXXXXXXX."` Reload the page — RUT input still shows the new value with `(editado por ti)`.
- [ ] **RUT edit — 8 digits, matches AMC read.** Same setup but type the AMC-read value back on top of an existing override. Land back on review. Flash reads `"RUT vuelto al valor leído por AMC."` The `(editado por ti)` marker is gone.
- [ ] **RUT edit — empty.** Clear the RUT, click **Guardar cambios**. Flash reads `"El RUT no puede quedar vacío."` No override persisted.
- [ ] **Marcar en blanco with empty RUT** (copy where AMC did not read a RUT). Click "Marcar en blanco" on one question. Blanking lands. Flash reads `"Pregunta qX marcada en blanco."` (no RUT rejection).
- [ ] **Two-level cascade picker.** Open "Nuevo control". "Desde" and "Hasta" render as two selects each (document → section). Choose a document; sections repopulate. Choose a section; the form submits with the composite value. Also with JavaScript disabled: the flat `<select>` still renders and the form still works.
- [ ] **slog "save review" line.** After a save, `docker-compose logs server` shows a `msg="save review" control=… copy=… rut_from=…XXXX rut_to=…YYYY rut_action=… answers_changed=…` line. RUT values are masked to `…` + last 4 digits.

Also, per `apps/server/GOOGLE-CHECK.md`: not required — the diff does not touch the OIDC adapter, callback, or cookie, only what the request-log middleware does with the callback's URL.

## Reviews run

- **Round A** — mechanical gate GREEN (gofmt/vet/build/test-race/govulncheck), then parallel panel of `lens-correctness-tests`, `lens-arch-simplicity`, `lens-security` (no `lens-performance` — no hot-path touched, no perf goals in issue). Verifier over 5 important findings (COR-1, COR-2, COR-3, COR-4, ARQ-1); COR-4 refuted (unreachable branch — `RUTStatus` enum), others confirmed with adjusted severities. Human decision table: 10 ACT, 1 DISMISS, 2 DEFER, 2 PATTERN. Fixes in `ca48be9`. Per-fix recheck: **all 10 resolved** by originating lenses.
- **Round B** — docs panel: `lens-docs-completeness` and `lens-adr-hunter` returned; `lens-docs-accuracy` and `lens-agent-readability` hit a session limit mid-flight (not re-run — coverage was still meaningful with the two survivors). 3 new important findings (DCO-1, DCO-2, ADR-1 — one was actually a wrong-statute citation I made in an S3 comment, caught here) + 4 patterns. Important fixes in `54d3166`; patterns in `32f7983`.

## Notes

- **Coordination**: PR #227 (yolo `iframe→embed` fix) already merged; nothing to rebase against. WP-B (#229) and WP-C (#230) touch `handler/review.go` and `templates/layout.html` too — if one merges first, this rebases against updated main preserving both intentions.
- **ADR-1 catch**: my S3 comment cited "Ley 19.628" while the rest of `security-notes.md` classifies personal data under "Ley 21.719" (2024, supersedes 19.628). Fixed in Round B. Both statute numbers are now cross-referenced so a reader finds the note under either.
- **Deferred**: ARQ-3 (`RUTFrom` field used only by slog), COR-7 (cascade JS silently drops stale pre-selection) — both accepted as unlikely-in-practice residuals; opening as follow-up issues if they surface in Miguel's use.
- **Pattern deferred to follow-up**: ADR-2 (backoffice ships no `/static/` mount as a formal ADR) — the second real inline-JS case is the trigger.
