### PR TITLE
fix(content): anchor complejidad questions to their sections

### DIFF
--- a/content/courses/sample-course/11-complejidad-de-hilbert-al-big-o.mdx
+++ b/content/courses/sample-course/11-complejidad-de-hilbert-al-big-o.mdx
@@ -1681,7 +1681,7 @@ t_B(10) = 1000 · k_B = 1 s  →  k_B = 0.001`}</pre>
 
 <Questions>
 
-<Question id="por-que-oe-no-segundos">
+<Question id="por-que-oe-no-segundos" anchor="operaciones-elementales-oe">
 
 ¿Por qué medimos la complejidad de un algoritmo en **operaciones elementales**
 (OE) en vez de en **segundos**?
@@ -1698,7 +1698,7 @@ que queremos comparar entre algoritmos.
 
 </Question>
 
-<Question id="for-condition-count">
+<Question id="for-condition-count" anchor="primer-conteo-un-for-linea-a-linea">
 
 En un ciclo `for (int i = 0; i < n; i++)` que hace `n` iteraciones completas
 del cuerpo, ¿cuántas veces se evalúa la **condición** `i < n` en total?
@@ -1716,7 +1716,7 @@ total $$n + 1$$.
 
 </Question>
 
-<Question id="dos-contadores-distintos">
+<Question id="dos-contadores-distintos" anchor="twist-y-si-contamos-distinto">
 
 Dos personas cuentan OE para el mismo algoritmo. Una obtiene
 **T₁(n) = 2n + 3**; la otra, **T₂(n) = 3n + 2**. ¿Qué se puede concluir?
@@ -1735,7 +1735,7 @@ el mismo.
 
 </Question>
 
-<Question id="por-que-descartar-constantes">
+<Question id="por-que-descartar-constantes" anchor="las-constantes-no-son-del-algoritmo">
 
 En análisis asintótico, ¿por qué se descartan las constantes multiplicativas
 (por ejemplo, tratar **3n²** como **n²**)?
@@ -1753,7 +1753,7 @@ propiedad del algoritmo. Descartarla aísla lo que sí lo es: el orden $$n^2$$.
 
 </Question>
 
-<Question id="definicion-big-o">
+<Question id="definicion-big-o" anchor="big-o-la-definicion-formal">
 
 Decir que **f(n) ∈ O(g(n))** significa que:
 
@@ -1771,7 +1771,7 @@ es equivalencia asintótica, aún más fuerte.
 
 </Question>
 
-<Question id="definicion-omega">
+<Question id="definicion-omega" anchor="cota-inferior">
 
 ¿Cuál de las siguientes afirmaciones sobre **f(n) ∈ Ω(g(n))** es correcta?
 
@@ -1788,7 +1788,7 @@ caso (peor/mejor/promedio) — son dimensiones distintas.
 
 </Question>
 
-<Question id="regla-polinomio">
+<Question id="regla-polinomio" anchor="reglas-practicas-para-las-tres-notaciones">
 
 Un algoritmo tiene **T(n) = 5n³ + 100n² + 42**. ¿En qué clase asintótica
 está?
@@ -1807,7 +1807,7 @@ escribir la notación — los términos menores y los coeficientes se descartan.
 
 </Question>
 
-<Question id="suma-secuencial-constantes">
+<Question id="suma-secuencial-constantes" anchor="reglas-practicas-para-las-tres-notaciones">
 
 Un algoritmo hace dos operaciones consecutivas: la primera es **5n**
 operaciones y la segunda es **2n²** operaciones. ¿Cuál es su complejidad
@@ -1828,7 +1828,7 @@ ciclos anidados, no a bloques secuenciales.
 
 </Question>
 
-<Question id="cual-orden-mas-eficiente">
+<Question id="cual-orden-mas-eficiente" anchor="jerarquia-asintotica">
 
 A partir de un `n` suficientemente grande, ¿cuál algoritmo hace **menos
 operaciones**?
@@ -1847,7 +1847,7 @@ tres.
 
 </Question>
 
-<Question id="cota-vs-caso">
+<Question id="cota-vs-caso" anchor="cota-caso">
 
 ¿Cuál de las siguientes afirmaciones sobre notación y casos es correcta?
 
@@ -1865,7 +1865,7 @@ se consideró para analizar.
 
 </Question>
 
-<Question id="convencion-peor-caso">
+<Question id="convencion-peor-caso" anchor="convencion-cuando-decimos-o-sin-decir-el-caso">
 
 Un profesor dice: *"este algoritmo es O(n²)"*, sin mencionar caso. ¿A qué
 caso se refiere por convención?
@@ -1883,7 +1883,7 @@ requiere asumir una distribución particular de entradas.
 
 </Question>
 
-<Question id="cotas-validas-lineal">
+<Question id="cotas-validas-lineal" anchor="reglas-practicas-para-las-tres-notaciones">
 
 Si un algoritmo tiene **T(n) = 4n + 4**, ¿cuáles de las siguientes
 afirmaciones son **verdaderas**?
@@ -1902,7 +1902,7 @@ $$n^2$$". Y $$\Theta(n)$$ vale porque coincide $$O(n) \cap \Omega(n)$$.
 
 </Question>
 
-<Question id="complejidad-anidados">
+<Question id="complejidad-anidados" anchor="contando-la-segunda-solucion-doble-ciclo">
 
 ¿Cuál es la complejidad asintótica de este algoritmo?
 
@@ -1929,7 +1929,7 @@ cambia el orden.
 
 </Question>
 
-<Question id="secuencial-vs-anidado">
+<Question id="secuencial-vs-anidado" anchor="reglas-practicas-para-las-tres-notaciones">
 
 ¿Cuál es la diferencia entre estos dos algoritmos en términos asintóticos?
 
@@ -1958,7 +1958,7 @@ estructura del código: secuenciales vs anidados.
 
 </Question>
 
-<Question id="igualdades-asintoticas">
+<Question id="igualdades-asintoticas" anchor="reglas-practicas-para-las-tres-notaciones">
 
 ¿Cuáles de las siguientes igualdades entre clases asintóticas son
 **verdaderas**?
@@ -1979,7 +1979,7 @@ cabe en $$O(1)$$.
 
 </Question>
 
-<Question id="cruce-x-y">
+<Question id="cruce-x-y" anchor="los-ordenes-deciden-el-cruce">
 
 Dos algoritmos que resuelven el mismo problema: **X** hace **100n**
 operaciones, **Y** hace **n²** operaciones. Para `n` suficientemente
@@ -1999,7 +1999,7 @@ brecha se ensancha.
 
 </Question>
 
-<Question id="mitad-triangulo">
+<Question id="mitad-triangulo" anchor="reglas-practicas-para-las-tres-notaciones">
 
 ¿Cuál es la complejidad asintótica de este algoritmo?
 

--- a/content/courses/sample-course/13-complejidad-espacial.mdx
+++ b/content/courses/sample-course/13-complejidad-espacial.mdx
@@ -155,7 +155,7 @@ int[] reverseNuevo(int[] arr) {
 
 <Questions>
 
-<Question id="cual-crece-en-espacio">
+<Question id="cual-crece-en-espacio" anchor="espacio-aplicado-a-nuestros-ejemplos">
 
 ¿Cuál de los siguientes algoritmos tiene complejidad espacial que **crece
 con `n`** (no es constante)?


### PR DESCRIPTION
## Bug

Reported by Miguel while smoke-testing PR #234 (RUT + picker) on the Jetson: create a new control with the two-level picker, "desde" section 1 of `Complejidad · De Hilbert al Big O` to its last section → **422 "El rango no tiene preguntas todavía."**

Server log (visible thanks to the request middleware that just shipped in #234):

```
level=INFO msg=request method=POST path=/controls status=422 bytes=59249 duration_ms=29
```

## Cause

The 17 questions in `11-complejidad-de-hilbert-al-big-o.mdx` and the 1 question in `13-complejidad-espacial.mdx` were authored **without the `anchor` attribute**. The published `questions.json` carries them, but the server's `bank.Pool()` explicitly discards every question with `q.Anchor == ""` (`apps/server/internal/domain/course/bank/bank.go:465`), so the pool for any range in these two documents is empty → `ErrEmptyRange` → the flash Miguel saw.

Verified by curl of the published bank (`https://so77id.github.io/nalanda/questions.json`):

