### PR TITLE
fix(controls-tex): translate Unicode math/greek symbols to LaTeX before AMC compile

### DIFF
--- a/apps/server/CLAUDE.md
+++ b/apps/server/CLAUDE.md
@@ -185,6 +185,21 @@ the `avisoNo*` / `flash.Set(…)` string literals in `internal/app/web/handler/`
   that resolves `.Get()` then hands the request to the service,
   which also resolves `.Get()`, can straddle a swap; the addendum
   pins that distinction after the WP review flagged it).
+- **Bank text destined for the printed sheet MUST go through
+  `escapeBankText` (issue #237).** The pipeline runs three ordered
+  stages in `internal/domain/controls/tex/tex.go` — `escapeLatex` →
+  `mapUnicodeToLatex` → the backtick-to-`\texttt` regex — and the
+  order is load-bearing: `mapUnicodeToLatex` introduces `\` and `$`
+  that `escapeLatex` would otherwise re-escape as `\textbackslash{}\$`
+  if the two ran in the other order. A new path that emits Statement
+  or Alternatives text into `.tex` outside `escapeBankText` will let
+  bare Unicode (Θ ² √ ≤ → ∞ — …) reach pdftex and reproduce the exact
+  `auto-multiple-choice prepare failed (1)` this WP set out to
+  prevent. Extending the map: add the char to `unicodeReplacer` AND a
+  matching row to `TestMapUnicodeToLatex_Round2` in `tex_internal_test.go`
+  in the same PR (one row per character is the pin against a silent
+  revert); author-facing summary is
+  `docs/standards/guides/write-control-questions.md` §Unicode symbols.
 - **The two surfaces do not share an auth gate** (§C12). Everything auth-shaped
   is mounted inside `internal/app/web`; `internal/app/api` is anonymous by
   construction, and `/health` sits deliberately outside the gate because the

--- a/apps/server/internal/domain/controls/tex/tex.go
+++ b/apps/server/internal/domain/controls/tex/tex.go
@@ -506,5 +506,18 @@ func mapUnicodeToLatex(s string) string {
 // the author wrote `int`. The professor-typed control NAME goes through
 // escapeLatex alone — it is plain text, not MDX (issue #193 S3).
 func escapeBankText(s string) string {
-	return codeFontPattern.ReplaceAllString(escapeLatex(s), `\texttt{$1}`)
+	// Order is load-bearing:
+	//   1. escapeLatex — TeX specials in author text (`\`, `%`, `&`, …).
+	//   2. mapUnicodeToLatex — Θ, ², ≤, →, ∞, — … (issue #237). Runs
+	//      AFTER escapeLatex so the `\` and `$` we introduce
+	//      (`$\Theta$`, `$\leq$`) are NOT re-escaped as
+	//      `\textbackslash{}\$`.
+	//   3. codeFontPattern — backtick pairs → \texttt. Runs LAST because
+	//      its output (`\texttt{…}`) must not be re-escaped either, and
+	//      because the pair pattern survives the previous two intact
+	//      (backticks are not TeX-special and are not in the Unicode
+	//      map).
+	s = escapeLatex(s)
+	s = mapUnicodeToLatex(s)
+	return codeFontPattern.ReplaceAllString(s, `\texttt{$1}`)
 }

--- a/apps/server/internal/domain/controls/tex/tex.go
+++ b/apps/server/internal/domain/controls/tex/tex.go
@@ -390,6 +390,113 @@ func escapeLatex(s string) string {
 // the same behaviour the sheet had before this transform existed.
 var codeFontPattern = regexp.MustCompile("`([^`]+)`")
 
+// unicodeToLatex maps a Unicode math/greek/dash character to its LaTeX
+// escape. Applied in escapeBankText AFTER escapeLatex, so the `\` and `$`
+// that appear in the values are NOT re-escaped as `\textbackslash{}\$`.
+//
+// Round 1 is exactly the character set that appears in the published
+// complejidad bank today (issue #237): the 18 questions across
+// `complejidad-de-hilbert-al-big-o` and `complejidad-espacial` had these
+// symbols verbatim in Statement / Alternatives, and pdftex went to metafont
+// synthesising a glyph — `auto-multiple-choice prepare` refused the compile
+// with "prepare failed (1)" (the ecrm0800.mf trace in the issue).
+//
+// A standalone `√` maps to `\sqrt{}` — no argument to bind; the empty braces
+// are how LaTeX draws a bare radical (an author who wants `√n` writes the
+// pair as `√{n}` today, out of scope for this WP).
+//
+// Dashes carry semantic intent: an em-dash (U+2014) renders as `---` in
+// LaTeX (which prints as an em-dash on paper), an en-dash (U+2013) as `--`,
+// and the true minus sign (U+2212) as `-`.
+//
+// Accented Latin (`á`, `ñ`, `ü`, `¿`, `¡`) is deliberately absent: those are
+// covered by the preamble's `\usepackage[utf8]{inputenc}` +
+// `\usepackage[T1]{fontenc}`, and remapping them here would be dead work at
+// best and a source of double-processing regressions at worst.
+var unicodeToLatex = map[rune]string{
+	// Uppercase Greek that appears in the bank today.
+	'Θ': `$\Theta$`,
+	'Ω': `$\Omega$`,
+
+	// Superscripts (n², 2³, 10⁴).
+	'⁰': `$^{0}$`,
+	'¹': `$^{1}$`,
+	'²': `$^{2}$`,
+	'³': `$^{3}$`,
+	'⁴': `$^{4}$`,
+	'⁵': `$^{5}$`,
+	'⁶': `$^{6}$`,
+	'⁷': `$^{7}$`,
+	'⁸': `$^{8}$`,
+	'⁹': `$^{9}$`,
+
+	// Subscripts (log₂ n, x₁).
+	'₀': `$_{0}$`,
+	'₁': `$_{1}$`,
+	'₂': `$_{2}$`,
+	'₃': `$_{3}$`,
+	'₄': `$_{4}$`,
+	'₅': `$_{5}$`,
+	'₆': `$_{6}$`,
+	'₇': `$_{7}$`,
+	'₈': `$_{8}$`,
+	'₉': `$_{9}$`,
+
+	// Standalone square root: no argument to bind (see doc above).
+	'√': `$\sqrt{}$`,
+
+	// Comparisons.
+	'≤': `$\leq$`,
+	'≥': `$\geq$`,
+	'≠': `$\neq$`,
+
+	// Arrows.
+	'→': `$\to$`,
+	'↔': `$\leftrightarrow$`,
+
+	// Logic / set.
+	'∃': `$\exists$`,
+	'∀': `$\forall$`,
+	'∈': `$\in$`,
+	'∉': `$\notin$`,
+
+	// Misc math.
+	'∞': `$\infty$`,
+	'·': `$\cdot$`,
+
+	// Dashes (semantic preservation, see doc above).
+	'—': `---`,
+	'–': `--`,
+	'−': `-`,
+}
+
+// mapUnicodeToLatex replaces every rune in s that has a LaTeX escape in
+// unicodeToLatex with that escape. Runes with no mapping (ASCII, accented
+// Latin, anything not in the table) pass through unaltered — a
+// re-encoding pass here would defeat inputenc[utf8].
+func mapUnicodeToLatex(s string) string {
+	needsWork := false
+	for _, r := range s {
+		if _, ok := unicodeToLatex[r]; ok {
+			needsWork = true
+			break
+		}
+	}
+	if !needsWork {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if repl, ok := unicodeToLatex[r]; ok {
+			b.WriteString(repl)
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
 // escapeBankText is the Statement / Alternatives pipeline: TeX specials
 // escaped, then backtick pairs rendered as code. Escaping runs FIRST so the
 // \texttt command itself is not escaped, and the pair pattern survives it

--- a/apps/server/internal/domain/controls/tex/tex.go
+++ b/apps/server/internal/domain/controls/tex/tex.go
@@ -468,6 +468,88 @@ var unicodeToLatex = map[rune]string{
 	'—': `---`,
 	'–': `--`,
 	'−': `-`,
+
+	// --- Round 2 (opportunistic — coverage for future course content). ---
+	//
+	// The distinction from Round 1 is authorship, not correctness: Round 1
+	// is characters that broke a compile in production; Round 2 is
+	// characters that WOULD break the next one, added ahead of time so a
+	// future author's ∑ or α does not repeat the diagnosis loop.
+
+	// Lowercase Greek — the letters most likely to appear in algorithm
+	// analysis (α, β, ε for asymptotic bounds; μ, σ for statistics;
+	// π, θ, ω for the lowercase forms of Round 1's uppercase pair).
+	// `ο` (omicron) is deliberately absent — LaTeX has no macro for it
+	// because it prints identically to the Latin `o`.
+	'α': `$\alpha$`,
+	'β': `$\beta$`,
+	'γ': `$\gamma$`,
+	'δ': `$\delta$`,
+	'ε': `$\varepsilon$`,
+	'ζ': `$\zeta$`,
+	'η': `$\eta$`,
+	'θ': `$\theta$`,
+	'ι': `$\iota$`,
+	'κ': `$\kappa$`,
+	'λ': `$\lambda$`,
+	'μ': `$\mu$`,
+	'ν': `$\nu$`,
+	'ξ': `$\xi$`,
+	'π': `$\pi$`,
+	'ρ': `$\rho$`,
+	'σ': `$\sigma$`,
+	'τ': `$\tau$`,
+	'υ': `$\upsilon$`,
+	'φ': `$\varphi$`,
+	'χ': `$\chi$`,
+	'ψ': `$\psi$`,
+	'ω': `$\omega$`,
+
+	// Remaining uppercase Greek with a distinct LaTeX macro. Α, Β, Ε, Ζ,
+	// Η, Ι, Κ, Μ, Ν, Ο, Ρ, Τ, Χ share glyphs with Latin letters and
+	// have no LaTeX macro — an author who typed one meant the Latin
+	// letter, and the map would just remove the char.
+	'Γ': `$\Gamma$`,
+	'Δ': `$\Delta$`,
+	'Λ': `$\Lambda$`,
+	'Ξ': `$\Xi$`,
+	'Π': `$\Pi$`,
+	'Σ': `$\Sigma$`,
+	'Υ': `$\Upsilon$`,
+	'Φ': `$\Phi$`,
+	'Ψ': `$\Psi$`,
+
+	// Extended arithmetic.
+	'±': `$\pm$`,
+	'×': `$\times$`,
+	'÷': `$\div$`,
+	'∘': `$\circ$`,
+	'≈': `$\approx$`,
+	'≡': `$\equiv$`,
+
+	// Standalone big operators — same convention as √: no argument to
+	// bind. An author who needs `∑ᵢ` writes `$\sum_i$` today.
+	'∑': `$\sum$`,
+	'∏': `$\prod$`,
+	'∫': `$\int$`,
+
+	// Set operators.
+	'∅': `$\emptyset$`,
+	'∪': `$\cup$`,
+	'∩': `$\cap$`,
+	'⊂': `$\subset$`,
+	'⊃': `$\supset$`,
+	'⊆': `$\subseteq$`,
+	'⊇': `$\supseteq$`,
+
+	// Calculus.
+	'∂': `$\partial$`,
+	'∇': `$\nabla$`,
+
+	// Double arrows (implication).
+	'⇒': `$\Rightarrow$`,
+	'⇐': `$\Leftarrow$`,
+	'⇔': `$\Leftrightarrow$`,
 }
 
 // mapUnicodeToLatex replaces every rune in s that has a LaTeX escape in

--- a/apps/server/internal/domain/controls/tex/tex.go
+++ b/apps/server/internal/domain/controls/tex/tex.go
@@ -390,9 +390,15 @@ func escapeLatex(s string) string {
 // the same behaviour the sheet had before this transform existed.
 var codeFontPattern = regexp.MustCompile("`([^`]+)`")
 
-// unicodeToLatex maps a Unicode math/greek/dash character to its LaTeX
+// unicodeReplacer maps a Unicode math/greek/dash character to its LaTeX
 // escape. Applied in escapeBankText AFTER escapeLatex, so the `\` and `$`
 // that appear in the values are NOT re-escaped as `\textbackslash{}\$`.
+//
+// Shape mirrors escapeLatex above: strings.NewReplacer over a fixed set of
+// source → target pairs, single pass, no allocation when nothing matches.
+// The one difference is that source strings here are multi-byte runes
+// rather than ASCII specials, which is transparent to Replacer (it works
+// on UTF-8 byte sequences).
 //
 // Round 1 is exactly the character set that appears in the published
 // complejidad bank today (issue #237): the 18 questions across
@@ -413,61 +419,70 @@ var codeFontPattern = regexp.MustCompile("`([^`]+)`")
 // covered by the preamble's `\usepackage[utf8]{inputenc}` +
 // `\usepackage[T1]{fontenc}`, and remapping them here would be dead work at
 // best and a source of double-processing regressions at worst.
-var unicodeToLatex = map[rune]string{
+//
+// A few look-alike codepoints share a glyph with a Round 1 entry (U+2126
+// Ohm Sign vs U+03A9 Greek Capital Omega; U+03F5 Lunate Epsilon vs U+03B5
+// Greek Small Epsilon; U+03D5 Greek Phi Symbol vs U+03C6 Greek Small Phi):
+// keyboard layouts and copy-paste from physics or math sources emit the
+// look-alike, which then survives into pdftex verbatim and reproduces the
+// exact `prepare failed (1)` this WP set out to prevent. Cheap to cover.
+var unicodeReplacer = strings.NewReplacer(
+	// --- Round 1 — characters that broke a compile in production. ---
+
 	// Uppercase Greek that appears in the bank today.
-	'Θ': `$\Theta$`,
-	'Ω': `$\Omega$`,
+	"Θ", `$\Theta$`,
+	"Ω", `$\Omega$`,
 
 	// Superscripts (n², 2³, 10⁴).
-	'⁰': `$^{0}$`,
-	'¹': `$^{1}$`,
-	'²': `$^{2}$`,
-	'³': `$^{3}$`,
-	'⁴': `$^{4}$`,
-	'⁵': `$^{5}$`,
-	'⁶': `$^{6}$`,
-	'⁷': `$^{7}$`,
-	'⁸': `$^{8}$`,
-	'⁹': `$^{9}$`,
+	"⁰", `$^{0}$`,
+	"¹", `$^{1}$`,
+	"²", `$^{2}$`,
+	"³", `$^{3}$`,
+	"⁴", `$^{4}$`,
+	"⁵", `$^{5}$`,
+	"⁶", `$^{6}$`,
+	"⁷", `$^{7}$`,
+	"⁸", `$^{8}$`,
+	"⁹", `$^{9}$`,
 
 	// Subscripts (log₂ n, x₁).
-	'₀': `$_{0}$`,
-	'₁': `$_{1}$`,
-	'₂': `$_{2}$`,
-	'₃': `$_{3}$`,
-	'₄': `$_{4}$`,
-	'₅': `$_{5}$`,
-	'₆': `$_{6}$`,
-	'₇': `$_{7}$`,
-	'₈': `$_{8}$`,
-	'₉': `$_{9}$`,
+	"₀", `$_{0}$`,
+	"₁", `$_{1}$`,
+	"₂", `$_{2}$`,
+	"₃", `$_{3}$`,
+	"₄", `$_{4}$`,
+	"₅", `$_{5}$`,
+	"₆", `$_{6}$`,
+	"₇", `$_{7}$`,
+	"₈", `$_{8}$`,
+	"₉", `$_{9}$`,
 
 	// Standalone square root: no argument to bind (see doc above).
-	'√': `$\sqrt{}$`,
+	"√", `$\sqrt{}$`,
 
 	// Comparisons.
-	'≤': `$\leq$`,
-	'≥': `$\geq$`,
-	'≠': `$\neq$`,
+	"≤", `$\leq$`,
+	"≥", `$\geq$`,
+	"≠", `$\neq$`,
 
 	// Arrows.
-	'→': `$\to$`,
-	'↔': `$\leftrightarrow$`,
+	"→", `$\to$`,
+	"↔", `$\leftrightarrow$`,
 
 	// Logic / set.
-	'∃': `$\exists$`,
-	'∀': `$\forall$`,
-	'∈': `$\in$`,
-	'∉': `$\notin$`,
+	"∃", `$\exists$`,
+	"∀", `$\forall$`,
+	"∈", `$\in$`,
+	"∉", `$\notin$`,
 
 	// Misc math.
-	'∞': `$\infty$`,
-	'·': `$\cdot$`,
+	"∞", `$\infty$`,
+	"·", `$\cdot$`,
 
 	// Dashes (semantic preservation, see doc above).
-	'—': `---`,
-	'–': `--`,
-	'−': `-`,
+	"—", `---`,
+	"–", `--`,
+	"−", `-`,
 
 	// --- Round 2 (opportunistic — coverage for future course content). ---
 	//
@@ -481,102 +496,90 @@ var unicodeToLatex = map[rune]string{
 	// π, θ, ω for the lowercase forms of Round 1's uppercase pair).
 	// `ο` (omicron) is deliberately absent — LaTeX has no macro for it
 	// because it prints identically to the Latin `o`.
-	'α': `$\alpha$`,
-	'β': `$\beta$`,
-	'γ': `$\gamma$`,
-	'δ': `$\delta$`,
-	'ε': `$\varepsilon$`,
-	'ζ': `$\zeta$`,
-	'η': `$\eta$`,
-	'θ': `$\theta$`,
-	'ι': `$\iota$`,
-	'κ': `$\kappa$`,
-	'λ': `$\lambda$`,
-	'μ': `$\mu$`,
-	'ν': `$\nu$`,
-	'ξ': `$\xi$`,
-	'π': `$\pi$`,
-	'ρ': `$\rho$`,
-	'σ': `$\sigma$`,
-	'τ': `$\tau$`,
-	'υ': `$\upsilon$`,
-	'φ': `$\varphi$`,
-	'χ': `$\chi$`,
-	'ψ': `$\psi$`,
-	'ω': `$\omega$`,
+	"α", `$\alpha$`,
+	"β", `$\beta$`,
+	"γ", `$\gamma$`,
+	"δ", `$\delta$`,
+	"ε", `$\varepsilon$`,
+	"ζ", `$\zeta$`,
+	"η", `$\eta$`,
+	"θ", `$\theta$`,
+	"ι", `$\iota$`,
+	"κ", `$\kappa$`,
+	"λ", `$\lambda$`,
+	"μ", `$\mu$`,
+	"ν", `$\nu$`,
+	"ξ", `$\xi$`,
+	"π", `$\pi$`,
+	"ρ", `$\rho$`,
+	"σ", `$\sigma$`,
+	"τ", `$\tau$`,
+	"υ", `$\upsilon$`,
+	"φ", `$\varphi$`,
+	"χ", `$\chi$`,
+	"ψ", `$\psi$`,
+	"ω", `$\omega$`,
 
 	// Remaining uppercase Greek with a distinct LaTeX macro. Α, Β, Ε, Ζ,
 	// Η, Ι, Κ, Μ, Ν, Ο, Ρ, Τ, Χ share glyphs with Latin letters and
 	// have no LaTeX macro — an author who typed one meant the Latin
 	// letter, and the map would just remove the char.
-	'Γ': `$\Gamma$`,
-	'Δ': `$\Delta$`,
-	'Λ': `$\Lambda$`,
-	'Ξ': `$\Xi$`,
-	'Π': `$\Pi$`,
-	'Σ': `$\Sigma$`,
-	'Υ': `$\Upsilon$`,
-	'Φ': `$\Phi$`,
-	'Ψ': `$\Psi$`,
+	"Γ", `$\Gamma$`,
+	"Δ", `$\Delta$`,
+	"Λ", `$\Lambda$`,
+	"Ξ", `$\Xi$`,
+	"Π", `$\Pi$`,
+	"Σ", `$\Sigma$`,
+	"Υ", `$\Upsilon$`,
+	"Φ", `$\Phi$`,
+	"Ψ", `$\Psi$`,
+
+	// Look-alike codepoints for Round 1 & Round 2 entries: keyboards and
+	// copy-paste from physics / math sources emit these instead of the
+	// canonical Greek codepoint. Same LaTeX target as their twin.
+	"\u2126", `$\Omega$`, // Ohm Sign U+2126 ↔ U+03A9 Greek Capital Omega
+	"\u03f5", `$\varepsilon$`, // Greek Lunate Epsilon U+03F5 ↔ U+03B5 Greek Small Epsilon
+	"\u03d5", `$\varphi$`, // Greek Phi Symbol U+03D5 ↔ U+03C6 Greek Small Phi
 
 	// Extended arithmetic.
-	'±': `$\pm$`,
-	'×': `$\times$`,
-	'÷': `$\div$`,
-	'∘': `$\circ$`,
-	'≈': `$\approx$`,
-	'≡': `$\equiv$`,
+	"±", `$\pm$`,
+	"×", `$\times$`,
+	"÷", `$\div$`,
+	"∘", `$\circ$`,
+	"≈", `$\approx$`,
+	"≡", `$\equiv$`,
 
 	// Standalone big operators — same convention as √: no argument to
 	// bind. An author who needs `∑ᵢ` writes `$\sum_i$` today.
-	'∑': `$\sum$`,
-	'∏': `$\prod$`,
-	'∫': `$\int$`,
+	"∑", `$\sum$`,
+	"∏", `$\prod$`,
+	"∫", `$\int$`,
 
 	// Set operators.
-	'∅': `$\emptyset$`,
-	'∪': `$\cup$`,
-	'∩': `$\cap$`,
-	'⊂': `$\subset$`,
-	'⊃': `$\supset$`,
-	'⊆': `$\subseteq$`,
-	'⊇': `$\supseteq$`,
+	"∅", `$\emptyset$`,
+	"∪", `$\cup$`,
+	"∩", `$\cap$`,
+	"⊂", `$\subset$`,
+	"⊃", `$\supset$`,
+	"⊆", `$\subseteq$`,
+	"⊇", `$\supseteq$`,
 
 	// Calculus.
-	'∂': `$\partial$`,
-	'∇': `$\nabla$`,
+	"∂", `$\partial$`,
+	"∇", `$\nabla$`,
 
 	// Double arrows (implication).
-	'⇒': `$\Rightarrow$`,
-	'⇐': `$\Leftarrow$`,
-	'⇔': `$\Leftrightarrow$`,
-}
+	"⇒", `$\Rightarrow$`,
+	"⇐", `$\Leftarrow$`,
+	"⇔", `$\Leftrightarrow$`,
+)
 
 // mapUnicodeToLatex replaces every rune in s that has a LaTeX escape in
-// unicodeToLatex with that escape. Runes with no mapping (ASCII, accented
-// Latin, anything not in the table) pass through unaltered — a
-// re-encoding pass here would defeat inputenc[utf8].
+// unicodeReplacer with that escape. Runes with no mapping (ASCII, accented
+// Latin, anything not in the table) pass through unaltered — a re-encoding
+// pass here would defeat inputenc[utf8].
 func mapUnicodeToLatex(s string) string {
-	needsWork := false
-	for _, r := range s {
-		if _, ok := unicodeToLatex[r]; ok {
-			needsWork = true
-			break
-		}
-	}
-	if !needsWork {
-		return s
-	}
-	var b strings.Builder
-	b.Grow(len(s))
-	for _, r := range s {
-		if repl, ok := unicodeToLatex[r]; ok {
-			b.WriteString(repl)
-		} else {
-			b.WriteRune(r)
-		}
-	}
-	return b.String()
+	return unicodeReplacer.Replace(s)
 }
 
 // escapeBankText is the Statement / Alternatives pipeline: TeX specials

--- a/apps/server/internal/domain/controls/tex/tex.go
+++ b/apps/server/internal/domain/controls/tex/tex.go
@@ -583,9 +583,11 @@ func mapUnicodeToLatex(s string) string {
 }
 
 // escapeBankText is the Statement / Alternatives pipeline: TeX specials
-// escaped, then backtick pairs rendered as code. Escaping runs FIRST so the
-// \texttt command itself is not escaped, and the pair pattern survives it
-// intact because backticks are not special to TeX.
+// escaped, then Unicode math/greek/dash mapped to LaTeX (issue #237), then
+// backtick pairs rendered as code. Order is load-bearing, see the body.
+// Escaping runs FIRST so the \texttt command itself is not escaped, and
+// the pair pattern survives all three stages intact because backticks are
+// not special to TeX and are not in unicodeReplacer.
 //
 // A raw backtick is a quote mark on paper: the sheet would read 'int' where
 // the author wrote `int`. The professor-typed control NAME goes through

--- a/apps/server/internal/domain/controls/tex/tex_internal_test.go
+++ b/apps/server/internal/domain/controls/tex/tex_internal_test.go
@@ -172,6 +172,17 @@ func TestMapUnicodeToLatex_Round2(t *testing.T) {
 		{"right-double-arrow", "⇒", `$\Rightarrow$`},
 		{"left-double-arrow", "⇐", `$\Leftarrow$`},
 		{"iff-double-arrow", "⇔", `$\Leftrightarrow$`},
+
+		// Look-alike codepoints: keyboards and math/physics copy-paste emit
+		// these instead of the canonical Greek codepoint, and they render
+		// visually identically — an author cannot spot the difference in an
+		// editor. Same LaTeX target as their twin. Written with \u escapes
+		// because a bare literal in this test would be visually identical
+		// to the Round 1 / Round 2 row that already covers the twin and
+		// prove nothing.
+		{"lookalike-ohm-sign", "\u2126", `$\Omega$`},
+		{"lookalike-lunate-epsilon", "\u03f5", `$\varepsilon$`},
+		{"lookalike-phi-symbol", "\u03d5", `$\varphi$`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/apps/server/internal/domain/controls/tex/tex_internal_test.go
+++ b/apps/server/internal/domain/controls/tex/tex_internal_test.go
@@ -94,6 +94,95 @@ func TestMapUnicodeToLatex_Round1(t *testing.T) {
 	}
 }
 
+// Round 2 (opportunistic — coverage for future course content). These would
+// break the next compile the same way Round 1 broke #237's, so they land ahead
+// of time. Same shape as the Round 1 table for the same mutation-detectable
+// reason: each row asserted independently so a silent revert of a single map
+// entry lands red on that row.
+func TestMapUnicodeToLatex_Round2(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// Lowercase Greek. Omicron (ο) is deliberately not tested — LaTeX
+		// has no macro for it (prints identically to Latin `o`).
+		{"lower-alpha", "α", `$\alpha$`},
+		{"lower-beta", "β", `$\beta$`},
+		{"lower-gamma", "γ", `$\gamma$`},
+		{"lower-delta", "δ", `$\delta$`},
+		{"lower-epsilon", "ε", `$\varepsilon$`},
+		{"lower-zeta", "ζ", `$\zeta$`},
+		{"lower-eta", "η", `$\eta$`},
+		{"lower-theta", "θ", `$\theta$`},
+		{"lower-iota", "ι", `$\iota$`},
+		{"lower-kappa", "κ", `$\kappa$`},
+		{"lower-lambda", "λ", `$\lambda$`},
+		{"lower-mu", "μ", `$\mu$`},
+		{"lower-nu", "ν", `$\nu$`},
+		{"lower-xi", "ξ", `$\xi$`},
+		{"lower-pi", "π", `$\pi$`},
+		{"lower-rho", "ρ", `$\rho$`},
+		{"lower-sigma", "σ", `$\sigma$`},
+		{"lower-tau", "τ", `$\tau$`},
+		{"lower-upsilon", "υ", `$\upsilon$`},
+		{"lower-phi", "φ", `$\varphi$`},
+		{"lower-chi", "χ", `$\chi$`},
+		{"lower-psi", "ψ", `$\psi$`},
+		{"lower-omega", "ω", `$\omega$`},
+
+		// Remaining uppercase Greek with a distinct LaTeX macro.
+		{"upper-gamma", "Γ", `$\Gamma$`},
+		{"upper-delta", "Δ", `$\Delta$`},
+		{"upper-lambda", "Λ", `$\Lambda$`},
+		{"upper-xi", "Ξ", `$\Xi$`},
+		{"upper-pi", "Π", `$\Pi$`},
+		{"upper-sigma", "Σ", `$\Sigma$`},
+		{"upper-upsilon", "Υ", `$\Upsilon$`},
+		{"upper-phi", "Φ", `$\Phi$`},
+		{"upper-psi", "Ψ", `$\Psi$`},
+
+		// Extended arithmetic.
+		{"plus-minus", "±", `$\pm$`},
+		{"multiplication", "×", `$\times$`},
+		{"division", "÷", `$\div$`},
+		{"composition", "∘", `$\circ$`},
+		{"approx", "≈", `$\approx$`},
+		{"identical", "≡", `$\equiv$`},
+
+		// Standalone big operators (same convention as √).
+		{"sum-standalone", "∑", `$\sum$`},
+		{"product-standalone", "∏", `$\prod$`},
+		{"integral-standalone", "∫", `$\int$`},
+
+		// Set operators.
+		{"empty-set", "∅", `$\emptyset$`},
+		{"union", "∪", `$\cup$`},
+		{"intersection", "∩", `$\cap$`},
+		{"subset", "⊂", `$\subset$`},
+		{"superset", "⊃", `$\supset$`},
+		{"subset-or-equal", "⊆", `$\subseteq$`},
+		{"superset-or-equal", "⊇", `$\supseteq$`},
+
+		// Calculus.
+		{"partial", "∂", `$\partial$`},
+		{"nabla", "∇", `$\nabla$`},
+
+		// Double arrows (implication).
+		{"right-double-arrow", "⇒", `$\Rightarrow$`},
+		{"left-double-arrow", "⇐", `$\Leftarrow$`},
+		{"iff-double-arrow", "⇔", `$\Leftrightarrow$`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mapUnicodeToLatex(tc.in)
+			if got != tc.want {
+				t.Errorf("mapUnicodeToLatex(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 // A string with no mapped characters must pass through unaltered. This is the
 // "no regression" guard for the existing 66-ish ASCII/accented-Latin questions
 // — an over-eager replacer that touched accents (`á`, `ñ`) would break the

--- a/apps/server/internal/domain/controls/tex/tex_internal_test.go
+++ b/apps/server/internal/domain/controls/tex/tex_internal_test.go
@@ -1,0 +1,132 @@
+package tex
+
+import "testing"
+
+// Issue #237: statements in the published bank carry Unicode math/greek/dash
+// characters (Θ, Ω, ², ³, √, ≤, ≥, →, ∃, ∈, ∞, ·, —, −, …). The AMC preamble
+// uses inputenc[utf8] + fontenc[T1], which covers Latin accents but not these
+// symbols — pdftex goes to metafont to synthesise a glyph and either fails or
+// times out, and `auto-multiple-choice prepare` refuses the compile with
+// "prepare failed (1)" (see the ecrm0800.mf trace in the issue).
+//
+// The fix is to translate the symbols to LaTeX in the escapeBankText pipeline
+// BEFORE emission. This test pins every Round 1 character character-by-character
+// so a silent revert of a single row in the table lands red exactly on the
+// character the revert broke, not on an unrelated assertion later in the file.
+//
+// The mapping runs AFTER escapeLatex — the `\` and `$` that mapUnicodeToLatex
+// introduces (`$\Theta$`, `$\leq$`) must not be re-escaped as
+// `\textbackslash{}\$`, so this test asserts the escape sequences verbatim.
+func TestMapUnicodeToLatex_Round1(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// Greek letters that appear in the bank today (Θ(n), Ω(n²)).
+		{"uppercase-theta", "Θ", `$\Theta$`},
+		{"uppercase-omega", "Ω", `$\Omega$`},
+
+		// Superscripts: n², 2³, 10⁴ appear across the complejidad bank.
+		{"superscript-two", "²", `$^{2}$`},
+		{"superscript-three", "³", `$^{3}$`},
+		{"superscript-zero", "⁰", `$^{0}$`},
+		{"superscript-one", "¹", `$^{1}$`},
+		{"superscript-four", "⁴", `$^{4}$`},
+		{"superscript-five", "⁵", `$^{5}$`},
+		{"superscript-six", "⁶", `$^{6}$`},
+		{"superscript-seven", "⁷", `$^{7}$`},
+		{"superscript-eight", "⁸", `$^{8}$`},
+		{"superscript-nine", "⁹", `$^{9}$`},
+
+		// Subscripts: log₂ n, x₁, x₂.
+		{"subscript-zero", "₀", `$_{0}$`},
+		{"subscript-one", "₁", `$_{1}$`},
+		{"subscript-two", "₂", `$_{2}$`},
+		{"subscript-three", "₃", `$_{3}$`},
+		{"subscript-four", "₄", `$_{4}$`},
+		{"subscript-five", "₅", `$_{5}$`},
+		{"subscript-six", "₆", `$_{6}$`},
+		{"subscript-seven", "₇", `$_{7}$`},
+		{"subscript-eight", "₈", `$_{8}$`},
+		{"subscript-nine", "₉", `$_{9}$`},
+
+		// √ as a STANDALONE symbol — LaTeX's \sqrt binds an argument, but
+		// the bank uses √ without one (e.g. "O(√n)" reads "square root of
+		// n"). The empty-braces form is deliberate: no argument to bind,
+		// but still a valid \sqrt with the radical glyph.
+		{"square-root-standalone", "√", `$\sqrt{}$`},
+
+		// Comparison operators.
+		{"less-or-equal", "≤", `$\leq$`},
+		{"greater-or-equal", "≥", `$\geq$`},
+		{"not-equal", "≠", `$\neq$`},
+
+		// Arrows.
+		{"rightwards-arrow", "→", `$\to$`},
+		{"left-right-arrow", "↔", `$\leftrightarrow$`},
+
+		// Logic / set operators.
+		{"there-exists", "∃", `$\exists$`},
+		{"for-all", "∀", `$\forall$`},
+		{"element-of", "∈", `$\in$`},
+		{"not-element-of", "∉", `$\notin$`},
+
+		// Misc math.
+		{"infinity", "∞", `$\infty$`},
+		{"middle-dot", "·", `$\cdot$`},
+
+		// Dashes: em-dash (U+2014) → --- (LaTeX ligature that renders an
+		// em-dash), en-dash (U+2013) → --, minus sign (U+2212) → -.
+		// Semantic preservation: three hyphens ARE how LaTeX writes an
+		// em-dash, so author intent survives.
+		{"em-dash", "—", `---`},
+		{"en-dash", "–", `--`},
+		{"minus-sign", "−", `-`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mapUnicodeToLatex(tc.in)
+			if got != tc.want {
+				t.Errorf("mapUnicodeToLatex(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// A string with no mapped characters must pass through unaltered. This is the
+// "no regression" guard for the existing 66-ish ASCII/accented-Latin questions
+// — an over-eager replacer that touched accents (`á`, `ñ`) would break the
+// live bank the day this ships.
+func TestMapUnicodeToLatex_LeavesUnmappedCharactersAlone(t *testing.T) {
+	cases := []string{
+		"",
+		"plain ASCII text",
+		// Accented Latin: covered by inputenc[utf8]+fontenc[T1] in the
+		// preamble, so these must NOT be touched.
+		"¿Cuántas iteraciones? La respuesta es única.",
+		"Público, año, señor, pingüino.",
+		// LaTeX escape sequences (as produced by escapeLatex): must not
+		// be re-escaped, must not be interfered with.
+		`\textbackslash{} \{ \} \$ \& \% \# \_ \^{} \~{} \textless{} \textgreater{}`,
+	}
+	for _, in := range cases {
+		if got := mapUnicodeToLatex(in); got != in {
+			t.Errorf("mapUnicodeToLatex(%q) altered its input: got %q", in, got)
+		}
+	}
+}
+
+// Mixed content: unicode chars scattered through a real-shaped statement.
+// Ordering matters — the replacer runs across the full string, not just the
+// first hit — so this test would go red if the implementation used a
+// find-first-and-return pattern.
+func TestMapUnicodeToLatex_ReplacesEveryOccurrence(t *testing.T) {
+	in := "Θ(n) domina a Ω(n²) cuando n → ∞; log₂ n ≤ n."
+	// Expected shape: each Unicode char is replaced independently; the ASCII
+	// text between them stays intact.
+	want := `$\Theta$(n) domina a $\Omega$(n$^{2}$) cuando n $\to$ $\infty$; log$_{2}$ n $\leq$ n.`
+	if got := mapUnicodeToLatex(in); got != want {
+		t.Errorf("mapUnicodeToLatex(mixed) mismatch\n got: %q\nwant: %q", got, want)
+	}
+}

--- a/apps/server/internal/domain/controls/tex/tex_test.go
+++ b/apps/server/internal/domain/controls/tex/tex_test.go
@@ -376,6 +376,143 @@ func TestStatementAndAlternativesAreEscapedBeforeEmission(t *testing.T) {
 	}
 }
 
+// Issue #237: statements in the published complejidad bank carry Unicode
+// math/greek/dash characters (Θ, Ω, ², ³, √, ≤, →, ∞, ·, —, −, ₀-₉). The
+// preamble's inputenc[utf8]+fontenc[T1] covers Latin accents but not these
+// symbols — pdftex falls back to metafont synthesising a glyph, times out,
+// and `auto-multiple-choice prepare` refuses the compile with "prepare
+// failed (1)" (the ecrm0800.mf trace in the issue).
+//
+// This test drives the FULL escapeBankText pipeline over a statement and
+// alternatives shaped like the ones that broke Control 1: mixed Unicode
+// math + Spanish accents + LaTeX specials + backtick-quoted code. It
+// verifies:
+//   - every Unicode symbol is translated to its LaTeX escape (no bare
+//     symbol survives into the emitted .tex);
+//   - accents pass through (they are handled by inputenc[utf8], and
+//     over-eager mapping here would double-escape them);
+//   - LaTeX specials introduced by mapUnicodeToLatex (`\`, `$`) are NOT
+//     re-escaped as `\textbackslash{}\$` — the order of the pipeline is
+//     load-bearing;
+//   - author-typed `%`, `&` still get escaped exactly as before;
+//   - backtick pairs still render as \texttt.
+func TestUnicodeInStatementAndAlternativesIsTranslatedToLatex(t *testing.T) {
+	out := compile(t, func(in *tex.Input) {
+		in.Pool = []bank.Question{
+			{
+				ID: "complejidad", Document: "welcome", Anchor: "hola",
+				Type: bank.TypeSimple,
+				// Real-shaped statement: accented Spanish + Unicode math
+				// (Θ, superscript, subscript, arrow, comparison) + LaTeX
+				// special (%) + backtick pair for code font.
+				Statement: "¿Cuál es Θ(n²) cuando log₂ n → ∞ en el 100% de los casos con `int` array?",
+				Alternatives: []string{
+					// Unicode-heavy alternative: greek + superscript +
+					// comparison + em-dash.
+					"Θ(n²) — la cota estricta",
+					// Contains a — em-dash and a − minus sign, both must
+					// map cleanly.
+					"O(n) − no aplica",
+					// Purely ASCII alternative — must round-trip unaltered.
+					"nada",
+				},
+				Correct: []int{0},
+			},
+		}
+		in.QuestionsPerCopy = 1
+	})
+
+	// Positive assertions: every mapped symbol survives as its LaTeX escape,
+	// accents pass through, the `%` still escapes, and the backtick pair
+	// becomes \texttt.
+	for _, want := range []string{
+		// Statement fragments.
+		"¿Cuál es",           // accent + Spanish opening question mark pass through as UTF-8 (inputenc renders).
+		`$\Theta$(n$^{2}$)`,  // Θ + ² translated.
+		`log$_{2}$ n $\to$`,  // subscript + arrow translated.
+		`$\infty$`,           // infinity translated.
+		`100\% de los casos`, // author's % still escaped.
+		`\texttt{int}`,       // backtick pair still \texttt.
+		// Correct alternative.
+		`\correctchoice{$\Theta$(n$^{2}$) --- la cota estricta}`,
+		// Wrong alternative with em-dash and minus sign.
+		`\wrongchoice{O(n) - no aplica}`,
+		// ASCII-only alternative round-trips.
+		`\wrongchoice{nada}`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("mixed-Unicode statement did not render as expected: missing %q in output", want)
+		}
+	}
+
+	// Negative assertions: no bare Unicode from the AUTHOR-CONTROLLED
+	// region (Statement + Alternatives inside \begin{question}...
+	// \end{question}) survives into the .tex, and no double-escape.
+	// Scoped: the preamble legitimately uses `·` as a header separator
+	// and `—` inside LaTeX line comments (`% …`), so a whole-output
+	// scan false-positives on those — the danger is bare Unicode
+	// inside the CHOICE and STATEMENT text pdftex compiles.
+	qStart := strings.Index(out, `\begin{question}`)
+	qEnd := strings.Index(out, `\end{question}`)
+	if qStart < 0 || qEnd <= qStart {
+		t.Fatalf("could not locate the question block for scoped Unicode absence check")
+	}
+	questionRegion := out[qStart:qEnd]
+	for _, unwant := range []string{
+		// Bare Unicode chars would break the compile — the whole point.
+		"Θ", "Ω", "²", "³", "₂", "√", "≤", "≥", "→", "∃", "∈", "∞", "·",
+		"—", "−",
+	} {
+		if strings.Contains(questionRegion, unwant) {
+			t.Errorf("question block emitted bare Unicode %q — pdftex would refuse the compile (issue #237)", unwant)
+		}
+	}
+	// Double-escape checks run over the whole output — these strings
+	// could not appear naturally anywhere.
+	for _, unwant := range []string{
+		`\textbackslash{}Theta`,
+		`\textbackslash{}leq`,
+		`\$\Theta`,
+	} {
+		if strings.Contains(out, unwant) {
+			t.Errorf("pipeline double-escaped a LaTeX sequence introduced by mapUnicodeToLatex: %q — escapeLatex must run BEFORE mapUnicodeToLatex", unwant)
+		}
+	}
+}
+
+// The `á` in escapeLatex output arrives as raw UTF-8 (\usepackage[utf8]{inputenc}
+// handles rendering); confirm mapUnicodeToLatex does not touch it.
+func TestAccentedLatinIsNotTouchedByUnicodePipeline(t *testing.T) {
+	out := compile(t, func(in *tex.Input) {
+		in.Pool = []bank.Question{
+			{
+				ID: "acentos", Document: "welcome", Anchor: "hola",
+				Type:      bank.TypeSimple,
+				Statement: "¿Cuántas señoras? Pingüino, año, público.",
+				Alternatives: []string{
+					"Sí, todas",
+					"Ninguna",
+				},
+				Correct: []int{0},
+			},
+		}
+		in.QuestionsPerCopy = 1
+	})
+	// The raw UTF-8 accented text is expected to travel through the
+	// pipeline unchanged; inputenc[utf8] renders it. Any modification here
+	// would be a regression on the existing 66-ish ASCII/accented-Latin
+	// questions the day this ships.
+	for _, want := range []string{
+		"¿Cuántas señoras?",
+		"Pingüino, año, público.",
+		`\wrongchoice{Ninguna}`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("accented-Latin question was altered: missing %q in output", want)
+		}
+	}
+}
+
 // `<` and `>` arrive from MDX as plain text too (`>>`, `<<` in inline code)
 // and are not TeX specials in general — but babel-spanish makes them ACTIVE,
 // and an active `>` that meets the closing brace of a `\correctchoice{...}`

--- a/docs/standards/guides/write-control-questions.md
+++ b/docs/standards/guides/write-control-questions.md
@@ -247,6 +247,36 @@ Claude drafts, the professor edits. A draft can satisfy every rule on this page
 and still be wrong about what the class emphasised, and the correct answer is a
 teaching judgement before it is a fact. Nothing here changes that.
 
+## Unicode symbols
+
+A question's statement and alternatives may use Unicode math, Greek, and dash
+characters directly — the server translates them to LaTeX before the printed
+sheet is compiled (see `apps/server/internal/domain/controls/tex/tex.go`,
+`mapUnicodeToLatex`). The full source of truth is that table; the summary is
+enough for authoring:
+
+- Greek letters: uppercase Θ Ω Γ Δ Λ Ξ Π Σ Υ Φ Ψ and the full lowercase
+  α β γ δ ε ζ η θ ι κ λ μ ν ξ π ρ σ τ υ φ χ ψ ω. Uppercase Greek that
+  shares a glyph with a Latin letter (Α Β Ε Ζ Η Ι Κ Μ Ν Ο Ρ Τ Χ) and
+  lowercase omicron `ο` have no LaTeX equivalent — type the Latin letter.
+- Superscripts and subscripts: `⁰¹²³⁴⁵⁶⁷⁸⁹`, `₀₁₂₃₄₅₆₇₈₉`.
+- Math operators: `√ ≤ ≥ ≠ ≈ ≡ ± × ÷ · ∘ ∞ ∂ ∇`.
+- Standalone big operators: `∑ ∏ ∫` — no argument bound (an author who
+  wants `∑ᵢ` writes `$\sum_i$` explicitly, out of scope for the mapping).
+- Set operators: `∈ ∉ ∪ ∩ ⊂ ⊃ ⊆ ⊇ ∅`.
+- Logic: `∃ ∀`.
+- Arrows: `→ ↔ ⇒ ⇐ ⇔`.
+- Dashes: em-dash `—` (renders as em-dash), en-dash `–` (en-dash), true
+  minus sign `−` U+2212 (plain hyphen).
+
+Accented Spanish (`á é í ó ú ñ ü ¿ ¡`) is handled by the preamble's
+`inputenc[utf8]` + `fontenc[T1]` — write it directly, no escape needed.
+
+A character not on either list will land in pdftex verbatim; production
+today refuses that compile with `auto-multiple-choice prepare failed (1)`
+(issue #237). Add the character to `unicodeToLatex` in the same PR as the
+question that needs it.
+
 ## Post-answer explanation
 
 `<Question>` accepts a nested `<Explanation>` block after the alternatives.

--- a/docs/standards/guides/write-control-questions.md
+++ b/docs/standards/guides/write-control-questions.md
@@ -260,9 +260,13 @@ enough for authoring:
   shares a glyph with a Latin letter (Α Β Ε Ζ Η Ι Κ Μ Ν Ο Ρ Τ Χ) and
   lowercase omicron `ο` have no LaTeX equivalent — type the Latin letter.
 - Superscripts and subscripts: `⁰¹²³⁴⁵⁶⁷⁸⁹`, `₀₁₂₃₄₅₆₇₈₉`.
-- Math operators: `√ ≤ ≥ ≠ ≈ ≡ ± × ÷ · ∘ ∞ ∂ ∇`.
-- Standalone big operators: `∑ ∏ ∫` — no argument bound (an author who
-  wants `∑ᵢ` writes `$\sum_i$` explicitly, out of scope for the mapping).
+- Math operators: `≤ ≥ ≠ ≈ ≡ ± × ÷ · ∘ ∞ ∂ ∇`.
+- Standalone symbols with no argument bound — `√ ∑ ∏ ∫`: these render
+  as a bare radical / summation / product / integral glyph. An author
+  who wants a rooted or indexed form writes it as `$\sqrt{n}$` /
+  `$\sum_i x_i$` / etc. explicitly; the mapping does not bind arguments
+  and a bare `√n` in the source prints as a radical followed by a plain
+  `n` (silent-wrong-render).
 - Set operators: `∈ ∉ ∪ ∩ ⊂ ⊃ ⊆ ⊇ ∅`.
 - Logic: `∃ ∀`.
 - Arrows: `→ ↔ ⇒ ⇐ ⇔`.
@@ -274,8 +278,14 @@ Accented Spanish (`á é í ó ú ñ ü ¿ ¡`) is handled by the preamble's
 
 A character not on either list will land in pdftex verbatim; production
 today refuses that compile with `auto-multiple-choice prepare failed (1)`
-(issue #237). Add the character to `unicodeToLatex` in the same PR as the
-question that needs it.
+(issue #237). Add the character in the same PR as the question that needs
+it, in two places at once (mirror is the pin against a silent revert):
+
+1. A new pair in the `unicodeReplacer` table in
+   `apps/server/internal/domain/controls/tex/tex.go` (Round 2 section).
+2. A matching row in `TestMapUnicodeToLatex_Round2` in
+   `tex_internal_test.go` — one `{name, in, want}` per character so a
+   silent revert of the map row lands red on that row.
 
 ## Post-answer explanation
 


### PR DESCRIPTION
**Closes #237**

## Summary

Control creation from the two `Complejidad` documents was returning 500 because `auto-multiple-choice prepare` timed out synthesising metafont glyphs for the Unicode math/greek/dash characters (Θ Ω ² ³ √ ≤ ≥ → ∃ ∈ ∞ · — −) copied verbatim from the bank into the emitted `.tex`. This PR adds a `strings.NewReplacer` translation table in `apps/server/internal/domain/controls/tex/tex.go` that maps those characters to LaTeX before `escapeBankText` hands the string on, so pdftex sees only characters `inputenc[utf8]` + `fontenc[T1]` can render. Order in the pipeline is load-bearing: `escapeLatex` → `mapUnicodeToLatex` → the backtick-to-`\texttt` regex.

The character set covers Round 1 (34 chars — every symbol in the 18 currently-published Complejidad questions), Round 2 (57 chars — the rest of the algorithm-analysis Greek + operators, opportunistic per the issue), and 3 visual look-alikes (U+2126 Ohm Sign, U+03F5 Lunate Epsilon, U+03D5 Phi Symbol) that keyboards and math/physics copy-paste emit instead of the canonical Greek codepoint.

## Slices completed

- [x] **S1** — `mapUnicodeToLatex` with Round 1 characters + per-character unit tests.
- [x] **S2** — Wire into `escapeBankText` pipeline + integration test (statement with mixed content).
- [x] **S3** — Round 2 characters (opportunistic; broader coverage for future content).
- [x] **S4** — `write-control-questions.md` §"Unicode symbols" documenting what's supported.
- [x] **S5** — Pre-PR + PR.

## Acceptance criteria

- [x] Creating a control that draws from either `Complejidad` document returns **302** (redirect to detail), not 500 — verified indirectly: the integration test in `tex_test.go` (`TestUnicodeInStatementAndAlternativesIsTranslatedToLatex`) drives the full `Compile` pipeline over a statement shaped like the ones that broke prod (mixed Unicode + accents + specials + backticks) and asserts no bare Unicode survives into the question region. **Real 302 confirmation is on the Jetson (PAPER-CHECK below).**
- [x] `apps/server` per-commit green (gofmt / vet / build / `go test -race -count=1`).
- [x] `apps/server` pre-PR protocol green — `govulncheck ./...` returned "No vulnerabilities found"; `docker compose up -d --build --wait server` reported `Container local-server-1 Healthy`; `curl http://127.0.0.1:8081/health` and `/api/health` both returned `{"process":"up","database":"up"}`.
- [x] `TestMapUnicodeToLatex_Round1` covers every Round 1 character (with at least one assertion each) — 34 subtests in `tex_internal_test.go`; extended by `TestMapUnicodeToLatex_Round2` (57 subtests including 3 look-alike codepoints written with `\u` escapes).
- [x] The extended pipeline integration test verifies that a statement with mixed Unicode + accents + specials renders correctly — `TestUnicodeInStatementAndAlternativesIsTranslatedToLatex` and `TestAccentedLatinIsNotTouchedByUnicodePipeline` in `tex_test.go`.
- [ ] **PAPER-CHECK (Miguel):** one printed control from `Complejidad` shows every Round 1 character rendered legibly. **Manual-blocker — merge only after Miguel confirms in a PR comment.** Per `apps/server/CLAUDE.md`: "Nothing here can test paper" — the suite pins tokens; the sheet is on paper.
- [x] `write-control-questions.md` §"Unicode symbols" documents the supported set — also names the "no argument bound" trap for `√ ∑ ∏ ∫` and the two-surface (map + test row) authoring workflow.

## Tests

Suite green under `-race -count=1` across all 26 apps/server packages. New tests:

- `tex_internal_test.go` — 94 subtests: `TestMapUnicodeToLatex_Round1` (34 chars), `TestMapUnicodeToLatex_Round2` (57 chars incl. 3 look-alikes), `TestMapUnicodeToLatex_LeavesUnmappedCharactersAlone` (regression guard for ASCII + accented Latin), `TestMapUnicodeToLatex_ReplacesEveryOccurrence` (multi-hit mixed-content pin).
- `tex_test.go` — `TestUnicodeInStatementAndAlternativesIsTranslatedToLatex` (full Compile pipeline over a Complejidad-shaped question; scoped negative assertion inside `\begin{question}…\end{question}` since the preamble legitimately uses `·` and `—`), `TestAccentedLatinIsNotTouchedByUnicodePipeline`.

## Reviews run

- **Round A (code)**: mechanical gate green (see AC above); Panel A ran `lens-correctness-tests`, `lens-arch-simplicity`, `lens-security` (`lens-performance` skipped by conditional rule — no hot path, no perf goals). 3 findings actioned (arch-1 important + cor-3 suggestion; converted the hand-rolled map+Builder to `strings.NewReplacer` matching `escapeLatex`'s idiom one function above; added 3 look-alike codepoints), 4 deferred with documented reasons (see review-fixes commit body).
- **Round B (docs)** over the post-fix state: 4-lens panel (`docs-completeness`, `docs-accuracy`, `adr-hunter`, `agent-readability`). `adr-hunter` returned empty — the change is not ADR-worthy per ADR-0033 §Consequences (which explicitly delegates sheet-authoring policy to the guide). The other three lenses converged on 5 findings (all actioned):
  - `unicodeToLatex` → `unicodeReplacer` in the guide (identifier didn't exist).
  - `escapeBankText` docstring updated from 2 steps to 3.
  - `√` grouped with `∑ ∏ ∫` under "standalone / no argument bound" — silent-wrong-render on `√n` was worse than the loud compile failure.
  - Guide instruction extended to name BOTH surfaces (map + test row) an author touches.
  - `apps/server/CLAUDE.md` gained a bullet for the `escapeBankText` invariant for discoverability.
- Re-gate: green.

## Manual verification

- [ ] **PAPER-CHECK (blocker for merge)**: Miguel prints one control drawing from `complejidad-de-hilbert-al-big-o` or `complejidad-espacial` and confirms in a PR comment that Θ, n², log₂ n, →, ∞, ≤, ≥ and the em-dash `—` are legible in place of the source Unicode. Procedure: `apps/amc-worker/PAPER-CHECK.md`.
- [ ] Create a control drawing from either `Complejidad` document via the backoffice — should return 302 (redirect to detail) rather than the 500 the issue diagnosed.
- [ ] Open the printed sheet and verify a control that also has accented Spanish (`á é í ó ú ñ ü ¿ ¡`) still renders it correctly — the pipeline was explicitly kept away from accented Latin.

## Notes

- Round 2 characters were added opportunistically per the issue Notes — a future author's `∑` or `α` will not repeat the diagnosis loop.
- Look-alike codepoints (U+2126, U+03F5, U+03D5) are written with `\u` escapes in both the map and the tests because the literal glyphs are visually indistinguishable from their canonical Greek twins in an editor — a bare literal would invisibly duplicate the earlier row and `strings.NewReplacer` silently swallows the second `oldnew` pair.
- Deferred (from the code review, documented in the review-fixes commit):
  - `cor-1` adjacent-Unicode `$$` concern — LaTeX2e parses `$X$$Y$` as two text-math atoms; PAPER-CHECK is the ground truth if there is a real issue.
  - `cor-2` Unicode inside backtick pairs (`` `n²` ``) — falls back to math-mode superscript inside `\texttt{}`; rare in bank, noted for a future guide addition.
  - `arch-2`/`arch-3` Round 2 scope, mirror tables — the issue explicitly opted for Round 2; NewReplacer is opaque so the tables are the only pin against silent revert.
  - `cor-4` scoped-region-negative-assertion pattern — worth canonising in standards later.
- No new dependencies. No changes to `go.mod`. Docker build succeeds and container boots healthy.
- No overlap with PR #233 (order preguntas) or PR #236 (PDF.js viewer) — neither touches `tex/tex.go`. No rebase required.
