### PR TITLE
fix(controls-tex): use T1 \guillemotleft/\guillemotright instead of babel \og/\fg

### DIFF
--- a/apps/server/CLAUDE.md
+++ b/apps/server/CLAUDE.md
@@ -208,10 +208,13 @@ the `avisoNo*` / `flash.Set(…)` string literals in `internal/app/web/handler/`
      AND another `*` on the outside of a marker, so `n*m*p` arithmetic
      and cross-`**` italic bleed (`n**m es la … 2**3`) are both blocked
      (#239 COR-1).
-  6. `mapAsciiQuotes` — `"…"` → `\og … \fg{}` (babel-spanish
-     guillemets). State machine: first quote opens, second closes, so
-     on. `[T1]{fontenc}` would otherwise compose a diacritic onto the
-     next glyph on a bare `"` (#239).
+  6. `mapAsciiQuotes` — `"…"` → `\guillemotleft{}…\guillemotright{}`
+     (T1-encoding guillemets). State machine: first quote opens, second
+     closes, so on. `[T1]{fontenc}` would otherwise compose a diacritic
+     onto the next glyph on a bare `"` (#239). Uses T1 macros directly
+     rather than `\og`/`\fg{}` — the babel-spanish shortcuts require
+     `activeacute` to be set and produce "Undefined control sequence"
+     otherwise (2026-08-27 post-#240 regression).
   7. `restoreCodePayloads` — puts each backtick payload back as
      `\texttt{escapeLatex(mapUnicodeToLatex(payload))}`. Emphasis /
      quote transforms are deliberately NOT re-applied to code content.

--- a/apps/server/internal/domain/controls/tex/tex.go
+++ b/apps/server/internal/domain/controls/tex/tex.go
@@ -392,7 +392,8 @@ func escapeLatex(s string) string {
 //
 // Backtick payloads are EXTRACTED before the emphasis / quote transforms
 // run so `*`, `"` and `**` inside code fragments cannot bleed into
-// \textit / \og / \textbf — see extractCodePayloads and issue #239 COR-2.
+// \textit / \guillemotleft / \textbf — see extractCodePayloads and issue
+// #239 COR-2.
 var codeFontPattern = regexp.MustCompile("`([^`]+)`")
 
 // boldPattern matches an MDX-style bold marker `**text**` and renders as
@@ -493,17 +494,25 @@ func italicBoundaryOK(rs []rune, i int) bool {
 	return !unicode.IsLetter(r) && !unicode.IsDigit(r)
 }
 
-// mapAsciiQuotes replaces every ASCII `"` with a Spanish babel guillemet
-// macro. The first quote in the string opens (`\og `), the second closes
-// (`\fg{}`), and so on — a running toggle rather than a regex, because a
-// pair is defined by ordinal position, not by matching parentheses. The
-// preamble already loads `\usepackage[spanish]{babel}` so `\og` and `\fg`
-// are defined; no package change (issue #239).
+// mapAsciiQuotes replaces every ASCII `"` with a T1-encoding guillemet
+// macro. The first quote in the string opens (`\guillemotleft{}`), the
+// second closes (`\guillemotright{}`), and so on — a running toggle rather
+// than a regex, because a pair is defined by ordinal position, not by
+// matching parentheses.
 //
-// Why guillemets: `[T1]{fontenc}` makes a bare ASCII `"` a
-// diacritic-composition trigger — `"este"` on paper prints as an unintended
-// superscript-e on the `e`. Guillemets are also the Spanish typographic
-// convention for a quotation on the printed sheet.
+// Why `\guillemotleft{}` / `\guillemotright{}` and not babel's
+// `\og`/`\fg{}`: those babel-spanish shortcuts are gated behind an
+// `activeacute` (or `es-noshorthands`) option that this preamble does
+// not set — `\usepackage[spanish]{babel}` alone leaves them undefined,
+// and AMC compiled a Complejidad control with them into "! Undefined
+// control sequence" (2026-08-27). `\guillemotleft{}` is a T1 encoding
+// macro; `[T1]{fontenc}` is already in the preamble, so it works with no
+// package change.
+//
+// Why guillemets at all: `[T1]{fontenc}` makes a bare ASCII `"` a
+// diacritic-composition trigger — `"este"` on paper prints as an
+// unintended superscript-e on the `e`. Guillemets are also the Spanish
+// typographic convention for a quotation on the printed sheet.
 //
 // An odd number of quotes in one field (a stray `"` alone) still emits
 // legal LaTeX: the state machine opens, and without a partner the print
@@ -522,9 +531,9 @@ func mapAsciiQuotes(s string) string {
 			continue
 		}
 		if open {
-			b.WriteString(`\og `)
+			b.WriteString(`\guillemotleft{}`)
 		} else {
-			b.WriteString(`\fg{}`)
+			b.WriteString(`\guillemotright{}`)
 		}
 		open = !open
 	}
@@ -738,8 +747,8 @@ const (
 // the ordered list of payloads. The emphasis / quote pipeline that runs
 // downstream then cannot bleed into what the author wrote as code — the
 // pre-#239 pipeline processed “ `a*b*c` “ as `\texttt{a\textit{b}c}` and
-// “ `.equals("María")` “ as `\texttt{.equals(\og María\fg{})}` (issue
-// #239 COR-2, shipped bug in buscar-con-equals). MDX treats backticks as
+// “ `.equals("María")` “ as `\texttt{.equals(\guillemotleft{}María\guillemotright{})}`
+// (issue #239 COR-2, shipped bug in buscar-con-equals). MDX treats backticks as
 // inviolable on-screen, so the printed sheet needs the same guarantee.
 //
 // A backtick without its pair passes through — the pattern only matches
@@ -813,7 +822,8 @@ func escapeBankText(s string) string {
 	//      adjacent `*` on the outside (which pure `\B` cannot), blocking
 	//      arithmetic like `n*m*p` and cross-`**` italic bleed in
 	//      strings like `n**m es la … 2**3` (issue #239 COR-1).
-	//   6. mapAsciiQuotes — `"..."` → `\og … \fg{}` (issue #239). Runs
+	//   6. mapAsciiQuotes — `"..."` → `\guillemotleft{}…\guillemotright{}`
+	//      (issue #239; babel-shortcut fixed post-#240). Runs
 	//      AFTER the emphasis transforms so an author's `*"quoted"*` still
 	//      picks up italic on the whole span.
 	//   7. restoreCodePayloads — put each backtick payload back as

--- a/apps/server/internal/domain/controls/tex/tex_test.go
+++ b/apps/server/internal/domain/controls/tex/tex_test.go
@@ -712,9 +712,13 @@ func TestNestedItalicInsideBoldRendersAsBothInOrder(t *testing.T) {
 // Spanish sheet anyway.
 //
 // The fix pairs each `"` with its partner and emits guillemets via the
-// babel-spanish macros `\og … \fg{}` — the standard Spanish typography, and
-// already covered by the preamble's `\usepackage[spanish]{babel}` (no
-// package change needed). A simple state machine toggles open/close on
+// T1-encoding macros `\guillemotleft{}` / `\guillemotright{}` — the
+// standard Spanish typography, and already covered by the preamble's
+// `\usepackage[T1]{fontenc}` (no package change needed). An earlier
+// revision used babel-spanish's `\og … \fg{}` shortcuts, which
+// `\usepackage[spanish]{babel}` does NOT define unless `activeacute` is
+// set — AMC compiled it into "! Undefined control sequence" (2026-08-27,
+// post-#240 regression). A simple state machine toggles open/close on
 // every quote; an odd number of quotes in one field is a degenerate input
 // (the professor would have to have typed a stray `"` alone), covered by
 // the "unbalanced" test below.
@@ -736,12 +740,12 @@ func TestAsciiQuotesRenderAsSpanishGuillemets(t *testing.T) {
 		in.QuestionsPerCopy = 1
 	})
 	for _, want := range []string{
-		`\og este algoritmo\fg{}`,
-		`\correctchoice{\og correcto\fg{} según la definición}`,
-		`\wrongchoice{también llamado \og peor caso\fg{}}`,
+		`\guillemotleft{}este algoritmo\guillemotright{}`,
+		`\correctchoice{\guillemotleft{}correcto\guillemotright{} según la definición}`,
+		`\wrongchoice{también llamado \guillemotleft{}peor caso\guillemotright{}}`,
 	} {
 		if !strings.Contains(out, want) {
-			t.Errorf("ASCII quote pair was not translated to babel guillemets: missing %q in output", want)
+			t.Errorf("ASCII quote pair was not translated to T1 guillemets: missing %q in output", want)
 		}
 	}
 	// The raw `"` must not survive into the .tex — that is the fontenc[T1]
@@ -758,8 +762,8 @@ func TestAsciiQuotesRenderAsSpanishGuillemets(t *testing.T) {
 
 // An odd number of quotes in one field is degenerate input — the author
 // typed a stray `"` alone. The state machine still toggles: the first
-// stray opens (`\og`) and, without a close partner, prints as an open
-// guillemet with a trailing thin space (`\og`). No brace-balancing damage
+// stray opens (`\guillemotleft{}`) and, without a close partner, prints
+// as a lone open guillemet on the sheet. No brace-balancing damage
 // downstream. Verified so a review does not have to reason about it.
 func TestUnbalancedQuoteStillProducesLegalTex(t *testing.T) {
 	out := compile(t, func(in *tex.Input) {
@@ -774,8 +778,8 @@ func TestUnbalancedQuoteStillProducesLegalTex(t *testing.T) {
 		}
 		in.QuestionsPerCopy = 1
 	})
-	if !strings.Contains(out, `mira \og esto pero no cierra`) {
-		t.Error("unbalanced open quote did not become \\og — the state machine must still fire on a lone quote")
+	if !strings.Contains(out, `mira \guillemotleft{}esto pero no cierra`) {
+		t.Error("unbalanced open quote did not become \\guillemotleft{} — the state machine must still fire on a lone quote")
 	}
 	// Scoped: the preamble's `\lstset{literate=…}` block legitimately
 	// contains `\"u` and friends, which include the ASCII `"` byte
@@ -802,7 +806,7 @@ func TestUnbalancedQuoteStillProducesLegalTex(t *testing.T) {
 //   - `**bold**` around the whole expression (must render as \textbf, wrapping
 //     the translated math);
 //   - `*italic*` and `**bold *italic* end**` (must nest correctly);
-//   - `"quoted"` (must render as `\og … \fg{}`);
+//   - `"quoted"` (must render as `\guillemotleft{}…\guillemotright{}`);
 //   - a backtick pair (must render as \texttt, run LAST).
 //
 // The alternatives repeat the same interleaving on smaller strings so the
@@ -841,14 +845,14 @@ func TestEmphasisPipelineHandlesMixedContentInOneQuestion(t *testing.T) {
 		// Statement: bold wraps the translated math, italic runs on the
 		// residue, `%` survived escapeLatex, quotes became guillemets, the
 		// backtick pair became \texttt at the end.
-		"\\textbf{$\\Theta$(n$^{2}$)} es la cota \\textit{ajustada} del 100\\% en el \\og peor caso\\fg{} con \\texttt{for} loop.",
+		"\\textbf{$\\Theta$(n$^{2}$)} es la cota \\textit{ajustada} del 100\\% en el \\guillemotleft{}peor caso\\guillemotright{} con \\texttt{for} loop.",
 		// Alternative 0: bold-then-italic pin holds, and code inside bold
 		// still wraps as \texttt because restoreCodePayloads rewrites the
 		// sentinel back to \texttt{…} at the end.
 		"\\correctchoice{\\textbf{bold \\textit{italic} con \\texttt{code}}}",
 		// Alternative 1: quotes translated inside a wrongchoice, `&` still
 		// escaped by escapeLatex.
-		"\\wrongchoice{llamado \\og peor caso\\fg{} \\& similares}",
+		"\\wrongchoice{llamado \\guillemotleft{}peor caso\\guillemotright{} \\& similares}",
 		// Alternative 2: italic wraps math after both transforms fire.
 		"\\wrongchoice{complejidad \\textit{$\\Theta$(n$^{2}$)}}",
 	} {
@@ -968,7 +972,7 @@ func TestBoldDoesNotFireOnDoubleAsteriskArithmetic(t *testing.T) {
 // once the payload has entered its `\texttt{…}`. Live shipped case at
 // the time of this WP: buscar-con-equals in
 // `09-arrays-y-funciones.mdx` had alternatives like “ `.equals("María")` “
-// rendered as `\texttt{.equals(\og María\fg{})}` — «María» in monospace
+// rendered as `\texttt{.equals(\guillemotleft{}María\guillemotright{})}` — «María» in monospace
 // on paper vs. the correct `.equals("María")` on screen.
 //
 // The fix extracts each backtick payload before the emphasis / quote
@@ -1013,7 +1017,7 @@ func TestCodeFragmentContentIsNotTouchedByEmphasisOrQuotes(t *testing.T) {
 			t.Errorf("code payload was mutated by an emphasis or quote transform: missing %q in output (issue #239 COR-2)", want)
 		}
 	}
-	// Negative: no `\og` or `\fg{}` inside a `\texttt{…}`, no `\textit`
+	// Negative: no guillemet macro inside a `\texttt{…}`, no `\textit`
 	// or `\textbf` inside a `\texttt{…}`. Grep the question region for
 	// the pathological substrings the pre-fix pipeline emitted.
 	qStart := strings.Index(out, `\begin{question}`)
@@ -1023,10 +1027,10 @@ func TestCodeFragmentContentIsNotTouchedByEmphasisOrQuotes(t *testing.T) {
 	}
 	region := out[qStart:qEnd]
 	for _, unwant := range []string{
-		`\texttt{\og`,      // guillemet macro started inside \texttt
-		`\og María`,        // pre-fix bleed
-		`\texttt{a\textit`, // pre-fix italic bleed
-		`\texttt{\textbf`,  // pre-fix bold bleed
+		`\texttt{\guillemotleft`, // guillemet macro started inside \texttt
+		`\guillemotleft{}María`,  // pre-fix bleed
+		`\texttt{a\textit`,       // pre-fix italic bleed
+		`\texttt{\textbf`,        // pre-fix bold bleed
 	} {
 		if strings.Contains(region, unwant) {
 			t.Errorf("emphasis or quote transform bled into a code payload: found %q in the question block (issue #239 COR-2)", unwant)

--- a/docs/standards/guides/write-control-questions.md
+++ b/docs/standards/guides/write-control-questions.md
@@ -304,7 +304,7 @@ the server translates each one to LaTeX before the printed sheet is compiled
   (monospace). A backtick without its partner prints as a quote mark on paper
   and is not what any reader expects; pair them.
 - **Quotation** — an ASCII double quote pair, `"así"`, renders as
-  babel-spanish guillemets `«así»`. Straight ASCII quotes are NOT rendered
+  T1-encoding guillemets `«así»`. Straight ASCII quotes are NOT rendered
   as such: writing `"así"` on the page produces the Spanish typographic
   form, and the transform also sidesteps a `fontenc[T1]` diacritic-composition
   trap where a bare `"` before a vowel produced an unintended superscript


### PR DESCRIPTION
## Bug

Post-#240 regression. Miguel tried to create a control drawn from Complejidad after the deploy and got another 500. Server log (thanks to the request-logging from #234):

```
level=ERROR msg="creating a control" error="controls: the AMC worker refused the request:
controls/TKDAPSSYRTL5WYWVGQFZR4MQP4 answered 400: auto-multiple-choice prepare failed (1)
(worker detail: … ! Undefined control sequence. <argument> \og este algoritmo es O(n$^{2}$)\fg …)"
level=INFO msg=request method=POST path=/controls status=500 duration_ms=7992
```

pdftex refused `\og` — the babel-spanish shortcut this WP started calling on every ASCII quote pair.

## Cause

`\og` / `\fg{}` in babel-spanish are gated behind an `activeacute` (or `es-noshorthands`) option. This preamble loads `\usepackage[spanish]{babel}` on its own — the shortcuts are undefined at compile time and pdftex bails.

Every control that drew a question with ASCII quotes 500'd. From the published bank at time of merge: 14 quote occurrences across `complejidad-de-hilbert-al-big-o`, `arrays-y-funciones`, `objetos`.

The bad call was mine — I suggested `\og`/`\fg{}` in the #239 issue body and the design confirmation, assuming babel-spanish exposed them by default. It doesn't in this preamble.

## Fix

Switch `mapAsciiQuotes` from `\og … \fg{}` to `\guillemotleft{}` / `\guillemotright{}`. Both are T1-encoding macros; `\usepackage[T1]{fontenc}` is already in the preamble, so no package change needed. Same visual output (« … »), same Spanish typographic convention, no diacritic-composition trap.

## Files touched

- `apps/server/internal/domain/controls/tex/tex.go` — `mapAsciiQuotes` body + doc-comment; two other in-file references (codeFontPattern doc, `.equals` example, pipeline overview step 6) rewritten to the new macro name.
- `apps/server/internal/domain/controls/tex/tex_test.go` — three assertion sets and two comments updated to expect `\guillemotleft{}…\guillemotright{}`.
- `apps/server/CLAUDE.md` — pipeline step 6 now names T1 macros and records the babel-shortcut regression as the reason for the switch.
- `docs/standards/guides/write-control-questions.md` — Quotation bullet mentions T1 rather than babel-spanish.

## Yolo scope

Per `docs/conventions.md`: one mechanical macro swap + doc/comment/test refreshes, no behaviour change beyond the correct LaTeX runtime, no schema / preamble / package change. Full apps/server suite green with `-race -count=1`.

## Verification after merge

1. Watchtower pushes the new server image to the Jetson (≤5 min post-merge to main).
2. Recreate the Control 3 the previous version 500'd on (same range: Complejidad §1 → last section).
3. The POST should return 302 (redirect to detail); the sujet PDF should download with `«…»` where the source had `"…"`.
4. **PAPER-CHECK still bloqueante** on the parent issue #239: verify on print that the guillemet renders as expected around quoted phrases and that the `.equals("María")` case (backtick quarantine) still shows literal ASCII quotes inside monospace, unchanged.

## Related

- **#239 / #240** — the WP this regression came from. Same file, same pipeline, same PAPER-CHECK.
- **#241** — Round B docs fixes; the CLAUDE.md and guide edits here supersede the (now-wrong) `\og`/`\fg{}` mentions that #241 added.
- **#237** — Unicode → LaTeX, preserved intact.