```
=== complejidad-de-hilbert-al-big-o (58 sections) ===
  questions: 17
  with anchor:    0
  without anchor: 17
=== complejidad-espacial (3 sections) ===
  questions: 1
  with anchor:    0
  without anchor: 1
```

Every other document in the bank has anchored questions — this is data drift from the recent authoring of these two documents (#219), not a regression in the picker (#234) or the server.

## Fix

Add `anchor="<section-slug>"` to each `<Question>`. Each anchor is chosen to point at the slide (or `##` heading) that teaches what the question evaluates.

Six of the seventeen land on the same anchor `reglas-practicas-para-las-tres-notaciones` because they exercise the same slide's rules of thumb (drop constants, sum of secuential blocks, dominant term, product rule for nested loops, half-triangle sum). If pedagogy wants them split, changing an anchor is one line per question.

The `questionBank.test.ts` suite enforces "anchor names a real section of the document"; the 1214/1214 test pass here confirms every anchor here matches a heading that already lives in the MDX — no invented slugs.

## Yolo scope

Per `docs/conventions.md`: 18 identical mechanical changes (`<Question id="X">` → `<Question id="X" anchor="Y">`) across 2 content files, zero logic changes. All greens (test 1214/1214, oxlint, tsc).

## Verification after merge

Once GH Pages redeploys `questions.json` (≤5 min post-merge to `main`), and once `apps/server` re-fetches the bank (either via the 5-minute ticker just shipped in #232 or the "Recargar banco" button in the sidebar), Miguel can retry the "desde complejidad §1 hasta su última sección" range in the create-control form. The 422 should turn into a normal 302 → detail page.

## Related

- **#234** — the request logging middleware that made this diagnosable at all (previous version of `apps/server` logged nothing at request-level).
- **#232** — the bank hot-refresh that makes this fix visible without a Docker restart.
- **#219** — the WP that shipped the two `complejidad` documents; the missing `anchor` attributes are content-drift from that WP's questions, not a regression here.
