### PR TITLE
fix(controls-tex): translate MDX bold/italic/quotes to LaTeX, quarantine backtick payloads

### DIFF
--- a/apps/server/internal/domain/controls/tex/tex.go
+++ b/apps/server/internal/domain/controls/tex/tex.go
@@ -390,6 +390,22 @@ func escapeLatex(s string) string {
 // the same behaviour the sheet had before this transform existed.
 var codeFontPattern = regexp.MustCompile("`([^`]+)`")
 
+// boldPattern matches an MDX-style bold marker `**text**` and renders as
+// \textbf. The inner class allows single `*` runes so a nested italic
+// (`**bold *italic* end**`) is captured whole and italicPattern can find its
+// pair inside the resulting `\textbf{…}`. `[^*]+(?:\*[^*]+)*` reads as "one
+// or more non-star runs, glued by single stars" — which forbids `**` inside
+// (each glue star is required to be followed by non-stars), keeping each
+// bold pair local. Runs BEFORE italicPattern so the `**` pairs are consumed
+// before the simpler italic regex sees the string (issue #239).
+var boldPattern = regexp.MustCompile(`\*\*([^*]+(?:\*[^*]+)*)\*\*`)
+
+// italicPattern matches an MDX-style italic marker `*text*` and renders as
+// \textit. Safe to use the simple `\*([^*]+)\*` shape because boldPattern
+// has already consumed every `**` pair upstream — the only `*` runes left
+// in the string are single italic markers (issue #239).
+var italicPattern = regexp.MustCompile(`\*([^*]+)\*`)
+
 // unicodeReplacer maps a Unicode math/greek/dash character to its LaTeX
 // escape. Applied in escapeBankText AFTER escapeLatex, so the `\` and `$`
 // that appear in the values are NOT re-escaped as `\textbackslash{}\$`.
@@ -584,10 +600,11 @@ func mapUnicodeToLatex(s string) string {
 
 // escapeBankText is the Statement / Alternatives pipeline: TeX specials
 // escaped, then Unicode math/greek/dash mapped to LaTeX (issue #237), then
+// MDX emphasis markers (bold, italic — issue #239) translated, then
 // backtick pairs rendered as code. Order is load-bearing, see the body.
-// Escaping runs FIRST so the \texttt command itself is not escaped, and
-// the pair pattern survives all three stages intact because backticks are
-// not special to TeX and are not in unicodeReplacer.
+// Escaping runs FIRST so the \textbf / \textit / \texttt commands themselves
+// are not escaped, and the marker patterns survive the earlier stages intact
+// because `*` and “ ` “ are not TeX-special and are not in unicodeReplacer.
 //
 // A raw backtick is a quote mark on paper: the sheet would read 'int' where
 // the author wrote `int`. The professor-typed control NAME goes through
@@ -599,12 +616,22 @@ func escapeBankText(s string) string {
 	//      AFTER escapeLatex so the `\` and `$` we introduce
 	//      (`$\Theta$`, `$\leq$`) are NOT re-escaped as
 	//      `\textbackslash{}\$`.
-	//   3. codeFontPattern — backtick pairs → \texttt. Runs LAST because
+	//   3. boldPattern — `**text**` → \textbf (issue #239). Runs BEFORE
+	//      italicPattern so the double asterisks are consumed as a pair;
+	//      if italic ran first, its `\*([^*]+)\*` would match the two
+	//      asterisks that open and close a `**bold**` marker and destroy
+	//      the bold.
+	//   4. italicPattern — `*text*` → \textit (issue #239). Safe to use
+	//      the simple pattern here because boldPattern has already removed
+	//      every `**` pair.
+	//   5. codeFontPattern — backtick pairs → \texttt. Runs LAST because
 	//      its output (`\texttt{…}`) must not be re-escaped either, and
-	//      because the pair pattern survives the previous two intact
-	//      (backticks are not TeX-special and are not in the Unicode
-	//      map).
+	//      because the pair pattern survives the previous stages intact
+	//      (backticks are not TeX-special, not in the Unicode map, and
+	//      not touched by the emphasis patterns).
 	s = escapeLatex(s)
 	s = mapUnicodeToLatex(s)
+	s = boldPattern.ReplaceAllString(s, `\textbf{$1}`)
+	s = italicPattern.ReplaceAllString(s, `\textit{$1}`)
 	return codeFontPattern.ReplaceAllString(s, `\texttt{$1}`)
 }

--- a/apps/server/internal/domain/controls/tex/tex.go
+++ b/apps/server/internal/domain/controls/tex/tex.go
@@ -406,6 +406,44 @@ var boldPattern = regexp.MustCompile(`\*\*([^*]+(?:\*[^*]+)*)\*\*`)
 // in the string are single italic markers (issue #239).
 var italicPattern = regexp.MustCompile(`\*([^*]+)\*`)
 
+// mapAsciiQuotes replaces every ASCII `"` with a Spanish babel guillemet
+// macro. The first quote in the string opens (`\og `), the second closes
+// (`\fg{}`), and so on — a running toggle rather than a regex, because a
+// pair is defined by ordinal position, not by matching parentheses. The
+// preamble already loads `\usepackage[spanish]{babel}` so `\og` and `\fg`
+// are defined; no package change (issue #239).
+//
+// Why guillemets: `[T1]{fontenc}` makes a bare ASCII `"` a
+// diacritic-composition trigger — `"este"` on paper prints as an unintended
+// superscript-e on the `e`. Guillemets are also the Spanish typographic
+// convention for a quotation on the printed sheet.
+//
+// An odd number of quotes in one field (a stray `"` alone) still emits
+// legal LaTeX: the state machine opens, and without a partner the print
+// shows an unmatched open guillemet — visible on the sheet, but does not
+// break brace matching. Covered by TestUnbalancedQuoteStillProducesLegalTex.
+func mapAsciiQuotes(s string) string {
+	if !strings.ContainsRune(s, '"') {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	open := true
+	for _, r := range s {
+		if r != '"' {
+			b.WriteRune(r)
+			continue
+		}
+		if open {
+			b.WriteString(`\og `)
+		} else {
+			b.WriteString(`\fg{}`)
+		}
+		open = !open
+	}
+	return b.String()
+}
+
 // unicodeReplacer maps a Unicode math/greek/dash character to its LaTeX
 // escape. Applied in escapeBankText AFTER escapeLatex, so the `\` and `$`
 // that appear in the values are NOT re-escaped as `\textbackslash{}\$`.
@@ -600,11 +638,13 @@ func mapUnicodeToLatex(s string) string {
 
 // escapeBankText is the Statement / Alternatives pipeline: TeX specials
 // escaped, then Unicode math/greek/dash mapped to LaTeX (issue #237), then
-// MDX emphasis markers (bold, italic — issue #239) translated, then
-// backtick pairs rendered as code. Order is load-bearing, see the body.
-// Escaping runs FIRST so the \textbf / \textit / \texttt commands themselves
-// are not escaped, and the marker patterns survive the earlier stages intact
-// because `*` and “ ` “ are not TeX-special and are not in unicodeReplacer.
+// MDX emphasis markers (bold, italic — issue #239) translated, then ASCII
+// quotes turned into babel-spanish guillemets (issue #239), then backtick
+// pairs rendered as code. Order is load-bearing, see the body. Escaping
+// runs FIRST so the \textbf / \textit / \og / \fg / \texttt commands are
+// not themselves escaped, and the marker patterns survive the earlier
+// stages intact because `*`, `"` and the backtick are not TeX-special
+// and are not in unicodeReplacer.
 //
 // A raw backtick is a quote mark on paper: the sheet would read 'int' where
 // the author wrote `int`. The professor-typed control NAME goes through
@@ -624,14 +664,20 @@ func escapeBankText(s string) string {
 	//   4. italicPattern — `*text*` → \textit (issue #239). Safe to use
 	//      the simple pattern here because boldPattern has already removed
 	//      every `**` pair.
-	//   5. codeFontPattern — backtick pairs → \texttt. Runs LAST because
+	//   5. mapAsciiQuotes — `"..."` → `\og … \fg{}` (issue #239). Runs
+	//      AFTER the emphasis transforms so an author's `*"quoted"*` still
+	//      picks up italic on the whole span (the `"` chars sit inside the
+	//      italic text and only later toggle open/close on their way
+	//      through).
+	//   6. codeFontPattern — backtick pairs → \texttt. Runs LAST because
 	//      its output (`\texttt{…}`) must not be re-escaped either, and
 	//      because the pair pattern survives the previous stages intact
 	//      (backticks are not TeX-special, not in the Unicode map, and
-	//      not touched by the emphasis patterns).
+	//      not touched by the emphasis or quote transforms).
 	s = escapeLatex(s)
 	s = mapUnicodeToLatex(s)
 	s = boldPattern.ReplaceAllString(s, `\textbf{$1}`)
 	s = italicPattern.ReplaceAllString(s, `\textit{$1}`)
+	s = mapAsciiQuotes(s)
 	return codeFontPattern.ReplaceAllString(s, `\texttt{$1}`)
 }

--- a/apps/server/internal/domain/controls/tex/tex.go
+++ b/apps/server/internal/domain/controls/tex/tex.go
@@ -744,6 +744,15 @@ const (
 // A backtick without its pair passes through — the pattern only matches
 // pairs, same behaviour as the pre-#239 codeFontPattern.
 func extractCodePayloads(s string) (string, []string) {
+	// Strip any NUL bytes already in s so the sentinel remains
+	// unambiguous. Normal MDX / YAML tooling rejects or strips NUL,
+	// so this is a defence for a case that should not happen — pdftex
+	// would refuse a NUL anyway, but the strip keeps restoreCodePayloads
+	// from binding its `strings.Replace` to an author-typed sentinel
+	// lookalike (issue #239 review recheck).
+	if strings.ContainsRune(s, '\x00') {
+		s = strings.ReplaceAll(s, "\x00", "")
+	}
 	if !strings.Contains(s, "`") {
 		return s, nil
 	}

--- a/apps/server/internal/domain/controls/tex/tex.go
+++ b/apps/server/internal/domain/controls/tex/tex.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"unicode"
 
 	"github.com/so77id/nalanda/apps/server/internal/domain/course/bank"
 )
@@ -388,6 +389,10 @@ func escapeLatex(s string) string {
 // code, which the sheet renders as \texttt. A backtick without its pair is
 // not matched and stays where it was — it renders as a quote mark, which is
 // the same behaviour the sheet had before this transform existed.
+//
+// Backtick payloads are EXTRACTED before the emphasis / quote transforms
+// run so `*`, `"` and `**` inside code fragments cannot bleed into
+// \textit / \og / \textbf — see extractCodePayloads and issue #239 COR-2.
 var codeFontPattern = regexp.MustCompile("`([^`]+)`")
 
 // boldPattern matches an MDX-style bold marker `**text**` and renders as
@@ -396,15 +401,96 @@ var codeFontPattern = regexp.MustCompile("`([^`]+)`")
 // pair inside the resulting `\textbf{…}`. `[^*]+(?:\*[^*]+)*` reads as "one
 // or more non-star runs, glued by single stars" — which forbids `**` inside
 // (each glue star is required to be followed by non-stars), keeping each
-// bold pair local. Runs BEFORE italicPattern so the `**` pairs are consumed
-// before the simpler italic regex sees the string (issue #239).
-var boldPattern = regexp.MustCompile(`\*\*([^*]+(?:\*[^*]+)*)\*\*`)
+// bold pair local.
+//
+// `\B` on both outer sides gates the marker to non-word-adjacent positions,
+// so author-typed arithmetic like `n**m**p` never fires as bold. `\B`
+// (opposite of `\b`) asserts "no word boundary here"; since `*` is itself
+// non-word, `\B` next to `*` forbids a word character on the outside — the
+// only way it matches is if the outer neighbour is start-of-string,
+// whitespace, or punctuation. Same gate is applied to italicPattern below
+// for the same reason (issue #239 COR-1). Runs BEFORE italicPattern so the
+// `**` pairs are consumed before the simpler italic regex sees the string.
+var boldPattern = regexp.MustCompile(`\B\*\*([^*]+(?:\*[^*]+)*)\*\*\B`)
 
-// italicPattern matches an MDX-style italic marker `*text*` and renders as
-// \textit. Safe to use the simple `\*([^*]+)\*` shape because boldPattern
-// has already consumed every `**` pair upstream — the only `*` runes left
-// in the string are single italic markers (issue #239).
-var italicPattern = regexp.MustCompile(`\*([^*]+)\*`)
+// mapItalic replaces MDX italic markers `*text*` with `\textit{text}`. A
+// `*` is treated as an italic marker only when the rune immediately outside
+// it (start-of-string counts as "outside") is neither a word character nor
+// another `*`. This gate blocks two arithmetic patterns from being read as
+// italic (issue #239 COR-1):
+//
+//   - `n*m*p`, `O(a*b*c*d)`, `5*3*2` — the `*` between word chars is
+//     multiplication, not emphasis;
+//   - `n**m es la potencia … 2**3` — bold left the `**` pairs alone
+//     because its own `\B` gate rejected them, and a pure-regex italic
+//     with `\B` would match the two inner `*`s across the whole span
+//     (both `*` chars are non-word, so `\B` between them is satisfied).
+//
+// A pure Go regex cannot express "no `*` on the outside" without
+// lookaround; a manual left-to-right scan handles both rules cleanly and
+// preserves adjacent-italic-pair cases like `*foo* *bar*` that a
+// boundary-consuming regex would drop the second half of.
+//
+// Content between the pair must not contain `*` and must be non-empty.
+// Safe to assume no `**` pairs remain in s: boldPattern runs first and
+// consumes them.
+func mapItalic(s string) string {
+	if !strings.ContainsRune(s, '*') {
+		return s
+	}
+	runes := []rune(s)
+	var b strings.Builder
+	b.Grow(len(s) + 16)
+	for i := 0; i < len(runes); {
+		if runes[i] != '*' || !italicBoundaryOK(runes, i-1) {
+			b.WriteRune(runes[i])
+			i++
+			continue
+		}
+		end := -1
+		for j := i + 1; j < len(runes); j++ {
+			if runes[j] != '*' {
+				continue
+			}
+			// A `*` inside `[^*]+` content is not allowed — bail.
+			// (No inner `*` here because we look for the FIRST `*`
+			// after i and check its right boundary.)
+			if j > i+1 && italicBoundaryOK(runes, j+1) {
+				end = j
+			}
+			break
+		}
+		if end < 0 {
+			b.WriteRune(runes[i])
+			i++
+			continue
+		}
+		b.WriteString(`\textit{`)
+		for k := i + 1; k < end; k++ {
+			b.WriteRune(runes[k])
+		}
+		b.WriteRune('}')
+		i = end + 1
+	}
+	return b.String()
+}
+
+// italicBoundaryOK reports whether the rune at position i in rs is safe as
+// the OUTSIDE neighbour of an italic `*` marker. Start-of-string
+// (i == -1) and end-of-string (i == len(rs)) both count as safe. A word
+// character (Unicode letter or digit) is unsafe — that is arithmetic /
+// intra-word `*`. Another `*` is unsafe — that would be an arithmetic
+// `**` pair or a stray triple that bold left alone.
+func italicBoundaryOK(rs []rune, i int) bool {
+	if i < 0 || i >= len(rs) {
+		return true
+	}
+	r := rs[i]
+	if r == '*' {
+		return false
+	}
+	return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+}
 
 // mapAsciiQuotes replaces every ASCII `"` with a Spanish babel guillemet
 // macro. The first quote in the string opens (`\og `), the second closes
@@ -636,48 +722,99 @@ func mapUnicodeToLatex(s string) string {
 	return unicodeReplacer.Replace(s)
 }
 
-// escapeBankText is the Statement / Alternatives pipeline: TeX specials
-// escaped, then Unicode math/greek/dash mapped to LaTeX (issue #237), then
-// MDX emphasis markers (bold, italic — issue #239) translated, then ASCII
-// quotes turned into babel-spanish guillemets (issue #239), then backtick
-// pairs rendered as code. Order is load-bearing, see the body. Escaping
-// runs FIRST so the \textbf / \textit / \og / \fg / \texttt commands are
-// not themselves escaped, and the marker patterns survive the earlier
-// stages intact because `*`, `"` and the backtick are not TeX-special
-// and are not in unicodeReplacer.
+// codePlaceholder is the sentinel form escapeBankText holds a backtick
+// payload behind while the emphasis / quote transforms run. Two null bytes
+// bracket a decimal index — null is not a rune any author types, is not
+// touched by any downstream transform, and never appears in valid UTF-8
+// text. Kept package-scoped so tests can pin the shape if they need to.
+const (
+	codePlaceholderOpen  = "\x00CODE"
+	codePlaceholderClose = "\x00"
+)
+
+// extractCodePayloads pulls every backtick pair out of s and replaces it
+// with a sentinel placeholder, returning the placeholderized string plus
+// the ordered list of payloads. The emphasis / quote pipeline that runs
+// downstream then cannot bleed into what the author wrote as code — the
+// pre-#239 pipeline processed “ `a*b*c` “ as `\texttt{a\textit{b}c}` and
+// “ `.equals("María")` “ as `\texttt{.equals(\og María\fg{})}` (issue
+// #239 COR-2, shipped bug in buscar-con-equals). MDX treats backticks as
+// inviolable on-screen, so the printed sheet needs the same guarantee.
 //
-// A raw backtick is a quote mark on paper: the sheet would read 'int' where
-// the author wrote `int`. The professor-typed control NAME goes through
-// escapeLatex alone — it is plain text, not MDX (issue #193 S3).
+// A backtick without its pair passes through — the pattern only matches
+// pairs, same behaviour as the pre-#239 codeFontPattern.
+func extractCodePayloads(s string) (string, []string) {
+	if !strings.Contains(s, "`") {
+		return s, nil
+	}
+	var payloads []string
+	replaced := codeFontPattern.ReplaceAllStringFunc(s, func(match string) string {
+		// match includes the two backticks; the payload sits between them.
+		payloads = append(payloads, match[1:len(match)-1])
+		return codePlaceholderOpen + fmt.Sprintf("%d", len(payloads)-1) + codePlaceholderClose
+	})
+	return replaced, payloads
+}
+
+// restoreCodePayloads swaps each sentinel placeholder back for a
+// \texttt{…} wrapping the original code payload, with escapeLatex +
+// mapUnicodeToLatex applied to that payload — the same two transforms the
+// pre-#239 pipeline effectively ran on backtick content, since it ran the
+// whole pipeline on the raw string. Emphasis / quote transforms are
+// deliberately NOT applied: this is the whole point of the extraction.
+func restoreCodePayloads(s string, payloads []string) string {
+	if len(payloads) == 0 {
+		return s
+	}
+	for i, payload := range payloads {
+		placeholder := codePlaceholderOpen + fmt.Sprintf("%d", i) + codePlaceholderClose
+		escaped := mapUnicodeToLatex(escapeLatex(payload))
+		s = strings.Replace(s, placeholder, `\texttt{`+escaped+`}`, 1)
+	}
+	return s
+}
+
+// escapeBankText is the Statement / Alternatives pipeline. Six stages in a
+// load-bearing order; each stage names its "why here" in the body. The
+// professor-typed control NAME goes through escapeLatex alone — it is
+// plain text, not MDX (issue #193 S3).
 func escapeBankText(s string) string {
 	// Order is load-bearing:
-	//   1. escapeLatex — TeX specials in author text (`\`, `%`, `&`, …).
-	//   2. mapUnicodeToLatex — Θ, ², ≤, →, ∞, — … (issue #237). Runs
+	//   1. extractCodePayloads — pull every backtick pair aside behind a
+	//      sentinel placeholder so the emphasis / quote transforms
+	//      cannot bleed into `code` content (issue #239 COR-2). The
+	//      payload is restored last, wrapped in \texttt with only
+	//      escapeLatex + mapUnicodeToLatex applied to it.
+	//   2. escapeLatex — TeX specials in author text (`\`, `%`, `&`, …).
+	//      Runs on the placeholderized string; the placeholders survive
+	//      unchanged because null and `CODE<n>` are not TeX specials.
+	//   3. mapUnicodeToLatex — Θ, ², ≤, →, ∞, — … (issue #237). Runs
 	//      AFTER escapeLatex so the `\` and `$` we introduce
 	//      (`$\Theta$`, `$\leq$`) are NOT re-escaped as
 	//      `\textbackslash{}\$`.
-	//   3. boldPattern — `**text**` → \textbf (issue #239). Runs BEFORE
-	//      italicPattern so the double asterisks are consumed as a pair;
-	//      if italic ran first, its `\*([^*]+)\*` would match the two
+	//   4. boldPattern — `**text**` → \textbf (issue #239). Runs BEFORE
+	//      italicPattern so the `**` pairs are consumed as a pair; if
+	//      italic ran first, its `\*(...)\*` would match the two
 	//      asterisks that open and close a `**bold**` marker and destroy
-	//      the bold.
-	//   4. italicPattern — `*text*` → \textit (issue #239). Safe to use
-	//      the simple pattern here because boldPattern has already removed
-	//      every `**` pair.
-	//   5. mapAsciiQuotes — `"..."` → `\og … \fg{}` (issue #239). Runs
+	//      the bold. Gated with `\B` on both outer sides (see the
+	//      boldPattern doc) so `n**m**p` arithmetic is not read as bold.
+	//   5. mapItalic — `*text*` → \textit (issue #239). A manual scan
+	//      rather than a regex so the boundary check can also forbid an
+	//      adjacent `*` on the outside (which pure `\B` cannot), blocking
+	//      arithmetic like `n*m*p` and cross-`**` italic bleed in
+	//      strings like `n**m es la … 2**3` (issue #239 COR-1).
+	//   6. mapAsciiQuotes — `"..."` → `\og … \fg{}` (issue #239). Runs
 	//      AFTER the emphasis transforms so an author's `*"quoted"*` still
-	//      picks up italic on the whole span (the `"` chars sit inside the
-	//      italic text and only later toggle open/close on their way
-	//      through).
-	//   6. codeFontPattern — backtick pairs → \texttt. Runs LAST because
-	//      its output (`\texttt{…}`) must not be re-escaped either, and
-	//      because the pair pattern survives the previous stages intact
-	//      (backticks are not TeX-special, not in the Unicode map, and
-	//      not touched by the emphasis or quote transforms).
+	//      picks up italic on the whole span.
+	//   7. restoreCodePayloads — put each backtick payload back as
+	//      \texttt{escaped}. Restores the extraction from step 1, so
+	//      what the author wrote as code reaches the sheet as code — the
+	//      screen-vs-paper parity MDX already gives on-screen.
+	s, codes := extractCodePayloads(s)
 	s = escapeLatex(s)
 	s = mapUnicodeToLatex(s)
 	s = boldPattern.ReplaceAllString(s, `\textbf{$1}`)
-	s = italicPattern.ReplaceAllString(s, `\textit{$1}`)
+	s = mapItalic(s)
 	s = mapAsciiQuotes(s)
-	return codeFontPattern.ReplaceAllString(s, `\texttt{$1}`)
+	return restoreCodePayloads(s, codes)
 }

--- a/apps/server/internal/domain/controls/tex/tex_test.go
+++ b/apps/server/internal/domain/controls/tex/tex_test.go
@@ -791,6 +791,98 @@ func TestUnbalancedQuoteStillProducesLegalTex(t *testing.T) {
 	}
 }
 
+// Issue #239 integration: every transform in escapeBankText fires in the same
+// question, in the load-bearing order. This is the fixture that would go red
+// on a silent reorder of the pipeline (e.g. italic before bold, or quotes
+// before bold) — a single-transform test cannot see the interaction with the
+// others. The statement carries:
+//
+//   - author-typed `%` (must survive escapeLatex);
+//   - Unicode math `Θ` and `²` (must translate to `$\Theta$` and `$^{2}$`);
+//   - `**bold**` around the whole expression (must render as \textbf, wrapping
+//     the translated math);
+//   - `*italic*` and `**bold *italic* end**` (must nest correctly);
+//   - `"quoted"` (must render as `\og … \fg{}`);
+//   - a backtick pair (must render as \texttt, run LAST).
+//
+// The alternatives repeat the same interleaving on smaller strings so the
+// assertion set covers both regions the pipeline can touch (Statement and
+// Alternatives share escapeBankText but are emitted through different call
+// sites — writeQuestion vs. emitAlternative).
+func TestEmphasisPipelineHandlesMixedContentInOneQuestion(t *testing.T) {
+	out := compile(t, func(in *tex.Input) {
+		in.Pool = []bank.Question{
+			{
+				ID: "mixed", Document: "welcome", Anchor: "hola",
+				Type: bank.TypeSimple,
+				// bold(Θ(n²)) + author % + italic word + quoted phrase
+				// + backtick code. Every stage of escapeBankText has to
+				// fire, and their order has to hold.
+				Statement: "**Θ(n²)** es la cota *ajustada* del 100% en el \"peor caso\" con `for` loop.",
+				Alternatives: []string{
+					// bold with a nested italic AND a nested backtick.
+					"**bold *italic* con `code`**",
+					// quoted alternative with an author-escaped &.
+					"llamado \"peor caso\" & similares",
+					// unicode + emphasis mix.
+					"complejidad *Θ(n²)*",
+				},
+				Correct: []int{0},
+			},
+		}
+		in.QuestionsPerCopy = 1
+	})
+
+	// Positive assertions — every transform lands its output on the exact
+	// shape the printed sheet needs. Each assertion pins ONE decision (a
+	// transform, a run order, or a downstream survival) so a regression
+	// names the broken stage rather than the whole pipeline.
+	for _, want := range []string{
+		// Statement: bold wraps the translated math, italic runs on the
+		// residue, `%` survived escapeLatex, quotes became guillemets, the
+		// backtick pair became \texttt at the end.
+		"\\textbf{$\\Theta$(n$^{2}$)} es la cota \\textit{ajustada} del 100\\% en el \\og peor caso\\fg{} con \\texttt{for} loop.",
+		// Alternative 0: bold-then-italic pin holds, code inside bold runs
+		// because codeFontPattern comes last.
+		"\\correctchoice{\\textbf{bold \\textit{italic} con \\texttt{code}}}",
+		// Alternative 1: quotes translated inside a wrongchoice, `&` still
+		// escaped by escapeLatex.
+		"\\wrongchoice{llamado \\og peor caso\\fg{} \\& similares}",
+		// Alternative 2: italic wraps math after both transforms fire.
+		"\\wrongchoice{complejidad \\textit{$\\Theta$(n$^{2}$)}}",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("mixed-content statement did not render as expected: missing %q in output", want)
+		}
+	}
+
+	// Negative assertions — no marker survives into the question block.
+	// Scoped: the preamble legitimately carries `%` (LaTeX comments) and
+	// `"` (`\lstset{literate={"u}...}`); the danger is bare markers inside
+	// what compiles as the question's own text.
+	qStart := strings.Index(out, `\begin{question}`)
+	qEnd := strings.Index(out, `\end{question}`)
+	if qStart < 0 || qEnd <= qStart {
+		t.Fatalf("could not locate the question block for scoped absence checks")
+	}
+	region := out[qStart:qEnd]
+	for _, unwant := range []string{
+		"**", // bold pair
+		`"`,  // ASCII quote
+		"Θ",  // bare Unicode
+		"²",  // bare Unicode
+	} {
+		if strings.Contains(region, unwant) {
+			t.Errorf("raw marker %q survived into the question block — the pipeline failed to consume it (issue #239)", unwant)
+		}
+	}
+	// A stray `*` should not survive either — italic must have consumed
+	// every remaining pair after bold ran.
+	if strings.Contains(region, "*") {
+		t.Error(`a bare "*" survived into the question block — italic did not consume every remaining marker`)
+	}
+}
+
 // Issue #185: the generator branches on Input.DuplexPadding.
 //
 //   - true (historical): emits \AMCcleardoublepage inside \onecopy so each

--- a/apps/server/internal/domain/controls/tex/tex_test.go
+++ b/apps/server/internal/domain/controls/tex/tex_test.go
@@ -590,6 +590,119 @@ func TestBacktickPairsRenderAsTypewriterText(t *testing.T) {
 	}
 }
 
+// Issue #239: MDX authors write `**bold**` and `*italic*` in Statement and
+// Alternatives. Without translation, the double asterisks print verbatim on
+// paper (raw markers around the word), and a lone `*` renders as a low
+// asterisk with no emphasis at all. The fix wires two more transforms into
+// escapeBankText — boldPattern (`**text**` → `\textbf{text}`), then
+// italicPattern (`*text*` → `\textit{text}`) — with bold FIRST so the
+// simpler italic pattern does not eat the two asterisks of a bold marker.
+//
+// Scope in production (from the published bank at issue-time): 44 `**`
+// occurrences across 5 documents, mostly in `complejidad-de-hilbert-al-big-o`.
+func TestBoldMarkersRenderAsTextbf(t *testing.T) {
+	out := compile(t, func(in *tex.Input) {
+		in.Pool = []bank.Question{
+			{
+				ID: "bold", Document: "welcome", Anchor: "hola",
+				Type:      bank.TypeSimple,
+				Statement: "El algoritmo se ejecuta en vez de en **segundos**.",
+				Alternatives: []string{
+					"lineal **exacto**",
+					"cuadrático **peor caso**",
+					"nada",
+				},
+				Correct: []int{0},
+			},
+		}
+		in.QuestionsPerCopy = 1
+	})
+	for _, want := range []string{
+		`en vez de en \textbf{segundos}`,
+		`\correctchoice{lineal \textbf{exacto}}`,
+		`\wrongchoice{cuadrático \textbf{peor caso}}`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("bold marker was not translated to \\textbf: missing %q in output", want)
+		}
+	}
+	// The raw `**` must not survive into the .tex — that is the printed-sheet
+	// bug the WP was opened for.
+	if strings.Contains(out, "**segundos**") {
+		t.Error("raw **bold** survived into the .tex — the printed sheet would show the asterisks (issue #239)")
+	}
+	if strings.Contains(out, "**exacto**") || strings.Contains(out, "**peor caso**") {
+		t.Error("raw **bold** survived in a \\wrongchoice — the printed sheet would show the asterisks")
+	}
+}
+
+// A single `*text*` marker in an author-typed Statement or Alternative renders
+// as \textit on paper. The italic pipeline runs AFTER bold has consumed every
+// `**` pair, so its regex is the simple `\*([^*]+)\*` — no negative-context
+// gymnastics needed.
+func TestItalicMarkersRenderAsTextit(t *testing.T) {
+	out := compile(t, func(in *tex.Input) {
+		in.Pool = []bank.Question{
+			{
+				ID: "italic", Document: "welcome", Anchor: "hola",
+				Type:      bank.TypeSimple,
+				Statement: "*este algoritmo* corre en tiempo constante.",
+				Alternatives: []string{
+					"para *cada* caso",
+					"solo en el *peor* caso",
+					"nada",
+				},
+				Correct: []int{0},
+			},
+		}
+		in.QuestionsPerCopy = 1
+	})
+	for _, want := range []string{
+		`\textit{este algoritmo} corre`,
+		`\correctchoice{para \textit{cada} caso}`,
+		`\wrongchoice{solo en el \textit{peor} caso}`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("italic marker was not translated to \\textit: missing %q in output", want)
+		}
+	}
+	if strings.Contains(out, "*este algoritmo*") ||
+		strings.Contains(out, "*cada*") ||
+		strings.Contains(out, "*peor*") {
+		t.Error("raw *italic* survived into the .tex — on paper it renders as a bare asterisk (issue #239)")
+	}
+}
+
+// The bold pattern MUST run before the italic pattern: if italic ran first,
+// its `\*([^*]+)\*` would match the two asterisks that open and close a
+// `**bold**` marker, translating `**foo**` into `\textit{}foo\textit{}` (or
+// worse, matching across a following pair) and losing the bold entirely. The
+// order is the pin.
+func TestNestedItalicInsideBoldRendersAsBothInOrder(t *testing.T) {
+	out := compile(t, func(in *tex.Input) {
+		in.Pool = []bank.Question{
+			{
+				ID: "nested", Document: "welcome", Anchor: "hola",
+				Type: bank.TypeSimple,
+				// **bold *italic* end** exercises the interleaving: bold
+				// consumes the `**` pairs, leaving `bold *italic* end` for
+				// italic to translate.
+				Statement:    "es **bold *italic* end** del enunciado.",
+				Alternatives: []string{"única", "otra"},
+				Correct:      []int{0},
+			},
+		}
+		in.QuestionsPerCopy = 1
+	})
+	want := `\textbf{bold \textit{italic} end}`
+	if !strings.Contains(out, want) {
+		t.Errorf("nested *italic* inside **bold** did not render as %q — bold-then-italic order is the pin (issue #239)", want)
+	}
+	if strings.Contains(out, "**bold") || strings.Contains(out, "end**") {
+		t.Error("raw ** survived alongside the nested marker — bold pattern did not consume the outer pair")
+	}
+}
+
 // Issue #185: the generator branches on Input.DuplexPadding.
 //
 //   - true (historical): emits \AMCcleardoublepage inside \onecopy so each

--- a/apps/server/internal/domain/controls/tex/tex_test.go
+++ b/apps/server/internal/domain/controls/tex/tex_test.go
@@ -703,6 +703,94 @@ func TestNestedItalicInsideBoldRendersAsBothInOrder(t *testing.T) {
 	}
 }
 
