### PR TITLE
fix(controls-review): cap alt index by bank count, not Answer.Max

### DIFF
--- a/apps/server/internal/app/web/handler/review.go
+++ b/apps/server/internal/app/web/handler/review.go
@@ -176,6 +176,7 @@ func (h *Controls) SaveReview(w http.ResponseWriter, r *http.Request) {
 		CopyNumber: copyNumber,
 		RUT:        rut,
 	}
+	bnk := h.Bank.Get()
 	for _, a := range reading.Answers {
 		edit := controls.AnswerEdit{QuestionRef: a.QuestionRef}
 		if a.QuestionRef == blank {
@@ -184,12 +185,22 @@ func (h *Controls) SaveReview(w http.ResponseWriter, r *http.Request) {
 		} else {
 			field := "q" + a.QuestionRef
 			values := r.PostForm[field]
-			// SEC-2: cap the mark index at the answer's known alternative
-			// count — the form was never generated with options past
-			// a.Max, so anything higher is data pollution.
-			maxMark := int(a.Max)
-			if maxMark < 1 {
-				maxMark = 26 // fallback cap (a professor cannot author more)
+			// SEC-2 (S3 review, revised post-#234 regression): cap the mark
+			// index at the question's ACTUAL alternative count from the bank.
+			// The prior revision used `a.Max`, but Max is the SCORING weight
+			// (1 for a simple question, N-of-correct for a multiple), not the
+			// alternative count — a simple question with 4 alternatives has
+			// Max=1, so parseAnswerValues rejected any mark on B/C/D as
+			// "exceeds this question's alternatives (1)" and every re-submit
+			// on a copy where AMC read anything past option A came back as
+			// "El formulario tiene un valor inválido." (reported 2026-08-27).
+			// The bank is authoritative on the count; a missing bank entry
+			// (test paths, or a question dropped from the pool) falls back
+			// to the 26-option ceiling so the form is not the one that
+			// refuses.
+			maxMark := 26 // fallback cap (a professor cannot author more)
+			if q, ok := lookupQuestion(bnk, a.QuestionRef); ok && len(q.Alternatives) > 0 {
+				maxMark = len(q.Alternatives)
 			}
 			marks, err := parseAnswerValues(values, maxMark)
 			if err != nil {

--- a/apps/server/internal/app/web/handler/save_review_test.go
+++ b/apps/server/internal/app/web/handler/save_review_test.go
@@ -450,6 +450,51 @@ func TestSaveReviewBlankButtonAcceptsEmptyRUT(t *testing.T) {
 	}
 }
 
+// TestSaveReviewAcceptsMarksBeyondScoringWeight pins the regression fixed
+// post-#234: the SEC-2 cap must use the question's bank alternative COUNT,
+// not `Answer.Max` (which is the scoring weight — 1 for a simple, N for a
+// multiple's number-of-correct). The old code rejected any mark index > Max
+// on a simple question, so any copy where AMC read option B, C, or D was
+// unsavable — every re-submit came back with "El formulario tiene un valor
+// inválido." (reported 2026-08-27 against Control 2 copy 9).
+//
+// The fixture's q3 has Max=1 (simple) but the bank declares 2 alternatives
+// ("a", "b"); marking option 2 must land, not refuse.
+func TestSaveReviewAcceptsMarksBeyondScoringWeight(t *testing.T) {
+	f, controlID := saveReviewFixture(t)
+	values := url.Values{}
+	values.Set("rut", "20111111") // unchanged
+	values.Set("qq3", "2")        // Max=1 but bank has 2 alternatives → must land
+	values.Set("qq4", "1")        // unchanged
+
+	rec := postSaveReview(t, f, controlID, 1, values)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d\nbody: %s", rec.Code, rec.Body.String())
+	}
+	got := flashFromResponse(t, rec)
+	if got == "El formulario tiene un valor inválido." {
+		t.Fatalf("SEC-2 cap rejected a mark within the question's real alternative count — pre-fix behaviour: got %q", got)
+	}
+	// Positive: the answer moved from [1] to [2].
+	reading, err := f.service.ReadingFor(f.authedRequest(t, http.MethodGet, "/", nil).Context(), controlID, 1)
+	if err != nil {
+		t.Fatalf("ReadingFor: %v", err)
+	}
+	var q3 *controls.Answer
+	for i := range reading.Answers {
+		if reading.Answers[i].QuestionRef == "q3" {
+			q3 = &reading.Answers[i]
+		}
+	}
+	if q3 == nil || q3.Override == nil || len(q3.Override.Marked) != 1 || q3.Override.Marked[0] != 2 {
+		t.Fatalf("q3 override did not persist mark [2]: %+v", q3)
+	}
+	if want := "Cambios en 1 respuesta."; got != want {
+		t.Errorf("flash = %q, want %q — the move on q3 must be reported", got, want)
+	}
+}
+
 // TestSaveReviewBlankButtonAlsoReportsOtherMovedAnswers pins COR-5: when
 // the professor mid-edits other radios and then clicks the blank button,
 // the count of OTHER moves is not swallowed by the blank line.


### PR DESCRIPTION
## Bug

Miguel intentó editar el RUT en Control 2 copia 9 hoy: `21921651` (8 dígitos válidos) → flash **"El formulario tiene un valor inválido."** → nada se persiste. Ni RUT ni respuestas. Y aplica a **cualquier submit sin edit** también.

Log del server (con el logging middleware del #234):
```
level=INFO msg=request method=POST path=/controls/…/copies/9/review status=303 bytes=0 duration_ms=12
```

12ms → salió por early return sin llegar a `SaveOverrides`. Sin el `save review` slog.Info del path exitoso.

## Cause

SEC-2 en el S3 review de #234 dijo *"cap the mark index at the answer's known alternative count"* y la implementación quedó como:

```go
maxMark := int(a.Max)
if maxMark < 1 {
    maxMark = 26 // fallback
}
```

**Fue mi call en la review, y estaba mal**: `Answer.Max` es el **peso de scoring** (1 para simple, N para multiple's number-of-correct), no el **conteo de alternativas**.

Efecto: para una question simple con 4 alternativas (A/B/C/D) → `maxMark = int(1.0) = 1` → `parseAnswerValues` rechaza cualquier mark > 1 → **solo A pasa**. Cualquier re-submit sobre una copia donde AMC leyó B, C, o D (o donde el prof marcó una de esas) fallaba, incluyendo un re-submit sin ediciones — el value pre-marcado del propio form era inválido para su propio handler.

Verificado en la DB de la Jetson: `answer.max=1.0` para todas las questions simple; una copia tenía `marked=[3]` (opción C leída por AMC).

## Fix

Cap por `len(bank.Question.Alternatives)` — el bank es autoritativo sobre el conteo, y el mismo call site que render usó para armar el form:

```go
maxMark := 26 // fallback (question missing from bank, or dropped from pool)
if q, ok := lookupQuestion(bnk, a.QuestionRef); ok && len(q.Alternatives) > 0 {
    maxMark = len(q.Alternatives)
}
```

Consistencia por construcción: el form fue renderizado con esas mismas alternatives (`toReviewQuestions` en la misma request).

## Files

- `apps/server/internal/app/web/handler/review.go` — 3 líneas de cambio en el body del handler + comment expandido nombrando la regresión.
- `apps/server/internal/app/web/handler/save_review_test.go` — nuevo `TestSaveReviewAcceptsMarksBeyondScoringWeight` que reproduce el bug (q3 con Max=1, prof marca alternativa 2, debe pasar). Con el código pre-fix el test falla con "El formulario tiene un valor inválido."

## Verificación

- `gofmt -l .` clean.
- `go vet ./...` clean.
- `go test -race -count=1 ./...` full apps/server → verde.
- Manual post-merge: Miguel puede editar el RUT (o cualquier respuesta) en Control 2 copia 9 sin obtener "formulario inválido".

## Yolo scope

Regresión clara del #234 review. 3 líneas de código + 1 test + comment expandido. Sin cambios de schema, sin migración, sin PAPER-CHECK. Blocker de UX para cualquier revisión de copias.

## Related

- **#234** — el WP que shipped SEC-2 con el bug. `SaveOverrides` domain-side ya estaba OK; el bug vive solo en el handler cap.
- **#243** (WP en curso — multi-page scan): distinto path, no overlap. wp243-pages sigue trabajando en su fix.
