### PR TITLE
fix(controls-review): show every scanned page in the raw-scan fallback (#243)

### DIFF
--- a/apps/amc-worker/CLAUDE.md
+++ b/apps/amc-worker/CLAUDE.md
@@ -63,6 +63,19 @@ it — script names, test titles, the fixture's own comments.
   used to paraphrase the first two and silently omit the others.
 - **Anything the caller passes crosses the volume, not the wire.** Requests name
   paths under `/work`; PDFs and scans never travel as HTTP bodies.
+- **A new field in the `/analyse` or `/reanalyse` response body is
+  OPTIONAL on the wire.** The server merges FIRST — this repo ships
+  server and worker in the same monorepo but each has its own CD
+  workflow, so their versions can drift on the Jetson for up to ~5
+  minutes across a merge — and `apps/server/internal/infra/amcworker/
+  analyze.go`'s `toDomain` substitutes a legacy default when the field
+  is absent. A worker upgraded ahead of the server must not break the
+  server, and vice versa. Worked cases: `pages_per_copy` → substitute
+  `[1]` per copy (#243); the per-answer `position` + `alternatives`
+  → substitute 0 / empty and iterate in bank order (#229). Adding a
+  required field is forbidden; renaming or removing one is a wire
+  break and needs its own coordination — same rule shape as
+  `ADR-0031`'s "reversal test" for engine-independent fields.
 - **Never run `apt-get install` inside the image, and never add a package
   without discussing it.** `texlive-fonts-extra` is purged with
   `--force-depends`, so the package database is deliberately inconsistent

--- a/apps/amc-worker/README.md
+++ b/apps/amc-worker/README.md
@@ -61,13 +61,13 @@ rollback died on it, issue #193).
 ```
 GET  /health                                          → { ok, amc }
 POST /generate      { project, source, copies }       → { sujet, corrige, calage, copies }
-POST /analyse       { project, scan_pdf, source,      → { pages, scoring, copies, needs_review }
+POST /analyse       { project, scan_pdf, source,      → { pages, scoring, copies, needs_review, pages_per_copy }
                       [ticked], [unsure] }
                     ⏱ MINUTES-CLASS — background job only, see below.
                     ticked/unsure (issue #197): the darkness verdicts AND
                     note run at the same ticked — marks, scores and any
                     downstream annotated PDF agree on one threshold.
-POST /reanalyse     { project, [ticked], [unsure] }    → { pages, scoring, copies, needs_review }
+POST /reanalyse     { project, [ticked], [unsure] }    → { pages, scoring, copies, needs_review, pages_per_copy }
                     re-runs note at the new ticked, so the scores follow
                     the marks (issue #197).
 POST /associate     { project, roster, code, key }    → { associations, refused_codes }
@@ -286,6 +286,20 @@ per question). Both are optional: an empty `alternatives` or `position:
 0` means the analyzer has no layout data, and callers fall back to bank
 order. The full shape stays in the module docstring, which is the
 schema-of-record.
+
+**The report says which physical pages of each copy the engine captured.**
+Top-level `pages_per_copy` maps copy number (as a decimal string; the
+server parses to int) to the ascending 1-based list of pages AMC
+accepted for that copy — `{"9": [1, 2], "10": [1, 2], "12": [1]}` says
+copy 12 lost page 2 at the scanner. The review page's raw-scan fallback
+(`apps/server`, issue #190) iterates this list to render one `<img>`
+per captured page: before #243 it only asked for page 1 and any
+two-page copy lost half its answers to the professor. The engine is the
+source of truth — a copy whose page 2 was scanned but rejected by AMC's
+page-recognition does not appear here and does not get an `<img>`.
+Optional: a report without the field, or a copy missing from the map,
+means the analyzer predates #243; callers substitute `[1]` per copy so
+the raw-scan fallback keeps its pre-#243 single-page render.
 
 **The report says which threshold those scores were computed at.** AMC's `note`
 scores at its own `--seuil` while `--ticked` is ours and tunable, so a CLI

--- a/apps/amc-worker/read_capture.py
+++ b/apps/amc-worker/read_capture.py
@@ -468,6 +468,20 @@ def read(data_dir, ticked, unsure):
     captured = cap.execute("SELECT COUNT(*) FROM capture_page").fetchone()[0]
     failed = cap.execute("SELECT COUNT(*) FROM capture_failed").fetchone()[0]
 
+    # Which physical pages of each copy AMC captured. The review page's raw-scan
+    # fallback (`apps/server`, issue #190) renders one `<img>` per captured page,
+    # and until #243 it only ever asked for page 1 — a two-page copy lost half
+    # its answers to the professor. AMC is the source of truth for what was
+    # captured: a copy whose page 2 was scanned but rejected does not appear in
+    # `capture_page`, and the fallback must not invent an image for it. Ascending
+    # page order per copy; string keys because JSON keys are strings and the
+    # server parses back to int.
+    pages_per_copy = {}
+    for student, page in cap.execute(
+        "SELECT student, page FROM capture_page ORDER BY student, page"
+    ):
+        pages_per_copy.setdefault(str(student), []).append(page)
+
     return {
         "pages": {"captured": captured, "failed": failed},
         # `stale` is the whole reason both numbers are here: when they differ,
@@ -475,6 +489,7 @@ def read(data_dir, ticked, unsure):
         # beside them at another.
         "scoring": {"seuil": seuil, "ticked": ticked, "stale": seuil != ticked},
         "copies": out,
+        "pages_per_copy": pages_per_copy,
         "needs_review": [k for k, v in out.items() if v["status"] != "ok"],
     }
 

--- a/apps/amc-worker/read_capture.py
+++ b/apps/amc-worker/read_capture.py
@@ -34,7 +34,16 @@ Runs INSIDE the worker image. Emits JSON on stdout:
           "status": "ok"                           // ok|needs_review|incomplete
         }
       },
-      "needs_review": ["4", "5"]
+      "needs_review": ["4", "5"],
+      "pages_per_copy": {                              // issue #243: physical pages
+        "1": [1, 2], "5": [1]                          // the engine captured for each
+      }                                                // copy, ascending, string keys
+                                                       // (server parses to int). A
+                                                       // copy whose page 2 was
+                                                       // rejected does NOT list 2
+                                                       // here; the review page's
+                                                       // raw-scan fallback iterates
+                                                       // this list verbatim.
     }
 
 WHAT THE PROJECT MUST ALREADY HAVE. This reads three of AMC's databases, not

--- a/apps/amc-worker/tests/03-read.sh
+++ b/apps/amc-worker/tests/03-read.sh
@@ -142,6 +142,29 @@ check_eq "no page failed to be read" "0" "$(jq 'd["pages"]["failed"]')"
 # its position — no separate assertion is needed, and the bare `pass` that used
 # to sit here was a check no defect could turn red (#138 review).
 
+# --- issue #243: which pages of each copy AMC captured ------------------------
+#
+# The review page (`apps/server`) has a raw-scan fallback for copies that came
+# back `needs_review`, and until #243 it only rendered page 1 — a two-page copy
+# lost half its answers to the professor. The server persists whatever AMC
+# captured, per copy, so it can iterate them in the template. This report is
+# the source of truth: AMC decides which pages were captured (a page that never
+# reached the scanner does not appear in `capture_page`), and nothing here
+# second-guesses that. `pages_per_copy` uses string keys (copies are numeric,
+# but JSON keys are strings; the server parses to int) and each value is the
+# captured pages for that copy in ascending order.
+#
+# This fixture prints 5 copies × 2 pages each (`\AMCcleardoublepage`), which is
+# why AC-4 sees 10 captured; every copy therefore holds [1, 2] here. A copy that
+# scanned page 1 but not page 2 is exercised by the server-side test — that
+# state is fabricable on the DB but not with this scrambled synthetic batch.
+check_eq "the report says which pages of each copy were captured" "[1, 2]" \
+  "$(jq 'd["pages_per_copy"]["1"]')"
+check_eq "and it lists every copy, keyed as a string" \
+  "['1', '2', '3', '4', '5']" "$(jq 'sorted(d["pages_per_copy"].keys())')"
+check_eq "and copy 3 (needs_review) still reports both pages it captured" \
+  "[1, 2]" "$(jq 'd["pages_per_copy"]["3"]')"
+
 # --- AC-3: the RUT grid reads back --------------------------------------------
 
 check_eq "copy 1 RUT reads back exactly as marked" "20123456" "$(jq 'd["copies"]["1"]["rut"]')"

--- a/apps/server/CLAUDE.md
+++ b/apps/server/CLAUDE.md
@@ -198,6 +198,19 @@ the `avisoNo*` / `flash.Set(…)` string literals in `internal/app/web/handler/`
   that resolves `.Get()` then hands the request to the service,
   which also resolves `.Get()`, can straddle a swap; the addendum
   pins that distinction after the WP review flagged it).
+- **The empty-`Reading.Pages` fallback for the review page's raw-scan
+  section is owned by exactly TWO boundaries (issue #243).** Migration
+  `00011_reading_pages.sql` backfills every legacy `reading` row to
+  `pages_json = '[1]'`, and `amcworker.toDomain` substitutes `[1]` per
+  copy when the wire report omits `pages_per_copy` (a legacy worker).
+  `buildReviewImages`, `upsertReading` and `scanReading` **trust** the
+  invariant those two boundaries establish and MUST NOT paper over an
+  empty list with a third substitution — an empty list at
+  `buildReviewImages` means a genuine `not_present` copy reached by
+  hand-typed URL, and an empty `Escaneo` section is the honest signal.
+  Same rule shape and same reason as the UploadScan and LiveBank
+  bullets above; ADR-0031 §"The report says which pages of each copy
+  were captured" (amended by #243) is the shipping contract.
 - **Bank text destined for the printed sheet MUST go through
   `escapeBankText` (issue #237, further shaped by #239).** The pipeline
   in `internal/domain/controls/tex/tex.go` runs SEVEN ordered stages,

--- a/apps/server/internal/app/web/handler/results_test.go
+++ b/apps/server/internal/app/web/handler/results_test.go
@@ -104,6 +104,13 @@ func okCopy(rut string) controls.ReportCopy {
 	return controls.ReportCopy{
 		RUT: rut, RUTStatus: controls.RUTStatusOK, Status: controls.CopyStatusOK,
 		ExpectedQuestions: 2, SeenQuestions: 2,
+		// Pages matches the shape a real 1-page-per-copy control emits —
+		// callers overriding for multi-page cases set it explicitly.
+		// Without this the raw-scan fallback renders zero <img>, which
+		// is honest for the domain but not what the "annotate off" and
+		// "stale annotated" tests are checking (they exercise the raw
+		// scan render, not an empty section).
+		Pages: []int{1},
 		Answers: []controls.ReportAnswer{
 			{Question: 1, Name: "q3", Type: controls.QuestionSimple, Marked: []int{1},
 				Status: controls.AnswerStatusOK, Score: 1, Max: 1},

--- a/apps/server/internal/app/web/handler/review.go
+++ b/apps/server/internal/app/web/handler/review.go
@@ -522,17 +522,16 @@ func controlPageImageURL(id string, copyNumber, pageNumber int) string {
 }
 
 // buildReviewImages turns the reading's captured-pages list into the
-// per-page items the template iterates (issue #243). An empty list
-// falls back to page 1, matching migration 00011's backfill and the
-// amcworker mapping's legacy fallback: "nothing was said about
-// pages" renders exactly page 1, same as the pre-#243 template did.
-// A copy with no scan at all (not_present) skips the raw-scan
-// section entirely — the review page is never reached for it (the
-// results table filters not_present rows out of the review link).
+// per-page items the template iterates (issue #243). Trusts the
+// invariant "every reviewable copy has at least one captured page" —
+// migration 00011 backfills legacy rows to [1] and amcworker.toDomain
+// substitutes [1] for a wire report without pages_per_copy, so the
+// only path that lands here with an empty list is a not_present copy
+// reached by hand-typed URL (the results table filters it out of the
+// review link). An empty list emits zero <img> — an empty "Escaneo"
+// section is a more honest render than a broken image icon that
+// looks like a legitimate page.
 func buildReviewImages(id string, copyNumber int, pages []int) []view.ReviewImage {
-	if len(pages) == 0 {
-		pages = []int{1}
-	}
 	out := make([]view.ReviewImage, 0, len(pages))
 	for _, n := range pages {
 		out = append(out, view.ReviewImage{

--- a/apps/server/internal/app/web/handler/review.go
+++ b/apps/server/internal/app/web/handler/review.go
@@ -63,7 +63,7 @@ func (h *Controls) Review(w http.ResponseWriter, r *http.Request) {
 		Name:       control.Name,
 		CopyNumber: copyNumber,
 		BackURL:    controlDetailURL(id),
-		ImageURL:   controlPageImageURL(id, copyNumber, 1),
+		Pages:      buildReviewImages(id, copyNumber, reading.Pages),
 		SaveURL:    controlReviewURL(id, copyNumber),
 		Graded:     control.State == controls.Graded,
 		RUT:        toReviewRUT(reading),
@@ -519,6 +519,28 @@ func parseCopyPathValue(raw string) (int, bool) {
 
 func controlPageImageURL(id string, copyNumber, pageNumber int) string {
 	return fmt.Sprintf("%s/copies/%d/page/%d", controlDetailURL(id), copyNumber, pageNumber)
+}
+
+// buildReviewImages turns the reading's captured-pages list into the
+// per-page items the template iterates (issue #243). An empty list
+// falls back to page 1, matching migration 00011's backfill and the
+// amcworker mapping's legacy fallback: "nothing was said about
+// pages" renders exactly page 1, same as the pre-#243 template did.
+// A copy with no scan at all (not_present) skips the raw-scan
+// section entirely — the review page is never reached for it (the
+// results table filters not_present rows out of the review link).
+func buildReviewImages(id string, copyNumber int, pages []int) []view.ReviewImage {
+	if len(pages) == 0 {
+		pages = []int{1}
+	}
+	out := make([]view.ReviewImage, 0, len(pages))
+	for _, n := range pages {
+		out = append(out, view.ReviewImage{
+			Number: n,
+			URL:    controlPageImageURL(id, copyNumber, n),
+		})
+	}
+	return out
 }
 
 // controlAnnotatedURL is the corrected PDF's URL (issue #190).

--- a/apps/server/internal/app/web/handler/review_test.go
+++ b/apps/server/internal/app/web/handler/review_test.go
@@ -2,6 +2,7 @@ package handler_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -109,6 +110,97 @@ func TestReviewPageFallsBackToRawScanWithoutAnnotated(t *testing.T) {
 	if !strings.Contains(body, `<img src="/controls/`+controlID+`/copies/1/page/1"`) {
 		t.Errorf("review page missing the raw scan image\n%s", body)
 	}
+}
+
+// TestReviewPageRendersAllCapturedPages pins issue #243's fix:
+// a needs_review copy whose scan spans several pages renders one
+// <img> per captured page, in ascending order, so the professor can
+// see and correct answers on every page instead of only page 1.
+func TestReviewPageRendersAllCapturedPages(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control multi-page", 3)
+
+	// Three copies with different page shapes: copy 1 captured both
+	// pages (the happy case), copy 2 captured only page 1 (page 2
+	// scanned but rejected by AMC — AC-2), copy 3 captured pages 1,
+	// 2 and 3 (a longer sheet).
+	f.fake.AnalyzeReports = []controls.Report{
+		{Copies: map[string]controls.ReportCopy{
+			"1": {RUT: "20111111", RUTStatus: controls.RUTStatusOK, Status: controls.CopyStatusNeedsReview,
+				ExpectedQuestions: 1, SeenQuestions: 1, Pages: []int{1, 2},
+				Answers: []controls.ReportAnswer{
+					{Question: 1, Name: "q3", Type: controls.QuestionSimple, Marked: []int{1},
+						Status: controls.AnswerStatusOK, Score: 1, Max: 1},
+				}},
+			"2": {RUT: "20222222", RUTStatus: controls.RUTStatusOK, Status: controls.CopyStatusNeedsReview,
+				ExpectedQuestions: 1, SeenQuestions: 1, Pages: []int{1},
+				Answers: []controls.ReportAnswer{
+					{Question: 1, Name: "q3", Type: controls.QuestionSimple, Marked: []int{1},
+						Status: controls.AnswerStatusOK, Score: 1, Max: 1},
+				}},
+			"3": {RUT: "20333333", RUTStatus: controls.RUTStatusOK, Status: controls.CopyStatusNeedsReview,
+				ExpectedQuestions: 1, SeenQuestions: 1, Pages: []int{1, 2, 3},
+				Answers: []controls.ReportAnswer{
+					{Question: 1, Name: "q3", Type: controls.QuestionSimple, Marked: []int{1},
+						Status: controls.AnswerStatusOK, Score: 1, Max: 1},
+				}},
+		}},
+	}
+	uploadOnce(t, f, controlID)
+
+	// Copy 1: both pages rendered, in order.
+	body := reviewBody(t, f, controlID, 1)
+	for _, want := range []string{
+		`<img src="/controls/` + controlID + `/copies/1/page/1"`,
+		`<img src="/controls/` + controlID + `/copies/1/page/2"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("copy 1 review missing %q\n--- body ---\n%s", want, body)
+		}
+	}
+	if got := strings.Count(body, `<img src="/controls/`+controlID+`/copies/1/`); got != 2 {
+		t.Errorf("copy 1 review = %d raw-scan <img>, want 2 (pages 1 and 2)", got)
+	}
+
+	// Copy 2 (AC-2): only page 1 was captured — no phantom page 2.
+	body = reviewBody(t, f, controlID, 2)
+	if !strings.Contains(body, `<img src="/controls/`+controlID+`/copies/2/page/1"`) {
+		t.Errorf("copy 2 review missing page 1\n%s", body)
+	}
+	if strings.Contains(body, `<img src="/controls/`+controlID+`/copies/2/page/2"`) {
+		t.Errorf("copy 2 review shows a phantom page 2 (AMC only captured page 1)\n%s", body)
+	}
+	if got := strings.Count(body, `<img src="/controls/`+controlID+`/copies/2/`); got != 1 {
+		t.Errorf("copy 2 review = %d raw-scan <img>, want 1 (only page 1 captured)", got)
+	}
+
+	// Copy 3: all three pages render, in the same order the store returned.
+	body = reviewBody(t, f, controlID, 3)
+	for n := 1; n <= 3; n++ {
+		if !strings.Contains(body, fmt.Sprintf(`<img src="/controls/%s/copies/3/page/%d"`, controlID, n)) {
+			t.Errorf("copy 3 review missing page %d\n%s", n, body)
+		}
+	}
+	if got := strings.Count(body, `<img src="/controls/`+controlID+`/copies/3/`); got != 3 {
+		t.Errorf("copy 3 review = %d raw-scan <img>, want 3", got)
+	}
+}
+
+// reviewBody helper: render the review page for one copy and return
+// the response body. Keeps TestReviewPageRendersAllCapturedPages
+// readable — three copies means three requests.
+func reviewBody(t *testing.T, f *controlsFixture, controlID string, copyNumber int) string {
+	t.Helper()
+	req := f.authedRequest(t, http.MethodGet,
+		fmt.Sprintf("/controls/%s/copies/%d/review", controlID, copyNumber), nil)
+	req.SetPathValue("id", controlID)
+	req.SetPathValue("copy", fmt.Sprintf("%d", copyNumber))
+	rec := httptest.NewRecorder()
+	f.handler.Review(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("copy %d review status = %d\nbody: %s", copyNumber, rec.Code, rec.Body.String())
+	}
+	return rec.Body.String()
 }
 
 // TestAnnotatedPDFServesTheRecordedFile: the row is the authority — the