+// Issue #239: straight ASCII double quotes in a Statement or Alternative
+// leak two bugs onto the printed sheet at once. First, with [T1]{fontenc}
+// the `"` glyph is a diacritic-composition trigger — the character
+// immediately after `"` prints with an unintended umlaut / superscript
+// artefact (`*"este algoritmo"*` prints as `*"ᵉste algoritmo*"` on paper).
+// Second, the raw ASCII quote is not the typographic convention for a
+// Spanish sheet anyway.
+//
+// The fix pairs each `"` with its partner and emits guillemets via the
+// babel-spanish macros `\og … \fg{}` — the standard Spanish typography, and
+// already covered by the preamble's `\usepackage[spanish]{babel}` (no
+// package change needed). A simple state machine toggles open/close on
+// every quote; an odd number of quotes in one field is a degenerate input
+// (the professor would have to have typed a stray `"` alone), covered by
+// the "unbalanced" test below.
+func TestAsciiQuotesRenderAsSpanishGuillemets(t *testing.T) {
+	out := compile(t, func(in *tex.Input) {
+		in.Pool = []bank.Question{
+			{
+				ID: "quotes", Document: "welcome", Anchor: "hola",
+				Type:      bank.TypeSimple,
+				Statement: `¿Qué significa "este algoritmo" en la clase?`,
+				Alternatives: []string{
+					`"correcto" según la definición`,
+					`también llamado "peor caso"`,
+					"nada",
+				},
+				Correct: []int{0},
+			},
+		}
+		in.QuestionsPerCopy = 1
+	})
+	for _, want := range []string{
+		`\og este algoritmo\fg{}`,
+		`\correctchoice{\og correcto\fg{} según la definición}`,
+		`\wrongchoice{también llamado \og peor caso\fg{}}`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("ASCII quote pair was not translated to babel guillemets: missing %q in output", want)
+		}
+	}
+	// The raw `"` must not survive into the .tex — that is the fontenc[T1]
+	// diacritic-composition bug the WP was opened for.
+	qStart := strings.Index(out, `\begin{question}`)
+	qEnd := strings.Index(out, `\end{question}`)
+	if qStart < 0 || qEnd <= qStart {
+		t.Fatalf("could not locate the question block for scoped ASCII-quote absence check")
+	}
+	if strings.Contains(out[qStart:qEnd], `"`) {
+		t.Error(`a bare ASCII " survived into the question block — fontenc[T1] would compose a diacritic onto the next glyph (issue #239)`)
+	}
+}
+
+// An odd number of quotes in one field is degenerate input — the author
+// typed a stray `"` alone. The state machine still toggles: the first
+// stray opens (`\og`) and, without a close partner, prints as an open
+// guillemet with a trailing thin space (`\og`). No brace-balancing damage
+// downstream. Verified so a review does not have to reason about it.
+func TestUnbalancedQuoteStillProducesLegalTex(t *testing.T) {
+	out := compile(t, func(in *tex.Input) {
+		in.Pool = []bank.Question{
+			{
+				ID: "unbal", Document: "welcome", Anchor: "hola",
+				Type:         bank.TypeSimple,
+				Statement:    `mira "esto pero no cierra`,
+				Alternatives: []string{"única", "otra"},
+				Correct:      []int{0},
+			},
+		}
+		in.QuestionsPerCopy = 1
+	})
+	if !strings.Contains(out, `mira \og esto pero no cierra`) {
+		t.Error("unbalanced open quote did not become \\og — the state machine must still fire on a lone quote")
+	}
+	// Scoped: the preamble's `\lstset{literate=…}` block legitimately
+	// contains `\"u` and friends, which include the ASCII `"` byte
+	// — a whole-output scan false-positives on them. The bug is bare `"`
+	// inside the question block.
+	qStart := strings.Index(out, `\begin{question}`)
+	qEnd := strings.Index(out, `\end{question}`)
+	if qStart < 0 || qEnd <= qStart {
+		t.Fatalf("could not locate the question block for scoped ASCII-quote absence check")
+	}
+	if strings.Contains(out[qStart:qEnd], `"`) {
+		t.Error(`a bare ASCII " survived into the question block even on an unbalanced input`)
+	}
+}
+
 // Issue #185: the generator branches on Input.DuplexPadding.
 //
 //   - true (historical): emits \AMCcleardoublepage inside \onecopy so each

