### PR TITLE
docs(issue-239): Round B docs panel fixes (post-merge follow-up to #240)

### DIFF
--- a/apps/server/CLAUDE.md
+++ b/apps/server/CLAUDE.md
@@ -186,20 +186,62 @@ the `avisoNo*` / `flash.Set(…)` string literals in `internal/app/web/handler/`
   which also resolves `.Get()`, can straddle a swap; the addendum
   pins that distinction after the WP review flagged it).
 - **Bank text destined for the printed sheet MUST go through
-  `escapeBankText` (issue #237).** The pipeline runs three ordered
-  stages in `internal/domain/controls/tex/tex.go` — `escapeLatex` →
-  `mapUnicodeToLatex` → the backtick-to-`\texttt` regex — and the
-  order is load-bearing: `mapUnicodeToLatex` introduces `\` and `$`
-  that `escapeLatex` would otherwise re-escape as `\textbackslash{}\$`
-  if the two ran in the other order. A new path that emits Statement
-  or Alternatives text into `.tex` outside `escapeBankText` will let
-  bare Unicode (Θ ² √ ≤ → ∞ — …) reach pdftex and reproduce the exact
-  `auto-multiple-choice prepare failed (1)` this WP set out to
-  prevent. Extending the map: add the char to `unicodeReplacer` AND a
-  matching row to `TestMapUnicodeToLatex_Round2` in `tex_internal_test.go`
-  in the same PR (one row per character is the pin against a silent
-  revert); author-facing summary is
-  `docs/standards/guides/write-control-questions.md` §Unicode symbols.
+  `escapeBankText` (issue #237, further shaped by #239).** The pipeline
+  in `internal/domain/controls/tex/tex.go` runs SEVEN ordered stages,
+  bracketed by a quarantine mechanism for content the author wants
+  literal. Order top-to-bottom, load-bearing at every step (the
+  step-by-step "why here" is on `escapeBankText`'s doc-comment):
+  1. `extractCodePayloads` — pulls every backtick pair out to a
+     `\x00CODE<n>\x00` sentinel BEFORE the emphasis / quote / Unicode
+     passes run, so nothing bleeds into `` `code` `` content. Author's
+     `` `.equals("María")` `` reaches the sheet as `.equals("María")`
+     in monospace, matching MDX's on-screen "backticks are inviolable"
+     rule (#239 COR-2, shipped bug in `buscar-con-equals`).
+  2. `escapeLatex` — TeX specials in author text.
+  3. `mapUnicodeToLatex` — Θ ² √ ≤ → ∞ — … (#237). Runs AFTER
+     `escapeLatex` so the `\` and `$` it introduces are not re-escaped.
+  4. `boldPattern` — `**text**` → `\textbf{…}`. `\B` gates on BOTH
+     outer sides so `n**m` arithmetic never fires as bold (#239).
+  5. `mapItalic` — `*text*` → `\textit{…}`. Manual scan, not a regex:
+     Go's RE2 cannot express "no `*` on the outside" without lookaround.
+     The boundary check (`italicBoundaryOK`) forbids BOTH word chars
+     AND another `*` on the outside of a marker, so `n*m*p` arithmetic
+     and cross-`**` italic bleed (`n**m es la … 2**3`) are both blocked
+     (#239 COR-1).
+  6. `mapAsciiQuotes` — `"…"` → `\og … \fg{}` (babel-spanish
+     guillemets). State machine: first quote opens, second closes, so
+     on. `[T1]{fontenc}` would otherwise compose a diacritic onto the
+     next glyph on a bare `"` (#239).
+  7. `restoreCodePayloads` — puts each backtick payload back as
+     `\texttt{escapeLatex(mapUnicodeToLatex(payload))}`. Emphasis /
+     quote transforms are deliberately NOT re-applied to code content.
+
+  A new path that emits Statement or Alternatives text into `.tex`
+  outside `escapeBankText` will let bare Unicode reach pdftex and
+  reproduce the exact `auto-multiple-choice prepare failed (1)` #237
+  set out to prevent — and now also lets raw `**`, `"` and stray `*`
+  leak onto paper as literal markers.
+
+  Extension conventions the pipeline pins (non-negotiable when adding
+  a new transform):
+  - A new Unicode row goes in `unicodeReplacer` AND a matching row in
+    `TestMapUnicodeToLatex_Round2` (`tex_internal_test.go`), one per
+    character — the pin against a silent revert.
+  - **A new inviolable payload type** (author-controlled content that
+    must reach the sheet literally) follows the
+    `extractCodePayloads` / `restoreCodePayloads` recipe — sentinel
+    swap before the transform pipeline, unwrap after. Do NOT insert a
+    new transform in the middle of the chain and hope authors won't
+    hit the bleed; #239 COR-2 was that hope, and it printed on paper.
+  - **A new emphasis marker** (a `~~strike~~`-shaped rule) needs its
+    outer-boundary check to forbid BOTH word chars AND another
+    marker-char — worked case: `italicBoundaryOK` in `tex.go`. A pure
+    `\B` gate is not enough; #239 COR-1 shows the exact silent-corruption
+    failure mode.
+  - Author-facing summary lives in
+    `docs/standards/guides/write-control-questions.md` §"Unicode
+    symbols" and §"Text emphasis" — both get a matching update in the
+    same PR (documentation.md Rule 1).
 - **The two surfaces do not share an auth gate** (§C12). Everything auth-shaped
   is mounted inside `internal/app/web`; `internal/app/api` is anonymous by
   construction, and `/health` sits deliberately outside the gate because the

--- a/apps/server/internal/domain/controls/tex/tex.go
+++ b/apps/server/internal/domain/controls/tex/tex.go
@@ -397,20 +397,21 @@ var codeFontPattern = regexp.MustCompile("`([^`]+)`")
 
 // boldPattern matches an MDX-style bold marker `**text**` and renders as
 // \textbf. The inner class allows single `*` runes so a nested italic
-// (`**bold *italic* end**`) is captured whole and italicPattern can find its
-// pair inside the resulting `\textbf{…}`. `[^*]+(?:\*[^*]+)*` reads as "one
-// or more non-star runs, glued by single stars" — which forbids `**` inside
-// (each glue star is required to be followed by non-stars), keeping each
-// bold pair local.
+// (`**bold *italic* end**`) is captured whole and mapItalic (below) can
+// find its pair inside the resulting `\textbf{…}`. `[^*]+(?:\*[^*]+)*`
+// reads as "one or more non-star runs, glued by single stars" — which
+// forbids `**` inside (each glue star is required to be followed by
+// non-stars), keeping each bold pair local.
 //
 // `\B` on both outer sides gates the marker to non-word-adjacent positions,
 // so author-typed arithmetic like `n**m**p` never fires as bold. `\B`
 // (opposite of `\b`) asserts "no word boundary here"; since `*` is itself
 // non-word, `\B` next to `*` forbids a word character on the outside — the
 // only way it matches is if the outer neighbour is start-of-string,
-// whitespace, or punctuation. Same gate is applied to italicPattern below
-// for the same reason (issue #239 COR-1). Runs BEFORE italicPattern so the
-// `**` pairs are consumed before the simpler italic regex sees the string.
+// whitespace, or punctuation. mapItalic below uses a stricter version of
+// the same gate — its `italicBoundaryOK` also forbids an adjacent `*`,
+// which pure `\B` cannot express (issue #239 COR-1). Runs BEFORE mapItalic
+// so the `**` pairs are consumed before the single-`*` scan sees them.
 var boldPattern = regexp.MustCompile(`\B\*\*([^*]+(?:\*[^*]+)*)\*\*\B`)
 
 // mapItalic replaces MDX italic markers `*text*` with `\textit{text}`. A
@@ -783,8 +784,8 @@ func restoreCodePayloads(s string, payloads []string) string {
 	return s
 }
 
-// escapeBankText is the Statement / Alternatives pipeline. Six stages in a
-// load-bearing order; each stage names its "why here" in the body. The
+// escapeBankText is the Statement / Alternatives pipeline. Seven stages in
+// a load-bearing order; each stage names its "why here" in the body. The
 // professor-typed control NAME goes through escapeLatex alone — it is
 // plain text, not MDX (issue #193 S3).
 func escapeBankText(s string) string {
@@ -802,8 +803,8 @@ func escapeBankText(s string) string {
 	//      (`$\Theta$`, `$\leq$`) are NOT re-escaped as
 	//      `\textbackslash{}\$`.
 	//   4. boldPattern — `**text**` → \textbf (issue #239). Runs BEFORE
-	//      italicPattern so the `**` pairs are consumed as a pair; if
-	//      italic ran first, its `\*(...)\*` would match the two
+	//      mapItalic so the `**` pairs are consumed as a pair; if
+	//      italic ran first, its single-`*` scan would match the two
 	//      asterisks that open and close a `**bold**` marker and destroy
 	//      the bold. Gated with `\B` on both outer sides (see the
 	//      boldPattern doc) so `n**m**p` arithmetic is not read as bold.

--- a/apps/server/internal/domain/controls/tex/tex_test.go
+++ b/apps/server/internal/domain/controls/tex/tex_test.go
@@ -595,8 +595,8 @@ func TestBacktickPairsRenderAsTypewriterText(t *testing.T) {
 // paper (raw markers around the word), and a lone `*` renders as a low
 // asterisk with no emphasis at all. The fix wires two more transforms into
 // escapeBankText — boldPattern (`**text**` → `\textbf{text}`), then
-// italicPattern (`*text*` → `\textit{text}`) — with bold FIRST so the
-// simpler italic pattern does not eat the two asterisks of a bold marker.
+// mapItalic (`*text*` → `\textit{text}`) — with bold FIRST so the
+// single-`*` scan does not eat the two asterisks of a bold marker.
 //
 // Scope in production (from the published bank at issue-time): 44 `**`
 // occurrences across 5 documents, mostly in `complejidad-de-hilbert-al-big-o`.
@@ -842,8 +842,9 @@ func TestEmphasisPipelineHandlesMixedContentInOneQuestion(t *testing.T) {
 		// residue, `%` survived escapeLatex, quotes became guillemets, the
 		// backtick pair became \texttt at the end.
 		"\\textbf{$\\Theta$(n$^{2}$)} es la cota \\textit{ajustada} del 100\\% en el \\og peor caso\\fg{} con \\texttt{for} loop.",
-		// Alternative 0: bold-then-italic pin holds, code inside bold runs
-		// because codeFontPattern comes last.
+		// Alternative 0: bold-then-italic pin holds, and code inside bold
+		// still wraps as \texttt because restoreCodePayloads rewrites the
+		// sentinel back to \texttt{…} at the end.
 		"\\correctchoice{\\textbf{bold \\textit{italic} con \\texttt{code}}}",
 		// Alternative 1: quotes translated inside a wrongchoice, `&` still
 		// escaped by escapeLatex.
@@ -888,10 +889,11 @@ func TestEmphasisPipelineHandlesMixedContentInOneQuestion(t *testing.T) {
 // survive verbatim. Same for the same shape wrapped in parentheses,
 // digits, and — since Miguel's imminent complexity-exercise batch is
 // exactly the authoring context — expressions like `O(a*b*c*d)` and
-// `5*3*2`. Pinned with `\B` on both outer sides of italicPattern
-// (regex asserts no word boundary at the outer `*` position, and since
-// `*` is itself non-word, a word char on the outside would create a
-// boundary and disqualify the match).
+// `5*3*2`. Pinned by mapItalic's boundary check (italicBoundaryOK): a
+// `*` is treated as an italic marker only when the rune immediately
+// outside it is neither a word character nor another `*`. Manual scan
+// rather than a regex because Go's RE2 cannot express the "no `*` on
+// the outside" half without lookaround.
 func TestItalicDoesNotFireOnArithmeticAsterisks(t *testing.T) {
 	out := compile(t, func(in *tex.Input) {
 		in.Pool = []bank.Question{

--- a/docs/standards/guides/write-control-questions.md
+++ b/docs/standards/guides/write-control-questions.md
@@ -310,20 +310,27 @@ the server translates each one to LaTeX before the printed sheet is compiled
   trap where a bare `"` before a vowel produced an unintended superscript
   glyph on paper.
 
-Nested emphasis works in one direction: an italic inside a bold
-(`**bold *italic* end**`) renders as `\textbf{bold \textit{italic} end}`
-because the pipeline runs bold first. The reverse order, bold inside italic
-(`*italic **bold** end*`), is undefined — bold consumes the `**` pair and
-italic does not see a matching pair on either side. Author-time: pick one
-kind of emphasis per span.
+Nested emphasis works in both directions when the inner marker sits with
+whitespace around it: `**bold *italic* end**` renders as
+`\textbf{bold \textit{italic} end}`, and `*italic **bold** end*` renders as
+`\textit{italic \textbf{bold} end}`. The one shape that misfires is
+contiguous nesting with no space around the inner marker
+(`*italic**bold**end*`): bold's word-boundary gate rejects the inner
+`**bold**` because it sits between two letters, and italic then sees no
+clean pair. Author-time: keep a space around inner emphasis, or pick one
+kind per span.
 
 **Two guarantees the pipeline pins**:
 
-- **Backticks are inviolable.** Anything the author wraps in `` `…` ``
-  reaches the sheet as monospace, literally. `` `**not bold**` ``,
-  `` `"María"` `` and `` `n*m*p` `` all print exactly as written inside
-  `\texttt{…}` — no bold, no guillemets, no italic bleeds into a code
-  fragment. Same rule MDX applies on-screen.
+- **Backticks quarantine their content from emphasis and quote transforms.**
+  Anything the author wraps in `` `…` `` reaches the sheet as monospace,
+  and no bold, italic or guillemet transform touches the payload —
+  `` `**not bold**` ``, `` `"María"` `` and `` `n*m*p` `` all print
+  exactly as written inside `\texttt{…}`. Same rule MDX applies on-screen.
+  (TeX-special escapes and the Unicode map still apply inside code, so
+  `` `70%` `` prints as `70%` and `` `Θ(n)` `` renders the Greek letter
+  correctly in monospace — the guarantee is scoped to the four MDX
+  emphasis markers.)
 - **`*` between word characters is arithmetic, not emphasis.** `n*m*p`,
   `O(a*b*c*d)`, `5*3*2` and `n**m` all print with their asterisks intact.
   An emphasis marker requires whitespace or punctuation on the OUTSIDE of


### PR DESCRIPTION
Follow-up to #240 (merged). Round B docs panel of the review pipeline for WP #239 ran after the merge and converged on a real docs gap plus several stale-symbol references. Bundling all findings into this one docs-only PR.

## Summary

- **`apps/server/CLAUDE.md`** — the `escapeBankText` bullet still described the pre-#237 three-stage pipeline. Rewritten to list the seven current stages, name the extract-and-restore quarantine mechanism, and encode the three non-negotiable conventions for extending the pipeline (new Unicode row, new inviolable payload type, new emphasis marker). Cites both #237 and #239. Convergent finding from three lenses (docs-completeness DCO-1, docs-accuracy DAC-2, agent-readability AGR-1/AGR-2/AGR-3).
- **`write-control-questions.md`** — the "reverse order is undefined" claim about nested emphasis was verified empirically to be FALSE: `*italic **bold** end*` renders correctly as `\textit{italic \textbf{bold} end}`. Replaced with the correct asymmetry — contiguous nesting without whitespace around the inner marker (`*italic**bold**end*`) is the shape that misfires (bold's `\B` gate rejects the word-adjacent inner `**`). Also tightened the "backticks are inviolable" wording to scope the guarantee to the four MDX emphasis markers (TeX-special escapes and Unicode map still apply inside code). DAC-1, DAC-7.
- **`tex.go` / `tex_test.go`** — stale references to `italicPattern` (the symbol was replaced by `mapItalic` in the review-fixes commit), a "Six stages" comment where the block actually lists 7, and a "codeFontPattern comes last" test comment that is now wrong (codeFontPattern is invoked FIRST inside `extractCodePayloads`; `restoreCodePayloads` wraps `\texttt{…}` at the end). DAC-3, DAC-4, DAC-5, DAC-6.

## Not included

- **ADR candidates** (extract-and-restore quarantine pattern, guillemets typography stance) — deferred. Precedent from #237 shipped a parallel change without an ADR, and the extended CLAUDE.md bullet now carries the load. Optional future work.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/domain/controls/tex/...` green
- [x] Empirically verified DAC-1's counter-claim: ran `*italic **bold** end*`, `**bold *italic* end**`, and `*italic**bold**end*` through `tex.Compile` — first two nest correctly, third is unchanged (the misfire the guide now correctly documents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