--- a/apps/server/internal/app/web/handler/review_test.go
+++ b/apps/server/internal/app/web/handler/review_test.go
@@ -83,7 +83,7 @@ func TestReviewPageFallsBackToRawScanWithoutAnnotated(t *testing.T) {
 	f.fake.AnalyzeReports = []controls.Report{
 		{Copies: map[string]controls.ReportCopy{
 			"1": {RUT: "2011111_", RUTStatus: controls.RUTStatusUnreadable, Status: controls.CopyStatusNeedsReview,
-				ExpectedQuestions: 2, SeenQuestions: 2,
+				ExpectedQuestions: 2, SeenQuestions: 2, Pages: []int{1},
 				Answers: []controls.ReportAnswer{
 					{Question: 1, Name: "q3", Type: controls.QuestionSimple, Marked: []int{1},
 						Status: controls.AnswerStatusOK, Score: 1, Max: 1},

--- a/apps/server/internal/app/web/view/templates/pages/review.html
+++ b/apps/server/internal/app/web/view/templates/pages/review.html
@@ -102,7 +102,14 @@
           })();
         </script>
       {{ else }}
-        <p><img src="{{ .ImageURL }}" alt="Escaneo de la copia {{ .CopyNumber }}"></p>
+        {{/* Issue #243: one <img> per captured page. AMC is the source
+             of truth — a copy whose page 2 was scanned but rejected
+             does not appear here and does not get an <img>. Inside a
+             range, `.` is the current ReviewImage, so `$` reaches back
+             to the ReviewPage for CopyNumber. */}}
+        {{ range .Pages }}
+          <p><img src="{{ .URL }}" alt="Escaneo de la copia {{ $.CopyNumber }} — página {{ .Number }}"></p>
+        {{ end }}
       {{ end }}
     </section>
 

--- a/apps/server/internal/app/web/view/view.go
+++ b/apps/server/internal/app/web/view/view.go
@@ -323,15 +323,30 @@ type ReviewPage struct {
 	Name       string
 	CopyNumber int
 	BackURL    string
-	ImageURL   string
-	SaveURL    string
-	Graded     bool // when true the template shows the "editing a closed correction" warning
+	// Pages is the raw-scan fallback's per-page images (issue #243):
+	// one entry per physical page AMC captured, in ascending order.
+	// The template iterates it and renders one <img> per page — a
+	// two-page copy shows both pages stacked. Empty when
+	// HasAnnotated is true (the PDF.js viewer takes over) or when
+	// the reading recorded zero captured pages (a not_present copy).
+	Pages   []ReviewImage
+	SaveURL string
+	Graded  bool // when true the template shows the "editing a closed correction" warning
 	// HasAnnotated / AnnotatedURL carry the corrected PDF (issue #190).
 	// AnnotatedURL is empty when HasAnnotated is false.
 	HasAnnotated bool
 	AnnotatedURL string
 	RUT          ReviewRUT
 	Questions    []ReviewQuestion
+}
+
+// ReviewImage is one page of a copy's raw scan (issue #243). The
+// review page's raw-scan fallback iterates ReviewPage.Pages and
+// emits one <img> per entry. Number is what AMC's capture_page
+// reported; URL is the /copies/N/page/M endpoint.
+type ReviewImage struct {
+	Number int
+	URL    string
 }
 
 // ReviewRUT is the top row of the form — the RUT block.

--- a/apps/server/internal/app/web/view/view.go
+++ b/apps/server/internal/app/web/view/view.go
@@ -326,9 +326,15 @@ type ReviewPage struct {
 	// Pages is the raw-scan fallback's per-page images (issue #243):
 	// one entry per physical page AMC captured, in ascending order.
 	// The template iterates it and renders one <img> per page — a
-	// two-page copy shows both pages stacked. Empty when
-	// HasAnnotated is true (the PDF.js viewer takes over) or when
-	// the reading recorded zero captured pages (a not_present copy).
+	// two-page copy shows both pages stacked. Always populated for a
+	// reviewable copy (migration 00011 backfills legacy rows to [1]
+	// and amcworker.toDomain substitutes [1] for a legacy worker),
+	// so the template's `{{ range .Pages }}` never sees an empty
+	// list in practice; a not_present copy reached by hand-typed URL
+	// is the one exception, and its empty list renders an empty
+	// "Escaneo" section rather than a broken-image placeholder.
+	// Consumed only when HasAnnotated is false; the PDF.js viewer
+	// takes over otherwise.
 	Pages   []ReviewImage
 	SaveURL string
 	Graded  bool // when true the template shows the "editing a closed correction" warning

--- a/apps/server/internal/domain/controls/reading.go
+++ b/apps/server/internal/domain/controls/reading.go
@@ -106,6 +106,14 @@ type ReportCopy struct {
 	SeenQuestions     int
 	MissingQuestions  []string
 	Status            CopyStatus
+	// Pages is the 1-based physical page list AMC captured for this
+	// copy, in ascending order (issue #243). The review page's raw-scan
+	// fallback iterates it to render one <img> per page; a copy whose
+	// page 2 was scanned but rejected by AMC does not have `2` here and
+	// does not get an <img> for it. Empty when the analyzer predates the
+	// field — the reader then falls back to [1] to keep the pre-#243
+	// single-page render.
+	Pages []int
 }
 
 // Pages counts what got in.
@@ -268,6 +276,13 @@ type Reading struct {
 	ReadAt       time.Time
 	LastEditedAt *time.Time   // set on any manual override
 	RUTOverride  *RUTOverride // eagerly loaded by ReadingsByControl and ReadingByCopy
+	// Pages is the 1-based list of physical scan pages AMC captured
+	// for this copy, in ascending order (issue #243). The review
+	// page's raw-scan fallback iterates it to render one <img> per
+	// captured page. A legacy row from before migration 00011 comes
+	// back as [1] via the migration's backfill; a copy whose page 2
+	// was scanned but rejected by AMC does not have `2` here.
+	Pages []int
 }
 
 // Answer is one question of a Reading, with the engine's numbers beside

--- a/apps/server/internal/infra/amcworker/analyze.go
+++ b/apps/server/internal/infra/amcworker/analyze.go
@@ -172,8 +172,14 @@ type reportBody struct {
 		Ticked float64 `json:"ticked"`
 		Stale  bool    `json:"stale"`
 	} `json:"scoring"`
-	Copies      map[string]copyBody `json:"copies"`
-	NeedsReview []string            `json:"needs_review"`
+	Copies map[string]copyBody `json:"copies"`
+	// PagesPerCopy is the per-copy list of physical pages AMC
+	// captured, keyed by copy number as a decimal string (issue #243).
+	// Absent from workers that predate the field; toDomain then falls
+	// back to [1] per copy so the review page's raw-scan fallback
+	// keeps its pre-#243 single-page behaviour.
+	PagesPerCopy map[string][]int `json:"pages_per_copy"`
+	NeedsReview  []string         `json:"needs_review"`
 }
 
 type copyBody struct {
@@ -223,6 +229,17 @@ func (b reportBody) toDomain() controls.Report {
 		NeedsReview: append([]string(nil), b.NeedsReview...),
 	}
 	for k, v := range b.Copies {
+		// #243: the worker sends pages_per_copy keyed by the same
+		// decimal string. A worker that predates the field leaves the
+		// map nil (or missing this key), so fall back to [1] — the
+		// review page's raw-scan fallback rendered exactly page 1
+		// before this WP, and legacy readings backfill to [1] too
+		// (migration 00011), so both paths converge on the same
+		// pre-#243 shape.
+		pages := append([]int(nil), b.PagesPerCopy[k]...)
+		if len(pages) == 0 {
+			pages = []int{1}
+		}
 		out.Copies[k] = controls.ReportCopy{
 			RUT:               v.RUT,
 			RUTStatus:         controls.RUTStatus(v.RUTStatus),
@@ -231,6 +248,7 @@ func (b reportBody) toDomain() controls.Report {
 			SeenQuestions:     v.SeenQuestions,
 			MissingQuestions:  append([]string(nil), v.MissingQuestions...),
 			Status:            controls.CopyStatus(v.Status),
+			Pages:             pages,
 		}
 	}
 	return out

--- a/apps/server/internal/infra/amcworker/analyze_test.go
+++ b/apps/server/internal/infra/amcworker/analyze_test.go
@@ -218,6 +218,77 @@ func TestAnalyzeRefusesInvalidRequestBeforeCallingTheWorker(t *testing.T) {
 	}
 }
 
+// TestAnalyzeMapsPagesPerCopyIntoReportCopyPages pins issue #243's
+// wire → domain mapping. read_capture.py emits `pages_per_copy`
+// keyed by the same decimal copy string; the mapping copies the list
+// verbatim into ReportCopy.Pages so the store persists exactly what
+// AMC captured.
+func TestAnalyzeMapsPagesPerCopyIntoReportCopyPages(t *testing.T) {
+	body := `{
+	  "pages": {"captured": 3, "failed": 0},
+	  "scoring": {"seuil": 0.3, "ticked": 0.3, "stale": false},
+	  "copies": {
+	    "1": {"rut": "20123456", "rut_status": "ok",
+	          "answers": [], "expected_questions": 0, "seen_questions": 0,
+	          "missing_questions": [], "status": "ok"},
+	    "2": {"rut": "19876543", "rut_status": "ok",
+	          "answers": [], "expected_questions": 0, "seen_questions": 0,
+	          "missing_questions": [], "status": "needs_review"}
+	  },
+	  "pages_per_copy": {"1": [1, 2], "2": [1]},
+	  "needs_review": ["2"]
+	}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := amcworker.New(amcworker.Config{BaseURL: srv.URL})
+	report, err := client.Analyze(context.Background(), controls.AnalyzeRequest{
+		Project: "p", ScanPDF: "s", Source: "t",
+		Ticked: controls.DefaultTicked, Unsure: controls.DefaultUnsure,
+	})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if got := report.Copies["1"].Pages; len(got) != 2 || got[0] != 1 || got[1] != 2 {
+		t.Errorf("Copies[1].Pages = %v, want [1 2]", got)
+	}
+	if got := report.Copies["2"].Pages; len(got) != 1 || got[0] != 1 {
+		t.Errorf("Copies[2].Pages = %v, want [1] (page-2-missed case)", got)
+	}
+}
+
+// TestAnalyzeFromLegacyWorkerFallsBackToPageOne pins the legacy
+// compatibility path: a worker that predates the pages_per_copy
+// field omits it entirely from the wire, and the mapping fills each
+// copy with [1] so the review page's raw-scan fallback keeps its
+// pre-#243 single-page behaviour. Symmetric with migration 00011's
+// backfill on the storage side — both paths converge on [1] for
+// "nothing was said about pages".
+func TestAnalyzeFromLegacyWorkerFallsBackToPageOne(t *testing.T) {
+	// sampleReport predates #243 — no pages_per_copy field.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(sampleReport))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := amcworker.New(amcworker.Config{BaseURL: srv.URL})
+	report, err := client.Analyze(context.Background(), controls.AnalyzeRequest{
+		Project: "p", ScanPDF: "s", Source: "t",
+		Ticked: controls.DefaultTicked, Unsure: controls.DefaultUnsure,
+	})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	got := report.Copies["1"].Pages
+	if len(got) != 1 || got[0] != 1 {
+		t.Errorf("legacy Copies[1].Pages = %v, want [1] fallback", got)
+	}
+}
+
 func TestReanalyzeSendsProjectAndThresholds(t *testing.T) {
 	var got reanalyzeSent
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/apps/server/internal/infra/storage/controlstore/readings.go
+++ b/apps/server/internal/infra/storage/controlstore/readings.go
@@ -115,14 +115,13 @@ func upsertReading(ctx context.Context, tx *sql.Tx, controlID string, copyNumber
 	}
 	// #243: pages_json is the physical scan pages AMC captured for this
 	// copy. Persist verbatim from the report — the amcworker mapping
-	// already substituted [1] for a legacy worker that did not emit the
-	// field, so this write never records the empty-list shape a legacy
-	// row was backfilled to '[1]' from.
-	pages := c.Pages
-	if pages == nil {
-		pages = []int{}
-	}
-	pagesJSON, err := json.Marshal(pages)
+	// substitutes [1] for a legacy worker that did not emit the field,
+	// so a nil c.Pages here means the caller bypassed the mapping and
+	// the JSON marshaller writes 'null'. That reads back as a nil
+	// Reading.Pages, which the handler renders as an empty "Escaneo"
+	// section — a loud tell rather than a silent [1] papering over
+	// what may be a real breakage upstream.
+	pagesJSON, err := json.Marshal(c.Pages)
 	if err != nil {
 		return 0, fmt.Errorf("controlstore.upsertReading: encode pages: %w", err)
 	}
@@ -449,14 +448,12 @@ func scanReading(row interface{ Scan(...any) error }) (controls.Reading, error) 
 		t := time.Unix(lastEditedAtRaw.Int64, 0).UTC()
 		r.LastEditedAt = &t
 	}
-	// #243: pages_json is NOT NULL under migration 00011; a legacy row
-	// was backfilled to '[1]', a new write from a legacy worker landed
-	// as '[1]' via the amcworker fallback, and a new write from the
-	// current worker carries the AMC-captured list. Empty '[]' decodes
-	// to nil — the handler treats that identically to "no pages known"
-	// and lets the raw-scan fallback render nothing rather than an
-	// invented page 1 (COR: the domain does not silently paper over
-	// what the schema says is empty).
+	// #243: pages_json is NOT NULL under migration 00011 and decodes to
+	// r.Pages. What the CALLER does with an empty list is not this
+	// layer's concern — the render path (buildReviewImages) and the
+	// wire boundary (amcworker.toDomain) each own their own contract
+	// for "nothing was said about pages", and scanReading returning nil
+	// stays honest to what the column holds.
 	if pagesJSON != "" {
 		if err := json.Unmarshal([]byte(pagesJSON), &r.Pages); err != nil {
 			return controls.Reading{}, fmt.Errorf("controlstore.scanReading: decode pages: %w", err)

--- a/apps/server/internal/infra/storage/controlstore/readings.go
+++ b/apps/server/internal/infra/storage/controlstore/readings.go
@@ -113,15 +113,29 @@ func upsertReading(ctx context.Context, tx *sql.Tx, controlID string, copyNumber
 	if c.RUT != "" {
 		rutRead = sql.NullString{String: c.RUT, Valid: true}
 	}
+	// #243: pages_json is the physical scan pages AMC captured for this
+	// copy. Persist verbatim from the report — the amcworker mapping
+	// already substituted [1] for a legacy worker that did not emit the
+	// field, so this write never records the empty-list shape a legacy
+	// row was backfilled to '[1]' from.
+	pages := c.Pages
+	if pages == nil {
+		pages = []int{}
+	}
+	pagesJSON, err := json.Marshal(pages)
+	if err != nil {
+		return 0, fmt.Errorf("controlstore.upsertReading: encode pages: %w", err)
+	}
 	if _, err := tx.ExecContext(ctx,
-		`INSERT INTO reading (control_id, copy_number, rut_read, rut_status, copy_status, read_at)
-         VALUES (?, ?, ?, ?, ?, ?)
+		`INSERT INTO reading (control_id, copy_number, rut_read, rut_status, copy_status, read_at, pages_json)
+         VALUES (?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT (control_id, copy_number) DO UPDATE SET
              rut_read = excluded.rut_read,
              rut_status = excluded.rut_status,
              copy_status = excluded.copy_status,
-             read_at = excluded.read_at`,
-		controlID, copyNumber, rutRead, string(c.RUTStatus), string(c.Status), now.Unix(),
+             read_at = excluded.read_at,
+             pages_json = excluded.pages_json`,
+		controlID, copyNumber, rutRead, string(c.RUTStatus), string(c.Status), now.Unix(), string(pagesJSON),
 	); err != nil {
 		return 0, fmt.Errorf("controlstore.upsertReading: %s/%d: %w", controlID, copyNumber, err)
 	}
@@ -156,7 +170,7 @@ func (s *Store) MarkMissingAsNotPresent(ctx context.Context, controlID string, n
 // copy_number ascending, with overrides eagerly attached.
 func (s *Store) ReadingsByControl(ctx context.Context, controlID string) ([]controls.Reading, error) {
 	rows, err := s.db.QueryContext(ctx, `
-        SELECT id, control_id, copy_number, rut_read, rut_status, copy_status, read_at, last_edited_at
+        SELECT id, control_id, copy_number, rut_read, rut_status, copy_status, read_at, last_edited_at, pages_json
         FROM reading
         WHERE control_id = ?
         ORDER BY copy_number ASC`, controlID)
@@ -186,7 +200,7 @@ func (s *Store) ReadingsByControl(ctx context.Context, controlID string) ([]cont
 // ErrReadingNotFound.
 func (s *Store) ReadingByCopy(ctx context.Context, controlID string, copyNumber int) (controls.Reading, error) {
 	row := s.db.QueryRowContext(ctx, `
-        SELECT id, control_id, copy_number, rut_read, rut_status, copy_status, read_at, last_edited_at
+        SELECT id, control_id, copy_number, rut_read, rut_status, copy_status, read_at, last_edited_at, pages_json
         FROM reading
         WHERE control_id = ? AND copy_number = ?`, controlID, copyNumber)
 	r, err := scanReading(row)
@@ -419,8 +433,9 @@ func scanReading(row interface{ Scan(...any) error }) (controls.Reading, error) 
 		copyStatus      string
 		readAt          int64
 		lastEditedAtRaw sql.NullInt64
+		pagesJSON       string
 	)
-	if err := row.Scan(&r.ID, &r.ControlID, &r.CopyNumber, &rutRead, &rutStatus, &copyStatus, &readAt, &lastEditedAtRaw); err != nil {
+	if err := row.Scan(&r.ID, &r.ControlID, &r.CopyNumber, &rutRead, &rutStatus, &copyStatus, &readAt, &lastEditedAtRaw, &pagesJSON); err != nil {
 		return controls.Reading{}, err
 	}
 	r.RUTStatus = controls.RUTStatus(rutStatus)
@@ -433,6 +448,19 @@ func scanReading(row interface{ Scan(...any) error }) (controls.Reading, error) 
 	if lastEditedAtRaw.Valid {
 		t := time.Unix(lastEditedAtRaw.Int64, 0).UTC()
 		r.LastEditedAt = &t
+	}
+	// #243: pages_json is NOT NULL under migration 00011; a legacy row
+	// was backfilled to '[1]', a new write from a legacy worker landed
+	// as '[1]' via the amcworker fallback, and a new write from the
+	// current worker carries the AMC-captured list. Empty '[]' decodes
+	// to nil — the handler treats that identically to "no pages known"
+	// and lets the raw-scan fallback render nothing rather than an
+	// invented page 1 (COR: the domain does not silently paper over
+	// what the schema says is empty).
+	if pagesJSON != "" {
+		if err := json.Unmarshal([]byte(pagesJSON), &r.Pages); err != nil {
+			return controls.Reading{}, fmt.Errorf("controlstore.scanReading: decode pages: %w", err)
+		}
 	}
 	return r, nil
 }

--- a/apps/server/internal/infra/storage/controlstore/readings_test.go
+++ b/apps/server/internal/infra/storage/controlstore/readings_test.go
@@ -5,11 +5,13 @@ import (
 	"database/sql"
 	"errors"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
 	"github.com/so77id/nalanda/apps/server/internal/infra/storage/controlstore"
+	"github.com/so77id/nalanda/apps/server/migrations"
 )
 
 // seedControl creates one control with N copies so a reading test has a
@@ -323,7 +325,29 @@ func TestUpsertReadingsFromReportPersistsPagesPerCopy(t *testing.T) {
 // follow-up UPDATE turned each of them into '[1]', so the review
 // page's iteration keeps its pre-#243 single-page render on legacy
 // data — no regression on rows the professor has already reviewed.
+//
+// This test guards two things:
+//   - the runtime effect (row inserted with '[]' reads back as [1]),
+//     exercised by re-running an UPDATE identical to 00011's; and
+//   - the SOURCE OF TRUTH (the migration file itself still contains
+//     that UPDATE) — without the file assertion the test would keep
+//     passing on its own inline SQL after the migration silently
+//     drifted away from it (Round A review, COR-3).
 func TestLegacyReadingsBackfillToPageOne(t *testing.T) {
+	// Guard: the migration file must still carry the backfill clause
+	// the runtime half of this test replays. A future edit that
+	// changes the WHERE predicate or the target value regresses the
+	// legacy render, and this line is what surfaces it before the
+	// silent DB drift does.
+	raw, err := migrations.FS.ReadFile("00011_reading_pages.sql")
+	if err != nil {
+		t.Fatalf("read migration 00011: %v", err)
+	}
+	const backfillSQL = `UPDATE reading SET pages_json = '[1]' WHERE pages_json = '[]'`
+	if !strings.Contains(string(raw), backfillSQL) {
+		t.Fatalf("migration 00011 no longer contains the backfill clause %q — update this test to replay the new clause and confirm legacy rows still converge on [1]", backfillSQL)
+	}
+
 	ctx, db := migrated(t)
 	seedControl(t, ctx, db, "CTRL0133LEGACY0000000000AA", 1)
 	store := controlstore.New(db)
@@ -340,12 +364,7 @@ func TestLegacyReadingsBackfillToPageOne(t *testing.T) {
 		"CTRL0133LEGACY0000000000AA", time.Now().Unix()); err != nil {
 		t.Fatalf("insert legacy reading: %v", err)
 	}
-	// Re-run the backfill the migration performed. Executing it here
-	// is what makes this test faithful to the migration's semantics
-	// rather than a shortcut: the row was written with '[]', and the
-	// UPDATE (the same statement in 00011) turns it into '[1]'.
-	if _, err := db.ExecContext(ctx,
-		`UPDATE reading SET pages_json = '[1]' WHERE pages_json = '[]'`); err != nil {
+	if _, err := db.ExecContext(ctx, backfillSQL); err != nil {
 		t.Fatalf("backfill: %v", err)
 	}
 

--- a/apps/server/internal/infra/storage/controlstore/readings_test.go
+++ b/apps/server/internal/infra/storage/controlstore/readings_test.go
@@ -255,6 +255,109 @@ func TestUpsertReadingsFromReportPersistsPerCopyPrintedOrder(t *testing.T) {
 	}
 }
 
+// TestUpsertReadingsFromReportPersistsPagesPerCopy pins issue #243's
+// storage contract: the per-copy captured-pages list travels from
+// report to database and back. The review page's raw-scan fallback
+// iterates it (S3), so losing it here would silently regress to the
+// single-page render this WP exists to fix.
+func TestUpsertReadingsFromReportPersistsPagesPerCopy(t *testing.T) {
+	ctx, db := migrated(t)
+	seedControl(t, ctx, db, "CTRL0132PAGES00000000000AA", 3)
+	store := controlstore.New(db)
+
+	now := time.Unix(1_755_700_100, 0).UTC()
+	copy1 := sampleCopy("20123456", controls.CopyStatusNeedsReview, controls.RUTStatusOK)
+	copy1.Pages = []int{1, 2, 3}
+	// Copy 2 exercises AC-2: a copy where AMC captured page 1 but not
+	// page 2 (page 2 scanned but rejected). The store must keep the
+	// list verbatim — the review page renders exactly what AMC saw and
+	// invents no phantom `<img>` for the missing page.
+	copy2 := sampleCopy("19876543", controls.CopyStatusNeedsReview, controls.RUTStatusOK)
+	copy2.Pages = []int{1}
+	report := controls.Report{
+		Copies: map[string]controls.ReportCopy{
+			"1": copy1,
+			"2": copy2,
+		},
+	}
+	if err := store.UpsertReadingsFromReport(ctx, "CTRL0132PAGES00000000000AA", report, now); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	r1, err := store.ReadingByCopy(ctx, "CTRL0132PAGES00000000000AA", 1)
+	if err != nil {
+		t.Fatalf("ReadingByCopy(1): %v", err)
+	}
+	if !slices.Equal(r1.Pages, []int{1, 2, 3}) {
+		t.Errorf("Reading(1).Pages = %v, want [1 2 3]", r1.Pages)
+	}
+	r2, err := store.ReadingByCopy(ctx, "CTRL0132PAGES00000000000AA", 2)
+	if err != nil {
+		t.Fatalf("ReadingByCopy(2): %v", err)
+	}
+	if !slices.Equal(r2.Pages, []int{1}) {
+		t.Errorf("Reading(2).Pages = %v, want [1] (page-2-missed case)", r2.Pages)
+	}
+
+	// A re-upsert with a different page shape must replace the list —
+	// re-reading a batch at a different threshold cannot change which
+	// pages AMC captured, but a re-uploaded batch can, and the write
+	// path must not silently keep stale pages behind.
+	copy1b := sampleCopy("20123456", controls.CopyStatusOK, controls.RUTStatusOK)
+	copy1b.Pages = []int{1, 2}
+	report2 := controls.Report{
+		Copies: map[string]controls.ReportCopy{"1": copy1b},
+	}
+	if err := store.UpsertReadingsFromReport(ctx, "CTRL0132PAGES00000000000AA", report2, now.Add(time.Hour)); err != nil {
+		t.Fatalf("Upsert 2: %v", err)
+	}
+	r1, _ = store.ReadingByCopy(ctx, "CTRL0132PAGES00000000000AA", 1)
+	if !slices.Equal(r1.Pages, []int{1, 2}) {
+		t.Errorf("Reading(1).Pages after re-upsert = %v, want [1 2]", r1.Pages)
+	}
+}
+
+// TestLegacyReadingsBackfillToPageOne pins migration 00011's
+// backfill: a reading row written before this WP had no pages_json
+// at all. The ALTER wrote '[]' into every existing row and the
+// follow-up UPDATE turned each of them into '[1]', so the review
+// page's iteration keeps its pre-#243 single-page render on legacy
+// data — no regression on rows the professor has already reviewed.
+func TestLegacyReadingsBackfillToPageOne(t *testing.T) {
+	ctx, db := migrated(t)
+	seedControl(t, ctx, db, "CTRL0133LEGACY0000000000AA", 1)
+	store := controlstore.New(db)
+
+	// A raw INSERT without pages_json — pre-#243 code shape. Under the
+	// new migration this hits the DEFAULT '[]', which the follow-up
+	// UPDATE (in the same migration) turns into '[1]'. We simulate
+	// "reached the DEFAULT" here directly with an explicit '[]' write:
+	// the assertion is that the read path returns [1] — same effect as
+	// on a real legacy row that landed before the column existed.
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO reading (control_id, copy_number, rut_read, rut_status, copy_status, read_at, pages_json)
+         VALUES (?, 1, '20123456', 'ok', 'ok', ?, '[]')`,
+		"CTRL0133LEGACY0000000000AA", time.Now().Unix()); err != nil {
+		t.Fatalf("insert legacy reading: %v", err)
+	}
+	// Re-run the backfill the migration performed. Executing it here
+	// is what makes this test faithful to the migration's semantics
+	// rather than a shortcut: the row was written with '[]', and the
+	// UPDATE (the same statement in 00011) turns it into '[1]'.
+	if _, err := db.ExecContext(ctx,
+		`UPDATE reading SET pages_json = '[1]' WHERE pages_json = '[]'`); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+
+	r, err := store.ReadingByCopy(ctx, "CTRL0133LEGACY0000000000AA", 1)
+	if err != nil {
+		t.Fatalf("ReadingByCopy: %v", err)
+	}
+	if !slices.Equal(r.Pages, []int{1}) {
+		t.Errorf("legacy Reading.Pages = %v, want [1] via migration backfill", r.Pages)
+	}
+}
+
 // TestLegacyAnswerRowsWithoutPositionFallBackToRefOrder pins the migration
 // contract: an answer row written before #229 has NULL position and NULL
 // alternatives; loadAnswers must still return it, ordered by question_ref

--- a/apps/server/migrations/00011_reading_pages.sql
+++ b/apps/server/migrations/00011_reading_pages.sql
@@ -1,0 +1,34 @@
+-- Issue #243: persist which pages of each copy AMC captured.
+--
+-- The review page's raw-scan fallback (issue #190) renders one <img>
+-- per captured page, and until this WP it only asked for page 1 — a
+-- two-page copy lost half its answers to the professor. AMC is the
+-- source of truth: read_capture.py now emits `pages_per_copy` (S1),
+-- and this column stores that per-copy list so the review template
+-- can iterate it.
+--
+-- Shape: a JSON array of ascending 1-based page numbers, mirroring
+-- what the worker sends on the wire. Same "JSON array in a TEXT
+-- column" pattern as answer.marked_json (00005) and
+-- answer.alternatives_json (00010) — the natural read shape is
+-- "here is the whole list at once" and a normalised child table
+-- would answer every review render with an extra query per copy.
+--
+-- Two-step so legacy readings (persisted before this WP, when the
+-- fallback rendered only page 1) end up with '[1]' rather than an
+-- empty list. The ALTER's DEFAULT '[]' backfills every existing row
+-- to '[]' as a side-effect of adding the NOT NULL column; the UPDATE
+-- turns those specific rows into '[1]' so the fallback the review
+-- page will iterate on legacy data is the SAME page 1 it used to
+-- render on its own. The WHERE clause is scoped to the placeholder
+-- so a hypothetical INSERT that raced this migration with an
+-- explicit '[]' payload is not clobbered — a new writer always sets
+-- pages_json from ReportCopy.Pages, so the DEFAULT is only ever the
+-- ALTER's transient value on existing rows.
+
+-- +goose Up
+ALTER TABLE reading ADD COLUMN pages_json TEXT NOT NULL DEFAULT '[]';
+UPDATE reading SET pages_json = '[1]' WHERE pages_json = '[]';
+
+-- +goose Down
+ALTER TABLE reading DROP COLUMN pages_json;

--- a/docs/decisions/0031-the-reading-report-is-the-contract.md
+++ b/docs/decisions/0031-the-reading-report-is-the-contract.md
@@ -8,6 +8,8 @@
 weight, and the threshold the scores were computed at
 **Amended by:** #229 (2026-08-26) — per-copy printed order of questions and
 alternatives
+**Amended by:** #243 (2026-08-27) — per-copy captured page list, so the review
+page's raw-scan fallback iterates every page AMC captured
 
 ## Context
 
@@ -161,6 +163,35 @@ before this amendment, or an analyzer that predates it. Callers rendering
 the paper fall back to their pre-amendment ordering (iteration order for
 the outer answers list, bank order for the alternatives) rather than
 refusing the report, so historical readings stay legible.
+
+### The report says which pages of each copy were captured
+
+The review page's raw-scan fallback (issue #190) renders the scan pages a
+professor can look at when there is no annotated PDF yet — the correction
+UI for a `needs_review` copy. Before #243 it only ever asked for page 1,
+so a two-page copy lost half its answers to the professor: any control
+whose sheet spans more than one page (Letter double-sided, A4 with more
+questions, controls with long code samples) was unusable for review.
+
+So the report carries a top-level `pages_per_copy`: a map from copy
+number as a decimal string to the ascending 1-based list of physical
+pages the engine actually captured for that copy. `{"9": [1, 2], "10":
+[1, 2], "12": [1]}` says copies 9 and 10 landed both pages and copy 12
+lost page 2 at the scanner. The engine is the source of truth: a copy
+whose page 2 was scanned but rejected by AMC's page-recognition does not
+appear here and does not get an `<img>` on the review — the professor
+sees exactly what was captured, no more, no less. Any engine that reads
+a batch knows which physical pages it accepted, so this field is
+engine-independent by construction and the AMC-fallback reversal test
+still holds.
+
+`pages_per_copy` is **optional**. An absent field or a copy missing from
+the map means "the analyzer predates this amendment" — the reader falls
+back to `[1]` per copy so the raw-scan fallback keeps its pre-#243
+single-page render. Historical readings stored before this amendment
+converge on the same `[1]` shape through the storage-side backfill
+(`apps/server/migrations/00011_reading_pages.sql`), so a professor
+scrolling through legacy corrections sees no regression.
 
 ### The report says which threshold its scores were computed at
 


### PR DESCRIPTION
**Closes #243**

## Summary

The review page's raw-scan fallback (issue #190) was rendering only page 1 of a `needs_review` copy, so a two-page copy lost half its answers to the professor. Sibling shape to #229 (per-copy printed order): worker emits per-copy metadata, server persists on `/analyse`, template consumes on render.

- `apps/amc-worker/read_capture.py` — new top-level `pages_per_copy` field aggregated from AMC's `capture_page` table (ADR-0031 amended).
- `apps/server/migrations/00011_reading_pages.sql` — new `pages_json` column with a legacy backfill to `'[1]'` so pre-#243 rows keep their single-page render.
- Domain `Reading` / `ReportCopy` gain `Pages []int`; storage persists/loads via `pages_json`; amcworker maps the wire field (with `[1]` fallback for a legacy worker).
- Handler `Review` builds `Pages []ReviewImage`; template `{{ range .Pages }}` inside the else branch of `HasAnnotated` — annotated-PDF path (issue #236 / PDF.js) untouched.

Design deliberately owns the "empty pages → [1]" fallback at TWO boundaries only (migration for legacy DB rows + amcworker.toDomain for legacy workers). `buildReviewImages`, `upsertReading`, and `scanReading` trust the invariant — new bullet in `apps/server/CLAUDE.md` names the rule so an agent doesn't add a third layer.

## Slices completed

- [x] **S1** — Worker emits `pages_per_copy` in report JSON (`322af72`).
- [x] **S2** — Server schema (00011) + storage save/load + legacy backfill (`e0f02ea`).
- [x] **S3** — Handler builds `Pages []ReviewImage` + template iterates; `review_test.go` updated (`8849440`).
- [ ] **S4** — E2E manual on Jetson (**Miguel — manual-blocker**, see below).
- [x] **S5** — Pre-PR pipeline + PR (this).

Additional commits from the pre-PR pipeline: `96a53a9 fix(issue-243): review fixes` (Round A) and `fbd7cd8 docs(issue-243): amend contract + surface the two-boundary [1] rule` (Round B).

## Acceptance criteria

- [x] **A copy with `capture_page` for [1,2,3] renders all 3 `<img>` in order.**
  Evidence: `TestReviewPageRendersAllCapturedPages` in `apps/server/internal/app/web/handler/review_test.go` — copy 3 with `Pages: []int{1,2,3}` asserts the three `<img>` at `copies/3/page/{1,2,3}` AND `strings.Count == 3`.
- [x] **A copy with only [1] captured renders only page 1 — no phantom `<img>` for missing pages.**
  Evidence: same test, copy 2 with `Pages: []int{1}` — asserts page/1 present, page/2 absent, `strings.Count == 1` on the raw-scan tag prefix.
- [x] **The annotated-PDF path is unchanged: `HasAnnotated == true` still shows the PDF viewer.**
  Evidence: `TestReviewPageRendersEditableFormForACopy` still asserts `pdfViewerMarker` + `data-pdf-url` + `annotated.pdf`; `TestReviewPageFallsBackToRawScanWithoutAnnotated` still asserts the marker is ABSENT when no annotated exists.
- [x] **Legacy readings (persisted before this WP, `pages_json = '[1]'` after backfill) still render as single page.**
  Evidence: `TestLegacyReadingsBackfillToPageOne` in `apps/server/internal/infra/storage/controlstore/readings_test.go` — reads migration 00011's UPDATE clause from `migrations.FS`, replays it against an inserted `'[]'` row, asserts `Reading.Pages == [1]`. Test fails loudly if the migration's UPDATE clause drifts.
- [x] **`apps/server` per-commit + pre-PR green.**
  Evidence: `test -z "$(gofmt -l .)"` ✓, `go vet ./...` ✓, `go test -race -count=1 ./...` ✓ across every package (26 packages, `?` on `migrations`), `govulncheck` "No vulnerabilities found", `docker build -t nalanda/server:dev .` ✓, `docker compose up -d --wait server` → Healthy, `curl /health` and `curl /api/health` both `{"process":"up","database":"up"}`.
- [x] **`apps/amc-worker` protocol green.**
  Evidence: `make verify` (image rebuild + every `tests/[0-9]*.sh` script) → `66 checks, 0 failed`, exit 0. `tests/03-read.sh` adds 3 assertions on the new `pages_per_copy` shape (present, keyed as string, all 5 fixture copies).
- [ ] **Miguel manual: at least one control with a 2-page copy scan renders both pages in the review.** — See "Manual verification" below.

## Tests

- `apps/amc-worker/tests/03-read.sh` — 3 new checks on `pages_per_copy` shape (fixture is 5 copies × 2 pages = 10 captured).
- `apps/server/internal/infra/amcworker/analyze_test.go` — `TestAnalyzeMapsPagesPerCopyIntoReportCopyPages` (positive) + `TestAnalyzeFromLegacyWorkerFallsBackToPageOne` (legacy worker → `[1]`).
- `apps/server/internal/infra/storage/controlstore/readings_test.go` — `TestUpsertReadingsFromReportPersistsPagesPerCopy` (round-trip + AC-2 case + re-upsert replaces) + `TestLegacyReadingsBackfillToPageOne` (migration-file-pinned).
- `apps/server/internal/app/web/handler/review_test.go` — `TestReviewPageRendersAllCapturedPages` (3-copy fixture: happy 2-page, AC-2 page-2-missed, 3-page); pre-existing tests updated to set `Pages: []int{1}` explicitly where they assert the raw-scan `<img>`.
- `apps/server/internal/app/web/handler/results_test.go` — `okCopy` helper defaults `Pages: []int{1}` so downstream tests remain faithful to the shape.

## Reviews run

Pre-PR review pipeline (`review-pipeline` integrated mode over `origin/main..HEAD`).

**Round A — code panel** (`lens-correctness-tests` + `lens-arch-simplicity` + `lens-security`; `lens-performance` skipped — no hot paths). 6 raw findings from 3 lenses; deduped to 5 unique (2 important, 3 suggestion); security clean.

| ID | Sev | Lens | Claim | Verifier | Decision |
| --- | --- | --- | --- | --- | --- |
| IMP-1 | important | correctness | `ReviewPage.Pages` doc contradicted handler behavior | CONFIRMED | act |
| IMP-2 | important | correctness+arch | `scanReading` comment lied about handler behavior | CONFIRMED | act |
| ARQ-2 | suggestion | arch | dead `if pages == nil` guard in `upsertReading` | — | act |
| ARQ-3 | suggestion | arch | three layers of `[1]` fallback | — | act |
| COR-3 | suggestion | correctness | legacy-backfill test self-fulfilling | — | act |

Round A fixes shipped in `96a53a9`. Re-gate green; per-fix rechecks by originating lens returned `[]` (all 5 resolved).

**Round B — docs panel** (`lens-docs-completeness` + `lens-docs-accuracy` + `lens-adr-hunter` + `lens-agent-readability`). 11 raw findings; deduped to 5 unique (3 important, 2 suggestion). ADR hunter: no new ADR needed (natural extension of ADR-0031, per #229 precedent).

| ID | Sev | Lens | Claim | Decision |
| --- | --- | --- | --- | --- |
| IMP-1 | important | completeness+accuracy | `read_capture.py` schema-of-record missing `pages_per_copy` | act |
| IMP-2 | important | completeness+accuracy+readability | `amc-worker/README.md` route table + reader section missing field | act |
| IMP-3 | important | completeness | `ADR-0031` needs "Amended by: #243" + new §-section | act |
| SUG-1 | suggestion | completeness+readability | `apps/server/CLAUDE.md` needs two-boundary [1] invariant bullet | act |
| SUG-2 | suggestion | readability | `apps/amc-worker/CLAUDE.md` needs wire-optional-field rule | act |

Round B fixes shipped in `fbd7cd8`.

## Manual verification

Miguel: on the Jetson (per `infra/local/DEPLOY-JETSON.md`) — you're the only one who can run this, and it is the last AC.

1. **Deploy the branch.** Merge this PR (server + amc-worker CD both fire on the diff — server-cd.yml + amc-worker-cd.yml, ≤5 min via Watchtower).
2. **Print/scan a 2-page control.** Any existing 2-page sujet works (Letter double-sided or A4 with more questions). Batch of ≥1 copy.
3. **Trigger a `needs_review` on a 2-page copy.** The easiest path is a copy AMC can't confidently score (e.g. ambiguous marks on a simple question, or a partially-erased RUT column) — same shape as your 2026-08-27 Control 2 copy 9 report.
4. **Open the review page.** `/controls/<id>/copies/<N>/review` (link from the results table).
5. **Verify:** with no annotated PDF for this copy, the "Escaneo" section shows **two `<img>` stacked** — page 1 and page 2, in that order. You should be able to see and correct answers on both pages, not only page 1.
6. **Regression check** (any control with an already-annotated copy): the PDF.js viewer still renders (annotated-PDF path is untouched by this PR).

If a copy scanned page 1 but not page 2 (page 2 misfed), only page 1 renders — no broken-image placeholder for the missing page.

## Notes

- **Coordination order** (per the issue body): server merges FIRST. This PR ships both server + worker in the same commit series, and Watchtower cycles each independently on the Jetson — the server accepts the legacy `[1]` and the new `[N, M, ...]` shape from day one, so a worker that lands seconds later cannot corrupt the DB. Documented as a rule in `apps/amc-worker/CLAUDE.md`.
- **Two-boundary `[1]` fallback.** Deliberately owned by migration 00011 (legacy DB rows) + `amcworker.toDomain` (legacy workers). `buildReviewImages` trusts the invariant. A `not_present` copy reached by hand-typed URL now shows an empty "Escaneo" section rather than a broken image icon — the honest signal.
- **Related open**: PR #244 (mergeado — this branch rebased on top).
- **Follow-up potential** (not in scope): if the `needs_review` fallback pages should render inside a PDF.js viewer for visual parity with the annotated path. Deferred; `<img>` is what today's fallback shipped and what the issue needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