--- a/apps/server/internal/domain/controls/tex/tex_test.go
+++ b/apps/server/internal/domain/controls/tex/tex_test.go
@@ -883,6 +883,155 @@ func TestEmphasisPipelineHandlesMixedContentInOneQuestion(t *testing.T) {
 	}
 }
 
+// Issue #239 COR-1: an author-typed `*` between word characters is
+// multiplication (or any adjacency), NOT an italic marker. `n*m*p` must
+// survive verbatim. Same for the same shape wrapped in parentheses,
+// digits, and — since Miguel's imminent complexity-exercise batch is
+// exactly the authoring context — expressions like `O(a*b*c*d)` and
+// `5*3*2`. Pinned with `\B` on both outer sides of italicPattern
+// (regex asserts no word boundary at the outer `*` position, and since
+// `*` is itself non-word, a word char on the outside would create a
+// boundary and disqualify the match).
+func TestItalicDoesNotFireOnArithmeticAsterisks(t *testing.T) {
+	out := compile(t, func(in *tex.Input) {
+		in.Pool = []bank.Question{
+			{
+				ID: "arith", Document: "welcome", Anchor: "hola",
+				Type:      bank.TypeSimple,
+				Statement: "El costo es O(a*b*c*d) para n*m*p iteraciones y 5*3*2 elementos.",
+				Alternatives: []string{
+					"una vez",
+					"n*log(n) veces",
+					"depende",
+				},
+				Correct: []int{0},
+			},
+		}
+		in.QuestionsPerCopy = 1
+	})
+	// The arithmetic must not become italic — the `*` runes stay literal
+	// asterisks on the printed sheet, which is how the author meant them.
+	for _, want := range []string{
+		"O(a*b*c*d) para n*m*p iteraciones y 5*3*2 elementos.",
+		`\wrongchoice{n*log(n) veces}`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("arithmetic `*` was consumed by italic pattern: missing %q in output", want)
+		}
+	}
+	// And nothing in this question region should carry a stray \textit —
+	// there is no legitimate italic in the input.
+	qStart := strings.Index(out, `\begin{question}`)
+	qEnd := strings.Index(out, `\end{question}`)
+	if qStart < 0 || qEnd <= qStart {
+		t.Fatalf("could not locate the question block")
+	}
+	if strings.Contains(out[qStart:qEnd], `\textit`) {
+		t.Errorf(`italic fired inside the arithmetic-only question: found \textit in the question block (issue #239 COR-1)`)
+	}
+}
+
+// The same gate must hold for boldPattern. `n**m**p` (Python-style
+// exponent, or an accidental double asterisk in a distractor) must not
+// become `n\textbf{m}p`. Same `\B` shape as italic.
+func TestBoldDoesNotFireOnDoubleAsteriskArithmetic(t *testing.T) {
+	out := compile(t, func(in *tex.Input) {
+		in.Pool = []bank.Question{
+			{
+				ID: "doubleast", Document: "welcome", Anchor: "hola",
+				Type:         bank.TypeSimple,
+				Statement:    "En Python n**m es la potencia; en Java 2**3 no compila.",
+				Alternatives: []string{"cierto", "falso"},
+				Correct:      []int{0},
+			},
+		}
+		in.QuestionsPerCopy = 1
+	})
+	if !strings.Contains(out, "En Python n**m es la potencia; en Java 2**3 no compila.") {
+		t.Error("word-adjacent `**` was consumed by bold pattern: the arithmetic did not survive verbatim")
+	}
+	qStart := strings.Index(out, `\begin{question}`)
+	qEnd := strings.Index(out, `\end{question}`)
+	if qStart < 0 || qEnd <= qStart {
+		t.Fatalf("could not locate the question block")
+	}
+	if strings.Contains(out[qStart:qEnd], `\textbf`) {
+		t.Errorf(`bold fired inside the arithmetic-only question: found \textbf in the question block (issue #239 COR-1)`)
+	}
+}
+
+// Issue #239 COR-2: content inside a backtick pair is CODE, and MDX
+// treats it as inviolable on-screen. The printed sheet must match — no
+// `*` becomes italic, no `"` becomes a guillemet, no `**` becomes bold
+// once the payload has entered its `\texttt{…}`. Live shipped case at
+// the time of this WP: buscar-con-equals in
+// `09-arrays-y-funciones.mdx` had alternatives like “ `.equals("María")` “
+// rendered as `\texttt{.equals(\og María\fg{})}` — «María» in monospace
+// on paper vs. the correct `.equals("María")` on screen.
+//
+// The fix extracts each backtick payload before the emphasis / quote
+// pipeline runs and restores it as `\texttt{escapeLatex(payload)}` at
+// the end.
+func TestCodeFragmentContentIsNotTouchedByEmphasisOrQuotes(t *testing.T) {
+	out := compile(t, func(in *tex.Input) {
+		in.Pool = []bank.Question{
+			{
+				ID: "javacode", Document: "welcome", Anchor: "hola",
+				Type: bank.TypeSimple,
+				// The exact shape that triggered the shipped bug.
+				Statement: "¿Cómo se compara `\"María\"` con otra cadena?",
+				Alternatives: []string{
+					"`.equals(\"María\")`",
+					"`== \"María\"`",
+					"`names == \"María\"`",
+					// And a code fragment whose payload contains
+					// authoring characters that used to bleed into it.
+					"`a*b*c` no aplica",
+					// A payload with `**` — must stay literal in
+					// monospace, not become bold.
+					"`**not bold**` tampoco",
+				},
+				Correct: []int{0},
+			},
+		}
+		in.QuestionsPerCopy = 1
+	})
+	// Positive: the emphasis / quote pipeline did NOT run inside the
+	// backtick payloads. `"María"` stays as `"María"`; `a*b*c` stays as
+	// `a*b*c`; `**not bold**` stays as `**not bold**`.
+	for _, want := range []string{
+		`\texttt{"María"}`,
+		`\texttt{.equals("María")}`,
+		`\texttt{== "María"}`,
+		`\texttt{names == "María"}`,
+		`\texttt{a*b*c}`,
+		`\texttt{**not bold**}`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("code payload was mutated by an emphasis or quote transform: missing %q in output (issue #239 COR-2)", want)
+		}
+	}
+	// Negative: no `\og` or `\fg{}` inside a `\texttt{…}`, no `\textit`
+	// or `\textbf` inside a `\texttt{…}`. Grep the question region for
+	// the pathological substrings the pre-fix pipeline emitted.
+	qStart := strings.Index(out, `\begin{question}`)
+	qEnd := strings.Index(out, `\end{question}`)
+	if qStart < 0 || qEnd <= qStart {
+		t.Fatalf("could not locate the question block")
+	}
+	region := out[qStart:qEnd]
+	for _, unwant := range []string{
+		`\texttt{\og`,      // guillemet macro started inside \texttt
+		`\og María`,        // pre-fix bleed
+		`\texttt{a\textit`, // pre-fix italic bleed
+		`\texttt{\textbf`,  // pre-fix bold bleed
+	} {
+		if strings.Contains(region, unwant) {
+			t.Errorf("emphasis or quote transform bled into a code payload: found %q in the question block (issue #239 COR-2)", unwant)
+		}
+	}
+}
+
 // Issue #185: the generator branches on Input.DuplexPadding.
 //
 //   - true (historical): emits \AMCcleardoublepage inside \onecopy so each

--- a/docs/standards/guides/write-control-questions.md
+++ b/docs/standards/guides/write-control-questions.md
@@ -287,6 +287,48 @@ it, in two places at once (mirror is the pin against a silent revert):
    `tex_internal_test.go` — one `{name, in, want}` per character so a
    silent revert of the map row lands red on that row.
 
+## Text emphasis
+
+A question's statement and alternatives may use four MDX inline markers, and
+the server translates each one to LaTeX before the printed sheet is compiled
+(same pipeline as Unicode above — `escapeBankText` in
+`apps/server/internal/domain/controls/tex/tex.go`).
+
+- **Bold** — `**palabra**` renders as `\textbf{palabra}`. The double asterisks
+  themselves never reach the paper; before the fix (issue #239) they printed
+  verbatim around the word.
+- **Italic** — `*palabra*` renders as `\textit{palabra}`. A single asterisk
+  without its partner stays as a bare `*` on the sheet — pair the marker or
+  omit it.
+- **Code** — a backtick pair, `` `int` ``, renders as `\texttt{int}`
+  (monospace). A backtick without its partner prints as a quote mark on paper
+  and is not what any reader expects; pair them.
+- **Quotation** — an ASCII double quote pair, `"así"`, renders as
+  babel-spanish guillemets `«así»`. Straight ASCII quotes are NOT rendered
+  as such: writing `"así"` on the page produces the Spanish typographic
+  form, and the transform also sidesteps a `fontenc[T1]` diacritic-composition
+  trap where a bare `"` before a vowel produced an unintended superscript
+  glyph on paper.
+
+Nested emphasis works in one direction: an italic inside a bold
+(`**bold *italic* end**`) renders as `\textbf{bold \textit{italic} end}`
+because the pipeline runs bold first. The reverse order, bold inside italic
+(`*italic **bold** end*`), is undefined — bold consumes the `**` pair and
+italic does not see a matching pair on either side. Author-time: pick one
+kind of emphasis per span.
+
+Everything else that looks like a Markdown marker (headers, lists, links,
+tables) is NOT supported here — statements are single-paragraph by
+convention (see §"A good simple question"), and those constructs would be
+neither authored today nor useful on a paper sheet. If a compile does need
+raw LaTeX one day (a formula, a diagram), that opt-in is tracked as issue
+#183; it is separate work from this markers set.
+
+Round-trip is that: the online reader renders the MDX natively (bold, italic,
+code, quotes read as prose on screen), and the printed sheet renders the
+same intent through LaTeX. The author writes ONE source, both surfaces read
+the same story.
+
 ## Post-answer explanation
 
 `<Question>` accepts a nested `<Explanation>` block after the alternatives.

--- a/docs/standards/guides/write-control-questions.md
+++ b/docs/standards/guides/write-control-questions.md
@@ -317,6 +317,20 @@ because the pipeline runs bold first. The reverse order, bold inside italic
 italic does not see a matching pair on either side. Author-time: pick one
 kind of emphasis per span.
 
+**Two guarantees the pipeline pins**:
+
+- **Backticks are inviolable.** Anything the author wraps in `` `…` ``
+  reaches the sheet as monospace, literally. `` `**not bold**` ``,
+  `` `"María"` `` and `` `n*m*p` `` all print exactly as written inside
+  `\texttt{…}` — no bold, no guillemets, no italic bleeds into a code
+  fragment. Same rule MDX applies on-screen.
+- **`*` between word characters is arithmetic, not emphasis.** `n*m*p`,
+  `O(a*b*c*d)`, `5*3*2` and `n**m` all print with their asterisks intact.
+  An emphasis marker requires whitespace or punctuation on the OUTSIDE of
+  each `*`; a `*` adjacent to a letter or digit is left alone. This lets
+  the complexity chapter carry `n*log(n)` in a distractor without an
+  emphasis transform corrupting the expression.
+
 Everything else that looks like a Markdown marker (headers, lists, links,
 tables) is NOT supported here — statements are single-paragraph by
 convention (see §"A good simple question"), and those constructs would be


### PR DESCRIPTION
Closes #239

## Summary

Extends `escapeBankText` in `apps/server/internal/domain/controls/tex/tex.go` with three new inline-emphasis transforms so MDX bold / italic / ASCII-quote markers reach the printed sheet as `\textbf{…}` / `\textit{…}` / `\og … \fg{}` instead of leaking as raw characters. Sibling of #237 — same file, same pipeline shape.

The review round found a live shipped bug that led to a second fix: the pre-existing pipeline order (emphasis / quotes BEFORE `codeFontPattern`) let those transforms bleed INTO backtick payloads. `` `.equals("María")` `` — a shipped alternative in `content/courses/sample-course/09-arrays-y-funciones.mdx` — was rendering as `\texttt{.equals(\og María\fg{})}` (guillemets in monospace on paper vs. ASCII quotes on screen). Fixed by extracting every backtick payload to a sentinel placeholder before the emphasis pipeline runs and restoring it as `\texttt{…}` at the end.

The italic regex `\*([^*]+)\*` also fired on arithmetic like `n*m*p` and across cross-`**` spans; replaced with a manual scan (`mapItalic`) that gates on both word-adjacency AND `*`-adjacency, blocking arithmetic while preserving adjacent-italic pairs. `boldPattern` gained matching `\B` gates.

## Slices

- [x] **S1** — `boldPattern` + `italicPattern` + tests (`be33586`).
- [x] **S2** — `mapAsciiQuotes` state machine + tests (`01bc8ba`).
- [x] **S3** — Integration test on mixed-content statement (`11bd1bb`).
- [x] **S4** — §"Text emphasis" in `write-control-questions.md` (`8f4b449`).
- [x] **S5** — Pre-PR review pipeline + PR (this).

Plus post-review: `fa65d51` (review fixes: COR-1 + COR-2), `4b4eda5` (harden `extractCodePayloads` against author-typed NUL), `b2f43ed` (docs: the two pipeline guarantees).

## Acceptance criteria + evidence

- [x] `**bold**` renders as `\textbf{bold}` — `TestBoldMarkersRenderAsTextbf` (`tex_test.go:601-641`).
- [x] `*italic*` renders as `\textit{italic}` — `TestItalicMarkersRenderAsTextit` (`tex_test.go:645-681`).
- [x] `"quoted text"` renders as `\og … \fg{}` — `TestAsciiQuotesRenderAsSpanishGuillemets` (`tex_test.go:727-770`).
- [x] Mixed `**bold *italic* end**` and `**bold `code`**` render correctly — `TestNestedItalicInsideBoldRendersAsBothInOrder` (`tex_test.go:685-705`) + `TestEmphasisPipelineHandlesMixedContentInOneQuestion` (`tex_test.go:820-897`).
- [x] Existing `` `code` `` renders as `\texttt{code}`, unchanged — `TestBacktickPairsRenderAsTypewriterText` (pre-existing, still green).
- [x] Unicode symbols from #237 still render — `TestUnicodeInStatementAndAlternativesIsTranslatedToLatex` (pre-existing, still green).
- [x] apps/server per-commit protocol green — `gofmt -l .` prints nothing; `go vet ./...` clean; `go test ./...` all packages ok.
- [x] apps/server pre-PR protocol green — `go test -race -count=1 ./...` full battery green (25 packages); `govulncheck` "No vulnerabilities found."; `docker build` succeeded on scratch base; container starts and both `/health` and `/api/health` respond `{"process":"up","database":"up"}`.
- [ ] **PAPER-CHECK on Jetson** — Miguel to verify bold / italic / quotes render as expected on paper (manual blocker; see below).

## Tests

Six new tests in `apps/server/internal/domain/controls/tex/tex_test.go`:

1. `TestBoldMarkersRenderAsTextbf`
2. `TestItalicMarkersRenderAsTextit`
3. `TestNestedItalicInsideBoldRendersAsBothInOrder`
4. `TestAsciiQuotesRenderAsSpanishGuillemets`
5. `TestUnbalancedQuoteStillProducesLegalTex`
6. `TestEmphasisPipelineHandlesMixedContentInOneQuestion`

Plus three regression tests from the review fixes:

7. `TestItalicDoesNotFireOnArithmeticAsterisks` — `n*m*p`, `O(a*b*c*d)`, `5*3*2` survive.
8. `TestBoldDoesNotFireOnDoubleAsteriskArithmetic` — `n**m`, `2**3` survive.
9. `TestCodeFragmentContentIsNotTouchedByEmphasisOrQuotes` — the exact shipped shape from `buscar-con-equals`.

## Reviews run

- **Round A (code panel)**: `lens-correctness-tests`, `lens-arch-simplicity`, `lens-security` spawned in parallel, isolated worktrees. Findings: 2 `important`, 4 `suggestion`, 2 `pattern`. Security: no findings.
- **Verifier** on the 2 important findings: COR-1 deflated to `suggestion` (no shipped occurrence today, but silent-corruption footgun for #221's complexity batch); COR-2 confirmed as a live shipped bug in `buscar-con-equals`.
- **Human decision table**: act on COR-1 + COR-2; defer COR-3 (orphan `**`), COR-5 (close-then-open unbalanced quote), COR-6 (composition pin), ARQ-1 (future backend-code-style note).
- **Per-fix recheck**: `lens-correctness-tests` re-spawned; verdict `resolved` for both COR-1 and COR-2. One new `suggestion` on NUL-byte sentinel collision, addressed in `4b4eda5`.
- **Round B (docs panel)**: was launched (`lens-docs-completeness`, `lens-docs-accuracy`, `lens-adr-hunter`, `lens-agent-readability`) but interrupted by a session limit at the model provider. Given that S4 + `b2f43ed` cover the documentation obligations the diff creates (author guide §"Text emphasis" + the two pipeline guarantees), and no new file / decision / dependency was introduced (this is fix-shaped work under the ADR-0033 anchor for the .tex generator), Round B was skipped for this PR. Flag it if you want me to re-run before merge.

## Manual verification (Miguel)

**PAPER-CHECK on the Jetson** — bloqueador de merge. Steps:

1. On the Jetson (`ssh jetson`, deploy dir `/opt/nalanda/repo/infra/local`), wait for Watchtower (≤5min) to pull the new image after merge, or pull manually.
2. Open the backoffice, generate a new control drawn from Complejidad (`complejidad-de-hilbert-al-big-o`). The `.tex` for that document carries **44 `**` occurrences across 13 questions** — every one of them must render as bold on the sheet.
3. Print and inspect the sujet PDF. Look for:
   - **Bold**: no visible `**` around any word. `en vez de en **segundos**` prints as `en vez de en **segundos**` in bold (no asterisks).
   - **Italic**: no visible single `*` around any word. `*este algoritmo*` prints in italic.
   - **Quotes**: no visible ASCII `"`. `"peor caso"` prints as `«peor caso»`.
   - **Java code fragments**: `` `.equals("María")` `` (from `buscar-con-equals` in `09-arrays-y-funciones.mdx`) prints as `.equals("María")` in monospace — literal ASCII quotes, NOT guillemets. Same for the other backtick-wrapped Java alternatives in `08-referencias-null-igualdad.mdx`, `07-java-tipos-y-flujo.mdx`, `10-objetos.mdx`.
   - **Arithmetic**: `n*m*p` or `n**m` in any distractor (currently none in the shipped bank; check the next complexity batch when it lands) prints with the asterisks intact.
4. **Corner case worth eyeballing**: a `<Question>` field with an ODD number of `"` (a stray unpaired ASCII quote — degenerate authoring) is DELIBERATELY emitted as an open guillemet (`«`) with no closer. This is intentional: the visible artefact on paper flags the authoring bug to the professor. If you see an unpaired `«` on any sheet, look up that question and fix the source.
5. If any of these render wrong on paper, comment on the PR with the sheet id and a photo of the affected question; do not merge.

Once PAPER-CHECK is green, this PR is unblocked.

## Notes

- Related merged: **#237** (Unicode→LaTeX, `ed2e3ae`) — this WP layers on the same pipeline.
- Related open: **#233** (order preguntas), **#236**/#231 (PDF.js viewer). Neither touches `tex/tex.go` — no rebase interaction.
- No new dependencies (`go.mod` / `go.sum` unchanged).
- No CGO surface touched; scratch-image runtime verified above.
- Follow-up recorded: an ADR-worthy pattern ("extract inviolable content, run stages, restore last" as a template for future MDX marker additions) could go into `docs/standards/backend-code-style.md` — deferred, not in this PR (ARQ-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
