### PR TITLE
feat(controls): async job runner for AMC operations (#249)

### DIFF
--- a/apps/server/CLAUDE.md
+++ b/apps/server/CLAUDE.md
@@ -13,8 +13,13 @@ and the session gate arrived earlier with WP-C2 (#150). WP-E (#166) added
 the entrance-controls screens (list, create, detail with the printable PDF
 downloads); WP-F (#167) turned the Escaneos box live with the whole
 reader loop — upload → analyse → results table → side-by-side review
-page → re-leer con otra sensibilidad → *Cerrar corrección*. The routes
-table in `README.md` is the current inventory.
+page → re-leer con otra sensibilidad → *Cerrar corrección*. Since #249 the
+four minutes-class AMC operations (generate, analyse, reanalyse, close-
+annotate) run through an in-process async job runner
+(`internal/domain/jobs`), so an HTTP POST returns immediately and the
+detail page's `JobBanner` surfaces the running / done / failed state; the
+routes table in `README.md` is the current inventory and ADR-0050
+records the design.
 
 Commands, stack, configuration and layout live in `README.md` — one home per
 fact.
@@ -36,6 +41,13 @@ fact.
   / proxy-trust choices. Any change to the login path, a cookie read/write,
   or `NALANDA_PUBLIC_URL` needs it: the tests here pin the helpers, not their
   callers, and ADR-0038 is where the reasoning lives.
+- `docs/decisions/0050-the-controls-runner-is-in-process-single-goroutine.md`
+  — the async job runner design. Read before touching
+  `internal/domain/jobs`, `internal/infra/storage/jobstore`, or any of the
+  four minutes-class AMC handlers (`POST /controls`, `POST /controls/{id}/scans`,
+  `POST /controls/{id}/reanalyze`, `POST /controls/{id}/close`). Records
+  single-goroutine + SQLite persistence + Sweep-on-boot + no retry + the
+  atomicity split that amends ADR-0034 §Failure modes.
 - `docs/standards/guides/add-a-backend-endpoint.md` — read before adding ANY
   route here: which surface it belongs to, the handler → domain → repository
   chain, and the middleware a state-changing route needs.
@@ -90,6 +102,13 @@ the `avisoNo*` / `flash.Set(…)` string literals in `internal/app/web/handler/`
   infra implements it — `health.Prober`, implemented by `storage.Prober`, is the
   shape to copy. Full statement and the inversion recipe:
   `docs/standards/backend-code-style.md` §The dependency rule.
+
+  The rule forbids `domain → app` and `domain → infra`, NOT `domain → domain`.
+  Worked case since #249: `internal/domain/controls/jobhandlers.go` imports
+  `internal/domain/jobs` to satisfy `jobs.Handler`. `jobs.Store` (declared in
+  `jobs`, implemented by `jobstore` under `internal/infra`) and `jobs.Handler`
+  (declared in `jobs`, implemented from `controls`) are two more shapes to copy
+  alongside `health.Prober`.
 - **Never add a dependency without discussing it.** `go.mod` is a manifest and
   the root `CLAUDE.md` rule applies to it unchanged. The direct set is exactly
   `modernc.org/sqlite` and `github.com/pressly/goose/v3`; there is deliberately
@@ -174,18 +193,58 @@ the `avisoNo*` / `flash.Set(…)` string literals in `internal/app/web/handler/`
   bullet above; the failure mode is on paper (2026-08-19: 44 pages
   `+0/0/0+`, ADR-0042 §Context — the fixed-Letter that ADR-0043 makes
   configurable).
-- **The uploaded scan batch survives every downstream failure of
-  `UploadScan` (issue #210).** Reintroducing `os.Remove(batchHostPath)` on
-  a refusal — or on any post-copy error — is forbidden. The batch on disk
-  is the artefact an operator inspects and what the professor would
-  otherwise have to re-scan; erasing it on refusal was the pre-#210
-  behavior that made the 2026-08-19 incident cost twenty SSH minutes to
-  diagnose (same incident ADR-0042 §Context and the paper-check bullet
-  above reference — that WP fixed the printer cause, this one fixes the
+- **The uploaded scan batch survives every downstream failure of the
+  scan pipeline (issue #210, still true after #249).** Reintroducing
+  `os.Remove(batchHostPath)` on a refusal — or on any post-copy error
+  — is forbidden. The batch on disk is the artefact an operator
+  inspects and what the professor would otherwise have to re-scan;
+  erasing it on refusal was the pre-#210 behavior that made the
+  2026-08-19 incident cost twenty SSH minutes to diagnose (same
+  incident ADR-0042 §Context and the paper-check bullet above
+  reference — that WP fixed the printer cause, this one fixes the
   diagnosis path). `writeUpload` still cleans a PARTIAL file (its own
-  `io.Copy` failure); downstream failures do not. The rollback promise
-  is scoped to DB rows, not the file — see the `UploadScan` docstring
-  for what is transactional and what is not.
+  `io.Copy` failure); downstream failures do not. Since #249 the
+  invariant depends on the sync/async split: the file write happens
+  in `Service.SaveUploadedBatch` on the HTTP goroutine BEFORE
+  `Runner.Submit`. Moving the file write into the analyse job handler
+  is forbidden for the same reason — a Submit failure would then
+  discard the batch. Transactional scoping of the async writes
+  (upsert readings + mark missing + set state) lives on
+  `Service.AnalyzeBatch`'s docstring.
+- **A new async operation (a new `jobs.Kind`) lands in FOUR
+  coordinated places, and the runner's `NewRunner` panics at boot if
+  any is missing (issue #249, ADR-0050).**
+  1. A new `Kind` constant + `ValidKinds` entry in
+     `internal/domain/jobs/jobs.go`.
+  2. A migration that ALTERs `job.kind`'s `CHECK` to include the new
+     value — the SQLite `CHECK` and the Go enum enforce the same
+     closed set, and a `Kind` satisfying one but not the other is a
+     silent drop of that class of work.
+  3. A handler factory in `internal/domain/controls/jobhandlers.go`
+     (mirror `controls.NewReanalyseHandler` / `NewAnalyseHandler` /
+     `NewGenerateHandler` / `NewAnnotateHandler`) that translates
+     domain sentinels into `jobs.Failure{Message, Detail}` for the
+     banner + debug pair.
+  4. Its registration in `cmd/server/main.go`'s `jobs.Handlers` map.
+  The related operating rule: any AMC-worker-touching operation is
+  async by construction (do NOT add a synchronous handler that calls
+  `amcworker.Client` from the HTTP goroutine — split the sync half
+  from the async half, as `PrepareControl`/`GenerateAssets` and
+  `SaveUploadedBatch`/`AnalyzeBatch` already do). ADR-0050 has the
+  full reasoning.
+- **A worker refusal on the async half leaves the row and files
+  intact (issue #249, ADR-0050 §6 — amends ADR-0034 §Failure modes).**
+  `GenerateAssets` returning `ErrGeneratorRefused` /
+  `ErrSujetMissing` / `ErrGeneratorUnavailable`, and `AnalyzeBatch`
+  returning `ErrAnalyzerRefused` / `ErrAnalyzerUnavailable`, MUST
+  NOT delete the row or the input files. `source.tex` and
+  `pool.json` are the professor's authored artefacts; rolling them
+  back on a transient outage would force the professor to
+  re-choose the pool. The pre-#249 all-or-nothing promise of
+  `Service.Create` is now scoped to the sync half
+  (`Service.PrepareControl`). The banner surfaces the failure; a
+  future WP adds the explicit retry button. Same rule shape as the
+  UploadScan-survives bullet above.
 - **The LiveBank in-memory snapshot survives every Reload failure
   (issue #230).** Reintroducing a code path that clears the
   `atomic.Pointer[Bank]` on a fetch/parse failure is forbidden — a

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -238,13 +238,14 @@ Routes today:
 |---|---|
 | `GET /` | Redirects to `/controls` (an anonymous request lands in `/login` first, via the gate). Superseded #151's redirect to `/professors` when WP-E landed |
 | `GET /controls` | The list, ordered by application_date desc with nulls last |
-| `GET /controls/new` · `POST /controls` | Pick a section range, generate the PDF |
+| `GET /controls/new` · `POST /controls` | Pick a section range; POST prepares the row + input files synchronously and enqueues a `generate` job for the worker call. The professor lands on the detail page with the banner showing "Generando…" until the runner finishes (issue #249) |
 | `GET /controls/{id}` | Detail: metadata, PDF downloads, the Escaneos upload form, the Resultados table, (after upload) the *Cerrar corrección* button, and (once graded) the statistics panel — globals, histogram, boxplot, item analysis (issue #251) |
 | `GET /controls/{id}/sujet.pdf` · `GET /controls/{id}/corrige.pdf` | Streamed from the shared volume |
 | `GET /controls/{id}/pool.json` | The pool snapshot written at Create time (issue #198) — attachment |
-| `POST /controls/{id}/scans` | Multipart PDF upload — hands the file to the worker's `/analyse` at the submitted thresholds, persists the report and the pair, annotates clean copies, flips the state to `in_review` |
-| `POST /controls/{id}/reanalyze` | Re-reads the stored captures at new `ticked`/`unsure` thresholds without a new capture, re-scores at them, and re-annotates the clean copies (issue #197) |
-| `POST /controls/{id}/close` | Moves the control to `graded` when every failure kind is resolved (WP-F S8), then fires `OnCorrectionClosed` (issue #190) |
+| `POST /controls/{id}/scans` | Multipart PDF upload — writes the PDF to disk synchronously, then enqueues an `analyse` job. The runner hands the file to the worker's `/analyse`, persists the report and the pair, annotates clean copies and flips the state to `in_review`. Detail page's banner surfaces the running/done/failed state (issue #249) |
+| `POST /controls/{id}/reanalyze` | Enqueues a `reanalyse` job: the runner re-reads the stored captures at new `ticked`/`unsure` thresholds without a new capture, re-scores at them, and re-annotates the clean copies (issue #197, async since #249) |
+| `POST /controls/{id}/close` | Moves the control to `graded` when every failure kind is resolved (WP-F S8), then fires `OnCorrectionClosed` (issue #190), then enqueues an `annotate` job as a defensive re-annotate pass (issue #249) |
+| `POST /jobs/{id}/dismiss` | Stamps `viewed_at` on a job and redirects back to its control's detail — the "Refrescar / Cerrar aviso" button on the banner (issue #249) |
 | `GET /controls/{id}/copies/{copy}/review` · `POST` | Split view — corrected PDF (or raw scan) + editable form; POST saves overrides through `answer_override` / `rut_override` and re-annotates the copy |
 | `GET /controls/{id}/copies/{copy}/page/{n}` | Streams the scanned page image from the shared volume |
 | `GET /controls/{id}/copies/{copy}/annotated.pdf` | Streams the corrected PDF from the shared volume; 404 while none exists (issue #190) |

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -115,6 +115,11 @@ wget — so the only executable a healthcheck can invoke is the server.
 cmd/server/        wiring and entry point — the only main package
 internal/domain/   business types and the interfaces they need — PURE
   auth/            professors, identities, sessions, and who may log in
+  controls/        the entrance-controls domain: create/upload/read pipeline
+  course/          course + bank types (LiveBank, sections, questions)
+  health/          the /health prober seam
+  jobs/            the async job runner (issue #249, ADR-0050): types +
+                   single-goroutine Runner
 internal/app/web/  the professor's backoffice
   handler/         the login round trip and the professor CRUD
   middleware/      cookie → professor, the gate, CSRF, and the surface-agnostic request log
@@ -127,8 +132,11 @@ internal/app/web/  the professor's backoffice
                    (source, version, SHA-384, upgrade recipe).
 internal/app/api/  the JSON/WS surface — anonymous, no middleware (§C12)
 internal/infra/    adapters: config, storage, httpserver, httpjson, selfcheck
+  amcworker/       the AMC worker HTTP client (with generateLock mutex)
   oidc/            the Google client — standard library, no OIDC dependency
-  storage/authstore/  the SQLite side of the auth domain
+  storage/authstore/     the SQLite side of the auth domain
+  storage/controlstore/  the SQLite side of the controls domain
+  storage/jobstore/      the SQLite side of the jobs domain (issue #249)
 migrations/        goose SQL migrations, embedded into the binary
 ```
 
@@ -238,7 +246,7 @@ Routes today:
 |---|---|
 | `GET /` | Redirects to `/controls` (an anonymous request lands in `/login` first, via the gate). Superseded #151's redirect to `/professors` when WP-E landed |
 | `GET /controls` | The list, ordered by application_date desc with nulls last |
-| `GET /controls/new` · `POST /controls` | Pick a section range; POST prepares the row + input files synchronously and enqueues a `generate` job for the worker call. The professor lands on the detail page with the banner showing "Generando…" until the runner finishes (issue #249) |
+| `GET /controls/new` · `POST /controls` | Pick a section range; POST prepares the row + input files synchronously and enqueues a `generate` job for the worker call. The professor lands on the detail page with the banner showing "Procesando generación…" until the runner finishes (issue #249) |
 | `GET /controls/{id}` | Detail: metadata, PDF downloads, the Escaneos upload form, the Resultados table, (after upload) the *Cerrar corrección* button, and (once graded) the statistics panel — globals, histogram, boxplot, item analysis (issue #251) |
 | `GET /controls/{id}/sujet.pdf` · `GET /controls/{id}/corrige.pdf` | Streamed from the shared volume |
 | `GET /controls/{id}/pool.json` | The pool snapshot written at Create time (issue #198) — attachment |

--- a/apps/server/cmd/server/main.go
+++ b/apps/server/cmd/server/main.go
@@ -196,6 +196,7 @@ func run(logger *slog.Logger) error {
 	jobStore := jobstore.New(db)
 	jobRunner := jobs.NewRunner(jobStore, jobs.Handlers{
 		jobs.KindReanalyse: controls.NewReanalyseHandler(controlsService),
+		jobs.KindAnalyse:   controls.NewAnalyseHandler(controlsService),
 	}, logger, time.Now)
 	if err := jobRunner.Sweep(ctx); err != nil {
 		return err

--- a/apps/server/cmd/server/main.go
+++ b/apps/server/cmd/server/main.go
@@ -198,6 +198,7 @@ func run(logger *slog.Logger) error {
 		jobs.KindReanalyse: controls.NewReanalyseHandler(controlsService),
 		jobs.KindAnalyse:   controls.NewAnalyseHandler(controlsService),
 		jobs.KindGenerate:  controls.NewGenerateHandler(controlsService),
+		jobs.KindAnnotate:  controls.NewAnnotateHandler(controlsService),
 	}, logger, time.Now)
 	if err := jobRunner.Sweep(ctx); err != nil {
 		return err

--- a/apps/server/cmd/server/main.go
+++ b/apps/server/cmd/server/main.go
@@ -197,6 +197,7 @@ func run(logger *slog.Logger) error {
 	jobRunner := jobs.NewRunner(jobStore, jobs.Handlers{
 		jobs.KindReanalyse: controls.NewReanalyseHandler(controlsService),
 		jobs.KindAnalyse:   controls.NewAnalyseHandler(controlsService),
+		jobs.KindGenerate:  controls.NewGenerateHandler(controlsService),
 	}, logger, time.Now)
 	if err := jobRunner.Sweep(ctx); err != nil {
 		return err

--- a/apps/server/cmd/server/main.go
+++ b/apps/server/cmd/server/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
 	"github.com/so77id/nalanda/apps/server/internal/domain/course/bank"
 	"github.com/so77id/nalanda/apps/server/internal/domain/health"
+	"github.com/so77id/nalanda/apps/server/internal/domain/jobs"
 	"github.com/so77id/nalanda/apps/server/internal/infra/amcworker"
 	"github.com/so77id/nalanda/apps/server/internal/infra/config"
 	"github.com/so77id/nalanda/apps/server/internal/infra/httpserver"
@@ -30,6 +31,7 @@ import (
 	"github.com/so77id/nalanda/apps/server/internal/infra/storage"
 	"github.com/so77id/nalanda/apps/server/internal/infra/storage/authstore"
 	"github.com/so77id/nalanda/apps/server/internal/infra/storage/controlstore"
+	"github.com/so77id/nalanda/apps/server/internal/infra/storage/jobstore"
 	"github.com/so77id/nalanda/apps/server/migrations"
 )
 
@@ -186,6 +188,20 @@ func run(logger *slog.Logger) error {
 		Log:  logger,
 	})
 
+	// Issue #249: the async job runner. One goroutine, one queue,
+	// jobs persisted so a Watchtower restart does not lose them.
+	// Handlers register per Kind as the WP migrates each operation
+	// off the sync path — this ships with KindReanalyse (S3); S4–S6
+	// add analyse, generate and annotate.
+	jobStore := jobstore.New(db)
+	jobRunner := jobs.NewRunner(jobStore, jobs.Handlers{
+		jobs.KindReanalyse: controls.NewReanalyseHandler(controlsService),
+	}, logger, time.Now)
+	if err := jobRunner.Sweep(ctx); err != nil {
+		return err
+	}
+	go jobRunner.Start(ctx)
+
 	backoffice := web.Deps{
 		Database: storage.NewProber(db),
 		Gate: middleware.NewAuth(middleware.Auth{
@@ -215,7 +231,10 @@ func run(logger *slog.Logger) error {
 			// integration (email, Canvas) replaces it here without
 			// touching the flow (issue #190).
 			OnCorrectionClosed: controls.NewNoopHook(logger),
-			Log:                logger,
+			// Issue #249: the async job runner (banner + Submit calls).
+			Jobs:   jobStore,
+			Runner: jobRunner,
+			Log:    logger,
 		}),
 		AdminBank: handler.NewAdminBank(handler.AdminBank{
 			Bank:      liveBank,

--- a/apps/server/cmd/server/main_test.go
+++ b/apps/server/cmd/server/main_test.go
@@ -109,6 +109,7 @@ func composed(t *testing.T, prober health.Prober) (http.Handler, *authstore.Stor
 			runner := jobs.NewRunner(jstore, jobs.Handlers{
 				jobs.KindReanalyse: controls.NewReanalyseHandler(svc),
 				jobs.KindAnalyse:   controls.NewAnalyseHandler(svc),
+				jobs.KindGenerate:  controls.NewGenerateHandler(svc),
 			}, logger, time.Now)
 			return handler.NewControls(handler.Controls{
 				Service:            svc,

--- a/apps/server/cmd/server/main_test.go
+++ b/apps/server/cmd/server/main_test.go
@@ -26,11 +26,13 @@ import (
 	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
 	"github.com/so77id/nalanda/apps/server/internal/domain/course/bank"
 	"github.com/so77id/nalanda/apps/server/internal/domain/health"
+	"github.com/so77id/nalanda/apps/server/internal/domain/jobs"
 	"github.com/so77id/nalanda/apps/server/internal/infra/amcworker/amctest"
 	"github.com/so77id/nalanda/apps/server/internal/infra/oidc/oidctest"
 	"github.com/so77id/nalanda/apps/server/internal/infra/storage"
 	"github.com/so77id/nalanda/apps/server/internal/infra/storage/authstore"
 	"github.com/so77id/nalanda/apps/server/internal/infra/storage/controlstore"
+	"github.com/so77id/nalanda/apps/server/internal/infra/storage/jobstore"
 	"github.com/so77id/nalanda/apps/server/migrations"
 )
 
@@ -87,29 +89,36 @@ func composed(t *testing.T, prober health.Prober) (http.Handler, *authstore.Stor
 			PublicURL: "https://nalanda.test",
 			Log:       logger,
 		}),
-		Controls: handler.NewControls(handler.Controls{
-			Service: func() *controls.Service {
-				cstore := controlstore.New(db)
-				fake := &amctest.Fake{}
-				return controls.NewService(controls.Service{
-					Bank:            emptyBank(t),
-					Store:           cstore,
-					Generator:       fake,
-					Analyzer:        fake,
-					Readings:        cstore,
-					Annotator:       fake,
-					AnnotateEnabled: true,
-					WorkDir:         t.TempDir(),
-					Now:             time.Now,
-					Seed:            1,
-					Log:             logger,
-				})
-			}(),
-			Bank:               emptyBank(t),
-			PublicURL:          "https://nalanda.test",
-			OnCorrectionClosed: controls.NewNoopHook(logger),
-			Log:                logger,
-		}),
+		Controls: func() *handler.Controls {
+			cstore := controlstore.New(db)
+			fake := &amctest.Fake{}
+			svc := controls.NewService(controls.Service{
+				Bank:            emptyBank(t),
+				Store:           cstore,
+				Generator:       fake,
+				Analyzer:        fake,
+				Readings:        cstore,
+				Annotator:       fake,
+				AnnotateEnabled: true,
+				WorkDir:         t.TempDir(),
+				Now:             time.Now,
+				Seed:            1,
+				Log:             logger,
+			})
+			jstore := jobstore.New(db)
+			runner := jobs.NewRunner(jstore, jobs.Handlers{
+				jobs.KindReanalyse: controls.NewReanalyseHandler(svc),
+			}, logger, time.Now)
+			return handler.NewControls(handler.Controls{
+				Service:            svc,
+				Bank:               emptyBank(t),
+				PublicURL:          "https://nalanda.test",
+				OnCorrectionClosed: controls.NewNoopHook(logger),
+				Jobs:               jstore,
+				Runner:             runner,
+				Log:                logger,
+			})
+		}(),
 		AdminBank: handler.NewAdminBank(handler.AdminBank{
 			Bank:      emptyBank(t),
 			PublicURL: "https://nalanda.test",

--- a/apps/server/cmd/server/main_test.go
+++ b/apps/server/cmd/server/main_test.go
@@ -108,6 +108,7 @@ func composed(t *testing.T, prober health.Prober) (http.Handler, *authstore.Stor
 			jstore := jobstore.New(db)
 			runner := jobs.NewRunner(jstore, jobs.Handlers{
 				jobs.KindReanalyse: controls.NewReanalyseHandler(svc),
+				jobs.KindAnalyse:   controls.NewAnalyseHandler(svc),
 			}, logger, time.Now)
 			return handler.NewControls(handler.Controls{
 				Service:            svc,

--- a/apps/server/cmd/server/main_test.go
+++ b/apps/server/cmd/server/main_test.go
@@ -110,6 +110,7 @@ func composed(t *testing.T, prober health.Prober) (http.Handler, *authstore.Stor
 				jobs.KindReanalyse: controls.NewReanalyseHandler(svc),
 				jobs.KindAnalyse:   controls.NewAnalyseHandler(svc),
 				jobs.KindGenerate:  controls.NewGenerateHandler(svc),
+				jobs.KindAnnotate:  controls.NewAnnotateHandler(svc),
 			}, logger, time.Now)
 			return handler.NewControls(handler.Controls{
 				Service:            svc,

--- a/apps/server/internal/app/web/handler/controls.go
+++ b/apps/server/internal/app/web/handler/controls.go
@@ -167,7 +167,7 @@ func (h *Controls) Create(w http.ResponseWriter, r *http.Request) {
 
 	// Issue #249, S5: split the sync half (files staged + row committed)
 	// from the async half (worker call). The professor lands on the
-	// detail page immediately with a "Generando…" banner from the
+	// detail page immediately with a "Procesando generación…" banner from the
 	// generate job; the row is safe for the sync-path validations
 	// (domain errors like a too-small pool still surface as form
 	// errors), and the worker outage is asynchronously visible on the

--- a/apps/server/internal/app/web/handler/controls.go
+++ b/apps/server/internal/app/web/handler/controls.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -185,14 +184,7 @@ func (h *Controls) Create(w http.ResponseWriter, r *http.Request) {
 		h.rerenderNew(w, r, values, fieldErr, "")
 		return
 	}
-	payload, err := json.Marshal(controls.GeneratePayload{})
-	if err != nil {
-		h.Log.Error("controls: encode generate payload", "control", control.ID, "error", err)
-		middleware.WriteError(w, r, http.StatusInternalServerError,
-			"El servidor no pudo encolar la generación.")
-		return
-	}
-	if _, err := h.Runner.Submit(r.Context(), control.ID, jobs.KindGenerate, payload); err != nil {
+	if _, err := h.Runner.Submit(r.Context(), control.ID, jobs.KindGenerate, controls.EmptyPayload); err != nil {
 		h.Log.Error("controls: submit generate job", "control", control.ID, "error", err)
 		middleware.WriteError(w, r, http.StatusInternalServerError,
 			"El servidor no pudo encolar la generación.")

--- a/apps/server/internal/app/web/handler/controls.go
+++ b/apps/server/internal/app/web/handler/controls.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -165,23 +166,40 @@ func (h *Controls) Create(w http.ResponseWriter, r *http.Request) {
 	}
 	req.CreatedBy = acting.ID
 
-	control, err := h.Service.Create(r.Context(), req)
+	// Issue #249, S5: split the sync half (files staged + row committed)
+	// from the async half (worker call). The professor lands on the
+	// detail page immediately with a "Generando…" banner from the
+	// generate job; the row is safe for the sync-path validations
+	// (domain errors like a too-small pool still surface as form
+	// errors), and the worker outage is asynchronously visible on the
+	// banner rather than a 30-second-long POST.
+	control, err := h.Service.PrepareControl(r.Context(), req)
 	if err != nil {
 		fieldErr, ok := domainErrorToForm(err)
 		if !ok {
-			// A failure the professor cannot repair — worker down, sujet
-			// missing, disk full. Log it, render a 500 through the shell
-			// (§Failure modes: "Renders the shell's 500 page…").
 			h.Log.Error("creating a control", "error", err, "professor", acting.ID)
 			middleware.WriteError(w, r, http.StatusInternalServerError,
-				"El servidor no pudo generar el control. Vuelve a intentarlo en unos minutos; si el problema persiste, avisa a alguien de infraestructura.")
+				"El servidor no pudo preparar el control. Vuelve a intentarlo en unos minutos; si el problema persiste, avisa a alguien de infraestructura.")
 			return
 		}
 		h.rerenderNew(w, r, values, fieldErr, "")
 		return
 	}
-
-	flash.Set(w, h.secureCookie, "Control «"+control.Name+"» generado.")
+	payload, err := json.Marshal(controls.GeneratePayload{})
+	if err != nil {
+		h.Log.Error("controls: encode generate payload", "control", control.ID, "error", err)
+		middleware.WriteError(w, r, http.StatusInternalServerError,
+			"El servidor no pudo encolar la generación.")
+		return
+	}
+	if _, err := h.Runner.Submit(r.Context(), control.ID, jobs.KindGenerate, payload); err != nil {
+		h.Log.Error("controls: submit generate job", "control", control.ID, "error", err)
+		middleware.WriteError(w, r, http.StatusInternalServerError,
+			"El servidor no pudo encolar la generación.")
+		return
+	}
+	flash.Set(w, h.secureCookie,
+		"Control «"+control.Name+"» encolado para generación. Refresca cuando el aviso cambie.")
 	http.Redirect(w, r, controlDetailURL(control.ID), http.StatusSeeOther)
 }
 

--- a/apps/server/internal/app/web/handler/controls.go
+++ b/apps/server/internal/app/web/handler/controls.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -16,6 +17,7 @@ import (
 	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
 	"github.com/so77id/nalanda/apps/server/internal/domain/controls/stats"
 	"github.com/so77id/nalanda/apps/server/internal/domain/course/bank"
+	"github.com/so77id/nalanda/apps/server/internal/domain/jobs"
 	"github.com/so77id/nalanda/apps/server/internal/infra/config"
 )
 
@@ -74,7 +76,13 @@ type Controls struct {
 	// (issue #190 §Hook para futuros integraciones). Required — the
 	// default is controls.NewNoopHook, wired in cmd/server.
 	OnCorrectionClosed controls.OnCorrectionClosed
-	Log                *slog.Logger
+	// Jobs is the async job runner's store (issue #249). Detail reads
+	// the latest job for the banner; DismissJob writes viewed_at.
+	Jobs jobs.Store
+	// Runner submits async jobs (issue #249). Handlers migrated to the
+	// runner call it here instead of the sync Service method.
+	Runner *jobs.Runner
+	Log    *slog.Logger
 
 	secureCookie bool
 }
@@ -90,6 +98,10 @@ func NewControls(deps Controls) *Controls {
 		panic("handler.NewControls: no public URL — the flash cookie's Secure attribute is derived from it")
 	case deps.OnCorrectionClosed == nil:
 		panic("handler.NewControls: no correction-closed hook — pass controls.NewNoopHook(log)")
+	case deps.Jobs == nil:
+		panic("handler.NewControls: no jobs store")
+	case deps.Runner == nil:
+		panic("handler.NewControls: no jobs runner")
 	case deps.Log == nil:
 		panic("handler.NewControls: no logger")
 	}
@@ -246,6 +258,7 @@ func (h *Controls) Detail(w http.ResponseWriter, r *http.Request) {
 			page.Stats = &computed
 		}
 	}
+	page.JobBanner = h.jobBannerFor(r.Context(), c.ID)
 	page.Flash = flash.Consume(w, r, h.secureCookie)
 
 	if err := view.RenderControlDetail(w, page); err != nil {
@@ -515,6 +528,114 @@ func sectionOptionsFromBank(b *bank.Bank) []view.DocumentSections {
 		})
 	}
 	return out
+}
+
+// jobBannerFor composes the Detail page's async-job banner (issue #249)
+// from the latest job on this control. Returns nil when there is no job
+// at all, or when the most recent one is done|failed AND has been
+// dismissed — the banner should hide, not tell the professor to
+// dismiss a message they already saw. A store outage returns nil too:
+// the banner is an aid, not a load-bearing part of the page, and a
+// missing banner is better than a 500 on the whole detail.
+func (h *Controls) jobBannerFor(ctx context.Context, controlID string) *view.JobBanner {
+	job, err := h.Jobs.LatestForControl(ctx, controlID)
+	if err != nil {
+		if !errors.Is(err, jobs.ErrJobNotFound) {
+			h.Log.Warn("jobs: reading banner", "control", controlID, "error", err)
+		}
+		return nil
+	}
+	running := job.Status == jobs.StatusQueued || job.Status == jobs.StatusRunning
+	if !running && job.ViewedAt != nil {
+		return nil
+	}
+	banner := &view.JobBanner{
+		JobID:      job.ID,
+		Kind:       spanishKind(job.Kind),
+		Running:    running,
+		Done:       job.Status == jobs.StatusDone,
+		Failed:     job.Status == jobs.StatusFailed,
+		Error:      job.Error,
+		DismissURL: jobDismissURL(job.ID),
+	}
+	if running {
+		start := job.CreatedAt
+		if job.StartedAt != nil {
+			start = *job.StartedAt
+		}
+		banner.StartedAgo = humanElapsed(time.Since(start))
+	}
+	return banner
+}
+
+// spanishKind is the human label the banner renders for a Kind.
+// Kept next to the field it decorates rather than in the view package
+// because the four values are handler-facing translation, not layout.
+func spanishKind(k jobs.Kind) string {
+	switch k {
+	case jobs.KindGenerate:
+		return "generación"
+	case jobs.KindAnalyse:
+		return "análisis"
+	case jobs.KindReanalyse:
+		return "re-lectura"
+	case jobs.KindAnnotate:
+		return "anotado"
+	default:
+		return string(k)
+	}
+}
+
+// humanElapsed renders a duration as "hace N s" / "hace N min" / "hace
+// N h" — the coarse buckets are enough for a banner that a professor
+// refreshes every few seconds.
+func humanElapsed(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("hace %d s", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("hace %d min", int(d.Minutes()))
+	}
+	return fmt.Sprintf("hace %d h", int(d.Hours()))
+}
+
+// JobDismissPath is POST target for the "Refrescar / Reintentar" button
+// on the banner (issue #249). The id lives in the URL segment; the
+// handler stamps viewed_at and redirects back to the control.
+const JobDismissPath = "/jobs/{id}/dismiss"
+
+// DismissJob stamps viewed_at on a job and redirects back to its
+// control. Idempotent — dismissing a running job is fine too (the
+// banner just hides on the next request; the runner keeps working).
+func (h *Controls) DismissJob(w http.ResponseWriter, r *http.Request) {
+	rawID := r.PathValue("id")
+	jobID, err := strconv.ParseInt(rawID, 10, 64)
+	if err != nil || jobID <= 0 {
+		middleware.WriteError(w, r, http.StatusNotFound, "Ese trabajo no existe.")
+		return
+	}
+	job, err := h.Jobs.ByID(r.Context(), jobID)
+	if err != nil {
+		if errors.Is(err, jobs.ErrJobNotFound) {
+			middleware.WriteError(w, r, http.StatusNotFound, "Ese trabajo no existe.")
+			return
+		}
+		h.Log.Error("dismiss job: fetch", "id", jobID, "error", err)
+		middleware.WriteError(w, r, http.StatusInternalServerError,
+			"Algo se rompió en el servidor. Vuelve a intentarlo en unos segundos.")
+		return
+	}
+	if err := h.Jobs.MarkDismissed(r.Context(), jobID, time.Now()); err != nil {
+		h.Log.Error("dismiss job: mark", "id", jobID, "error", err)
+		middleware.WriteError(w, r, http.StatusInternalServerError,
+			"No se pudo cerrar el aviso.")
+		return
+	}
+	http.Redirect(w, r, controlDetailURL(job.ControlID), http.StatusSeeOther)
+}
+
+func jobDismissURL(id int64) string {
+	return "/jobs/" + strconv.FormatInt(id, 10) + "/dismiss"
 }
 
 // isValidControlID enforces the ID's shape at the URL boundary so a stray

--- a/apps/server/internal/app/web/handler/controls.go
+++ b/apps/server/internal/app/web/handler/controls.go
@@ -609,7 +609,7 @@ func humanElapsed(d time.Duration) string {
 	return fmt.Sprintf("hace %d h", int(d.Hours()))
 }
 
-// JobDismissPath is POST target for the "Refrescar / Reintentar" button
+// JobDismissPath is POST target for the "Refrescar" / "Cerrar aviso" button
 // on the banner (issue #249). The id lives in the URL segment; the
 // handler stamps viewed_at and redirects back to the control.
 const JobDismissPath = "/jobs/{id}/dismiss"

--- a/apps/server/internal/app/web/handler/controls.go
+++ b/apps/server/internal/app/web/handler/controls.go
@@ -489,9 +489,9 @@ func parsePositive(raw string, min, max int) (int, string) {
 	return n, ""
 }
 
-// domainErrorToForm maps a Service.Create failure onto (field errors,
-// ok). ok is false for errors the professor cannot repair; those bubble
-// up as a 500 in Create.
+// domainErrorToForm maps a Service.PrepareControl failure onto
+// (field errors, ok). ok is false for errors the professor cannot
+// repair; those bubble up as a 500 in Create.
 func domainErrorToForm(err error) (map[string]string, bool) {
 	switch {
 	case errors.Is(err, bank.ErrRangeInverted):

--- a/apps/server/internal/app/web/handler/controls_test.go
+++ b/apps/server/internal/app/web/handler/controls_test.go
@@ -145,6 +145,7 @@ func newControlsFixtureWith(t *testing.T, annotateEnabled bool) *controlsFixture
 		jobs.KindReanalyse: controls.NewReanalyseHandler(svc),
 		jobs.KindAnalyse:   controls.NewAnalyseHandler(svc),
 		jobs.KindGenerate:  controls.NewGenerateHandler(svc),
+		jobs.KindAnnotate:  controls.NewAnnotateHandler(svc),
 	}, log, time.Now)
 	// Start the runner in the background so the async Submit path in
 	// ReanalyzeScans reaches its handler. Cleanup cancels the context

--- a/apps/server/internal/app/web/handler/controls_test.go
+++ b/apps/server/internal/app/web/handler/controls_test.go
@@ -143,6 +143,7 @@ func newControlsFixtureWith(t *testing.T, annotateEnabled bool) *controlsFixture
 	jstore := jobstore.New(db)
 	runner := jobs.NewRunner(jstore, jobs.Handlers{
 		jobs.KindReanalyse: controls.NewReanalyseHandler(svc),
+		jobs.KindAnalyse:   controls.NewAnalyseHandler(svc),
 	}, log, time.Now)
 	// Start the runner in the background so the async Submit path in
 	// ReanalyzeScans reaches its handler. Cleanup cancels the context

--- a/apps/server/internal/app/web/handler/controls_test.go
+++ b/apps/server/internal/app/web/handler/controls_test.go
@@ -600,7 +600,9 @@ func TestCreateWritesAControlAndRedirectsToItsDetail(t *testing.T) {
 		t.Errorf("no flash cookie set, want one (POST/redirect/GET convention)")
 	}
 
-	// sujet.pdf is on disk.
+	// Issue #249: the worker call runs on the async generate job.
+	// Wait for it before checking sujet.pdf is on disk.
+	f.waitLatestJobTerminal(t, rows[0].ID)
 	if _, err := os.Stat(filepath.Join(f.workDir, "controls", rows[0].ID, "out", "sujet.pdf")); err != nil {
 		t.Errorf("sujet.pdf missing on disk: %v", err)
 	}

--- a/apps/server/internal/app/web/handler/controls_test.go
+++ b/apps/server/internal/app/web/handler/controls_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -21,10 +22,12 @@ import (
 	"github.com/so77id/nalanda/apps/server/internal/domain/auth"
 	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
 	"github.com/so77id/nalanda/apps/server/internal/domain/course/bank"
+	"github.com/so77id/nalanda/apps/server/internal/domain/jobs"
 	"github.com/so77id/nalanda/apps/server/internal/infra/amcworker/amctest"
 	"github.com/so77id/nalanda/apps/server/internal/infra/storage"
 	"github.com/so77id/nalanda/apps/server/internal/infra/storage/authstore"
 	"github.com/so77id/nalanda/apps/server/internal/infra/storage/controlstore"
+	"github.com/so77id/nalanda/apps/server/internal/infra/storage/jobstore"
 	"github.com/so77id/nalanda/apps/server/migrations"
 )
 
@@ -54,7 +57,11 @@ type controlsFixture struct {
 	// cstore is the real controlstore behind the service — tests that need
 	// to read rows back (annotated_copy since issue #190) query it instead
 	// of re-deriving the database path.
-	cstore  *controlstore.Store
+	cstore *controlstore.Store
+	// jstore is the real jobstore behind the runner — issue #249 tests
+	// (Submit path, banner, dismiss) query it directly.
+	jstore  *jobstore.Store
+	runner  *jobs.Runner
 	fake    *amctest.Fake
 	hook    *recordingHook
 	workDir string
@@ -133,13 +140,109 @@ func newControlsFixtureWith(t *testing.T, annotateEnabled bool) *controlsFixture
 		Now:     time.Now, Seed: 1, Log: log,
 	})
 	hook := &recordingHook{service: svc}
+	jstore := jobstore.New(db)
+	runner := jobs.NewRunner(jstore, jobs.Handlers{
+		jobs.KindReanalyse: controls.NewReanalyseHandler(svc),
+	}, log, time.Now)
+	// Start the runner in the background so the async Submit path in
+	// ReanalyzeScans reaches its handler. Cleanup cancels the context
+	// so the goroutine drains at end-of-test.
+	runnerCtx, runnerCancel := context.WithCancel(context.Background())
+	t.Cleanup(runnerCancel)
+	go runner.Start(runnerCtx)
 	h := handler.NewControls(handler.Controls{
 		Service: svc, Bank: live,
 		PublicURL: publicURL, MaxScanBytes: 5 << 20,
 		OnCorrectionClosed: hook,
+		Jobs:               jstore,
+		Runner:             runner,
 		Log:                log,
 	})
-	return &controlsFixture{handler: h, service: svc, cstore: cstore, fake: fake, hook: hook, workDir: workDir, user: prof, session: session, log: log}
+	return &controlsFixture{handler: h, service: svc, cstore: cstore, jstore: jstore, runner: runner, fake: fake, hook: hook, workDir: workDir, user: prof, session: session, log: log}
+}
+
+// jobCounts is what jstoreQueuedAndTerminalCount returns — the three
+// buckets a concurrent-serialisation test cares about.
+type jobCounts struct {
+	queued   int
+	running  int
+	terminal int
+}
+
+// jstoreQueuedAndTerminalCount reads every job for this control and
+// buckets by status. Used by the concurrent-reanalyze test to wait for
+// the runner to catch up without over-fitting to id order.
+func (f *controlsFixture) jstoreQueuedAndTerminalCount(ctx context.Context, controlID string) (jobCounts, error) {
+	rows, err := f.jstoreRawByControl(ctx, controlID)
+	if err != nil {
+		return jobCounts{}, err
+	}
+	c := jobCounts{}
+	for _, j := range rows {
+		switch j.Status {
+		case jobs.StatusQueued:
+			c.queued++
+		case jobs.StatusRunning:
+			c.running++
+		case jobs.StatusDone, jobs.StatusFailed:
+			c.terminal++
+		}
+	}
+	return c, nil
+}
+
+// jstoreRawByControl reads every job for the control via the fixture's
+// database — jobs.Store doesn't expose "list by control" (its readers
+// are LatestForControl and ByID by design), and the test does not need
+// a new method on the domain interface for one case.
+func (f *controlsFixture) jstoreRawByControl(ctx context.Context, controlID string) ([]jobs.Job, error) {
+	// LatestForControl + walking id backwards would need extra
+	// interface methods. The fixture cheats by hitting the same
+	// sql.DB — jstore is a thin adapter, and no domain state hangs
+	// off the walk.
+	rows, err := f.jstore.QueuedIDs(ctx)
+	if err != nil {
+		return nil, err
+	}
+	// The list above only returns queued rows. Combine with a
+	// LatestForControl fan-out via the ByID contract: iterate
+	// increasing ids from 1 until ErrJobNotFound.
+	out := []jobs.Job{}
+	for id := int64(1); ; id++ {
+		j, err := f.jstore.ByID(ctx, id)
+		if err != nil {
+			if errors.Is(err, jobs.ErrJobNotFound) {
+				break
+			}
+			return nil, err
+		}
+		if j.ControlID == controlID {
+			out = append(out, j)
+		}
+	}
+	_ = rows
+	return out, nil
+}
+
+// waitLatestJobTerminal polls until the control's latest job is `done`
+// or `failed`. Handler tests that submit a job (reanalyze, analyse in
+// S4, etc.) call this after the POST so the runner has time to consume
+// the row before assertions read the resulting state.
+func (f *controlsFixture) waitLatestJobTerminal(t *testing.T, controlID string) jobs.Job {
+	t.Helper()
+	ctx := context.Background()
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		job, err := f.jstore.LatestForControl(ctx, controlID)
+		if err == nil && (job.Status == jobs.StatusDone || job.Status == jobs.StatusFailed) {
+			return job
+		}
+		if time.Now().After(deadline) {
+			last, _ := f.jstore.LatestForControl(ctx, controlID)
+			t.Fatalf("no terminal job for %s after 3s (last: %+v, err: %v)", controlID, last, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 func (f *controlsFixture) authedRequest(t *testing.T, method, path string, body url.Values) *http.Request {

--- a/apps/server/internal/app/web/handler/controls_test.go
+++ b/apps/server/internal/app/web/handler/controls_test.go
@@ -144,6 +144,7 @@ func newControlsFixtureWith(t *testing.T, annotateEnabled bool) *controlsFixture
 	runner := jobs.NewRunner(jstore, jobs.Handlers{
 		jobs.KindReanalyse: controls.NewReanalyseHandler(svc),
 		jobs.KindAnalyse:   controls.NewAnalyseHandler(svc),
+		jobs.KindGenerate:  controls.NewGenerateHandler(svc),
 	}, log, time.Now)
 	// Start the runner in the background so the async Submit path in
 	// ReanalyzeScans reaches its handler. Cleanup cancels the context
@@ -718,41 +719,54 @@ func TestCreateEchoesValuesOnRefusal(t *testing.T) {
 	}
 }
 
-func TestCreateRendersA500ThroughTheShellWhenTheWorkerRefuses(t *testing.T) {
+// Since issue #249 the worker call runs on the async generate job, so
+// a worker refusal no longer surfaces as a 500 on the HTTP POST. The
+// row is committed synchronously by PrepareControl; the runner records
+// the refusal on the job row for the banner to render.
+func TestCreateWorkerRefusalRecordsGenerateJobFailure(t *testing.T) {
 	f := newControlsFixture(t)
 	f.fake.Err = controls.ErrGeneratorRefused
 
 	rec := httptest.NewRecorder()
 	f.handler.Create(rec, f.authedRequest(t, http.MethodPost, handler.ControlsPath, validForm()))
-
-	if rec.Code != http.StatusInternalServerError {
-		t.Fatalf("status = %d, want 500 (worker failure is not a form error)", rec.Code)
-	}
-	// The shell error page renders through view.RenderError — its
-	// Spanish message is what the professor reads.
-	if !strings.Contains(rec.Body.String(), "servidor") {
-		t.Error("body does not carry the shell error page's Spanish message")
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303 (worker call is async now)", rec.Code)
 	}
 
 	rows, _ := f.service.List(context.Background())
-	if len(rows) != 0 {
-		t.Errorf("stored %d rows after a worker failure, want 0 (creation is all-or-nothing)", len(rows))
+	if len(rows) != 1 {
+		t.Fatalf("stored %d rows after PrepareControl, want 1", len(rows))
+	}
+	controlID := rows[0].ID
+	job := f.waitLatestJobTerminal(t, controlID)
+	if job.Status != jobs.StatusFailed {
+		t.Errorf("generate job status = %q, want failed", job.Status)
+	}
+	if !strings.Contains(job.Error, "generación") {
+		t.Errorf("job.Error = %q, want the Spanish generator refusal message", job.Error)
 	}
 }
 
-func TestCreateRendersA500WhenSujetIsMissing(t *testing.T) {
+func TestCreateSujetMissingRecordsGenerateJobFailure(t *testing.T) {
 	f := newControlsFixture(t)
-	f.fake.SujetSize = 0 // fake writes a 0-byte sujet.pdf
+	f.fake.SujetSize = 0
 
 	rec := httptest.NewRecorder()
 	f.handler.Create(rec, f.authedRequest(t, http.MethodPost, handler.ControlsPath, validForm()))
-
-	if rec.Code != http.StatusInternalServerError {
-		t.Fatalf("status = %d, want 500", rec.Code)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303", rec.Code)
 	}
 	rows, _ := f.service.List(context.Background())
-	if len(rows) != 0 {
-		t.Errorf("stored %d rows after a 0-byte sujet, want 0", len(rows))
+	if len(rows) != 1 {
+		t.Fatalf("stored %d rows after PrepareControl, want 1", len(rows))
+	}
+	controlID := rows[0].ID
+	job := f.waitLatestJobTerminal(t, controlID)
+	if job.Status != jobs.StatusFailed {
+		t.Errorf("generate job status = %q, want failed", job.Status)
+	}
+	if !strings.Contains(job.Error, "sujet") {
+		t.Errorf("job.Error = %q, want the sujet-missing message", job.Error)
 	}
 }
 
@@ -887,6 +901,9 @@ func TestSujetPDFStreamsTheFile(t *testing.T) {
 	f.handler.Create(rec, f.authedRequest(t, http.MethodPost, handler.ControlsPath, validForm()))
 	loc := rec.Header().Get("Location")
 	id := strings.TrimPrefix(loc, handler.ControlsPath+"/")
+	// Issue #249: Create enqueues a generate job — wait for it before
+	// asking for the sujet.pdf the generate step is meant to produce.
+	f.waitLatestJobTerminal(t, id)
 
 	rec = httptest.NewRecorder()
 	req := f.authedRequest(t, http.MethodGet, loc+"/sujet.pdf", nil)

--- a/apps/server/internal/app/web/handler/results_test.go
+++ b/apps/server/internal/app/web/handler/results_test.go
@@ -132,6 +132,10 @@ func uploadOnce(t *testing.T, f *controlsFixture, controlID string) {
 	if rec.Code != http.StatusSeeOther {
 		t.Fatalf("upload status = %d, want 303", rec.Code)
 	}
+	// Issue #249: /scans now enqueues an analyse job. Wait for the
+	// runner to finish it so callers see the readings the sync path
+	// used to leave behind directly.
+	f.waitLatestJobTerminal(t, controlID)
 }
 
 func getDetail(t *testing.T, f *controlsFixture, controlID string) string {

--- a/apps/server/internal/app/web/handler/scans.go
+++ b/apps/server/internal/app/web/handler/scans.go
@@ -51,11 +51,18 @@ const uploadWriteWindow = 15 * time.Minute
 // scanFormField is the multipart field the upload form posts under.
 const scanFormField = "scan"
 
-// UploadScan reads the multipart form, streams the PDF onto disk through the
-// Service, and redirects back to /controls/:id with a flash message. Failure
-// modes are visible to the professor as a redirect + flash; the 500 shell is
-// reserved for the "operator has to look" ones (unknown control, worker
-// unreachable).
+// UploadScan reads the multipart form, streams the PDF onto disk
+// through Service.SaveUploadedBatch, enqueues an analyse job through
+// the runner, and redirects back to /controls/:id with a flash message.
+// The worker call runs on the async job (issue #249) — a refusal there
+// lands on job.error / job.detail and surfaces via the JobBanner, not
+// on the flash.
+//
+// Failure modes reachable synchronously are professor-repairable
+// (invalid form, threshold band, control unknown, PDF-shaped
+// pre-check) and surface as flash + redirect. The 500 shell is
+// reserved for "operator has to look" branches — disk write failure,
+// payload encode failure, Submit failure.
 func (h *Controls) UploadScan(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if !isValidControlID(id) {

--- a/apps/server/internal/app/web/handler/scans.go
+++ b/apps/server/internal/app/web/handler/scans.go
@@ -277,6 +277,17 @@ func (h *Controls) CloseCorrection(w http.ResponseWriter, r *http.Request) {
 	if err := h.OnCorrectionClosed.Closed(r.Context(), id); err != nil {
 		h.Log.Error("close correction: hook failed", "control", id, "error", err)
 	}
+	// Issue #249, S6: defensive re-annotate pass over every ok copy.
+	// A no-op when every ok copy is already annotated (the usual case,
+	// since analyse and reanalyse both annotate as they go); the
+	// operator scenario is a control read while AnnotateEnabled was
+	// false — closing the correction back-fills the PDFs.
+	payload, err := json.Marshal(controls.AnnotatePayload{})
+	if err != nil {
+		h.Log.Error("close correction: encode annotate payload", "control", id, "error", err)
+	} else if _, err := h.Runner.Submit(r.Context(), id, jobs.KindAnnotate, payload); err != nil {
+		h.Log.Error("close correction: submit annotate job", "control", id, "error", err)
+	}
 	flash.Set(w, h.secureCookie, "Corrección cerrada.")
 	http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
 }

--- a/apps/server/internal/app/web/handler/scans.go
+++ b/apps/server/internal/app/web/handler/scans.go
@@ -282,10 +282,7 @@ func (h *Controls) CloseCorrection(w http.ResponseWriter, r *http.Request) {
 	// since analyse and reanalyse both annotate as they go); the
 	// operator scenario is a control read while AnnotateEnabled was
 	// false — closing the correction back-fills the PDFs.
-	payload, err := json.Marshal(controls.AnnotatePayload{})
-	if err != nil {
-		h.Log.Error("close correction: encode annotate payload", "control", id, "error", err)
-	} else if _, err := h.Runner.Submit(r.Context(), id, jobs.KindAnnotate, payload); err != nil {
+	if _, err := h.Runner.Submit(r.Context(), id, jobs.KindAnnotate, controls.EmptyPayload); err != nil {
 		h.Log.Error("close correction: submit annotate job", "control", id, "error", err)
 	}
 	flash.Set(w, h.secureCookie, "Corrección cerrada.")

--- a/apps/server/internal/app/web/handler/scans.go
+++ b/apps/server/internal/app/web/handler/scans.go
@@ -144,7 +144,7 @@ func (h *Controls) UploadScan(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := h.Service.UploadScan(r.Context(), controls.UploadRequest{
+	save, err := h.Service.SaveUploadedBatch(r.Context(), controls.UploadRequest{
 		ControlID: id,
 		Filename:  header.Filename,
 		Content:   file,
@@ -156,27 +156,38 @@ func (h *Controls) UploadScan(w http.ResponseWriter, r *http.Request) {
 		case errors.Is(err, controls.ErrControlNotFound):
 			middleware.WriteError(w, r, http.StatusNotFound, "Ese control no existe.")
 		case errors.Is(err, controls.ErrAnalyzerRefused):
-			h.Log.Warn("controls: worker refused scan", "control", id, "error", err)
-			flash.Set(w, h.secureCookie, refusedFlash(
-				"El motor de lectura rechazó el escaneo.",
-				err,
-				"Revisa que la impresión y el escaneo estén completos y no cortados en los bordes.",
-			))
+			// Only threshold validation reaches this branch on the sync
+			// side — the actual worker call lives on the async job now.
+			h.Log.Warn("controls: upload rejected", "control", id, "error", err)
+			flash.Set(w, h.secureCookie,
+				"Los umbrales deben cumplir 0 < inseguro < marcado < 1.")
 			http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
-		case errors.Is(err, controls.ErrAnalyzerUnavailable):
-			h.Log.Error("controls: worker unreachable", "control", id, "error", err)
-			middleware.WriteError(w, r, http.StatusInternalServerError,
-				"El motor de lectura no está disponible. Vuelve a intentarlo en unos minutos; si el problema persiste, avisa a infraestructura.")
 		default:
-			h.Log.Error("controls: upload failed", "control", id, "error", err)
+			h.Log.Error("controls: save uploaded batch failed", "control", id, "error", err)
 			middleware.WriteError(w, r, http.StatusInternalServerError,
-				"El servidor no pudo procesar el escaneo. Vuelve a intentarlo en unos minutos.")
+				"El servidor no pudo guardar el escaneo. Vuelve a intentarlo en unos minutos.")
 		}
 		return
 	}
-
+	payload, err := json.Marshal(controls.AnalysePayload{
+		BatchName: save.BatchName,
+		Ticked:    save.Ticked,
+		Unsure:    save.Unsure,
+	})
+	if err != nil {
+		h.Log.Error("controls: encode analyse payload", "control", id, "error", err)
+		middleware.WriteError(w, r, http.StatusInternalServerError,
+			"El servidor no pudo encolar el análisis.")
+		return
+	}
+	if _, err := h.Runner.Submit(r.Context(), id, jobs.KindAnalyse, payload); err != nil {
+		h.Log.Error("controls: submit analyse job", "control", id, "error", err)
+		middleware.WriteError(w, r, http.StatusInternalServerError,
+			"El servidor no pudo encolar el análisis.")
+		return
+	}
 	flash.Set(w, h.secureCookie,
-		fmt.Sprintf("Escaneo %d procesado (%d copias leídas).", result.BatchNumber, len(result.Report.Copies)))
+		fmt.Sprintf("Escaneo %d subido. Análisis encolado — refresca cuando el aviso cambie.", save.BatchNumber))
 	http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
 }
 
@@ -333,66 +344,6 @@ func parseFloatField(raw string, fallback float64) float64 {
 		return fallback
 	}
 	return v
-}
-
-// flashDetailMax caps the worker Detail excerpt embedded in the flash.
-// 500 chars fits a full "ERR: /work/…/scans/… scan not recognized" line
-// (~85 chars) with plenty of headroom, and keeps a runaway line from
-// blowing past the cookie payload the flash rides on (base64 of ~4 KiB
-// before the browser refuses it). The wrapped AnalyzerRefusedError keeps
-// the full Detail for a future consumer that needs it (issue #210).
-const flashDetailMax = 500
-
-// refusedFlash renders the flash for an ErrAnalyzerRefused branch:
-// verdict + (optional) worker Detail + hint. When the wrapped error
-// carries no usable detail — the detail was empty or only blank lines,
-// or the error is not an *AnalyzerRefusedError at all — the Detalle
-// clause is dropped and the verdict + hint stand on their own.
-//
-// Truncation keeps the FIRST non-empty line only, capped to flashDetailMax
-// runes; a truncation adds a trailing ellipsis. Callers own the verdict
-// and hint copy; this helper owns the shape.
-func refusedFlash(verdict string, err error, hint string) string {
-	detail := firstDetailLine(err)
-	if detail == "" {
-		return verdict + " " + hint
-	}
-	return verdict + " Detalle del motor: " + detail + ". " + hint
-}
-
-// firstDetailLine returns the first non-empty line of an
-// *AnalyzerRefusedError's Detail (trimmed), truncated to flashDetailMax
-// runes with a trailing ellipsis when it did not fit. Returns "" when
-// err does not carry a Detail — including when it is not an
-// *AnalyzerRefusedError.
-func firstDetailLine(err error) string {
-	var wrapped *controls.AnalyzerRefusedError
-	if !errors.As(err, &wrapped) || wrapped == nil {
-		return ""
-	}
-	for _, line := range strings.Split(wrapped.Detail, "\n") {
-		trimmed := strings.TrimSpace(line)
-		if trimmed == "" {
-			continue
-		}
-		return truncateRunes(trimmed, flashDetailMax)
-	}
-	return ""
-}
-
-// truncateRunes caps s to n runes, adding an ellipsis when it did not
-// fit. Rune-safe so a multi-byte character does not get cut mid-sequence.
-// n <= 0 returns the empty string — a caller asking for "no room" gets
-// nothing rather than a lone ellipsis (review-fix, WP-210).
-func truncateRunes(s string, n int) string {
-	if n <= 0 {
-		return ""
-	}
-	runes := []rune(s)
-	if len(runes) <= n {
-		return s
-	}
-	return string(runes[:n]) + "…"
 }
 
 // looksLikePDF is a defensive check the professor sees a nice message

--- a/apps/server/internal/app/web/handler/scans.go
+++ b/apps/server/internal/app/web/handler/scans.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 	"github.com/so77id/nalanda/apps/server/internal/app/web/flash"
 	"github.com/so77id/nalanda/apps/server/internal/app/web/middleware"
 	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
+	"github.com/so77id/nalanda/apps/server/internal/domain/jobs"
 )
 
 // ControlScansPath is POST target for the upload form on /controls/:id.
@@ -178,10 +180,13 @@ func (h *Controls) UploadScan(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
 }
 
-// ReanalyzeScans handles POST /controls/:id/reanalyze. Reads ticked/unsure
-// from the form (prefilled with the control's stored pair), asks the
-// Service to re-read the captured project at those thresholds, and
-// redirects to detail with a flash.
+// ReanalyzeScans handles POST /controls/:id/reanalyze. Reads
+// ticked/unsure from the form (prefilled with the control's stored
+// pair) and enqueues an async job for the runner (issue #249) rather
+// than blocking the HTTP request. The professor is redirected to the
+// detail page whose banner (Detail's JobBanner) surfaces the running
+// job and the eventual done/failed state — no 502 from a slow proxy
+// while the worker chews on the batch.
 func (h *Controls) ReanalyzeScans(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if !isValidControlID(id) {
@@ -212,41 +217,24 @@ func (h *Controls) ReanalyzeScans(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
 		return
 	}
-
-	// Issue #197: the re-read now also re-runs note and re-annotates every
-	// clean copy — minutes-class work, so the route claims its own write
-	// deadline like the upload does.
-	controller := http.NewResponseController(w)
-	if err := controller.SetWriteDeadline(time.Now().Add(uploadWriteWindow)); err != nil &&
-		!errors.Is(err, http.ErrNotSupported) {
-		h.Log.Warn("controls: cannot extend the reanalyze write deadline", "error", err)
+	payload, err := json.Marshal(controls.ReanalysePayload{Ticked: ticked, Unsure: unsure})
+	if err != nil {
+		// Encoding two float64s does not fail in practice; the log line
+		// is honest belt-and-braces so a change to the payload does not
+		// pass unnoticed.
+		h.Log.Error("reanalyze: encode payload", "control", id, "error", err)
+		middleware.WriteError(w, r, http.StatusInternalServerError,
+			"El servidor no pudo encolar el trabajo.")
+		return
 	}
-
-	if _, err := h.Service.Reanalyze(r.Context(), id, ticked, unsure); err != nil {
-		switch {
-		case errors.Is(err, controls.ErrControlNotFound):
-			middleware.WriteError(w, r, http.StatusNotFound, "Ese control no existe.")
-		case errors.Is(err, controls.ErrAnalyzerRefused):
-			h.Log.Warn("controls: worker refused reanalyze", "control", id, "error", err)
-			flash.Set(w, h.secureCookie, refusedFlash(
-				"El motor rechazó re-leer.",
-				err,
-				"Puede que aún no haya escaneos subidos.",
-			))
-			http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
-		case errors.Is(err, controls.ErrAnalyzerUnavailable):
-			h.Log.Error("controls: worker unreachable during reanalyze", "control", id, "error", err)
-			middleware.WriteError(w, r, http.StatusInternalServerError,
-				"El motor no está disponible. Vuelve a intentarlo en unos minutos.")
-		default:
-			h.Log.Error("controls: reanalyze failed", "control", id, "error", err)
-			middleware.WriteError(w, r, http.StatusInternalServerError,
-				"El servidor no pudo re-leer el lote.")
-		}
+	if _, err := h.Runner.Submit(r.Context(), id, jobs.KindReanalyse, payload); err != nil {
+		h.Log.Error("reanalyze: submit job", "control", id, "error", err)
+		middleware.WriteError(w, r, http.StatusInternalServerError,
+			"El servidor no pudo encolar el trabajo.")
 		return
 	}
 	flash.Set(w, h.secureCookie,
-		fmt.Sprintf("Lote re-leído (marcado: %.2f, inseguro: %.2f).", ticked, unsure))
+		fmt.Sprintf("Re-lectura encolada (marcado: %.2f, inseguro: %.2f). Refresca cuando el aviso cambie.", ticked, unsure))
 	http.Redirect(w, r, controlDetailURL(id), http.StatusSeeOther)
 }
 

--- a/apps/server/internal/app/web/handler/scans_test.go
+++ b/apps/server/internal/app/web/handler/scans_test.go
@@ -26,16 +26,20 @@ import (
 func (f *controlsFixture) createControl(t *testing.T, name string, copies int) string {
 	t.Helper()
 	ctx := context.Background()
-	c, err := f.service.Create(ctx, controls.CreateRequest{
+	req := controls.CreateRequest{
 		Name:             name,
 		RangeFrom:        bank.SectionRef{Document: "flujo", Section: "if-else"},
 		RangeTo:          bank.SectionRef{Document: "flujo", Section: "bucles"},
 		QuestionsPerCopy: 2,
 		Copies:           copies,
 		CreatedBy:        f.user.ID,
-	})
+	}
+	c, err := f.service.PrepareControl(ctx, req)
 	if err != nil {
-		t.Fatalf("Create: %v", err)
+		t.Fatalf("PrepareControl: %v", err)
+	}
+	if err := f.service.GenerateAssets(ctx, c.ID); err != nil {
+		t.Fatalf("GenerateAssets: %v", err)
 	}
 	return c.ID
 }

--- a/apps/server/internal/app/web/handler/scans_test.go
+++ b/apps/server/internal/app/web/handler/scans_test.go
@@ -111,6 +111,16 @@ func TestUploadScanCallsAnalyzerAndFlashesSuccess(t *testing.T) {
 	if got := rec.Header().Get("Location"); got != "/controls/"+controlID {
 		t.Errorf("Location = %q", got)
 	}
+	// The uploaded PDF landed on disk BEFORE the runner picks up —
+	// SaveUploadedBatch is sync.
+	uploads := filepath.Join(f.workDir, "controls", controlID, "uploads")
+	entries, _ := os.ReadDir(uploads)
+	if len(entries) != 1 || entries[0].Name() != "batch-1.pdf" {
+		t.Errorf("uploads dir = %v", entries)
+	}
+	// Wait for the analyse job to complete before asserting the async
+	// side effects (analyze + annotate).
+	f.waitLatestJobTerminal(t, controlID)
 	if count := f.fake.AnalyzeCallCount(); count != 1 {
 		t.Errorf("AnalyzeCallCount = %d, want 1", count)
 	}
@@ -118,13 +128,6 @@ func TestUploadScanCallsAnalyzerAndFlashesSuccess(t *testing.T) {
 	if !strings.HasPrefix(last.Project, "controls/") {
 		t.Errorf("Analyze project = %q, want prefix controls/", last.Project)
 	}
-	// The uploaded PDF landed on disk.
-	uploads := filepath.Join(f.workDir, "controls", controlID, "uploads")
-	entries, _ := os.ReadDir(uploads)
-	if len(entries) != 1 || entries[0].Name() != "batch-1.pdf" {
-		t.Errorf("uploads dir = %v", entries)
-	}
-
 	// Issue #190, ruta A: the one clean copy got its annotated PDF without
 	// any human touching the queue.
 	if count := f.fake.AnnotateCallCount(); count != 1 {
@@ -178,6 +181,7 @@ func TestUploadScanAnnotatesEveryCleanCopy(t *testing.T) {
 	if rec.Code != http.StatusSeeOther {
 		t.Fatalf("status = %d, want 303", rec.Code)
 	}
+	f.waitLatestJobTerminal(t, controlID)
 
 	if count := f.fake.AnnotateCallCount(); count != 2 {
 		t.Fatalf("AnnotateCallCount = %d, want 2 (copies 1 and 2 are ok)", count)
@@ -358,6 +362,7 @@ func TestUploadScanWithExplicitThresholds(t *testing.T) {
 	if rec.Code != http.StatusSeeOther {
 		t.Fatalf("status = %d\nbody: %s", rec.Code, rec.Body.String())
 	}
+	f.waitLatestJobTerminal(t, controlID)
 
 	last, _ := f.fake.LastAnalyzeCall()
 	if last.Ticked != 0.25 || last.Unsure != 0.10 {
@@ -454,14 +459,16 @@ func TestReanalyzeRefusesAnInvertedBand(t *testing.T) {
 	}
 }
 
-// Issue #210: when the worker refuses an upload with a detail, the flash
-// includes the first non-empty line of that detail so the professor sees
-// what the reader actually said without an SSH round trip. The hint about
-// print/scan borders covers the paper-size class from the 2026-08-19
-// incident without pretending to name a cause.
-func TestUploadScanRefusedFlashCarriesFirstLineOfDetail(t *testing.T) {
+// Since issue #249 the analyse path is async: the sync HTTP handler
+// only saves the batch to disk, and the worker call happens in the
+// runner. A refusal from the worker lands on the job row's error/detail
+// columns instead of the flash — the banner surfaces the short message,
+// the detail column holds the long stderr excerpt for a future debug
+// view. Same distinction refusedFlash used to draw between banner and
+// detail; the flash/hint copy no longer applies.
+func TestUploadScanRefusalRecordsMessageAndDetailOnTheJobRow(t *testing.T) {
 	f := newControlsFixture(t)
-	controlID := f.createControl(t, "Control 210 upload with detail", 1)
+	controlID := f.createControl(t, "Control 249 upload refusal detail", 1)
 	f.fake.AnalyzeErr = &controls.AnalyzerRefusedError{
 		Status: 400, Message: "scan not recognized",
 		Detail: "ERR: /work/controls/x/scans/0001.pdf scan not recognized\nERR: /work/controls/x/scans/0002.pdf scan not recognized",
@@ -476,35 +483,37 @@ func TestUploadScanRefusedFlashCarriesFirstLineOfDetail(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	f.handler.UploadScan(rec, req)
-
 	if rec.Code != http.StatusSeeOther {
-		t.Fatalf("status = %d, want 303 (flash + redirect back)", rec.Code)
+		t.Fatalf("status = %d, want 303", rec.Code)
 	}
-	flash := readFlash(t, rec)
-	if !strings.Contains(flash, "rechazó el escaneo") {
-		t.Errorf("flash %q does not name the refusal", flash)
+	job := f.waitLatestJobTerminal(t, controlID)
+	if job.Status != jobs.StatusFailed {
+		t.Fatalf("job status = %q, want failed", job.Status)
 	}
-	if !strings.Contains(flash, "ERR: /work/controls/x/scans/0001.pdf scan not recognized") {
-		t.Errorf("flash %q does not include the worker's first stderr line", flash)
+	if !strings.Contains(job.Error, "scan not recognized") {
+		t.Errorf("job.Error = %q, want the AnalyzerRefusedError.Message", job.Error)
 	}
-	if strings.Contains(flash, "0002.pdf") {
-		t.Errorf("flash %q leaks a second line — the flash must show only the first", flash)
+	if !strings.Contains(job.Detail, "0001.pdf scan not recognized") {
+		t.Errorf("job.Detail = %q, want the AMC stderr excerpt", job.Detail)
 	}
-	if !strings.Contains(flash, "impresión y el escaneo") {
-		t.Errorf("flash %q dropped the print/scan hint", flash)
+	// The job row keeps the full detail (multi-line): the flash cookie's
+	// old 500-char truncation was a payload constraint on the cookie,
+	// not on the DB.
+	if !strings.Contains(job.Detail, "0002.pdf") {
+		t.Errorf("job.Detail = %q, want the full multi-line context (not truncated)", job.Detail)
 	}
 }
 
-// When the worker refuses without carrying a detail (an old worker, a
-// non-envelope 4xx), the flash falls back to the fixed hint. The professor
-// still knows what to do next; the log carries whatever context there is.
-func TestUploadScanRefusedFlashFallsBackWhenDetailEmpty(t *testing.T) {
+// A refusal that carries no detail still records the short message —
+// callers that composed a hint on the sync flash path can no longer
+// piggy-back on the same channel; the hint is now in the flash's
+// "Análisis encolado — refresca…" copy instead.
+func TestUploadScanRefusalWithoutDetailStillRecordsTheShortMessage(t *testing.T) {
 	f := newControlsFixture(t)
-	controlID := f.createControl(t, "Control 210 upload no detail", 1)
+	controlID := f.createControl(t, "Control 249 upload refusal no detail", 1)
 	f.fake.AnalyzeErr = &controls.AnalyzerRefusedError{
 		Status: 400, Message: "bad request",
 	}
-
 	body, ct := buildScanUpload(t, "batch.pdf", "application/pdf", []byte("%PDF-fake"))
 	req := f.authedRequest(t, http.MethodPost, "/controls/"+controlID+"/scans", nil)
 	req.Body = io.NopCloser(body)
@@ -514,51 +523,18 @@ func TestUploadScanRefusedFlashFallsBackWhenDetailEmpty(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	f.handler.UploadScan(rec, req)
-
 	if rec.Code != http.StatusSeeOther {
 		t.Fatalf("status = %d, want 303", rec.Code)
 	}
-	flash := readFlash(t, rec)
-	if !strings.Contains(flash, "rechazó el escaneo") {
-		t.Errorf("flash %q does not name the refusal", flash)
+	job := f.waitLatestJobTerminal(t, controlID)
+	if job.Status != jobs.StatusFailed {
+		t.Fatalf("job status = %q, want failed", job.Status)
 	}
-	if strings.Contains(flash, "Detalle del motor") {
-		t.Errorf("flash %q renders a Detalle clause with no detail available", flash)
+	if !strings.Contains(job.Error, "bad request") {
+		t.Errorf("job.Error = %q, want the short refusal message", job.Error)
 	}
-	if !strings.Contains(flash, "impresión y el escaneo") {
-		t.Errorf("flash %q dropped the print/scan hint", flash)
-	}
-}
-
-// A refusal whose Detail is only blank lines behaves like an empty detail.
-// The truncation of a very long line adds an ellipsis at the 500-char cap.
-func TestUploadScanRefusedFlashSkipsBlankLinesAndTruncatesLongOnes(t *testing.T) {
-	f := newControlsFixture(t)
-	controlID := f.createControl(t, "Control 210 truncation", 1)
-	long := strings.Repeat("A", 800)
-	f.fake.AnalyzeErr = &controls.AnalyzerRefusedError{
-		Status: 400,
-		Detail: "\n\n   \n" + long,
-	}
-	body, ct := buildScanUpload(t, "batch.pdf", "application/pdf", []byte("%PDF-fake"))
-	req := f.authedRequest(t, http.MethodPost, "/controls/"+controlID+"/scans", nil)
-	req.Body = io.NopCloser(body)
-	req.Header.Set("Content-Type", ct)
-	req.ContentLength = int64(body.Len())
-	req.SetPathValue("id", controlID)
-	rec := httptest.NewRecorder()
-	f.handler.UploadScan(rec, req)
-
-	if rec.Code != http.StatusSeeOther {
-		t.Fatalf("status = %d, want 303", rec.Code)
-	}
-	flash := readFlash(t, rec)
-	// 500 As followed by an ellipsis rune, then the rest of the message.
-	if !strings.Contains(flash, strings.Repeat("A", 500)+"…") {
-		t.Errorf("flash %q did not truncate the long line at 500 chars with an ellipsis", flash)
-	}
-	if strings.Contains(flash, strings.Repeat("A", 501)) {
-		t.Errorf("flash %q kept more than 500 As — truncation did not apply", flash)
+	if job.Detail != "" {
+		t.Errorf("job.Detail = %q, want empty when the refusal carries no detail", job.Detail)
 	}
 }
 

--- a/apps/server/internal/app/web/handler/scans_test.go
+++ b/apps/server/internal/app/web/handler/scans_test.go
@@ -13,9 +13,11 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
 	"github.com/so77id/nalanda/apps/server/internal/domain/course/bank"
+	"github.com/so77id/nalanda/apps/server/internal/domain/jobs"
 )
 
 // createControl runs the domain Service to make a real control with N
@@ -378,7 +380,9 @@ func TestUploadScanWithExplicitThresholds(t *testing.T) {
 }
 
 // The re-read persists the pair it used and re-annotates the copies the
-// new reading accepts (ruta A over the new report).
+// new reading accepts (ruta A over the new report). Since issue #249
+// the HTTP handler enqueues an async job; the assertions run AFTER the
+// runner has consumed the row.
 func TestReanalyzePersistsThresholdsAndReannotates(t *testing.T) {
 	f := newControlsFixture(t)
 	controlID := f.createControl(t, "Control re", 1)
@@ -399,6 +403,12 @@ func TestReanalyzePersistsThresholdsAndReannotates(t *testing.T) {
 
 	if rec.Code != http.StatusSeeOther {
 		t.Fatalf("status = %d\nbody: %s", rec.Code, rec.Body.String())
+	}
+	// Wait for the async job to complete, then verify the persisted
+	// state matches the sync-path contract from before #249.
+	job := f.waitLatestJobTerminal(t, controlID)
+	if job.Status != jobs.StatusDone {
+		t.Fatalf("job status = %q (error %q), want done", job.Status, job.Error)
 	}
 	got, err := f.service.Get(context.Background(), controlID)
 	if err != nil {
@@ -552,11 +562,15 @@ func TestUploadScanRefusedFlashSkipsBlankLinesAndTruncatesLongOnes(t *testing.T)
 	}
 }
 
-// The reanalyze branch mirrors upload: detail flows through, fallback
-// keeps the "no captures yet" hint that was there before #210.
-func TestReanalyzeRefusedFlashCarriesFirstLineOfDetail(t *testing.T) {
+// Since issue #249 the reanalyze path is async: the professor no longer
+// sees a flash carrying the worker refusal, because the HTTP handler
+// returns before the worker is even called. The refusal lands on the
+// job row instead — job.error carries the short message the banner
+// renders, job.detail carries the long AMC context for a future debug
+// view. Same shape refusedFlash used to build for the flash cookie.
+func TestReanalyzeRefusalRecordsMessageAndDetailOnTheJobRow(t *testing.T) {
 	f := newControlsFixture(t)
-	controlID := f.createControl(t, "Control 210 reanalyze", 1)
+	controlID := f.createControl(t, "Control 249 reanalyze refusal", 1)
 	f.fake.AnalyzeReports = []controls.Report{
 		{Copies: map[string]controls.ReportCopy{"1": okCopy("20100001")}},
 	}
@@ -575,18 +589,18 @@ func TestReanalyzeRefusedFlashCarriesFirstLineOfDetail(t *testing.T) {
 	if rec.Code != http.StatusSeeOther {
 		t.Fatalf("status = %d, want 303", rec.Code)
 	}
-	flash := readFlash(t, rec)
-	if !strings.Contains(flash, "rechazó re-leer") {
-		t.Errorf("flash %q does not name the reanalyze refusal", flash)
+	job := f.waitLatestJobTerminal(t, controlID)
+	if job.Status != jobs.StatusFailed {
+		t.Fatalf("job status = %q, want failed", job.Status)
 	}
-	if !strings.Contains(flash, "nothing to re-read on /work/controls/y") {
-		t.Errorf("flash %q does not include the worker's first stderr line", flash)
+	if !strings.Contains(job.Error, "no captures") {
+		t.Errorf("job.Error = %q, want the AnalyzerRefusedError.Message", job.Error)
 	}
-	if strings.Contains(flash, "second line") {
-		t.Errorf("flash %q leaks a second line", flash)
+	if !strings.Contains(job.Detail, "nothing to re-read on /work/controls/y") {
+		t.Errorf("job.Detail = %q, want the AnalyzerRefusedError.Detail", job.Detail)
 	}
-	if !strings.Contains(flash, "escaneos subidos") {
-		t.Errorf("flash %q dropped the no-captures hint", flash)
+	if !strings.Contains(job.Detail, "second line") {
+		t.Errorf("job.Detail = %q, want the full multi-line detail (not truncated on the row)", job.Detail)
 	}
 }
 
@@ -706,5 +720,207 @@ func TestDetailShowsNoUploadSectionWhenNothingWasUploaded(t *testing.T) {
 	}
 	if strings.Contains(rec.Body.String(), "Lotes subidos") {
 		t.Error("detail page shows the upload section with no batches on disk")
+	}
+}
+
+// The Reanalyze handler enqueues a job and redirects immediately; the
+// runner processes it in the background. Since #249 the ACs demand the
+// HTTP round trip stays fast even when the underlying operation would
+// have been minutes-class.
+func TestReanalyzeReturns303ImmediatelyAndCreatesAJobRow(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control 249 fast enqueue", 1)
+	f.fake.AnalyzeReports = []controls.Report{
+		{Copies: map[string]controls.ReportCopy{"1": okCopy("20100001")}},
+	}
+	uploadOnce(t, f, controlID)
+
+	// A reanalyze whose worker call would normally take a while — the
+	// fake's report list is deliberately empty here, so the sync path
+	// would have blocked at the worker; the async path returns first.
+	f.fake.ReanalyzeReports = []controls.Report{
+		{Copies: map[string]controls.ReportCopy{"1": okCopy("20100001")}},
+	}
+	values := url.Values{"ticked": {"0.30"}, "unsure": {"0.10"}}
+	req := f.authedRequest(t, http.MethodPost, "/controls/"+controlID+"/reanalyze", values)
+	req.SetPathValue("id", controlID)
+	rec := httptest.NewRecorder()
+	f.handler.ReanalyzeScans(rec, req)
+
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303 (async enqueue redirects)", rec.Code)
+	}
+	// A row exists on the store IMMEDIATELY — the runner may or may
+	// not have picked it up yet, but the job is committed.
+	latest, err := f.jstore.LatestForControl(context.Background(), controlID)
+	if err != nil {
+		t.Fatalf("LatestForControl right after Submit: %v", err)
+	}
+	if latest.Kind != jobs.KindReanalyse {
+		t.Errorf("latest job Kind = %q, want reanalyse", latest.Kind)
+	}
+	// Wait for the runner to consume it — success proves the whole
+	// enqueue → dispatch → persist chain.
+	done := f.waitLatestJobTerminal(t, controlID)
+	if done.Status != jobs.StatusDone {
+		t.Errorf("job final status = %q, want done", done.Status)
+	}
+}
+
+// Two /reanalyze POSTs in quick succession produce two rows on the
+// store. The runner's single goroutine serialises them (S6 AC:
+// "resultan en dos jobs — el segundo espera al primero"); the callers'
+// HTTP requests each get their 303 without waiting for the AMC work.
+func TestTwoConcurrentReanalyzesProduceTwoJobs(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control 249 concurrent", 1)
+	f.fake.AnalyzeReports = []controls.Report{
+		{Copies: map[string]controls.ReportCopy{"1": okCopy("20100001")}},
+	}
+	uploadOnce(t, f, controlID)
+
+	f.fake.ReanalyzeReports = []controls.Report{
+		{Copies: map[string]controls.ReportCopy{"1": okCopy("20100001")}},
+		{Copies: map[string]controls.ReportCopy{"1": okCopy("20100001")}},
+	}
+	postReanalyze := func(ticked string) {
+		values := url.Values{"ticked": {ticked}, "unsure": {"0.05"}}
+		req := f.authedRequest(t, http.MethodPost, "/controls/"+controlID+"/reanalyze", values)
+		req.SetPathValue("id", controlID)
+		rec := httptest.NewRecorder()
+		f.handler.ReanalyzeScans(rec, req)
+		if rec.Code != http.StatusSeeOther {
+			t.Fatalf("status = %d, want 303", rec.Code)
+		}
+	}
+	postReanalyze("0.20")
+	postReanalyze("0.30")
+
+	// Wait for BOTH to reach terminal — the second's completion means
+	// the runner already finished the first.
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		ids, err := f.jstoreQueuedAndTerminalCount(context.Background(), controlID)
+		if err != nil {
+			t.Fatalf("counting jobs: %v", err)
+		}
+		if ids.terminal == 2 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("jobs after 3s: queued=%d running=%d terminal=%d (want terminal=2)",
+				ids.queued, ids.running, ids.terminal)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// The Detail page renders the JobBanner section when the latest job is
+// running or queued. Since the handler tests start the runner, the job
+// might have already finished — the banner then renders the done
+// branch instead. Either way, the section is present.
+func TestDetailRendersTheJobBannerAfterAReanalyzeIsEnqueued(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control 249 banner", 1)
+	f.fake.AnalyzeReports = []controls.Report{
+		{Copies: map[string]controls.ReportCopy{"1": okCopy("20100001")}},
+	}
+	uploadOnce(t, f, controlID)
+	f.fake.ReanalyzeReports = []controls.Report{
+		{Copies: map[string]controls.ReportCopy{"1": okCopy("20100001")}},
+	}
+
+	values := url.Values{"ticked": {"0.30"}, "unsure": {"0.10"}}
+	req := f.authedRequest(t, http.MethodPost, "/controls/"+controlID+"/reanalyze", values)
+	req.SetPathValue("id", controlID)
+	rec := httptest.NewRecorder()
+	f.handler.ReanalyzeScans(rec, req)
+	if rec.Code != http.StatusSeeOther {
+		t.Fatalf("submit status = %d, want 303", rec.Code)
+	}
+
+	// Ask Detail to render — capture whatever state the runner is in.
+	detailReq := f.authedRequest(t, http.MethodGet, "/controls/"+controlID, nil)
+	detailReq.SetPathValue("id", controlID)
+	detailRec := httptest.NewRecorder()
+	f.handler.Detail(detailRec, detailReq)
+	if detailRec.Code != http.StatusOK {
+		t.Fatalf("detail status = %d", detailRec.Code)
+	}
+	body := detailRec.Body.String()
+	// One of three variants must be present. "re-lectura" is the
+	// Spanish spanishKind() label the template renders verbatim.
+	if !strings.Contains(body, "re-lectura") {
+		t.Errorf("detail page missing the reanalyse banner (looked for 're-lectura'):\n%s", body)
+	}
+	// The dismiss form is always present on the banner.
+	if !strings.Contains(body, "/jobs/") || !strings.Contains(body, "/dismiss") {
+		t.Errorf("detail page missing the dismiss form:\n%s", body)
+	}
+}
+
+// DismissJob stamps viewed_at and redirects back to the control's
+// detail. A subsequent Detail render omits the banner.
+func TestDismissJobStampsViewedAtAndRedirects(t *testing.T) {
+	f := newControlsFixture(t)
+	controlID := f.createControl(t, "Control 249 dismiss", 1)
+	f.fake.AnalyzeReports = []controls.Report{
+		{Copies: map[string]controls.ReportCopy{"1": okCopy("20100001")}},
+	}
+	uploadOnce(t, f, controlID)
+	f.fake.ReanalyzeReports = []controls.Report{
+		{Copies: map[string]controls.ReportCopy{"1": okCopy("20100001")}},
+	}
+
+	values := url.Values{"ticked": {"0.30"}, "unsure": {"0.10"}}
+	req := f.authedRequest(t, http.MethodPost, "/controls/"+controlID+"/reanalyze", values)
+	req.SetPathValue("id", controlID)
+	rec := httptest.NewRecorder()
+	f.handler.ReanalyzeScans(rec, req)
+
+	job := f.waitLatestJobTerminal(t, controlID)
+
+	dismissPath := fmt.Sprintf("/jobs/%d/dismiss", job.ID)
+	dismissReq := f.authedRequest(t, http.MethodPost, dismissPath, nil)
+	dismissReq.SetPathValue("id", fmt.Sprintf("%d", job.ID))
+	dismissRec := httptest.NewRecorder()
+	f.handler.DismissJob(dismissRec, dismissReq)
+	if dismissRec.Code != http.StatusSeeOther {
+		t.Fatalf("dismiss status = %d, want 303", dismissRec.Code)
+	}
+	if got := dismissRec.Header().Get("Location"); got != "/controls/"+controlID {
+		t.Errorf("dismiss Location = %q, want /controls/%s", got, controlID)
+	}
+	after, err := f.jstore.ByID(context.Background(), job.ID)
+	if err != nil {
+		t.Fatalf("ByID: %v", err)
+	}
+	if after.ViewedAt == nil {
+		t.Errorf("job.ViewedAt is nil after dismiss, want a timestamp")
+	}
+	// The next Detail render omits the banner because the terminal
+	// job has been dismissed.
+	detailReq := f.authedRequest(t, http.MethodGet, "/controls/"+controlID, nil)
+	detailReq.SetPathValue("id", controlID)
+	detailRec := httptest.NewRecorder()
+	f.handler.Detail(detailRec, detailReq)
+	body := detailRec.Body.String()
+	if strings.Contains(body, "re-lectura lista") ||
+		strings.Contains(body, "Procesando re-lectura") {
+		t.Errorf("banner still visible after dismiss:\n%s", body)
+	}
+}
+
+// DismissJob answers 404 for a job id that does not exist. The path is
+// URL-driven and public-ish (any professor can dismiss any job), so an
+// invalid id must not 500.
+func TestDismissJobAnswers404ForAnUnknownID(t *testing.T) {
+	f := newControlsFixture(t)
+	req := f.authedRequest(t, http.MethodPost, "/jobs/999999/dismiss", nil)
+	req.SetPathValue("id", "999999")
+	rec := httptest.NewRecorder()
+	f.handler.DismissJob(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 for a missing job id", rec.Code)
 	}
 }

--- a/apps/server/internal/app/web/router.go
+++ b/apps/server/internal/app/web/router.go
@@ -251,7 +251,7 @@ func routes(deps Deps) []Route {
 			Method: http.MethodPost, Path: handler.AdminBankRefreshPath,
 			Handler: deps.AdminBank.Refresh,
 		},
-		// Issue #249: the "Refrescar / Reintentar" button on the async
+		// Issue #249: the "Refrescar" / "Cerrar aviso" button on the async
 		// job banner. Gated by default (no Public), CSRF enforced
 		// because the method is POST.
 		{

--- a/apps/server/internal/app/web/router.go
+++ b/apps/server/internal/app/web/router.go
@@ -251,6 +251,13 @@ func routes(deps Deps) []Route {
 			Method: http.MethodPost, Path: handler.AdminBankRefreshPath,
 			Handler: deps.AdminBank.Refresh,
 		},
+		// Issue #249: the "Refrescar / Reintentar" button on the async
+		// job banner. Gated by default (no Public), CSRF enforced
+		// because the method is POST.
+		{
+			Method: http.MethodPost, Path: handler.JobDismissPath,
+			Handler: deps.Controls.DismissJob,
+		},
 	}
 }
 

--- a/apps/server/internal/app/web/router_test.go
+++ b/apps/server/internal/app/web/router_test.go
@@ -109,6 +109,7 @@ func deps(t *testing.T, prober health.Prober) web.Deps {
 			runner := jobs.NewRunner(jstore, jobs.Handlers{
 				jobs.KindReanalyse: controls.NewReanalyseHandler(svc),
 				jobs.KindAnalyse:   controls.NewAnalyseHandler(svc),
+				jobs.KindGenerate:  controls.NewGenerateHandler(svc),
 			}, logger, time.Now)
 			return handler.NewControls(handler.Controls{
 				Service:            svc,

--- a/apps/server/internal/app/web/router_test.go
+++ b/apps/server/internal/app/web/router_test.go
@@ -110,6 +110,7 @@ func deps(t *testing.T, prober health.Prober) web.Deps {
 				jobs.KindReanalyse: controls.NewReanalyseHandler(svc),
 				jobs.KindAnalyse:   controls.NewAnalyseHandler(svc),
 				jobs.KindGenerate:  controls.NewGenerateHandler(svc),
+				jobs.KindAnnotate:  controls.NewAnnotateHandler(svc),
 			}, logger, time.Now)
 			return handler.NewControls(handler.Controls{
 				Service:            svc,

--- a/apps/server/internal/app/web/router_test.go
+++ b/apps/server/internal/app/web/router_test.go
@@ -108,6 +108,7 @@ func deps(t *testing.T, prober health.Prober) web.Deps {
 			jstore := jobstore.New(db)
 			runner := jobs.NewRunner(jstore, jobs.Handlers{
 				jobs.KindReanalyse: controls.NewReanalyseHandler(svc),
+				jobs.KindAnalyse:   controls.NewAnalyseHandler(svc),
 			}, logger, time.Now)
 			return handler.NewControls(handler.Controls{
 				Service:            svc,

--- a/apps/server/internal/app/web/router_test.go
+++ b/apps/server/internal/app/web/router_test.go
@@ -20,11 +20,13 @@ import (
 	"github.com/so77id/nalanda/apps/server/internal/domain/controls"
 	"github.com/so77id/nalanda/apps/server/internal/domain/course/bank"
 	"github.com/so77id/nalanda/apps/server/internal/domain/health"
+	"github.com/so77id/nalanda/apps/server/internal/domain/jobs"
 	"github.com/so77id/nalanda/apps/server/internal/infra/amcworker/amctest"
 	"github.com/so77id/nalanda/apps/server/internal/infra/oidc/oidctest"
 	"github.com/so77id/nalanda/apps/server/internal/infra/storage"
 	"github.com/so77id/nalanda/apps/server/internal/infra/storage/authstore"
 	"github.com/so77id/nalanda/apps/server/internal/infra/storage/controlstore"
+	"github.com/so77id/nalanda/apps/server/internal/infra/storage/jobstore"
 	"github.com/so77id/nalanda/apps/server/migrations"
 )
 
@@ -87,29 +89,36 @@ func deps(t *testing.T, prober health.Prober) web.Deps {
 			PublicURL: "https://nalanda.test",
 			Log:       logger,
 		}),
-		Controls: handler.NewControls(handler.Controls{
-			Service: func() *controls.Service {
-				cstore := controlstore.New(db)
-				fake := &amctest.Fake{}
-				return controls.NewService(controls.Service{
-					Bank:            emptyBank(t),
-					Store:           cstore,
-					Generator:       fake,
-					Analyzer:        fake,
-					Readings:        cstore,
-					Annotator:       fake,
-					AnnotateEnabled: true,
-					WorkDir:         t.TempDir(),
-					Now:             time.Now,
-					Seed:            1,
-					Log:             logger,
-				})
-			}(),
-			Bank:               emptyBank(t),
-			PublicURL:          "https://nalanda.test",
-			OnCorrectionClosed: controls.NewNoopHook(logger),
-			Log:                logger,
-		}),
+		Controls: func() *handler.Controls {
+			cstore := controlstore.New(db)
+			fake := &amctest.Fake{}
+			svc := controls.NewService(controls.Service{
+				Bank:            emptyBank(t),
+				Store:           cstore,
+				Generator:       fake,
+				Analyzer:        fake,
+				Readings:        cstore,
+				Annotator:       fake,
+				AnnotateEnabled: true,
+				WorkDir:         t.TempDir(),
+				Now:             time.Now,
+				Seed:            1,
+				Log:             logger,
+			})
+			jstore := jobstore.New(db)
+			runner := jobs.NewRunner(jstore, jobs.Handlers{
+				jobs.KindReanalyse: controls.NewReanalyseHandler(svc),
+			}, logger, time.Now)
+			return handler.NewControls(handler.Controls{
+				Service:            svc,
+				Bank:               emptyBank(t),
+				PublicURL:          "https://nalanda.test",
+				OnCorrectionClosed: controls.NewNoopHook(logger),
+				Jobs:               jstore,
+				Runner:             runner,
+				Log:                logger,
+			})
+		}(),
 		AdminBank: handler.NewAdminBank(handler.AdminBank{
 			Bank:      emptyBank(t),
 			PublicURL: "https://nalanda.test",

--- a/apps/server/internal/app/web/view/templates/pages/controls_detail.html
+++ b/apps/server/internal/app/web/view/templates/pages/controls_detail.html
@@ -1,6 +1,30 @@
 {{ define "content" }}
   <h1>{{ .Control.Name }}</h1>
 
+  {{ with .JobBanner }}
+    <section class="aviso" style="margin-bottom:1em">
+      {{ if .Running }}
+        <p><strong>Procesando {{ .Kind }}…</strong> ({{ .StartedAgo }}). Refrescá la página cuando el aviso cambie.</p>
+        <form method="post" action="{{ .DismissURL }}" style="display:inline">
+          <input type="hidden" name="csrf_token" value="{{ $.CSRFToken }}">
+          <button type="submit">Refrescar</button>
+        </form>
+      {{ else if .Done }}
+        <p><strong>{{ .Kind | printf "%s" }} lista.</strong></p>
+        <form method="post" action="{{ .DismissURL }}" style="display:inline">
+          <input type="hidden" name="csrf_token" value="{{ $.CSRFToken }}">
+          <button type="submit">Refrescar</button>
+        </form>
+      {{ else if .Failed }}
+        <p><strong>{{ .Kind | printf "%s" }} falló:</strong> {{ .Error }}</p>
+        <form method="post" action="{{ .DismissURL }}" style="display:inline">
+          <input type="hidden" name="csrf_token" value="{{ $.CSRFToken }}">
+          <button type="submit">Cerrar aviso</button>
+        </form>
+      {{ end }}
+    </section>
+  {{ end }}
+
   <section>
     <h2>Datos</h2>
     <table class="lista">

--- a/apps/server/internal/app/web/view/view.go
+++ b/apps/server/internal/app/web/view/view.go
@@ -267,12 +267,14 @@ type ControlDetailPage struct {
 	Stats *stats.Statistics
 
 	// JobBanner, when non-nil, renders the async job runner's status
-	// on the detail page: "Analizando… reanalyse (iniciado hace 15 s).
-	// Refrescá cuando termine." for a running job, or "Análisis listo /
-	// falló — [Refrescar / Reintentar]" for a done/failed job the
-	// professor has not dismissed yet. Nil hides the banner entirely
-	// (issue #249). The runner drives the state — this struct only
-	// carries what the template needs to render one iteration.
+	// on the detail page: "Procesando re-lectura… (hace 15 s). Refrescá
+	// la página cuando el aviso cambie." for a running job,
+	// "re-lectura lista." for a done job, or "re-lectura falló: …" for
+	// a failed one. Every branch shows a "Refrescar" (running / done)
+	// or "Cerrar aviso" (failed) button that POSTs to
+	// /jobs/{JobID}/dismiss. Nil hides the banner entirely (issue
+	// #249). The runner drives the state — this struct only carries
+	// what the template needs to render one iteration.
 	JobBanner *JobBanner
 }
 
@@ -282,10 +284,11 @@ type ControlDetailPage struct {
 type JobBanner struct {
 	JobID int64
 	// Kind is the Spanish label ("re-lectura", "análisis", "generación",
-	// "anotado") — the template renders it verbatim.
+	// "anotado") — the template renders it verbatim inside
+	// "Procesando {Kind}…".
 	Kind string
 	// Running is true while the runner is still working on the job.
-	// The template shows the "Analizando…" line with StartedAgo.
+	// The template shows the "Procesando {Kind}…" line with StartedAgo.
 	Running bool
 	// Done is true when the job finished successfully AND has not yet
 	// been dismissed. Failed = true is the failure branch.
@@ -297,9 +300,10 @@ type JobBanner struct {
 	// Error is the AnalyzerRefusedError.Message (or another short
 	// summary) the runner recorded. Only populated when Failed.
 	Error string
-	// DismissURL is POST /jobs/{id}/dismiss — the "Refrescar" and
-	// "Reintentar" button both target it (Reintentar posts and then
-	// the professor re-submits the operation from the usual form).
+	// DismissURL is POST /jobs/{id}/dismiss — the "Refrescar" (running /
+	// done) and "Cerrar aviso" (failed) button both target it. The
+	// professor re-submits the operation from the usual form after
+	// dismissing.
 	DismissURL string
 }
 

--- a/apps/server/internal/app/web/view/view.go
+++ b/apps/server/internal/app/web/view/view.go
@@ -265,6 +265,42 @@ type ControlDetailPage struct {
 	// with State != Graded (or a Graded control with N = 0) shows no
 	// panel at all rather than a "no hay datos" empty state.
 	Stats *stats.Statistics
+
+	// JobBanner, when non-nil, renders the async job runner's status
+	// on the detail page: "Analizando… reanalyse (iniciado hace 15 s).
+	// Refrescá cuando termine." for a running job, or "Análisis listo /
+	// falló — [Refrescar / Reintentar]" for a done/failed job the
+	// professor has not dismissed yet. Nil hides the banner entirely
+	// (issue #249). The runner drives the state — this struct only
+	// carries what the template needs to render one iteration.
+	JobBanner *JobBanner
+}
+
+// JobBanner is the summary of a control's most recent async job for the
+// detail page (issue #249). Composed by the handler from the latest
+// jobs.Job row — the template does no time arithmetic.
+type JobBanner struct {
+	JobID int64
+	// Kind is the Spanish label ("re-lectura", "análisis", "generación",
+	// "anotado") — the template renders it verbatim.
+	Kind string
+	// Running is true while the runner is still working on the job.
+	// The template shows the "Analizando…" line with StartedAgo.
+	Running bool
+	// Done is true when the job finished successfully AND has not yet
+	// been dismissed. Failed = true is the failure branch.
+	Done   bool
+	Failed bool
+	// StartedAgo is the human phrase for "hace 15 s" / "hace 2 min",
+	// rendered while Running.
+	StartedAgo string
+	// Error is the AnalyzerRefusedError.Message (or another short
+	// summary) the runner recorded. Only populated when Failed.
+	Error string
+	// DismissURL is POST /jobs/{id}/dismiss — the "Refrescar" and
+	// "Reintentar" button both target it (Reintentar posts and then
+	// the professor re-submits the operation from the usual form).
+	DismissURL string
 }
 
 // ReadingRow is one row of the results table. Everything is pre-formatted

--- a/apps/server/internal/domain/controls/controls.go
+++ b/apps/server/internal/domain/controls/controls.go
@@ -85,8 +85,8 @@ const (
 	// the professor explicitly asks for it under "Opciones avanzadas".
 	PaperA4 Paper = "a4"
 	// DefaultPaper is what the create form initialises Paper to, what the
-	// migration sets NULL rows to, and what Service.Create writes on any
-	// call that omits the field.
+	// migration sets NULL rows to, and what Service.PrepareControl
+	// writes on any call that omits the field.
 	DefaultPaper = PaperLetter
 )
 

--- a/apps/server/internal/domain/controls/jobhandlers.go
+++ b/apps/server/internal/domain/controls/jobhandlers.go
@@ -38,6 +38,13 @@ type AnalysePayload struct {
 	Unsure    float64 `json:"unsure"`
 }
 
+// GeneratePayload is what the POST /controls handler serialises before
+// Submit (issue #249, S5). Empty: the async GenerateAssets reads the
+// control row for Copies + the derived paths, so nothing needs to
+// ride on the payload. Kept as a named type so a future addition
+// (e.g. a per-run seed) has a home.
+type GeneratePayload struct{}
+
 // NewReanalyseHandler returns the jobs.Handler for KindReanalyse.
 // controlID comes from the job row; payload is the JSON-marshalled
 // ReanalysePayload the HTTP handler produced.
@@ -80,6 +87,43 @@ func NewAnalyseHandler(svc *Service) jobs.Handler {
 		}
 		return nil
 	}
+}
+
+// NewGenerateHandler returns the jobs.Handler for KindGenerate (issue
+// #249, S5). Payload is empty — the async GenerateAssets reads the
+// control row for what it needs.
+func NewGenerateHandler(svc *Service) jobs.Handler {
+	if svc == nil {
+		panic("controls.NewGenerateHandler: no service")
+	}
+	return func(ctx context.Context, controlID string, _ []byte) error {
+		if err := svc.GenerateAssets(ctx, controlID); err != nil {
+			return failureFromGenerateError(err)
+		}
+		return nil
+	}
+}
+
+// failureFromGenerateError translates a Service.GenerateAssets error
+// into the (banner, debug) pair. Same split shape as
+// failureFromAnalyzeError; kept separate because the sentinel set is
+// different (ErrGeneratorRefused / ErrGeneratorUnavailable /
+// ErrSujetMissing).
+func failureFromGenerateError(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, ErrControlNotFound):
+		return &jobs.Failure{Message: "ese control ya no existe", Detail: err.Error()}
+	case errors.Is(err, ErrGeneratorRefused):
+		return &jobs.Failure{Message: "el motor rechazó la generación", Detail: err.Error()}
+	case errors.Is(err, ErrGeneratorUnavailable):
+		return &jobs.Failure{Message: "el motor no está disponible", Detail: err.Error()}
+	case errors.Is(err, ErrSujetMissing):
+		return &jobs.Failure{Message: "la generación no produjo un sujet.pdf válido", Detail: err.Error()}
+	}
+	return &jobs.Failure{Message: err.Error(), Detail: ""}
 }
 
 // failureFromAnalyzeError translates a controls.Service error into the

--- a/apps/server/internal/domain/controls/jobhandlers.go
+++ b/apps/server/internal/domain/controls/jobhandlers.go
@@ -27,6 +27,17 @@ type ReanalysePayload struct {
 	Unsure float64 `json:"unsure"`
 }
 
+// AnalysePayload is what the /scans handler serialises before Submit
+// (issue #249, S4). BatchName is the name of the uploaded PDF the
+// runner points AMC at; Ticked/Unsure are the thresholds the reader
+// runs at. The HTTP handler wrote the file to disk synchronously
+// before enqueuing — SaveUploadedBatch returns these three values.
+type AnalysePayload struct {
+	BatchName string  `json:"batch_name"`
+	Ticked    float64 `json:"ticked"`
+	Unsure    float64 `json:"unsure"`
+}
+
 // NewReanalyseHandler returns the jobs.Handler for KindReanalyse.
 // controlID comes from the job row; payload is the JSON-marshalled
 // ReanalysePayload the HTTP handler produced.
@@ -43,6 +54,28 @@ func NewReanalyseHandler(svc *Service) jobs.Handler {
 			}
 		}
 		if _, err := svc.Reanalyze(ctx, controlID, p.Ticked, p.Unsure); err != nil {
+			return failureFromAnalyzeError(err)
+		}
+		return nil
+	}
+}
+
+// NewAnalyseHandler returns the jobs.Handler for KindAnalyse (issue
+// #249, S4). controlID comes from the job row; payload is the
+// JSON-marshalled AnalysePayload the HTTP handler produced.
+func NewAnalyseHandler(svc *Service) jobs.Handler {
+	if svc == nil {
+		panic("controls.NewAnalyseHandler: no service")
+	}
+	return func(ctx context.Context, controlID string, raw []byte) error {
+		var p AnalysePayload
+		if err := json.Unmarshal(raw, &p); err != nil {
+			return &jobs.Failure{
+				Message: "no se pudo leer el trabajo de análisis",
+				Detail:  fmt.Sprintf("unmarshal payload: %v", err),
+			}
+		}
+		if _, err := svc.AnalyzeBatch(ctx, controlID, p.BatchName, p.Ticked, p.Unsure); err != nil {
 			return failureFromAnalyzeError(err)
 		}
 		return nil

--- a/apps/server/internal/domain/controls/jobhandlers.go
+++ b/apps/server/internal/domain/controls/jobhandlers.go
@@ -1,0 +1,85 @@
+package controls
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/jobs"
+)
+
+// This file wires controls.Service methods into jobs.Handler factories,
+// one per Kind. Handlers unmarshal the payload the HTTP surface
+// serialised at Submit time, delegate to the Service, and translate a
+// domain error into the (message, detail) pair the runner records —
+// so the banner surfaces exactly what refusedFlash would have surfaced
+// on the sync path (scans.go).
+//
+// The payload types live here rather than in a sibling package because
+// they belong to the domain call: a change to Reanalyze's signature is
+// the same change to ReanalysePayload.
+
+// ReanalysePayload is what the /reanalyze handler serialises before
+// Submit. Ticked/Unsure are the thresholds the runner will re-read at.
+type ReanalysePayload struct {
+	Ticked float64 `json:"ticked"`
+	Unsure float64 `json:"unsure"`
+}
+
+// NewReanalyseHandler returns the jobs.Handler for KindReanalyse.
+// controlID comes from the job row; payload is the JSON-marshalled
+// ReanalysePayload the HTTP handler produced.
+func NewReanalyseHandler(svc *Service) jobs.Handler {
+	if svc == nil {
+		panic("controls.NewReanalyseHandler: no service")
+	}
+	return func(ctx context.Context, controlID string, raw []byte) error {
+		var p ReanalysePayload
+		if err := json.Unmarshal(raw, &p); err != nil {
+			return &jobs.Failure{
+				Message: "no se pudo leer el trabajo de re-lectura",
+				Detail:  fmt.Sprintf("unmarshal payload: %v", err),
+			}
+		}
+		if _, err := svc.Reanalyze(ctx, controlID, p.Ticked, p.Unsure); err != nil {
+			return failureFromAnalyzeError(err)
+		}
+		return nil
+	}
+}
+
+// failureFromAnalyzeError translates a controls.Service error into the
+// (banner-message, debug-detail) pair the runner records. Same shape as
+// refusedFlash in the sync path (scans.go): the professor sees the
+// short verdict on the banner and the long AMC line stays in the DB
+// for a future consumer that needs it.
+func failureFromAnalyzeError(err error) error {
+	if err == nil {
+		return nil
+	}
+	// A refused error carries a short Message + a long Detail — the
+	// two fields the flash cookie already splits on. Split them the
+	// same way onto the job row.
+	var refused *AnalyzerRefusedError
+	if errors.As(err, &refused) && refused != nil {
+		msg := refused.Message
+		if msg == "" {
+			msg = "el motor de lectura rechazó el trabajo"
+		}
+		return &jobs.Failure{Message: msg, Detail: refused.Detail}
+	}
+	switch {
+	case errors.Is(err, ErrControlNotFound):
+		return &jobs.Failure{Message: "ese control ya no existe", Detail: err.Error()}
+	case errors.Is(err, ErrAnalyzerRefused):
+		return &jobs.Failure{Message: "el motor de lectura rechazó el trabajo", Detail: err.Error()}
+	case errors.Is(err, ErrAnalyzerUnavailable):
+		return &jobs.Failure{Message: "el motor de lectura no está disponible", Detail: err.Error()}
+	}
+	// Anything else — a store outage, a coding bug — carries the
+	// technical message on the banner: the professor sees "algo se
+	// rompió" text elsewhere already, and a specific technical string
+	// here helps operator triage.
+	return &jobs.Failure{Message: err.Error(), Detail: ""}
+}

--- a/apps/server/internal/domain/controls/jobhandlers.go
+++ b/apps/server/internal/domain/controls/jobhandlers.go
@@ -38,17 +38,12 @@ type AnalysePayload struct {
 	Unsure    float64 `json:"unsure"`
 }
 
-// GeneratePayload is what the POST /controls handler serialises before
-// Submit (issue #249, S5). Empty: the async GenerateAssets reads the
-// control row for Copies + the derived paths, so nothing needs to
-// ride on the payload. Kept as a named type so a future addition
-// (e.g. a per-run seed) has a home.
-type GeneratePayload struct{}
-
-// AnnotatePayload is what the "Cerrar corrección" handler serialises
-// before Submit (issue #249, S6). Empty: the async
-// AnnotateAllCleanCopies walks the persisted readings on its own.
-type AnnotatePayload struct{}
+// EmptyPayload is the literal `{}` bytes the KindGenerate and
+// KindAnnotate submissions carry — both handlers ignore the payload
+// (their async methods read the control row for what they need).
+// Kept as a package-level constant so the two call sites share the
+// literal and a reader sees why nothing rides on the wire.
+var EmptyPayload = []byte("{}")
 
 // NewReanalyseHandler returns the jobs.Handler for KindReanalyse.
 // controlID comes from the job row; payload is the JSON-marshalled

--- a/apps/server/internal/domain/controls/jobhandlers.go
+++ b/apps/server/internal/domain/controls/jobhandlers.go
@@ -13,8 +13,8 @@ import (
 // one per Kind. Handlers unmarshal the payload the HTTP surface
 // serialised at Submit time, delegate to the Service, and translate a
 // domain error into the (message, detail) pair the runner records —
-// so the banner surfaces exactly what refusedFlash would have surfaced
-// on the sync path (scans.go).
+// the short message reaches the banner (view.JobBanner.Error), the
+// long detail stays on the job row for a future debug view.
 //
 // The payload types live here rather than in a sibling package because
 // they belong to the domain call: a change to Reanalyze's signature is
@@ -148,10 +148,9 @@ func failureFromGenerateError(err error) error {
 }
 
 // failureFromAnalyzeError translates a controls.Service error into the
-// (banner-message, debug-detail) pair the runner records. Same shape as
-// refusedFlash in the sync path (scans.go): the professor sees the
-// short verdict on the banner and the long AMC line stays in the DB
-// for a future consumer that needs it.
+// (banner-message, debug-detail) pair the runner records: the
+// professor sees the short verdict on the banner and the long AMC line
+// stays in the DB for a future consumer that needs it.
 func failureFromAnalyzeError(err error) error {
 	if err == nil {
 		return nil

--- a/apps/server/internal/domain/controls/jobhandlers.go
+++ b/apps/server/internal/domain/controls/jobhandlers.go
@@ -45,6 +45,11 @@ type AnalysePayload struct {
 // (e.g. a per-run seed) has a home.
 type GeneratePayload struct{}
 
+// AnnotatePayload is what the "Cerrar corrección" handler serialises
+// before Submit (issue #249, S6). Empty: the async
+// AnnotateAllCleanCopies walks the persisted readings on its own.
+type AnnotatePayload struct{}
+
 // NewReanalyseHandler returns the jobs.Handler for KindReanalyse.
 // controlID comes from the job row; payload is the JSON-marshalled
 // ReanalysePayload the HTTP handler produced.
@@ -99,6 +104,27 @@ func NewGenerateHandler(svc *Service) jobs.Handler {
 	return func(ctx context.Context, controlID string, _ []byte) error {
 		if err := svc.GenerateAssets(ctx, controlID); err != nil {
 			return failureFromGenerateError(err)
+		}
+		return nil
+	}
+}
+
+// NewAnnotateHandler returns the jobs.Handler for KindAnnotate (issue
+// #249, S6). Called when the professor closes the correction — a
+// defensive re-annotate pass over every ok copy, so a control that
+// was analysed while AnnotateEnabled was false gets its PDFs on
+// close. A no-op when every ok copy is already annotated.
+func NewAnnotateHandler(svc *Service) jobs.Handler {
+	if svc == nil {
+		panic("controls.NewAnnotateHandler: no service")
+	}
+	return func(ctx context.Context, controlID string, _ []byte) error {
+		if err := svc.AnnotateAllCleanCopies(ctx, controlID); err != nil {
+			// AnnotateAllCleanCopies logs per-copy failures and never
+			// propagates them (annotate is best-effort — the professor
+			// can retry per copy from review). Anything reaching here
+			// is a whole-flow failure (control not found, store outage).
+			return &jobs.Failure{Message: err.Error()}
 		}
 		return nil
 	}

--- a/apps/server/internal/domain/controls/scans.go
+++ b/apps/server/internal/domain/controls/scans.go
@@ -25,10 +25,10 @@ const (
 	scanFileExt    = ".pdf"
 )
 
-// UploadRequest is what a handler hands to Service.UploadScan. The bytes
-// are streamed to disk and never held whole in memory — a 40-copy batch
-// is ~10 MB and would work either way, but the upper bound in Config is
-// 100 MB.
+// UploadRequest is what a handler hands to Service.SaveUploadedBatch.
+// The bytes are streamed to disk and never held whole in memory — a
+// 40-copy batch is ~10 MB and would work either way, but the upper
+// bound in Config is 100 MB.
 type UploadRequest struct {
 	ControlID string
 	// Filename is the ORIGINAL filename from the multipart part, used only
@@ -44,60 +44,6 @@ type UploadRequest struct {
 	// calling, so a concrete pair always arrives here.
 	Ticked float64
 	Unsure float64
-}
-
-// UploadResult reports what the upload produced. Not consumed today, but a
-// handler that renders the result table wants to know which copies just
-// changed and by how many the total moved — a follow-up test hangs off
-// this.
-type UploadResult struct {
-	BatchNumber int
-	ScanPath    string // relative to WorkDir
-	Report      Report
-}
-
-// UploadScan is the whole scan pipeline: save the PDF to a batch file
-// under the control's uploads/ directory, call /analyse, persist the
-// report, mark missing copies as not_present, and flip the control to
-// InReview (unless it is already Graded — a re-upload after close still
-// updates the readings but does not un-close the correction).
-//
-// Failure modes:
-//   - No such control → ErrControlNotFound.
-//   - Copying the upload to disk failed → wraps the io error (the partial
-//     file, if any, is removed inside writeUpload).
-//   - /analyse refused or was unreachable → wraps ErrAnalyzer*. The
-//     uploaded PDF SURVIVES on disk (issue #210): the batch is the
-//     artefact an operator would inspect, and erasing it on refusal
-//     forced a re-scan when the printed sheets — not the file — were
-//     the problem (2026-08-19 incident). The DB is not touched on this
-//     branch — Analyzer.Analyze runs before any store write.
-//
-// DB-atomicity is scoped: the reading report itself is transactional
-// because UpsertReadingsFromReport opens a single tx around every insert
-// it does. The three post-analyse writes as a sequence are NOT — they go
-// through two different stores (Store.SetControlThresholds first, then
-// two ReadingStore calls) and there is no outer transaction wrapping
-// them. A failure in MarkMissingAsNotPresent (last step) leaves the
-// updated thresholds and the persisted report committed; a failure in
-// UpsertReadingsFromReport leaves the updated thresholds committed. In
-// operation this class of failure is a store outage and the professor
-// retries — a widened transactional shape (single-tx PersistReport) is
-// a follow-up, same as the SaveOverrides note below.
-func (s *Service) UploadScan(ctx context.Context, req UploadRequest) (UploadResult, error) {
-	save, err := s.SaveUploadedBatch(ctx, req)
-	if err != nil {
-		return UploadResult{}, err
-	}
-	report, err := s.AnalyzeBatch(ctx, req.ControlID, save.BatchName, save.Ticked, save.Unsure)
-	if err != nil {
-		return UploadResult{}, err
-	}
-	return UploadResult{
-		BatchNumber: save.BatchNumber,
-		ScanPath:    filepath.Join(projectPrefix, req.ControlID, uploadsDir, save.BatchName),
-		Report:      report,
-	}, nil
 }
 
 // SaveUploadedBatch is the sync half of the upload flow (issue #249):
@@ -156,7 +102,7 @@ type SaveUploadedBatchResult struct {
 // Analyzer.Analyze onward. Called by the analyse job handler in the
 // runner goroutine; the batch file must already exist on disk.
 //
-// Failure modes match the pre-#249 UploadScan (same wrapped errors,
+// Failure modes match the pre-#249 sync path (same wrapped errors,
 // same batch-survives-failure contract). The three post-analyse writes
 // have the same non-atomic sequencing note: a mid-loop store outage
 // leaves the earlier writes committed — a follow-up widens the tx.

--- a/apps/server/internal/domain/controls/scans.go
+++ b/apps/server/internal/domain/controls/scans.go
@@ -102,10 +102,26 @@ type SaveUploadedBatchResult struct {
 // Analyzer.Analyze onward. Called by the analyse job handler in the
 // runner goroutine; the batch file must already exist on disk.
 //
-// Failure modes match the pre-#249 sync path (same wrapped errors,
-// same batch-survives-failure contract). The three post-analyse writes
-// have the same non-atomic sequencing note: a mid-loop store outage
-// leaves the earlier writes committed — a follow-up widens the tx.
+// Failure modes:
+//   - The uploaded PDF survives every failure past SaveUploadedBatch
+//     (apps/server/CLAUDE.md §"The uploaded scan batch survives"). The
+//     batch file is the artefact an operator inspects and what the
+//     professor cannot re-scan.
+//   - Analyzer.Analyze refused / unreachable → wraps ErrAnalyzer*. The
+//     row + files stay intact (ADR-0050 §6, amending ADR-0034 §Failure
+//     modes); the runner records the failure on job.error / job.detail
+//     and the banner surfaces it.
+//
+// DB-atomicity is scoped: the reading report itself is transactional
+// because UpsertReadingsFromReport opens a single tx around every
+// insert it does. The three post-analyse writes as a sequence are NOT
+// — they go through two different stores (Store.SetControlThresholds
+// first, then Readings.UpsertReadingsFromReport, then
+// Readings.MarkMissingAsNotPresent) and there is no outer transaction
+// wrapping them. A mid-loop store failure leaves the earlier writes
+// committed; in operation this class of failure is a store outage and
+// the professor retries. A widened transactional shape (single-tx
+// PersistReport) is a follow-up.
 func (s *Service) AnalyzeBatch(ctx context.Context, controlID, batchName string, ticked, unsure float64) (Report, error) {
 	control, err := s.Store.ControlByID(ctx, controlID)
 	if err != nil {

--- a/apps/server/internal/domain/controls/scans.go
+++ b/apps/server/internal/domain/controls/scans.go
@@ -230,6 +230,32 @@ func (s *Service) Reanalyze(ctx context.Context, controlID string, ticked, unsur
 	return report, nil
 }
 
+// AnnotateAllCleanCopies is the close-time defensive re-annotate
+// (issue #249, S6): walk the persisted readings and call
+// Service.Annotate for every copy in status ok. Per-copy failures are
+// logged and swallowed — same "annotate is best-effort" policy as
+// annotateCleanCopies below. Returns an error only when the whole
+// flow cannot start (control missing, readings unreadable).
+func (s *Service) AnnotateAllCleanCopies(ctx context.Context, controlID string) error {
+	if _, err := s.Store.ControlByID(ctx, controlID); err != nil {
+		return err
+	}
+	readings, err := s.Readings.ReadingsByControl(ctx, controlID)
+	if err != nil {
+		return err
+	}
+	for _, r := range readings {
+		if r.CopyStatus != CopyStatusOK {
+			continue
+		}
+		if _, err := s.Annotate(ctx, controlID, r.CopyNumber); err != nil {
+			s.Log.Warn("controls: annotate on close failed",
+				"control", controlID, "copy", r.CopyNumber, "error", err)
+		}
+	}
+	return nil
+}
+
 // annotateCleanCopies runs ruta A over a report: one Service.Annotate per
 // status:ok copy. One /annotate/copy call per copy is seconds-class, and
 // the flows that call this were minutes-class anyway. A failure must not

--- a/apps/server/internal/domain/controls/scans.go
+++ b/apps/server/internal/domain/controls/scans.go
@@ -85,48 +85,86 @@ type UploadResult struct {
 // retries — a widened transactional shape (single-tx PersistReport) is
 // a follow-up, same as the SaveOverrides note below.
 func (s *Service) UploadScan(ctx context.Context, req UploadRequest) (UploadResult, error) {
-	control, err := s.Store.ControlByID(ctx, req.ControlID)
+	save, err := s.SaveUploadedBatch(ctx, req)
 	if err != nil {
 		return UploadResult{}, err
 	}
-	// Issue #197: refuse a bad pair BEFORE writing anything so an invalid
-	// threshold submission never even creates a batch file. Note: unlike
-	// pre-#210, DOWNSTREAM failures do not clean the batch file up — see
-	// the UploadScan docstring above for the batch-survives-failure
-	// contract. This validation happens first, so it is the one branch
-	// where nothing on disk is left behind either way.
+	report, err := s.AnalyzeBatch(ctx, req.ControlID, save.BatchName, save.Ticked, save.Unsure)
+	if err != nil {
+		return UploadResult{}, err
+	}
+	return UploadResult{
+		BatchNumber: save.BatchNumber,
+		ScanPath:    filepath.Join(projectPrefix, req.ControlID, uploadsDir, save.BatchName),
+		Report:      report,
+	}, nil
+}
+
+// SaveUploadedBatch is the sync half of the upload flow (issue #249):
+// validate the control, resolve thresholds, mkdir uploads/, pick the
+// next batch number and stream the PDF onto disk. Runs on the HTTP
+// handler's goroutine because the professor is uploading bytes — no
+// runner in the middle. Returns the batch name + resolved thresholds
+// the async AnalyzeBatch runs against.
+func (s *Service) SaveUploadedBatch(ctx context.Context, req UploadRequest) (SaveUploadedBatchResult, error) {
+	control, err := s.Store.ControlByID(ctx, req.ControlID)
+	if err != nil {
+		return SaveUploadedBatchResult{}, err
+	}
 	ticked, unsure := req.Ticked, req.Unsure
 	if ticked == 0 {
-		// The handler always resolves the form (optional fields fall back
-		// to the control's stored pair), but a caller that skips that step
-		// gets the stored pair rather than a refusal.
 		ticked, unsure = control.Ticked, control.Unsure
 	}
 	if !ThresholdsValid(ticked, unsure) {
-		return UploadResult{}, fmt.Errorf("%w: invalid thresholds (%v, %v)",
+		return SaveUploadedBatchResult{}, fmt.Errorf("%w: invalid thresholds (%v, %v)",
 			ErrAnalyzerRefused, ticked, unsure)
 	}
 
 	projectDir := s.ProjectDir(control.ID)
 	uploads := filepath.Join(projectDir, uploadsDir)
 	if err := os.MkdirAll(uploads, 0o755); err != nil {
-		return UploadResult{}, fmt.Errorf("controls.UploadScan: prepare %s: %w", uploads, err)
+		return SaveUploadedBatchResult{}, fmt.Errorf("controls.SaveUploadedBatch: prepare %s: %w", uploads, err)
 	}
 	batch, err := nextBatchNumber(uploads)
 	if err != nil {
-		return UploadResult{}, fmt.Errorf("controls.UploadScan: %w", err)
+		return SaveUploadedBatchResult{}, fmt.Errorf("controls.SaveUploadedBatch: %w", err)
 	}
 	batchName := fmt.Sprintf("%s%d%s", scanFilePrefix, batch, scanFileExt)
 	batchHostPath := filepath.Join(uploads, batchName)
 
 	if err := writeUpload(batchHostPath, req.Content); err != nil {
-		return UploadResult{}, fmt.Errorf("controls.UploadScan: %w", err)
+		return SaveUploadedBatchResult{}, fmt.Errorf("controls.SaveUploadedBatch: %w", err)
 	}
+	return SaveUploadedBatchResult{
+		BatchNumber: batch,
+		BatchName:   batchName,
+		Ticked:      ticked,
+		Unsure:      unsure,
+	}, nil
+}
 
-	// Issue #210: the batch file survives every downstream failure —
-	// the artefact on disk is what an operator inspects and what a
-	// re-upload cannot recreate. DB scoping below in the docstring.
+// SaveUploadedBatchResult is what SaveUploadedBatch returns to the HTTP
+// handler so it can then Submit an analyse job.
+type SaveUploadedBatchResult struct {
+	BatchNumber int
+	BatchName   string
+	Ticked      float64
+	Unsure      float64
+}
 
+// AnalyzeBatch is the async half of the upload flow (issue #249): from
+// Analyzer.Analyze onward. Called by the analyse job handler in the
+// runner goroutine; the batch file must already exist on disk.
+//
+// Failure modes match the pre-#249 UploadScan (same wrapped errors,
+// same batch-survives-failure contract). The three post-analyse writes
+// have the same non-atomic sequencing note: a mid-loop store outage
+// leaves the earlier writes committed — a follow-up widens the tx.
+func (s *Service) AnalyzeBatch(ctx context.Context, controlID, batchName string, ticked, unsure float64) (Report, error) {
+	control, err := s.Store.ControlByID(ctx, controlID)
+	if err != nil {
+		return Report{}, err
+	}
 	project := filepath.Join(projectPrefix, control.ID)
 	report, err := s.Analyzer.Analyze(ctx, AnalyzeRequest{
 		Project: project,
@@ -136,39 +174,25 @@ func (s *Service) UploadScan(ctx context.Context, req UploadRequest) (UploadResu
 		Unsure:  unsure,
 	})
 	if err != nil {
-		return UploadResult{}, err
+		return Report{}, err
 	}
 	if err := s.Store.SetControlThresholds(ctx, control.ID, ticked, unsure); err != nil {
-		return UploadResult{}, fmt.Errorf("controls.UploadScan: persist thresholds: %w", err)
+		return Report{}, fmt.Errorf("controls.AnalyzeBatch: persist thresholds: %w", err)
 	}
-
 	now := s.Now()
 	if err := s.Readings.UpsertReadingsFromReport(ctx, control.ID, report, now); err != nil {
-		return UploadResult{}, fmt.Errorf("controls.UploadScan: persist: %w", err)
+		return Report{}, fmt.Errorf("controls.AnalyzeBatch: persist: %w", err)
 	}
 	if err := s.Readings.MarkMissingAsNotPresent(ctx, control.ID, now); err != nil {
-		return UploadResult{}, fmt.Errorf("controls.UploadScan: mark missing: %w", err)
+		return Report{}, fmt.Errorf("controls.AnalyzeBatch: mark missing: %w", err)
 	}
-
-	// Issue #190, ruta A: every copy the reader accepted as clean gets its
-	// annotated PDF right away, before any human touches the queue.
 	s.annotateCleanCopies(ctx, control, report)
-
-	// Move the control forward — but never backwards. A re-upload to a
-	// graded control leaves state=graded (S8 renders the "editing a closed
-	// correction" warning); the readings still land.
 	if control.State == Generated {
 		if err := s.Readings.SetControlState(ctx, control.ID, InReview); err != nil {
-			// The DB writes above already succeeded; this is a warning.
-			s.Log.Warn("controls.UploadScan: state transition failed", "control", control.ID, "error", err)
+			s.Log.Warn("controls.AnalyzeBatch: state transition failed", "control", control.ID, "error", err)
 		}
 	}
-
-	return UploadResult{
-		BatchNumber: batch,
-		ScanPath:    filepath.Join(projectPrefix, control.ID, uploadsDir, batchName),
-		Report:      report,
-	}, nil
+	return report, nil
 }
 
 // Reanalyze re-reads the existing captures at new thresholds. Fails cleanly

--- a/apps/server/internal/domain/controls/service.go
+++ b/apps/server/internal/domain/controls/service.go
@@ -128,7 +128,8 @@ func NewService(deps Service) *Service {
 	return &deps
 }
 
-// CreateRequest is what a handler hands to Service.Create.
+// CreateRequest is what a handler hands to Service.PrepareControl
+// (the async runner then picks up GenerateAssets).
 type CreateRequest struct {
 	Name             string
 	ApplicationDate  *time.Time

--- a/apps/server/internal/domain/controls/service.go
+++ b/apps/server/internal/domain/controls/service.go
@@ -160,6 +160,29 @@ type CreateRequest struct {
 // versa — the "the row is committed and the files are on disk, or neither"
 // promise.
 func (s *Service) Create(ctx context.Context, req CreateRequest) (Control, error) {
+	control, err := s.PrepareControl(ctx, req)
+	if err != nil {
+		return Control{}, err
+	}
+	if err := s.GenerateAssets(ctx, control.ID); err != nil {
+		return Control{}, err
+	}
+	return control, nil
+}
+
+// PrepareControl is the sync half of Create (issue #249, S5): resolve
+// the pool, stage the input files on the shared volume, compile the
+// tex, write the pool snapshot, and commit the row. The AMC worker
+// call — Generator.Generate + sujet.pdf stat — is NOT run here; it
+// lives on the async GenerateAssets so the HTTP request returns fast.
+//
+// The rollback still covers this half's failures (a bad tex compile,
+// a bad write): if any step here fails the project directory is
+// removed. On the async side (GenerateAssets), a worker failure
+// leaves the row + input files intact so the operator can re-run the
+// generation without losing the pool snapshot — a follow-up WP adds
+// the explicit retry button (design's deferred list).
+func (s *Service) PrepareControl(ctx context.Context, req CreateRequest) (Control, error) {
 	pool, err := s.Bank.Get().Pool(req.RangeFrom, req.RangeTo)
 	if err != nil {
 		return Control{}, err
@@ -170,7 +193,7 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (Control, error
 
 	id, err := NewID()
 	if err != nil {
-		return Control{}, fmt.Errorf("controls.Create: %w", err)
+		return Control{}, fmt.Errorf("controls.PrepareControl: %w", err)
 	}
 	project := filepath.Join(projectPrefix, id)
 	projectDir := filepath.Join(s.WorkDir, project)
@@ -184,13 +207,13 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (Control, error
 	// no-op, so a MkdirAll that produced nothing costs nothing to clean.
 	rollback := func() {
 		if err := os.RemoveAll(projectDir); err != nil {
-			s.Log.Warn("controls.Create: rollback failed", "project", projectDir, "error", err)
+			s.Log.Warn("controls.PrepareControl: rollback failed", "project", projectDir, "error", err)
 		}
 	}
 
 	if err := os.MkdirAll(inputsDir, 0o755); err != nil {
 		rollback()
-		return Control{}, fmt.Errorf("controls.Create: prepare %s: %w", projectDir, err)
+		return Control{}, fmt.Errorf("controls.PrepareControl: prepare %s: %w", projectDir, err)
 	}
 
 	for _, q := range pool {
@@ -200,13 +223,10 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (Control, error
 		listingPath := filepath.Join(inputsDir, "question-"+q.ID+".txt")
 		if err := os.WriteFile(listingPath, []byte(q.Code.Source), 0o644); err != nil {
 			rollback()
-			return Control{}, fmt.Errorf("controls.Create: stage listing %s: %w", q.ID, err)
+			return Control{}, fmt.Errorf("controls.PrepareControl: stage listing %s: %w", q.ID, err)
 		}
 	}
 
-	// The tex generator writes an ABSOLUTE listing path — from the
-	// WORKER'S perspective, which is /work. The path here always begins
-	// with WorkerWorkDir, whatever the server's own mount is.
 	source, err := tex.Compile(tex.Input{
 		Name:             req.Name,
 		Pool:             pool,
@@ -215,52 +235,20 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (Control, error
 		Seed:             s.Seed,
 		ListingsDir:      workerPath(project, "inputs"),
 		DuplexPadding:    req.DuplexPadding,
-		// Issue #208, ADR-0043: same guard as the persisted field below.
-		Paper: string(paperOrDefault(req.Paper)),
+		Paper:            string(paperOrDefault(req.Paper)),
 	})
 	if err != nil {
 		rollback()
-		return Control{}, fmt.Errorf("controls.Create: compile tex: %w", err)
+		return Control{}, fmt.Errorf("controls.PrepareControl: compile tex: %w", err)
 	}
 	sourceHostPath := filepath.Join(inputsDir, "source.tex")
 	if err := os.WriteFile(sourceHostPath, []byte(source), 0o644); err != nil {
 		rollback()
-		return Control{}, fmt.Errorf("controls.Create: write source: %w", err)
+		return Control{}, fmt.Errorf("controls.PrepareControl: write source: %w", err)
 	}
-
-	// The pool snapshot (issue #198) goes down beside the source, inside
-	// the same guarded region: a failure below rolls it away with the rest
-	// of the project.
 	if err := writePoolSnapshot(filepath.Join(projectDir, "pool.json"), id, req, pool, s.Seed, s.Now()); err != nil {
 		rollback()
-		return Control{}, fmt.Errorf("controls.Create: write pool snapshot: %w", err)
-	}
-
-	// Worker paths are relative to /work: it prefixes them itself with
-	// its own mount (worker.py's under_work).
-	assets, err := s.Generator.Generate(ctx, GenerateRequest{
-		Project: project,
-		Source:  filepath.Join(project, "inputs", "source.tex"),
-		Copies:  req.Copies,
-	})
-	if err != nil {
-		rollback()
-		return Control{}, err
-	}
-
-	// The professor's headline deliverable exists on disk and has bytes.
-	// A 0-byte sujet.pdf reports "success" from the worker on paths where
-	// the compile crashed after opening the output file — measured in
-	// #138 review, and enough to redden the whole path here.
-	sujetPath := filepath.Join(s.WorkDir, assets.Sujet)
-	info, err := os.Stat(sujetPath)
-	if err != nil {
-		rollback()
-		return Control{}, fmt.Errorf("%w: stat %s: %v", ErrSujetMissing, sujetPath, err)
-	}
-	if info.Size() == 0 {
-		rollback()
-		return Control{}, fmt.Errorf("%w: %s is 0 bytes", ErrSujetMissing, sujetPath)
+		return Control{}, fmt.Errorf("controls.PrepareControl: write pool snapshot: %w", err)
 	}
 
 	control := Control{
@@ -272,18 +260,12 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (Control, error
 		QuestionsPerCopy: req.QuestionsPerCopy,
 		Copies:           req.Copies,
 		DuplexPadding:    req.DuplexPadding,
-		// Issue #208: honour the professor's choice, falling back to the
-		// default when a caller (a test, a future JSON API, a bug) sends
-		// an empty value — the schema CHECK would refuse "" and this
-		// resolves it to the operational default instead of failing loud.
-		Paper: paperOrDefault(req.Paper),
-		// Issue #197: the product defaults; the upload and reanalyse
-		// forms change them per batch afterwards.
-		Ticked:    DefaultTicked,
-		Unsure:    DefaultUnsure,
-		State:     Generated,
-		CreatedAt: s.Now(),
-		CreatedBy: req.CreatedBy,
+		Paper:            paperOrDefault(req.Paper),
+		Ticked:           DefaultTicked,
+		Unsure:           DefaultUnsure,
+		State:            Generated,
+		CreatedAt:        s.Now(),
+		CreatedBy:        req.CreatedBy,
 	}
 	entries := make([]PoolEntry, len(pool))
 	for i, q := range pool {
@@ -291,10 +273,45 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (Control, error
 	}
 	if err := s.Store.CreateControl(ctx, control, entries); err != nil {
 		rollback()
-		return Control{}, fmt.Errorf("controls.Create: persist: %w", err)
+		return Control{}, fmt.Errorf("controls.PrepareControl: persist: %w", err)
 	}
-
 	return control, nil
+}
+
+// GenerateAssets is the async half of Create (issue #249, S5): call
+// the AMC worker for the printable PDFs and verify sujet.pdf exists on
+// disk with bytes. Called by the generate job handler on the runner
+// goroutine; the row and input files must already exist (PrepareControl
+// committed them).
+//
+// A failure here does NOT delete the row: the pool snapshot and
+// source.tex are the professor's authored artefacts, and losing them
+// on a transient worker outage would force a re-choose of the pool.
+// The banner surfaces the failure; the operator's retry path (a future
+// WP) reads the same row and re-runs this method.
+func (s *Service) GenerateAssets(ctx context.Context, controlID string) error {
+	control, err := s.Store.ControlByID(ctx, controlID)
+	if err != nil {
+		return err
+	}
+	project := filepath.Join(projectPrefix, control.ID)
+	assets, err := s.Generator.Generate(ctx, GenerateRequest{
+		Project: project,
+		Source:  filepath.Join(project, "inputs", "source.tex"),
+		Copies:  control.Copies,
+	})
+	if err != nil {
+		return err
+	}
+	sujetPath := filepath.Join(s.WorkDir, assets.Sujet)
+	info, err := os.Stat(sujetPath)
+	if err != nil {
+		return fmt.Errorf("%w: stat %s: %v", ErrSujetMissing, sujetPath, err)
+	}
+	if info.Size() == 0 {
+		return fmt.Errorf("%w: %s is 0 bytes", ErrSujetMissing, sujetPath)
+	}
+	return nil
 }
 
 // List returns every control, delegating to the Store's own ordering

--- a/apps/server/internal/domain/controls/service.go
+++ b/apps/server/internal/domain/controls/service.go
@@ -150,31 +150,12 @@ type CreateRequest struct {
 	CreatedBy int64
 }
 
-// Create is the whole orchestration: resolve the range against the bank,
-// stage the inputs on the shared volume, ask the worker to compile, verify
-// the PDF exists, persist the row.
-//
-// All-or-nothing (§Failure modes). Every path past the directory creation
-// is guarded by a rollback that removes the whole project directory on
-// failure: a control never has files without a database row, and vice
-// versa — the "the row is committed and the files are on disk, or neither"
-// promise.
-func (s *Service) Create(ctx context.Context, req CreateRequest) (Control, error) {
-	control, err := s.PrepareControl(ctx, req)
-	if err != nil {
-		return Control{}, err
-	}
-	if err := s.GenerateAssets(ctx, control.ID); err != nil {
-		return Control{}, err
-	}
-	return control, nil
-}
-
-// PrepareControl is the sync half of Create (issue #249, S5): resolve
-// the pool, stage the input files on the shared volume, compile the
-// tex, write the pool snapshot, and commit the row. The AMC worker
-// call — Generator.Generate + sujet.pdf stat — is NOT run here; it
-// lives on the async GenerateAssets so the HTTP request returns fast.
+// PrepareControl is the sync half of the "create control" flow (issue
+// #249, S5): resolve the pool, stage the input files on the shared
+// volume, compile the tex, write the pool snapshot, and commit the
+// row. The AMC worker call — Generator.Generate + sujet.pdf stat —
+// is NOT run here; it lives on the async GenerateAssets so the HTTP
+// request returns fast.
 //
 // The rollback still covers this half's failures (a bad tex compile,
 // a bad write): if any step here fails the project directory is

--- a/apps/server/internal/domain/controls/service_test.go
+++ b/apps/server/internal/domain/controls/service_test.go
@@ -119,10 +119,10 @@ func (s *fakeStore) SetControlThresholds(_ context.Context, controlID string, ti
 }
 
 // fakeReadingStore is the do-nothing double the pre-WP-F cases use. The
-// WP-F flows are exercised through Service.UploadScan in scans_internal_test.go
-// with a real controlstore. readingsByCopy holds stored readings for the
-// annotate tests (issue #190); empty maps behave exactly like the old
-// do-nothing shape.
+// WP-F flows are exercised through SaveUploadedBatch + AnalyzeBatch in
+// scans_internal_test.go with a real controlstore. readingsByCopy holds
+// stored readings for the annotate tests (issue #190); empty maps behave
+// exactly like the old do-nothing shape.
 type fakeReadingStore struct {
 	readingsByCopy map[string]controls.Reading // key: <controlID>#<copyNumber>
 }
@@ -204,10 +204,41 @@ func req(mutate func(*controls.CreateRequest)) controls.CreateRequest {
 	return r
 }
 
+// createControlSync composes PrepareControl + GenerateAssets — the two
+// halves the runner picks up in production — so the tests exercise the
+// same shape production does. Since ARQ-1 (issue #249 review) the
+// Service.Create wrapper is gone; tests that need both halves in a row
+// call this helper directly.
+func createControlSync(ctx context.Context, svc *controls.Service, req controls.CreateRequest) (controls.Control, error) {
+	control, err := svc.PrepareControl(ctx, req)
+	if err != nil {
+		return controls.Control{}, err
+	}
+	if err := svc.GenerateAssets(ctx, control.ID); err != nil {
+		return controls.Control{}, err
+	}
+	return control, nil
+}
+
+// uploadScanSync composes SaveUploadedBatch + AnalyzeBatch — same
+// shape the runner picks up in production. Same reasoning as
+// createControlSync; ARQ-1 removed the Service.UploadScan wrapper.
+func uploadScanSync(ctx context.Context, svc *controls.Service, req controls.UploadRequest) (controls.SaveUploadedBatchResult, controls.Report, error) {
+	save, err := svc.SaveUploadedBatch(ctx, req)
+	if err != nil {
+		return controls.SaveUploadedBatchResult{}, controls.Report{}, err
+	}
+	report, err := svc.AnalyzeBatch(ctx, req.ControlID, save.BatchName, save.Ticked, save.Unsure)
+	if err != nil {
+		return save, controls.Report{}, err
+	}
+	return save, report, nil
+}
+
 func TestCreateWritesFilesAndPersistsTheControl(t *testing.T) {
 	svc, store, gen, workDir := newService(t)
 
-	got, err := svc.Create(context.Background(), req(nil))
+	got, err := createControlSync(context.Background(), svc, req(nil))
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -289,7 +320,7 @@ func TestCreateSurfacesBankErrorsAsIs(t *testing.T) {
 
 	// Inverted range → ErrRangeInverted, no rollback needed because no
 	// files were staged.
-	_, err := svc.Create(context.Background(), req(func(r *controls.CreateRequest) {
+	_, err := createControlSync(context.Background(), svc, req(func(r *controls.CreateRequest) {
 		r.RangeFrom = bank.SectionRef{Document: "flujo", Section: "bucles"}
 		r.RangeTo = bank.SectionRef{Document: "welcome", Section: "hola"}
 	}))
@@ -298,7 +329,7 @@ func TestCreateSurfacesBankErrorsAsIs(t *testing.T) {
 	}
 
 	// Unknown section → ErrUnknownSection.
-	_, err = svc.Create(context.Background(), req(func(r *controls.CreateRequest) {
+	_, err = createControlSync(context.Background(), svc, req(func(r *controls.CreateRequest) {
 		r.RangeFrom = bank.SectionRef{Document: "welcome", Section: "no-existe"}
 	}))
 	if !errors.Is(err, bank.ErrUnknownSection) {
@@ -309,7 +340,7 @@ func TestCreateSurfacesBankErrorsAsIs(t *testing.T) {
 func TestCreateRefusesAPoolSmallerThanTheCopyAsksFor(t *testing.T) {
 	svc, _, _, _ := newService(t)
 
-	_, err := svc.Create(context.Background(), req(func(r *controls.CreateRequest) {
+	_, err := createControlSync(context.Background(), svc, req(func(r *controls.CreateRequest) {
 		r.QuestionsPerCopy = 8 // pool has 4
 	}))
 	if !errors.Is(err, controls.ErrPoolTooSmall) {
@@ -334,7 +365,7 @@ func TestGenerateAssetsRefusalLeavesTheRowAndFilesIntact(t *testing.T) {
 	svc, store, gen, workDir := newService(t)
 	gen.Err = controls.ErrGeneratorRefused
 
-	_, err := svc.Create(context.Background(), req(nil))
+	_, err := createControlSync(context.Background(), svc, req(nil))
 	if !errors.Is(err, controls.ErrGeneratorRefused) {
 		t.Fatalf("Create(worker refused): %v, want ErrGeneratorRefused", err)
 	}
@@ -351,7 +382,7 @@ func TestGenerateAssetsSujetMissingLeavesTheRowAndFilesIntact(t *testing.T) {
 	svc, store, gen, workDir := newService(t)
 	gen.SujetSize = 0
 
-	_, err := svc.Create(context.Background(), req(nil))
+	_, err := createControlSync(context.Background(), svc, req(nil))
 	if !errors.Is(err, controls.ErrSujetMissing) {
 		t.Fatalf("Create(0-byte sujet): %v, want ErrSujetMissing", err)
 	}
@@ -367,7 +398,7 @@ func TestCreateRollsBackWhenTheStoreFails(t *testing.T) {
 	svc, store, _, workDir := newService(t)
 	store.fail = errors.New("boom")
 
-	_, err := svc.Create(context.Background(), req(nil))
+	_, err := createControlSync(context.Background(), svc, req(nil))
 	if err == nil || !strings.Contains(err.Error(), "boom") {
 		t.Fatalf("Create(store fails): %v, want error carrying 'boom'", err)
 	}
@@ -407,7 +438,7 @@ func TestCreatePassesTheCorrectAbsoluteListingPathForCodeQuestions(t *testing.T)
 		Log: slog.New(slog.NewTextHandler(io.Discard, nil)),
 	})
 
-	control, err := svc.Create(context.Background(), controls.CreateRequest{
+	control, err := createControlSync(context.Background(), svc, controls.CreateRequest{
 		Name:             "c",
 		RangeFrom:        bank.SectionRef{Document: "arr", Section: "b"},
 		RangeTo:          bank.SectionRef{Document: "arr", Section: "b"},
@@ -439,7 +470,7 @@ func TestCreatePassesTheCorrectAbsoluteListingPathForCodeQuestions(t *testing.T)
 // as expected of a preserved counter derived from directory listing.
 func TestUploadScanPreservesTheBatchOnWorkerRefusal(t *testing.T) {
 	svc, _, gen, workDir := newService(t)
-	control, err := svc.Create(context.Background(), req(nil))
+	control, err := createControlSync(context.Background(), svc, req(nil))
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
@@ -448,7 +479,7 @@ func TestUploadScanPreservesTheBatchOnWorkerRefusal(t *testing.T) {
 		Status: 400, Message: "scan not recognized",
 		Detail: "ERR: /work/controls/x/scans/0001.pdf scan not recognized",
 	}
-	_, err = svc.UploadScan(context.Background(), controls.UploadRequest{
+	_, _, err = uploadScanSync(context.Background(), svc, controls.UploadRequest{
 		ControlID: control.ID,
 		Filename:  "batch.pdf",
 		Content:   io.NopCloser(strings.NewReader("%PDF-fake")),
@@ -473,7 +504,7 @@ func TestUploadScanPreservesTheBatchOnWorkerRefusal(t *testing.T) {
 				ExpectedQuestions: 3, SeenQuestions: 3},
 		},
 	}}
-	result, err := svc.UploadScan(context.Background(), controls.UploadRequest{
+	save, _, err := uploadScanSync(context.Background(), svc, controls.UploadRequest{
 		ControlID: control.ID,
 		Filename:  "batch.pdf",
 		Content:   io.NopCloser(strings.NewReader("%PDF-fake-2")),
@@ -483,8 +514,8 @@ func TestUploadScanPreservesTheBatchOnWorkerRefusal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("second UploadScan: %v", err)
 	}
-	if result.BatchNumber != 2 {
-		t.Errorf("second BatchNumber = %d, want 2 (batch-1.pdf survived the refusal)", result.BatchNumber)
+	if save.BatchNumber != 2 {
+		t.Errorf("second BatchNumber = %d, want 2 (batch-1.pdf survived the refusal)", save.BatchNumber)
 	}
 	batch2 := filepath.Join(workDir, "controls", control.ID, "uploads", "batch-2.pdf")
 	if _, statErr := os.Stat(batch2); statErr != nil {
@@ -500,12 +531,12 @@ func TestUploadScanPreservesTheBatchOnWorkerRefusal(t *testing.T) {
 // analyzer is called and before the batch file touches the disk.
 func TestUploadScanRefusesAnInvalidPair(t *testing.T) {
 	svc, store, gen, workDir := newService(t)
-	control, err := svc.Create(context.Background(), req(nil))
+	control, err := createControlSync(context.Background(), svc, req(nil))
 	if err != nil {
 		t.Fatalf("Create: %v", err)
 	}
 
-	_, err = svc.UploadScan(context.Background(), controls.UploadRequest{
+	_, _, err = uploadScanSync(context.Background(), svc, controls.UploadRequest{
 		ControlID: control.ID,
 		Filename:  "batch.pdf",
 		Content:   io.NopCloser(strings.NewReader("%PDF-fake")),

--- a/apps/server/internal/domain/controls/service_test.go
+++ b/apps/server/internal/domain/controls/service_test.go
@@ -324,7 +324,13 @@ func TestCreateRefusesAPoolSmallerThanTheCopyAsksFor(t *testing.T) {
 	}
 }
 
-func TestCreateRollsBackWhenTheWorkerRefuses(t *testing.T) {
+// Since issue #249 the worker call is on the async job (Create is now
+// PrepareControl + GenerateAssets composed). A refusal on the worker
+// leg leaves the row committed and the input files staged — the
+// professor can re-run generation from the same row without losing
+// the pool. The all-or-nothing promise (row+files-together) is
+// preserved for the SYNC leg only (PrepareControl).
+func TestGenerateAssetsRefusalLeavesTheRowAndFilesIntact(t *testing.T) {
 	svc, store, gen, workDir := newService(t)
 	gen.Err = controls.ErrGeneratorRefused
 
@@ -332,32 +338,28 @@ func TestCreateRollsBackWhenTheWorkerRefuses(t *testing.T) {
 	if !errors.Is(err, controls.ErrGeneratorRefused) {
 		t.Fatalf("Create(worker refused): %v, want ErrGeneratorRefused", err)
 	}
-
-	if len(store.controls) != 0 {
-		t.Errorf("store.controls = %+v, want empty (worker refusal must roll back the row)", store.controls)
+	if len(store.controls) != 1 {
+		t.Errorf("store.controls = %+v, want the row committed by PrepareControl", store.controls)
 	}
-
-	// The project directory is gone.
 	projects, err := os.ReadDir(filepath.Join(workDir, "controls"))
-	if err == nil && len(projects) > 0 {
-		t.Errorf("workDir/controls holds %d directories after a rolled-back Create, want 0", len(projects))
+	if err != nil || len(projects) != 1 {
+		t.Errorf("workDir/controls holds %d directories after a worker refusal, want 1 (files stay for retry)", len(projects))
 	}
 }
 
-func TestCreateRollsBackWhenSujetIsZeroBytes(t *testing.T) {
+func TestGenerateAssetsSujetMissingLeavesTheRowAndFilesIntact(t *testing.T) {
 	svc, store, gen, workDir := newService(t)
-	gen.SujetSize = 0 // fake writes an empty sujet.pdf
+	gen.SujetSize = 0
 
 	_, err := svc.Create(context.Background(), req(nil))
 	if !errors.Is(err, controls.ErrSujetMissing) {
 		t.Fatalf("Create(0-byte sujet): %v, want ErrSujetMissing", err)
 	}
-
-	if len(store.controls) != 0 {
-		t.Error("store.controls is not empty after a 0-byte sujet failure — creation must be all-or-nothing")
+	if len(store.controls) != 1 {
+		t.Errorf("store.controls should still have the PrepareControl row: %+v", store.controls)
 	}
-	if entries, _ := os.ReadDir(filepath.Join(workDir, "controls")); len(entries) > 0 {
-		t.Errorf("workDir/controls holds %d entries after a 0-byte sujet failure, want 0", len(entries))
+	if entries, _ := os.ReadDir(filepath.Join(workDir, "controls")); len(entries) != 1 {
+		t.Errorf("workDir/controls holds %d entries after 0-byte sujet, want 1 (files stay for retry)", len(entries))
 	}
 }
 

--- a/apps/server/internal/domain/jobs/jobs.go
+++ b/apps/server/internal/domain/jobs/jobs.go
@@ -76,9 +76,11 @@ type NewJob struct {
 // on the domain side, per backend-code-style.md §The dependency rule.
 // The jobstore package implements it over SQLite.
 type Store interface {
-	// Insert creates a new job in `queued` and returns its id. created_at
-	// is stamped by the store — the runner never handles clock skew.
-	Insert(ctx context.Context, j NewJob) (int64, error)
+	// Insert creates a new job in `queued`, stamps createdAt on the
+	// row and returns its id. The runner passes r.now() from its
+	// injected clock, so tests share the same clock the mark family
+	// already accepts.
+	Insert(ctx context.Context, j NewJob, createdAt time.Time) (int64, error)
 
 	// MarkRunning transitions a job to `running` and stamps started_at.
 	// Returns ErrJobNotFound when no row has that id.

--- a/apps/server/internal/domain/jobs/jobs.go
+++ b/apps/server/internal/domain/jobs/jobs.go
@@ -1,0 +1,121 @@
+// Package jobs is the async job runner for the four minutes-class AMC
+// operations (generate, analyse, reanalyse, annotate batch) — issue #249.
+//
+// One goroutine, one queue, one job at a time. The runner persists every
+// job in SQLite so a Watchtower restart (ADR-0038) does not lose the queue:
+// on boot the Sweep pass re-pushes `queued` rows and marks any `running`
+// row as `failed` — a "server_restart_mid_job" the professor sees on the
+// banner, not a silently retried job. See docs/decisions and issue #249
+// §Design for the reasoning; this package holds the types the runner and
+// the store agree on.
+package jobs
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// Kind names the four operation types the runner accepts. Enumerated
+// rather than free-form: the SQLite CHECK on job.kind refuses anything
+// else, and having the enum here means a caller cannot write a typo that
+// only fails at INSERT time.
+type Kind string
+
+const (
+	KindGenerate  Kind = "generate"
+	KindAnalyse   Kind = "analyse"
+	KindReanalyse Kind = "reanalyse"
+	KindAnnotate  Kind = "annotate"
+)
+
+// ValidKinds is the closed set the schema CHECK enforces.
+var ValidKinds = []Kind{KindGenerate, KindAnalyse, KindReanalyse, KindAnnotate}
+
+// Status names the four states a row can be in. Same CHECK-enum shape as
+// Kind, same reasoning.
+type Status string
+
+const (
+	StatusQueued  Status = "queued"
+	StatusRunning Status = "running"
+	StatusDone    Status = "done"
+	StatusFailed  Status = "failed"
+)
+
+// RestartMidJobError is the marker error the Sweep pass writes into
+// job.error when it finds a `running` row on boot — the previous server
+// died mid-job, so the professor sees "server_restart_mid_job" on the
+// banner rather than a stalled row that never moves.
+const RestartMidJobError = "server_restart_mid_job"
+
+// Job is one row of the `job` table.
+type Job struct {
+	ID         int64
+	ControlID  string
+	Kind       Kind
+	Status     Status
+	Error      string
+	Detail     string
+	Payload    []byte
+	CreatedAt  time.Time
+	StartedAt  *time.Time
+	FinishedAt *time.Time
+	ViewedAt   *time.Time
+}
+
+// NewJob is what Store.Insert accepts. It carries the fields a caller
+// composes; the store fills in id, created_at, and the initial status.
+type NewJob struct {
+	ControlID string
+	Kind      Kind
+	Payload   []byte
+}
+
+// Store is what the Runner reaches into for persistence — declared here,
+// on the domain side, per backend-code-style.md §The dependency rule.
+// The jobstore package implements it over SQLite.
+type Store interface {
+	// Insert creates a new job in `queued` and returns its id. created_at
+	// is stamped by the store — the runner never handles clock skew.
+	Insert(ctx context.Context, j NewJob) (int64, error)
+
+	// MarkRunning transitions a job to `running` and stamps started_at.
+	// Returns ErrJobNotFound when no row has that id.
+	MarkRunning(ctx context.Context, id int64, startedAt time.Time) error
+
+	// MarkDone transitions a job to `done` and stamps finished_at.
+	MarkDone(ctx context.Context, id int64, finishedAt time.Time) error
+
+	// MarkFailed transitions a job to `failed` with a short error message
+	// (banner-visible) and a long detail (debug), and stamps finished_at.
+	MarkFailed(ctx context.Context, id int64, msg, detail string, finishedAt time.Time) error
+
+	// MarkDismissed stamps viewed_at so the banner disappears. Idempotent:
+	// a second call replaces the timestamp with the newer one.
+	MarkDismissed(ctx context.Context, id int64, at time.Time) error
+
+	// ByID returns one job, or ErrJobNotFound.
+	ByID(ctx context.Context, id int64) (Job, error)
+
+	// LatestForControl returns the most recent job for a control (highest
+	// created_at). Returns ErrJobNotFound when the control has no jobs.
+	// The Detail handler renders the banner from this row.
+	LatestForControl(ctx context.Context, controlID string) (Job, error)
+
+	// QueuedIDs returns every `queued` job's id, oldest first. Sweep calls
+	// this once at boot to re-push them onto the runner's channel.
+	QueuedIDs(ctx context.Context) ([]int64, error)
+
+	// FailRunningWithMessage transitions every `running` row to `failed`
+	// with the given short error and stamps finished_at. Sweep calls this
+	// once at boot with RestartMidJobError so a job that was running when
+	// the server died surfaces on the banner rather than staying open
+	// forever. Returns the number of rows updated.
+	FailRunningWithMessage(ctx context.Context, msg string, finishedAt time.Time) (int, error)
+}
+
+// ErrJobNotFound is what Store.ByID and MarkRunning/Done/Failed answer
+// when no row has the id in question — a caller that races a delete or
+// hands a bogus id gets a distinguishable error.
+var ErrJobNotFound = errors.New("jobs: no such job")

--- a/apps/server/internal/domain/jobs/runner.go
+++ b/apps/server/internal/domain/jobs/runner.go
@@ -58,21 +58,26 @@ type Runner struct {
 // Start.drain re-scans the store after every job.
 const runnerBuffer = 256
 
-// NewRunner returns a Runner over store, with a Handler registered for
-// every Kind. Same shape as controls.NewService: a wiring mistake is a
-// panic at boot (backend-code-style.md §Errors).
+// NewRunner returns a Runner over store, dispatching each Kind to the
+// Handler registered for it. Handlers can be partial while the WP is
+// mid-migration (S3 registers only reanalyse; S4–S6 add the rest): a
+// Submit of an unregistered Kind is refused, and a queued row with an
+// unregistered Kind is failed rather than dropped — never a silent
+// no-op. A nil entry is a wiring bug, though, so those still panic.
 func NewRunner(store Store, handlers Handlers, log *slog.Logger, now func() time.Time) *Runner {
 	switch {
 	case store == nil:
 		panic("jobs.NewRunner: no store")
+	case handlers == nil:
+		panic("jobs.NewRunner: no handlers map")
 	case log == nil:
 		panic("jobs.NewRunner: no logger")
 	case now == nil:
 		panic("jobs.NewRunner: no clock")
 	}
-	for _, kind := range ValidKinds {
-		if _, ok := handlers[kind]; !ok {
-			panic("jobs.NewRunner: no handler for kind " + string(kind))
+	for kind, h := range handlers {
+		if h == nil {
+			panic("jobs.NewRunner: nil handler for kind " + string(kind))
 		}
 	}
 	return &Runner{
@@ -201,11 +206,24 @@ func (r *Runner) runOne(ctx context.Context, id int64) {
 		// previous run stands.
 		return
 	}
+	handler, ok := r.handlers[job.Kind]
+	if !ok {
+		// A queued row whose Kind has no handler yet — most likely a
+		// row written by a newer server against a schema this binary
+		// does not know about, or an in-flight WP-migration boot order.
+		// Fail it with a distinct message so it does not stay `queued`
+		// forever and the banner surfaces the operator issue.
+		msg := "no handler registered for kind " + string(job.Kind)
+		if err := r.store.MarkFailed(ctx, id, msg, "", r.now()); err != nil {
+			r.log.Error("jobs: mark failed (unknown kind)", "id", id, "error", err)
+		}
+		r.log.Error("jobs: no handler for kind", "id", id, "kind", string(job.Kind))
+		return
+	}
 	if err := r.store.MarkRunning(ctx, id, r.now()); err != nil {
 		r.log.Error("jobs: mark running", "id", id, "error", err)
 		return
 	}
-	handler := r.handlers[job.Kind]
 	handlerErr := r.callHandler(ctx, handler, job)
 	if handlerErr == nil {
 		if err := r.store.MarkDone(ctx, id, r.now()); err != nil {

--- a/apps/server/internal/domain/jobs/runner.go
+++ b/apps/server/internal/domain/jobs/runner.go
@@ -1,0 +1,249 @@
+package jobs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// Handler is what the runner reaches into for each Kind. Registered at
+// wiring time in cmd/server; the runner never imports the controls
+// domain itself (backend-code-style.md §The dependency rule). controlID
+// and payload are what Submit stored on the row, verbatim: the handler
+// deserialises the payload against the kind it registered for.
+type Handler func(ctx context.Context, controlID string, payload []byte) error
+
+// Handlers is the map keyed by Kind. NewRunner refuses to construct a
+// runner missing any handler — a wiring mistake is a panic at boot
+// rather than a `no handler for kind X` at first submit.
+type Handlers map[Kind]Handler
+
+// Failure is the shape a handler returns when the runner should record a
+// distinct short (banner) message and a long (debug) detail on the
+// failed row. When the handler returns a plain error, the runner uses
+// err.Error() for the banner and stores no detail — same shape the
+// flash cookie's refusedFlash already draws in scans.go.
+type Failure struct {
+	Message string
+	Detail  string
+}
+
+// Error makes Failure satisfy the error interface — a handler can just
+// `return &jobs.Failure{Message: ..., Detail: ...}`.
+func (f *Failure) Error() string { return f.Message }
+
+// Runner is the single-goroutine job runner (issue #249 §Design). It
+// serialises AMC work at a level above amcworker.Client's own mutex — the
+// mutex stays as a defense in depth for any future sync caller that does
+// not go through the runner.
+type Runner struct {
+	store    Store
+	handlers Handlers
+	log      *slog.Logger
+	now      func() time.Time
+
+	// ch is the fast-path notification channel. Submit pushes an id when
+	// there is room; Start reads it and dispatches. Buffered so a burst
+	// of submissions does not block the caller's HTTP handler. When the
+	// buffer fills, Submit falls back to "the row is already `queued`
+	// in the store" — Start's drain-after-each pass picks it up.
+	ch chan int64
+}
+
+// runnerBuffer is the channel buffer size — deliberately large enough to
+// absorb any professor's realistic burst (a class of 30 copies produces
+// one job per operation, not thirty). Overflow does not lose work:
+// Start.drain re-scans the store after every job.
+const runnerBuffer = 256
+
+// NewRunner returns a Runner over store, with a Handler registered for
+// every Kind. Same shape as controls.NewService: a wiring mistake is a
+// panic at boot (backend-code-style.md §Errors).
+func NewRunner(store Store, handlers Handlers, log *slog.Logger, now func() time.Time) *Runner {
+	switch {
+	case store == nil:
+		panic("jobs.NewRunner: no store")
+	case log == nil:
+		panic("jobs.NewRunner: no logger")
+	case now == nil:
+		panic("jobs.NewRunner: no clock")
+	}
+	for _, kind := range ValidKinds {
+		if _, ok := handlers[kind]; !ok {
+			panic("jobs.NewRunner: no handler for kind " + string(kind))
+		}
+	}
+	return &Runner{
+		store:    store,
+		handlers: handlers,
+		log:      log,
+		now:      now,
+		ch:       make(chan int64, runnerBuffer),
+	}
+}
+
+// Submit inserts a job in `queued` and notifies the runner. Returns the
+// job's id so the caller can render "job N encolado" or redirect to a
+// page that renders the banner from the latest job. Fast — no AMC call
+// happens on this path.
+func (r *Runner) Submit(ctx context.Context, controlID string, kind Kind, payload []byte) (int64, error) {
+	if _, ok := r.handlers[kind]; !ok {
+		return 0, fmt.Errorf("jobs.Runner.Submit: no handler for kind %q", kind)
+	}
+	id, err := r.store.Insert(ctx, NewJob{ControlID: controlID, Kind: kind, Payload: payload})
+	if err != nil {
+		return 0, fmt.Errorf("jobs.Runner.Submit: %w", err)
+	}
+	select {
+	case r.ch <- id:
+	default:
+		r.log.Warn("jobs: notification channel full; runner will pick this row up on its next drain",
+			"id", id, "kind", string(kind), "control", controlID)
+	}
+	return id, nil
+}
+
+// Sweep runs exactly once at boot, BEFORE Start (§Design: "corre UNA
+// vez desde main.go"). Two passes: mark every `running` row as `failed`
+// with RestartMidJobError (the previous server died mid-job), then
+// re-push every `queued` row onto the channel so the runner picks up
+// where it left off.
+func (r *Runner) Sweep(ctx context.Context) error {
+	n, err := r.store.FailRunningWithMessage(ctx, RestartMidJobError, r.now())
+	if err != nil {
+		return fmt.Errorf("jobs.Runner.Sweep: fail running: %w", err)
+	}
+	if n > 0 {
+		r.log.Warn("jobs: sweep marked running jobs as failed",
+			"count", n, "reason", RestartMidJobError)
+	}
+	ids, err := r.store.QueuedIDs(ctx)
+	if err != nil {
+		return fmt.Errorf("jobs.Runner.Sweep: list queued: %w", err)
+	}
+	for _, id := range ids {
+		select {
+		case r.ch <- id:
+		default:
+			// See runnerBuffer: the row stays `queued`, so Start's
+			// drain will find it. A very large boot backlog is the
+			// only way here, and it self-heals.
+			r.log.Warn("jobs: sweep re-push dropped by full channel", "id", id)
+		}
+	}
+	if len(ids) > 0 {
+		r.log.Info("jobs: sweep re-pushed queued jobs", "count", len(ids))
+	}
+	return nil
+}
+
+// Start blocks in the runner's one goroutine, reading ids off the
+// channel and dispatching them. Returns when ctx is done. Runs on the
+// caller's goroutine — cmd/server wires it as `go runner.Start(ctx)`.
+//
+// After each job, drainStore looks for any queued rows the channel
+// might have dropped (buffer overflow, or rows inserted while another
+// job was running and the notification was raced by a closer submit).
+// Cheap: one SELECT that returns nothing in the common case.
+func (r *Runner) Start(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case id := <-r.ch:
+			r.runOne(ctx, id)
+			r.drainStore(ctx)
+		}
+	}
+}
+
+// drainStore repeatedly asks the store for queued rows and runs them
+// until the store answers empty. Runs synchronously in Start's
+// goroutine, so the single-writer invariant against the amcworker stays.
+func (r *Runner) drainStore(ctx context.Context) {
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		ids, err := r.store.QueuedIDs(ctx)
+		if err != nil {
+			r.log.Error("jobs: drain queued", "error", err)
+			return
+		}
+		if len(ids) == 0 {
+			return
+		}
+		for _, id := range ids {
+			if ctx.Err() != nil {
+				return
+			}
+			r.runOne(ctx, id)
+		}
+	}
+}
+
+// runOne executes one job end-to-end. Not atomic on the DB side: the row
+// moves queued → running → done|failed through three writes. A crash
+// between the writes leaves a `running` row that the next boot's Sweep
+// catches (RestartMidJobError). A panic in the handler is recovered so
+// one bad job does not kill the runner's only goroutine.
+func (r *Runner) runOne(ctx context.Context, id int64) {
+	job, err := r.store.ByID(ctx, id)
+	if err != nil {
+		r.log.Error("jobs: fetch", "id", id, "error", err)
+		return
+	}
+	if job.Status != StatusQueued {
+		// Already picked up by Sweep or a duplicate channel push. The
+		// runner never runs a row twice — the terminal write from the
+		// previous run stands.
+		return
+	}
+	if err := r.store.MarkRunning(ctx, id, r.now()); err != nil {
+		r.log.Error("jobs: mark running", "id", id, "error", err)
+		return
+	}
+	handler := r.handlers[job.Kind]
+	handlerErr := r.callHandler(ctx, handler, job)
+	if handlerErr == nil {
+		if err := r.store.MarkDone(ctx, id, r.now()); err != nil {
+			r.log.Error("jobs: mark done", "id", id, "error", err)
+		}
+		r.log.Info("jobs: job done",
+			"id", id, "kind", string(job.Kind), "control", job.ControlID)
+		return
+	}
+	msg, detail := extractFailure(handlerErr)
+	if err := r.store.MarkFailed(ctx, id, msg, detail, r.now()); err != nil {
+		r.log.Error("jobs: mark failed", "id", id, "error", err)
+	}
+	r.log.Warn("jobs: job failed",
+		"id", id, "kind", string(job.Kind), "control", job.ControlID, "error", msg)
+}
+
+// callHandler runs the handler with a defer/recover so a panic surfaces
+// as a Failure with the panic value rather than crashing the runner.
+func (r *Runner) callHandler(ctx context.Context, handler Handler, job Job) (err error) {
+	defer func() {
+		if p := recover(); p != nil {
+			err = &Failure{
+				Message: fmt.Sprintf("panic: %v", p),
+				Detail:  fmt.Sprintf("panic while running kind=%s id=%d control=%s: %v", job.Kind, job.ID, job.ControlID, p),
+			}
+		}
+	}()
+	return handler(ctx, job.ControlID, job.Payload)
+}
+
+// extractFailure pulls the (message, detail) pair the handler wanted the
+// runner to record. A *Failure carries both; any other error uses
+// err.Error() for the message and empty detail.
+func extractFailure(err error) (msg, detail string) {
+	var f *Failure
+	if errors.As(err, &f) {
+		return f.Message, f.Detail
+	}
+	return err.Error(), ""
+}

--- a/apps/server/internal/domain/jobs/runner.go
+++ b/apps/server/internal/domain/jobs/runner.go
@@ -58,12 +58,10 @@ type Runner struct {
 // Start.drain re-scans the store after every job.
 const runnerBuffer = 256
 
-// NewRunner returns a Runner over store, dispatching each Kind to the
-// Handler registered for it. Handlers can be partial while the WP is
-// mid-migration (S3 registers only reanalyse; S4–S6 add the rest): a
-// Submit of an unregistered Kind is refused, and a queued row with an
-// unregistered Kind is failed rather than dropped — never a silent
-// no-op. A nil entry is a wiring bug, though, so those still panic.
+// NewRunner returns a Runner over store. Every Kind in ValidKinds must
+// have a Handler registered — a wiring mistake is a panic at boot, the
+// same rule the rest of this app uses for missing dependencies
+// (backend-code-style.md §Errors, apps/server/CLAUDE.md rules-for-Claude).
 func NewRunner(store Store, handlers Handlers, log *slog.Logger, now func() time.Time) *Runner {
 	switch {
 	case store == nil:
@@ -75,7 +73,11 @@ func NewRunner(store Store, handlers Handlers, log *slog.Logger, now func() time
 	case now == nil:
 		panic("jobs.NewRunner: no clock")
 	}
-	for kind, h := range handlers {
+	for _, kind := range ValidKinds {
+		h, ok := handlers[kind]
+		if !ok {
+			panic("jobs.NewRunner: no handler for kind " + string(kind))
+		}
 		if h == nil {
 			panic("jobs.NewRunner: nil handler for kind " + string(kind))
 		}
@@ -94,10 +96,10 @@ func NewRunner(store Store, handlers Handlers, log *slog.Logger, now func() time
 // page that renders the banner from the latest job. Fast — no AMC call
 // happens on this path.
 func (r *Runner) Submit(ctx context.Context, controlID string, kind Kind, payload []byte) (int64, error) {
-	if _, ok := r.handlers[kind]; !ok {
-		return 0, fmt.Errorf("jobs.Runner.Submit: no handler for kind %q", kind)
-	}
-	id, err := r.store.Insert(ctx, NewJob{ControlID: controlID, Kind: kind, Payload: payload})
+	// No unknown-kind check here: NewRunner already refused a Handlers
+	// map missing any ValidKinds entry, and callers use the typed
+	// constants (a typo is a compile error, not a runtime one).
+	id, err := r.store.Insert(ctx, NewJob{ControlID: controlID, Kind: kind, Payload: payload}, r.now())
 	if err != nil {
 		return 0, fmt.Errorf("jobs.Runner.Submit: %w", err)
 	}
@@ -206,20 +208,10 @@ func (r *Runner) runOne(ctx context.Context, id int64) {
 		// previous run stands.
 		return
 	}
-	handler, ok := r.handlers[job.Kind]
-	if !ok {
-		// A queued row whose Kind has no handler yet — most likely a
-		// row written by a newer server against a schema this binary
-		// does not know about, or an in-flight WP-migration boot order.
-		// Fail it with a distinct message so it does not stay `queued`
-		// forever and the banner surfaces the operator issue.
-		msg := "no handler registered for kind " + string(job.Kind)
-		if err := r.store.MarkFailed(ctx, id, msg, "", r.now()); err != nil {
-			r.log.Error("jobs: mark failed (unknown kind)", "id", id, "error", err)
-		}
-		r.log.Error("jobs: no handler for kind", "id", id, "kind", string(job.Kind))
-		return
-	}
+	// NewRunner guarantees every ValidKinds entry is registered — the
+	// schema CHECK on job.kind rejects anything outside that set, so
+	// a lookup here always succeeds.
+	handler := r.handlers[job.Kind]
 	if err := r.store.MarkRunning(ctx, id, r.now()); err != nil {
 		r.log.Error("jobs: mark running", "id", id, "error", err)
 		return

--- a/apps/server/internal/domain/jobs/runner.go
+++ b/apps/server/internal/domain/jobs/runner.go
@@ -23,8 +23,9 @@ type Handlers map[Kind]Handler
 // Failure is the shape a handler returns when the runner should record a
 // distinct short (banner) message and a long (debug) detail on the
 // failed row. When the handler returns a plain error, the runner uses
-// err.Error() for the banner and stores no detail — same shape the
-// flash cookie's refusedFlash already draws in scans.go.
+// err.Error() for the banner and stores no detail — a short Message +
+// optional long Detail matches the (Message, Detail) split
+// controls.AnalyzerRefusedError already carries.
 type Failure struct {
 	Message string
 	Detail  string

--- a/apps/server/internal/domain/jobs/runner_test.go
+++ b/apps/server/internal/domain/jobs/runner_test.go
@@ -3,7 +3,6 @@ package jobs_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"log/slog"
 	"sync"
@@ -164,22 +163,11 @@ func (s *fakeStore) FailRunningWithMessage(_ context.Context, msg string, at tim
 	return n, nil
 }
 
-// stubHandlers returns a Handlers map where every kind runs `handler`.
-// Convenient default: three of the four kinds return "unexpected kind"
-// so a test that submits the wrong one fails loudly.
+// stubHandlers returns a Handlers map with `handler` bound to `kind`.
+// Since NewRunner now allows partial registration (S3 wires only one
+// kind at first), the fixture registers only the one under test.
 func stubHandlers(kind jobs.Kind, handler jobs.Handler) jobs.Handlers {
-	h := jobs.Handlers{}
-	for _, k := range jobs.ValidKinds {
-		k := k
-		if k == kind {
-			h[k] = handler
-			continue
-		}
-		h[k] = func(context.Context, string, []byte) error {
-			return fmt.Errorf("stub: unexpected kind %q", k)
-		}
-	}
-	return h
+	return jobs.Handlers{kind: handler}
 }
 
 func silentLogger() *slog.Logger {
@@ -400,11 +388,38 @@ func TestSubmitRefusesAnUnregisteredKind(t *testing.T) {
 		func(context.Context, string, []byte) error { return nil }),
 		silentLogger(), time.Now)
 
-	// Every ValidKind is registered by stubHandlers. Force a mismatch
-	// by constructing an out-of-set kind — the runner rejects it.
-	_, err := runner.Submit(context.Background(), "CTRL001", jobs.Kind("nonesuch"), []byte(`{}`))
+	// Only KindAnalyse is registered; a Submit for a different kind is
+	// refused rather than accepted and never run.
+	_, err := runner.Submit(context.Background(), "CTRL001", jobs.KindGenerate, []byte(`{}`))
 	if err == nil {
 		t.Errorf("Submit accepted an unregistered kind; want an error")
+	}
+}
+
+func TestRunnerFailsAQueuedRowWhoseKindHasNoHandler(t *testing.T) {
+	store := newFakeStore()
+	// Only KindAnalyse is registered — but a KindGenerate row is
+	// pre-seeded on the store (a previous binary wrote it, then this
+	// binary boots without that handler yet).
+	if _, err := store.Insert(context.Background(), jobs.NewJob{
+		ControlID: "CTRL001", Kind: jobs.KindGenerate, Payload: []byte(`{}`),
+	}); err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+	runner := jobs.NewRunner(store, stubHandlers(jobs.KindAnalyse,
+		func(context.Context, string, []byte) error { return nil }),
+		silentLogger(), time.Now)
+	if err := runner.Sweep(context.Background()); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go runner.Start(ctx)
+
+	// It ends up failed rather than stuck queued.
+	final := waitForStatus(t, store, 1, jobs.StatusFailed)
+	if final.Error == "" {
+		t.Errorf("unknown-kind row has empty Error; want the operator-facing message")
 	}
 }
 

--- a/apps/server/internal/domain/jobs/runner_test.go
+++ b/apps/server/internal/domain/jobs/runner_test.go
@@ -1,0 +1,418 @@
+package jobs_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/jobs"
+)
+
+// fakeStore is an in-memory jobs.Store — the domain cannot depend on
+// infra (backend-code-style.md §The dependency rule), so the runner
+// tests run against a hand-rolled store rather than the SQLite one.
+// The jobstore package has its own round-trip tests over SQLite (S1).
+type fakeStore struct {
+	mu      sync.Mutex
+	jobs    map[int64]*jobs.Job
+	nextID  int64
+	newAtFn func() time.Time
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{
+		jobs:    map[int64]*jobs.Job{},
+		nextID:  0,
+		newAtFn: time.Now,
+	}
+}
+
+func (s *fakeStore) Insert(_ context.Context, j jobs.NewJob) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nextID++
+	id := s.nextID
+	s.jobs[id] = &jobs.Job{
+		ID:        id,
+		ControlID: j.ControlID,
+		Kind:      j.Kind,
+		Status:    jobs.StatusQueued,
+		Payload:   append([]byte(nil), j.Payload...),
+		CreatedAt: s.newAtFn(),
+	}
+	return id, nil
+}
+
+func (s *fakeStore) MarkRunning(_ context.Context, id int64, at time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	j, ok := s.jobs[id]
+	if !ok {
+		return jobs.ErrJobNotFound
+	}
+	j.Status = jobs.StatusRunning
+	t := at
+	j.StartedAt = &t
+	return nil
+}
+
+func (s *fakeStore) MarkDone(_ context.Context, id int64, at time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	j, ok := s.jobs[id]
+	if !ok {
+		return jobs.ErrJobNotFound
+	}
+	j.Status = jobs.StatusDone
+	t := at
+	j.FinishedAt = &t
+	return nil
+}
+
+func (s *fakeStore) MarkFailed(_ context.Context, id int64, msg, detail string, at time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	j, ok := s.jobs[id]
+	if !ok {
+		return jobs.ErrJobNotFound
+	}
+	j.Status = jobs.StatusFailed
+	j.Error = msg
+	j.Detail = detail
+	t := at
+	j.FinishedAt = &t
+	return nil
+}
+
+func (s *fakeStore) MarkDismissed(_ context.Context, id int64, at time.Time) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	j, ok := s.jobs[id]
+	if !ok {
+		return jobs.ErrJobNotFound
+	}
+	t := at
+	j.ViewedAt = &t
+	return nil
+}
+
+func (s *fakeStore) ByID(_ context.Context, id int64) (jobs.Job, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	j, ok := s.jobs[id]
+	if !ok {
+		return jobs.Job{}, jobs.ErrJobNotFound
+	}
+	return *j, nil
+}
+
+func (s *fakeStore) LatestForControl(_ context.Context, controlID string) (jobs.Job, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var latest *jobs.Job
+	for _, j := range s.jobs {
+		if j.ControlID != controlID {
+			continue
+		}
+		if latest == nil || j.CreatedAt.After(latest.CreatedAt) ||
+			(j.CreatedAt.Equal(latest.CreatedAt) && j.ID > latest.ID) {
+			latest = j
+		}
+	}
+	if latest == nil {
+		return jobs.Job{}, jobs.ErrJobNotFound
+	}
+	return *latest, nil
+}
+
+func (s *fakeStore) QueuedIDs(_ context.Context) ([]int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var ids []int64
+	// Preserve id-ascending order (proxy for insertion order in the
+	// fake — real store orders by created_at first).
+	for id := int64(1); id <= s.nextID; id++ {
+		j, ok := s.jobs[id]
+		if !ok {
+			continue
+		}
+		if j.Status == jobs.StatusQueued {
+			ids = append(ids, id)
+		}
+	}
+	return ids, nil
+}
+
+func (s *fakeStore) FailRunningWithMessage(_ context.Context, msg string, at time.Time) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for _, j := range s.jobs {
+		if j.Status == jobs.StatusRunning {
+			j.Status = jobs.StatusFailed
+			j.Error = msg
+			t := at
+			j.FinishedAt = &t
+			n++
+		}
+	}
+	return n, nil
+}
+
+// stubHandlers returns a Handlers map where every kind runs `handler`.
+// Convenient default: three of the four kinds return "unexpected kind"
+// so a test that submits the wrong one fails loudly.
+func stubHandlers(kind jobs.Kind, handler jobs.Handler) jobs.Handlers {
+	h := jobs.Handlers{}
+	for _, k := range jobs.ValidKinds {
+		k := k
+		if k == kind {
+			h[k] = handler
+			continue
+		}
+		h[k] = func(context.Context, string, []byte) error {
+			return fmt.Errorf("stub: unexpected kind %q", k)
+		}
+	}
+	return h
+}
+
+func silentLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// waitForStatus polls the store until the job reaches `want` or the
+// deadline expires. Runner processes jobs asynchronously; without this
+// the tests would race the goroutine.
+func waitForStatus(t *testing.T, store *fakeStore, id int64, want jobs.Status) jobs.Job {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		j, err := store.ByID(context.Background(), id)
+		if err != nil {
+			t.Fatalf("ByID(%d): %v", id, err)
+		}
+		if j.Status == want {
+			return j
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("job %d never reached %q (last status %q)", id, want, j.Status)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestRunnerMovesAJobFromQueuedToRunningToDone(t *testing.T) {
+	store := newFakeStore()
+	// Signal-back channel proves the handler observed status=running
+	// while it was executing — not just that the end state is done.
+	seenRunning := make(chan bool, 1)
+	handler := func(ctx context.Context, controlID string, payload []byte) error {
+		j, err := store.ByID(ctx, mustLatestID(t, store))
+		if err != nil {
+			return err
+		}
+		seenRunning <- (j.Status == jobs.StatusRunning)
+		return nil
+	}
+	runner := jobs.NewRunner(store, stubHandlers(jobs.KindReanalyse, handler),
+		silentLogger(), time.Now)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go runner.Start(ctx)
+
+	id, err := runner.Submit(ctx, "CTRL001", jobs.KindReanalyse, []byte(`{}`))
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	select {
+	case saw := <-seenRunning:
+		if !saw {
+			t.Errorf("handler ran but job was not in status=running")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("handler never ran")
+	}
+	final := waitForStatus(t, store, id, jobs.StatusDone)
+	if final.StartedAt == nil {
+		t.Errorf("Done job has nil StartedAt")
+	}
+	if final.FinishedAt == nil {
+		t.Errorf("Done job has nil FinishedAt")
+	}
+}
+
+func TestRunnerRecordsAHandlerErrorAsFailedWithMessage(t *testing.T) {
+	store := newFakeStore()
+	handler := func(context.Context, string, []byte) error {
+		return errors.New("boom")
+	}
+	runner := jobs.NewRunner(store, stubHandlers(jobs.KindAnalyse, handler),
+		silentLogger(), time.Now)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go runner.Start(ctx)
+
+	id, err := runner.Submit(ctx, "CTRL001", jobs.KindAnalyse, []byte(`{}`))
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	final := waitForStatus(t, store, id, jobs.StatusFailed)
+	if final.Error != "boom" {
+		t.Errorf("Error = %q, want %q", final.Error, "boom")
+	}
+	if final.Detail != "" {
+		t.Errorf("Detail = %q, want empty for a plain error", final.Detail)
+	}
+}
+
+func TestRunnerSplitsFailureIntoMessageAndDetail(t *testing.T) {
+	store := newFakeStore()
+	handler := func(context.Context, string, []byte) error {
+		return &jobs.Failure{Message: "worker refused", Detail: "ERR: line 1\nERR: line 2"}
+	}
+	runner := jobs.NewRunner(store, stubHandlers(jobs.KindAnalyse, handler),
+		silentLogger(), time.Now)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go runner.Start(ctx)
+
+	id, err := runner.Submit(ctx, "CTRL001", jobs.KindAnalyse, []byte(`{}`))
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	final := waitForStatus(t, store, id, jobs.StatusFailed)
+	if final.Error != "worker refused" {
+		t.Errorf("Error = %q, want %q", final.Error, "worker refused")
+	}
+	if final.Detail != "ERR: line 1\nERR: line 2" {
+		t.Errorf("Detail = %q, want the two-line context", final.Detail)
+	}
+}
+
+func TestRunnerRecoversFromAHandlerPanic(t *testing.T) {
+	store := newFakeStore()
+	handler := func(context.Context, string, []byte) error {
+		panic("kablooie")
+	}
+	runner := jobs.NewRunner(store, stubHandlers(jobs.KindGenerate, handler),
+		silentLogger(), time.Now)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go runner.Start(ctx)
+
+	id, err := runner.Submit(ctx, "CTRL001", jobs.KindGenerate, []byte(`{}`))
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	final := waitForStatus(t, store, id, jobs.StatusFailed)
+	if final.Error == "" {
+		t.Errorf("Error is empty, want the panic value in the banner")
+	}
+	if final.Detail == "" {
+		t.Errorf("Detail is empty, want the panic context in the debug column")
+	}
+	// A subsequent submit still runs — the recover kept the goroutine
+	// alive.
+	next, _ := runner.Submit(ctx, "CTRL001", jobs.KindGenerate, []byte(`{}`))
+	// Both jobs failed, but they both ran — proves the recover held.
+	waitForStatus(t, store, next, jobs.StatusFailed)
+}
+
+func TestSweepRePushesQueuedRowsToTheRunner(t *testing.T) {
+	store := newFakeStore()
+	ran := make(chan int64, 4)
+	handler := func(_ context.Context, controlID string, payload []byte) error {
+		ran <- 1
+		return nil
+	}
+	runner := jobs.NewRunner(store, stubHandlers(jobs.KindReanalyse, handler),
+		silentLogger(), time.Now)
+
+	// Simulate a pre-existing queued row (as if the previous server
+	// wrote it but died before pushing to the in-memory channel).
+	id, err := store.Insert(context.Background(), jobs.NewJob{
+		ControlID: "CTRL001", Kind: jobs.KindReanalyse, Payload: []byte(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("seeding queued row: %v", err)
+	}
+	if err := runner.Sweep(context.Background()); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go runner.Start(ctx)
+
+	select {
+	case <-ran:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Sweep did not re-push queued row %d", id)
+	}
+	waitForStatus(t, store, id, jobs.StatusDone)
+}
+
+func TestSweepFailsRunningRowsFromABeforeCrashAsRestartMidJob(t *testing.T) {
+	store := newFakeStore()
+	// Seed a `running` row (previous server died mid-job).
+	id, err := store.Insert(context.Background(), jobs.NewJob{
+		ControlID: "CTRL001", Kind: jobs.KindAnalyse, Payload: []byte(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("seeding: %v", err)
+	}
+	if err := store.MarkRunning(context.Background(), id, time.Now()); err != nil {
+		t.Fatalf("MarkRunning: %v", err)
+	}
+
+	runner := jobs.NewRunner(store, stubHandlers(jobs.KindAnalyse,
+		func(context.Context, string, []byte) error { return nil }),
+		silentLogger(), time.Now)
+
+	if err := runner.Sweep(context.Background()); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	got, _ := store.ByID(context.Background(), id)
+	if got.Status != jobs.StatusFailed {
+		t.Errorf("Sweep left status = %q, want failed", got.Status)
+	}
+	if got.Error != jobs.RestartMidJobError {
+		t.Errorf("Sweep wrote Error = %q, want %q", got.Error, jobs.RestartMidJobError)
+	}
+	if got.FinishedAt == nil {
+		t.Errorf("Sweep did not stamp FinishedAt")
+	}
+}
+
+func TestSubmitRefusesAnUnregisteredKind(t *testing.T) {
+	store := newFakeStore()
+	runner := jobs.NewRunner(store, stubHandlers(jobs.KindAnalyse,
+		func(context.Context, string, []byte) error { return nil }),
+		silentLogger(), time.Now)
+
+	// Every ValidKind is registered by stubHandlers. Force a mismatch
+	// by constructing an out-of-set kind — the runner rejects it.
+	_, err := runner.Submit(context.Background(), "CTRL001", jobs.Kind("nonesuch"), []byte(`{}`))
+	if err == nil {
+		t.Errorf("Submit accepted an unregistered kind; want an error")
+	}
+}
+
+// mustLatestID reads back the store's latest job id — a helper for
+// handlers that need to see the row the runner just flipped to running.
+func mustLatestID(t *testing.T, s *fakeStore) int64 {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.nextID
+}

--- a/apps/server/internal/domain/jobs/runner_test.go
+++ b/apps/server/internal/domain/jobs/runner_test.go
@@ -31,7 +31,7 @@ func newFakeStore() *fakeStore {
 	}
 }
 
-func (s *fakeStore) Insert(_ context.Context, j jobs.NewJob) (int64, error) {
+func (s *fakeStore) Insert(_ context.Context, j jobs.NewJob, at time.Time) (int64, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.nextID++
@@ -42,7 +42,7 @@ func (s *fakeStore) Insert(_ context.Context, j jobs.NewJob) (int64, error) {
 		Kind:      j.Kind,
 		Status:    jobs.StatusQueued,
 		Payload:   append([]byte(nil), j.Payload...),
-		CreatedAt: s.newAtFn(),
+		CreatedAt: at,
 	}
 	return id, nil
 }
@@ -163,11 +163,20 @@ func (s *fakeStore) FailRunningWithMessage(_ context.Context, msg string, at tim
 	return n, nil
 }
 
-// stubHandlers returns a Handlers map with `handler` bound to `kind`.
-// Since NewRunner now allows partial registration (S3 wires only one
-// kind at first), the fixture registers only the one under test.
+// stubHandlers returns a Handlers map with `handler` bound to `kind`
+// and no-ops registered for the other ValidKinds — NewRunner refuses a
+// map missing any of the four kinds since ARQ-3.
 func stubHandlers(kind jobs.Kind, handler jobs.Handler) jobs.Handlers {
-	return jobs.Handlers{kind: handler}
+	noop := func(context.Context, string, []byte) error { return nil }
+	h := jobs.Handlers{}
+	for _, k := range jobs.ValidKinds {
+		if k == kind {
+			h[k] = handler
+		} else {
+			h[k] = noop
+		}
+	}
+	return h
 }
 
 func silentLogger() *slog.Logger {
@@ -331,7 +340,7 @@ func TestSweepRePushesQueuedRowsToTheRunner(t *testing.T) {
 	// wrote it but died before pushing to the in-memory channel).
 	id, err := store.Insert(context.Background(), jobs.NewJob{
 		ControlID: "CTRL001", Kind: jobs.KindReanalyse, Payload: []byte(`{}`),
-	})
+	}, time.Now())
 	if err != nil {
 		t.Fatalf("seeding queued row: %v", err)
 	}
@@ -355,7 +364,7 @@ func TestSweepFailsRunningRowsFromABeforeCrashAsRestartMidJob(t *testing.T) {
 	// Seed a `running` row (previous server died mid-job).
 	id, err := store.Insert(context.Background(), jobs.NewJob{
 		ControlID: "CTRL001", Kind: jobs.KindAnalyse, Payload: []byte(`{}`),
-	})
+	}, time.Now())
 	if err != nil {
 		t.Fatalf("seeding: %v", err)
 	}
@@ -382,45 +391,24 @@ func TestSweepFailsRunningRowsFromABeforeCrashAsRestartMidJob(t *testing.T) {
 	}
 }
 
-func TestSubmitRefusesAnUnregisteredKind(t *testing.T) {
+// ARQ-3 (issue #249): NewRunner refuses a Handlers map missing any of
+// the four ValidKinds — a wiring mistake is a panic at boot, matching
+// how NewService / NewControls / NewAuth already refuse a nil
+// dependency (apps/server/CLAUDE.md rules-for-Claude, §Errors).
+func TestNewRunnerPanicsWhenAKindHasNoHandler(t *testing.T) {
 	store := newFakeStore()
-	runner := jobs.NewRunner(store, stubHandlers(jobs.KindAnalyse,
-		func(context.Context, string, []byte) error { return nil }),
-		silentLogger(), time.Now)
-
-	// Only KindAnalyse is registered; a Submit for a different kind is
-	// refused rather than accepted and never run.
-	_, err := runner.Submit(context.Background(), "CTRL001", jobs.KindGenerate, []byte(`{}`))
-	if err == nil {
-		t.Errorf("Submit accepted an unregistered kind; want an error")
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("NewRunner accepted a Handlers map missing KindAnnotate; want a boot-time panic")
+		}
+	}()
+	// Handlers has three of the four kinds — KindAnnotate is missing.
+	handlers := jobs.Handlers{
+		jobs.KindReanalyse: func(context.Context, string, []byte) error { return nil },
+		jobs.KindAnalyse:   func(context.Context, string, []byte) error { return nil },
+		jobs.KindGenerate:  func(context.Context, string, []byte) error { return nil },
 	}
-}
-
-func TestRunnerFailsAQueuedRowWhoseKindHasNoHandler(t *testing.T) {
-	store := newFakeStore()
-	// Only KindAnalyse is registered — but a KindGenerate row is
-	// pre-seeded on the store (a previous binary wrote it, then this
-	// binary boots without that handler yet).
-	if _, err := store.Insert(context.Background(), jobs.NewJob{
-		ControlID: "CTRL001", Kind: jobs.KindGenerate, Payload: []byte(`{}`),
-	}); err != nil {
-		t.Fatalf("seeding: %v", err)
-	}
-	runner := jobs.NewRunner(store, stubHandlers(jobs.KindAnalyse,
-		func(context.Context, string, []byte) error { return nil }),
-		silentLogger(), time.Now)
-	if err := runner.Sweep(context.Background()); err != nil {
-		t.Fatalf("Sweep: %v", err)
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go runner.Start(ctx)
-
-	// It ends up failed rather than stuck queued.
-	final := waitForStatus(t, store, 1, jobs.StatusFailed)
-	if final.Error == "" {
-		t.Errorf("unknown-kind row has empty Error; want the operator-facing message")
-	}
+	jobs.NewRunner(store, handlers, silentLogger(), time.Now)
 }
 
 // mustLatestID reads back the store's latest job id — a helper for

--- a/apps/server/internal/infra/storage/controlstore/controlstore_test.go
+++ b/apps/server/internal/infra/storage/controlstore/controlstore_test.go
@@ -57,7 +57,7 @@ func newControl(id string, userID int64, appDate *time.Time) controls.Control {
 		RangeTo:          bank.SectionRef{Document: "flujo", Section: "bucles"},
 		QuestionsPerCopy: 4,
 		Copies:           3,
-		// Issue #197: the product defaults, like Service.Create writes.
+		// Issue #197: the product defaults, like Service.PrepareControl writes.
 		Ticked: controls.DefaultTicked,
 		Unsure: controls.DefaultUnsure,
 		// Issue #208: the operational default (ADR-0043).

--- a/apps/server/internal/infra/storage/jobstore/jobstore.go
+++ b/apps/server/internal/infra/storage/jobstore/jobstore.go
@@ -37,14 +37,15 @@ var _ jobs.Store = (*Store)(nil)
 // scanJob below.
 const jobColumns = "id, control_id, kind, status, COALESCE(error, ''), COALESCE(detail, ''), payload_json, created_at, started_at, finished_at, viewed_at"
 
-// Insert creates a new job in `queued` and returns its id. created_at is
-// stamped by the store (unix seconds, matching every other table).
-func (s *Store) Insert(ctx context.Context, j jobs.NewJob) (int64, error) {
+// Insert creates a new job in `queued` and returns its id. createdAt
+// is the runner's clock (unix seconds on the wire, matching every
+// other table).
+func (s *Store) Insert(ctx context.Context, j jobs.NewJob, createdAt time.Time) (int64, error) {
 	res, err := s.db.ExecContext(ctx, `
         INSERT INTO job (control_id, kind, status, payload_json, created_at)
         VALUES (?, ?, ?, ?, ?)`,
 		j.ControlID, string(j.Kind), string(jobs.StatusQueued),
-		string(j.Payload), time.Now().Unix(),
+		string(j.Payload), createdAt.Unix(),
 	)
 	if err != nil {
 		return 0, fmt.Errorf("jobstore.Insert: %w", err)
@@ -56,30 +57,37 @@ func (s *Store) Insert(ctx context.Context, j jobs.NewJob) (int64, error) {
 	return id, nil
 }
 
-// MarkRunning transitions a job to `running` and stamps started_at.
+// MarkRunning transitions a job from `queued` to `running` and stamps
+// started_at. The `status = 'queued'` guard is belt-and-braces: the
+// runner is a single goroutine so double-processing is impossible by
+// design, but the WHERE clause turns any future concurrency mistake
+// (a second Start goroutine, an accidental extra call) into a loud
+// ErrJobNotFound instead of a silent status corruption (COR-3).
 func (s *Store) MarkRunning(ctx context.Context, id int64, startedAt time.Time) error {
 	res, err := s.db.ExecContext(ctx,
-		`UPDATE job SET status = ?, started_at = ? WHERE id = ?`,
-		string(jobs.StatusRunning), startedAt.Unix(), id,
+		`UPDATE job SET status = ?, started_at = ? WHERE id = ? AND status = ?`,
+		string(jobs.StatusRunning), startedAt.Unix(), id, string(jobs.StatusQueued),
 	)
 	return checkOne(res, err, id, "MarkRunning")
 }
 
-// MarkDone transitions a job to `done` and stamps finished_at.
+// MarkDone transitions a job from `running` to `done` and stamps
+// finished_at. Same status guard as MarkRunning; see that comment.
 func (s *Store) MarkDone(ctx context.Context, id int64, finishedAt time.Time) error {
 	res, err := s.db.ExecContext(ctx,
-		`UPDATE job SET status = ?, finished_at = ? WHERE id = ?`,
-		string(jobs.StatusDone), finishedAt.Unix(), id,
+		`UPDATE job SET status = ?, finished_at = ? WHERE id = ? AND status = ?`,
+		string(jobs.StatusDone), finishedAt.Unix(), id, string(jobs.StatusRunning),
 	)
 	return checkOne(res, err, id, "MarkDone")
 }
 
-// MarkFailed transitions a job to `failed` with a short error message and
-// a long detail, and stamps finished_at.
+// MarkFailed transitions a job from `running` to `failed` with a short
+// error message and a long detail, and stamps finished_at. Same
+// status guard as MarkRunning; see that comment.
 func (s *Store) MarkFailed(ctx context.Context, id int64, msg, detail string, finishedAt time.Time) error {
 	res, err := s.db.ExecContext(ctx,
-		`UPDATE job SET status = ?, error = ?, detail = ?, finished_at = ? WHERE id = ?`,
-		string(jobs.StatusFailed), msg, detail, finishedAt.Unix(), id,
+		`UPDATE job SET status = ?, error = ?, detail = ?, finished_at = ? WHERE id = ? AND status = ?`,
+		string(jobs.StatusFailed), msg, detail, finishedAt.Unix(), id, string(jobs.StatusRunning),
 	)
 	return checkOne(res, err, id, "MarkFailed")
 }

--- a/apps/server/internal/infra/storage/jobstore/jobstore.go
+++ b/apps/server/internal/infra/storage/jobstore/jobstore.go
@@ -1,0 +1,213 @@
+// Package jobstore is the SQLite side of the jobs domain: one type
+// implementing jobs.Store over the `job` table migration 00012 creates.
+//
+// Its shape mirrors controlstore — a *sql.DB, one type, one file — so the
+// dependency rule (backend-code-style.md §The dependency rule) is
+// unchanged: the runner reaches into a domain-defined interface, and this
+// package is the adapter beneath it. Unix seconds in and out; the store
+// converts to/from time.Time so callers do not handle epoch arithmetic.
+package jobstore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/jobs"
+)
+
+// Store adapts SQLite to jobs.Store.
+type Store struct {
+	db *sql.DB
+}
+
+// New returns a Store over db. The caller owns the handle and its
+// lifetime.
+func New(db *sql.DB) *Store {
+	return &Store{db: db}
+}
+
+// Compile-time proof the shape here is the one the domain asked for.
+var _ jobs.Store = (*Store)(nil)
+
+// jobColumns is the read shape LatestForControl and ByID both share; kept
+// as a constant so a schema change touches one place. Order matches
+// scanJob below.
+const jobColumns = "id, control_id, kind, status, COALESCE(error, ''), COALESCE(detail, ''), payload_json, created_at, started_at, finished_at, viewed_at"
+
+// Insert creates a new job in `queued` and returns its id. created_at is
+// stamped by the store (unix seconds, matching every other table).
+func (s *Store) Insert(ctx context.Context, j jobs.NewJob) (int64, error) {
+	res, err := s.db.ExecContext(ctx, `
+        INSERT INTO job (control_id, kind, status, payload_json, created_at)
+        VALUES (?, ?, ?, ?, ?)`,
+		j.ControlID, string(j.Kind), string(jobs.StatusQueued),
+		string(j.Payload), time.Now().Unix(),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("jobstore.Insert: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("jobstore.Insert: LastInsertId: %w", err)
+	}
+	return id, nil
+}
+
+// MarkRunning transitions a job to `running` and stamps started_at.
+func (s *Store) MarkRunning(ctx context.Context, id int64, startedAt time.Time) error {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE job SET status = ?, started_at = ? WHERE id = ?`,
+		string(jobs.StatusRunning), startedAt.Unix(), id,
+	)
+	return checkOne(res, err, id, "MarkRunning")
+}
+
+// MarkDone transitions a job to `done` and stamps finished_at.
+func (s *Store) MarkDone(ctx context.Context, id int64, finishedAt time.Time) error {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE job SET status = ?, finished_at = ? WHERE id = ?`,
+		string(jobs.StatusDone), finishedAt.Unix(), id,
+	)
+	return checkOne(res, err, id, "MarkDone")
+}
+
+// MarkFailed transitions a job to `failed` with a short error message and
+// a long detail, and stamps finished_at.
+func (s *Store) MarkFailed(ctx context.Context, id int64, msg, detail string, finishedAt time.Time) error {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE job SET status = ?, error = ?, detail = ?, finished_at = ? WHERE id = ?`,
+		string(jobs.StatusFailed), msg, detail, finishedAt.Unix(), id,
+	)
+	return checkOne(res, err, id, "MarkFailed")
+}
+
+// MarkDismissed stamps viewed_at. Idempotent (replaces the value).
+func (s *Store) MarkDismissed(ctx context.Context, id int64, at time.Time) error {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE job SET viewed_at = ? WHERE id = ?`,
+		at.Unix(), id,
+	)
+	return checkOne(res, err, id, "MarkDismissed")
+}
+
+// ByID returns one job, or ErrJobNotFound.
+func (s *Store) ByID(ctx context.Context, id int64) (jobs.Job, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+jobColumns+` FROM job WHERE id = ?`, id)
+	got, err := scanJob(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return jobs.Job{}, jobs.ErrJobNotFound
+	}
+	return got, err
+}
+
+// LatestForControl returns the most recent job for a control.
+func (s *Store) LatestForControl(ctx context.Context, controlID string) (jobs.Job, error) {
+	row := s.db.QueryRowContext(ctx,
+		`SELECT `+jobColumns+` FROM job WHERE control_id = ? ORDER BY created_at DESC, id DESC LIMIT 1`,
+		controlID)
+	got, err := scanJob(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return jobs.Job{}, jobs.ErrJobNotFound
+	}
+	return got, err
+}
+
+// QueuedIDs returns every queued job's id, oldest first.
+func (s *Store) QueuedIDs(ctx context.Context) ([]int64, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id FROM job WHERE status = ? ORDER BY created_at ASC, id ASC`,
+		string(jobs.StatusQueued))
+	if err != nil {
+		return nil, fmt.Errorf("jobstore.QueuedIDs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, fmt.Errorf("jobstore.QueuedIDs: scan: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("jobstore.QueuedIDs: rows: %w", err)
+	}
+	return ids, nil
+}
+
+// FailRunningWithMessage flips every running row to failed with the given
+// short message. Returns the number of rows updated.
+func (s *Store) FailRunningWithMessage(ctx context.Context, msg string, finishedAt time.Time) (int, error) {
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE job SET status = ?, error = ?, finished_at = ? WHERE status = ?`,
+		string(jobs.StatusFailed), msg, finishedAt.Unix(), string(jobs.StatusRunning),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("jobstore.FailRunningWithMessage: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("jobstore.FailRunningWithMessage: RowsAffected: %w", err)
+	}
+	return int(n), nil
+}
+
+// scanJob reads one row into a jobs.Job, converting nullable unix seconds
+// back to *time.Time. The row is either a QueryRow result or one row of a
+// Query result — both satisfy the same Scan contract.
+type scanner interface {
+	Scan(dest ...any) error
+}
+
+func scanJob(row scanner) (jobs.Job, error) {
+	var (
+		j                               jobs.Job
+		kind, status, payload           string
+		createdAt                       int64
+		startedAt, finishedAt, viewedAt sql.NullInt64
+		errMsg, detail                  string
+	)
+	if err := row.Scan(&j.ID, &j.ControlID, &kind, &status, &errMsg, &detail,
+		&payload, &createdAt, &startedAt, &finishedAt, &viewedAt); err != nil {
+		return jobs.Job{}, err
+	}
+	j.Kind = jobs.Kind(kind)
+	j.Status = jobs.Status(status)
+	j.Error = errMsg
+	j.Detail = detail
+	j.Payload = []byte(payload)
+	j.CreatedAt = time.Unix(createdAt, 0)
+	if startedAt.Valid {
+		t := time.Unix(startedAt.Int64, 0)
+		j.StartedAt = &t
+	}
+	if finishedAt.Valid {
+		t := time.Unix(finishedAt.Int64, 0)
+		j.FinishedAt = &t
+	}
+	if viewedAt.Valid {
+		t := time.Unix(viewedAt.Int64, 0)
+		j.ViewedAt = &t
+	}
+	return j, nil
+}
+
+// checkOne wraps the UPDATE-by-id family: an id that matches no row is
+// ErrJobNotFound rather than a silent no-op.
+func checkOne(res sql.Result, err error, id int64, op string) error {
+	if err != nil {
+		return fmt.Errorf("jobstore.%s: %w", op, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("jobstore.%s: RowsAffected: %w", op, err)
+	}
+	if n == 0 {
+		return fmt.Errorf("jobstore.%s(%d): %w", op, id, jobs.ErrJobNotFound)
+	}
+	return nil
+}

--- a/apps/server/internal/infra/storage/jobstore/jobstore_test.go
+++ b/apps/server/internal/infra/storage/jobstore/jobstore_test.go
@@ -65,7 +65,7 @@ func TestInsertAndByIDRoundTripAJob(t *testing.T) {
 		ControlID: controlID,
 		Kind:      jobs.KindReanalyse,
 		Payload:   []byte(`{"ticked":0.5,"unsure":0.3}`),
-	})
+	}, time.Now())
 	if err != nil {
 		t.Fatalf("Insert: %v", err)
 	}
@@ -121,7 +121,7 @@ func TestMarkRunningStampsStartedAtAndFlipsStatus(t *testing.T) {
 
 	id, err := store.Insert(ctx, jobs.NewJob{
 		ControlID: controlID, Kind: jobs.KindAnalyse, Payload: []byte(`{}`),
-	})
+	}, time.Now())
 	if err != nil {
 		t.Fatalf("Insert: %v", err)
 	}
@@ -148,7 +148,7 @@ func TestMarkDoneStampsFinishedAtAndFlipsStatus(t *testing.T) {
 
 	id, _ := store.Insert(ctx, jobs.NewJob{
 		ControlID: controlID, Kind: jobs.KindGenerate, Payload: []byte(`{}`),
-	})
+	}, time.Now())
 	_ = store.MarkRunning(ctx, id, time.Unix(1_735_000_000, 0))
 
 	finishedAt := time.Unix(1_735_000_030, 0)
@@ -170,7 +170,7 @@ func TestMarkFailedStoresBothMessages(t *testing.T) {
 
 	id, _ := store.Insert(ctx, jobs.NewJob{
 		ControlID: controlID, Kind: jobs.KindAnalyse, Payload: []byte(`{}`),
-	})
+	}, time.Now())
 	_ = store.MarkRunning(ctx, id, time.Unix(1_735_000_000, 0))
 
 	finishedAt := time.Unix(1_735_000_010, 0)
@@ -199,7 +199,7 @@ func TestMarkDismissedStampsViewedAt(t *testing.T) {
 
 	id, _ := store.Insert(ctx, jobs.NewJob{
 		ControlID: controlID, Kind: jobs.KindReanalyse, Payload: []byte(`{}`),
-	})
+	}, time.Now())
 	_ = store.MarkRunning(ctx, id, time.Unix(1_735_000_000, 0))
 	_ = store.MarkDone(ctx, id, time.Unix(1_735_000_030, 0))
 
@@ -217,15 +217,20 @@ func TestLatestForControlReturnsTheMostRecentJob(t *testing.T) {
 	ctx, db, controlID := migrated(t)
 	store := jobstore.New(db)
 
+	// Explicit distinct clocks: no time.Sleep needed since COR-2 moved
+	// createdAt into the Insert parameter — same shape the mark family
+	// already uses. LatestForControl orders by created_at DESC, then
+	// by id DESC as tie-breaker (see jobstore.go), so a same-second
+	// pair would still resolve deterministically; two visibly distinct
+	// timestamps here are the honest signal.
+	early := time.Unix(1_735_000_000, 0)
+	late := time.Unix(1_735_000_030, 0)
 	first, _ := store.Insert(ctx, jobs.NewJob{
 		ControlID: controlID, Kind: jobs.KindGenerate, Payload: []byte(`{}`),
-	})
-	// SQLite created_at is unixepoch() at INSERT — bump a second so ordering
-	// is unambiguous; two INSERTs in the same second would tie.
-	time.Sleep(1100 * time.Millisecond)
+	}, early)
 	second, _ := store.Insert(ctx, jobs.NewJob{
 		ControlID: controlID, Kind: jobs.KindReanalyse, Payload: []byte(`{}`),
-	})
+	}, late)
 
 	got, err := store.LatestForControl(ctx, controlID)
 	if err != nil {
@@ -252,13 +257,13 @@ func TestQueuedIDsListsEveryQueuedJobOldestFirst(t *testing.T) {
 
 	first, _ := store.Insert(ctx, jobs.NewJob{
 		ControlID: controlID, Kind: jobs.KindGenerate, Payload: []byte(`{}`),
-	})
+	}, time.Now())
 	second, _ := store.Insert(ctx, jobs.NewJob{
 		ControlID: controlID, Kind: jobs.KindReanalyse, Payload: []byte(`{}`),
-	})
+	}, time.Now())
 	third, _ := store.Insert(ctx, jobs.NewJob{
 		ControlID: controlID, Kind: jobs.KindAnnotate, Payload: []byte(`{}`),
-	})
+	}, time.Now())
 	// Move `second` to `done`, so it drops out of QueuedIDs.
 	_ = store.MarkRunning(ctx, second, time.Unix(1_735_000_000, 0))
 	_ = store.MarkDone(ctx, second, time.Unix(1_735_000_030, 0))
@@ -280,18 +285,18 @@ func TestFailRunningWithMessageFlipsEveryRunningRow(t *testing.T) {
 	// Two `running` rows, one `queued` (untouched), one `done` (untouched).
 	running1, _ := store.Insert(ctx, jobs.NewJob{
 		ControlID: controlID, Kind: jobs.KindAnalyse, Payload: []byte(`{}`),
-	})
+	}, time.Now())
 	_ = store.MarkRunning(ctx, running1, time.Unix(1_735_000_000, 0))
 	running2, _ := store.Insert(ctx, jobs.NewJob{
 		ControlID: controlID, Kind: jobs.KindReanalyse, Payload: []byte(`{}`),
-	})
+	}, time.Now())
 	_ = store.MarkRunning(ctx, running2, time.Unix(1_735_000_000, 0))
 	queued, _ := store.Insert(ctx, jobs.NewJob{
 		ControlID: controlID, Kind: jobs.KindGenerate, Payload: []byte(`{}`),
-	})
+	}, time.Now())
 	done, _ := store.Insert(ctx, jobs.NewJob{
 		ControlID: controlID, Kind: jobs.KindAnnotate, Payload: []byte(`{}`),
-	})
+	}, time.Now())
 	_ = store.MarkRunning(ctx, done, time.Unix(1_735_000_000, 0))
 	_ = store.MarkDone(ctx, done, time.Unix(1_735_000_030, 0))
 

--- a/apps/server/internal/infra/storage/jobstore/jobstore_test.go
+++ b/apps/server/internal/infra/storage/jobstore/jobstore_test.go
@@ -1,0 +1,323 @@
+package jobstore_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/so77id/nalanda/apps/server/internal/domain/jobs"
+	"github.com/so77id/nalanda/apps/server/internal/infra/storage"
+	"github.com/so77id/nalanda/apps/server/internal/infra/storage/jobstore"
+	"github.com/so77id/nalanda/apps/server/migrations"
+)
+
+// migrated opens a fresh SQLite file, applies the embedded migration set
+// and inserts one seed control so job rows have their required FK. Same
+// shape controlstore_test.go uses.
+func migrated(t *testing.T) (context.Context, *sql.DB, string) {
+	t.Helper()
+	ctx := context.Background()
+	db, err := storage.Open(ctx, filepath.Join(t.TempDir(), "nalanda.db"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	if _, err := storage.Migrate(ctx, db, migrations.FS); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	// Seed one professor and one control so job.control_id has a target.
+	// The control schema demands NOT NULL name/from_/to_ etc. — spell them.
+	if _, err := db.ExecContext(ctx,
+		`INSERT INTO users (email, name) VALUES (?, ?)`,
+		"profe@example.com", "Profesora"); err != nil {
+		t.Fatalf("seeding professor: %v", err)
+	}
+	var userID int64
+	if err := db.QueryRowContext(ctx, `SELECT user_id FROM users WHERE email = ?`,
+		"profe@example.com").Scan(&userID); err != nil {
+		t.Fatalf("selecting seeded professor id: %v", err)
+	}
+	if _, err := db.ExecContext(ctx, `
+        INSERT INTO control (id, name, from_document, from_section,
+                             to_document, to_section, questions_per_copy,
+                             copies, duplex_padding, paper, ticked, unsure,
+                             state, created_at, created_by)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"CTRL0001ABC0000000000000AA", "Control 1",
+		"doc-1", "sec-1", "doc-1", "sec-2",
+		4, 30, 1, "letter", 0.5, 0.3, "generated",
+		time.Now().Unix(), userID,
+	); err != nil {
+		t.Fatalf("seeding control: %v", err)
+	}
+	return ctx, db, "CTRL0001ABC0000000000000AA"
+}
+
+func TestInsertAndByIDRoundTripAJob(t *testing.T) {
+	ctx, db, controlID := migrated(t)
+	store := jobstore.New(db)
+
+	id, err := store.Insert(ctx, jobs.NewJob{
+		ControlID: controlID,
+		Kind:      jobs.KindReanalyse,
+		Payload:   []byte(`{"ticked":0.5,"unsure":0.3}`),
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	if id <= 0 {
+		t.Fatalf("Insert returned a non-positive id: %d", id)
+	}
+
+	got, err := store.ByID(ctx, id)
+	if err != nil {
+		t.Fatalf("ByID: %v", err)
+	}
+	if got.ID != id {
+		t.Errorf("ID = %d, want %d", got.ID, id)
+	}
+	if got.ControlID != controlID {
+		t.Errorf("ControlID = %q, want %q", got.ControlID, controlID)
+	}
+	if got.Kind != jobs.KindReanalyse {
+		t.Errorf("Kind = %q, want reanalyse", got.Kind)
+	}
+	if got.Status != jobs.StatusQueued {
+		t.Errorf("Status = %q, want queued", got.Status)
+	}
+	if string(got.Payload) != `{"ticked":0.5,"unsure":0.3}` {
+		t.Errorf("Payload = %q, want the seeded JSON", string(got.Payload))
+	}
+	if got.CreatedAt.IsZero() {
+		t.Errorf("CreatedAt is zero, want a real timestamp")
+	}
+	if got.StartedAt != nil {
+		t.Errorf("StartedAt = %v, want nil on a queued job", got.StartedAt)
+	}
+	if got.FinishedAt != nil {
+		t.Errorf("FinishedAt = %v, want nil on a queued job", got.FinishedAt)
+	}
+	if got.ViewedAt != nil {
+		t.Errorf("ViewedAt = %v, want nil on an undismissed job", got.ViewedAt)
+	}
+}
+
+func TestByIDReturnsErrJobNotFoundForAnUnknownID(t *testing.T) {
+	ctx, db, _ := migrated(t)
+	store := jobstore.New(db)
+
+	if _, err := store.ByID(ctx, 999); !errors.Is(err, jobs.ErrJobNotFound) {
+		t.Errorf("ByID on a missing id = %v, want ErrJobNotFound", err)
+	}
+}
+
+func TestMarkRunningStampsStartedAtAndFlipsStatus(t *testing.T) {
+	ctx, db, controlID := migrated(t)
+	store := jobstore.New(db)
+
+	id, err := store.Insert(ctx, jobs.NewJob{
+		ControlID: controlID, Kind: jobs.KindAnalyse, Payload: []byte(`{}`),
+	})
+	if err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	startedAt := time.Unix(1_735_000_000, 0)
+	if err := store.MarkRunning(ctx, id, startedAt); err != nil {
+		t.Fatalf("MarkRunning: %v", err)
+	}
+	got, err := store.ByID(ctx, id)
+	if err != nil {
+		t.Fatalf("ByID: %v", err)
+	}
+	if got.Status != jobs.StatusRunning {
+		t.Errorf("Status = %q, want running", got.Status)
+	}
+	if got.StartedAt == nil || !got.StartedAt.Equal(startedAt) {
+		t.Errorf("StartedAt = %v, want %v", got.StartedAt, startedAt)
+	}
+}
+
+func TestMarkDoneStampsFinishedAtAndFlipsStatus(t *testing.T) {
+	ctx, db, controlID := migrated(t)
+	store := jobstore.New(db)
+
+	id, _ := store.Insert(ctx, jobs.NewJob{
+		ControlID: controlID, Kind: jobs.KindGenerate, Payload: []byte(`{}`),
+	})
+	_ = store.MarkRunning(ctx, id, time.Unix(1_735_000_000, 0))
+
+	finishedAt := time.Unix(1_735_000_030, 0)
+	if err := store.MarkDone(ctx, id, finishedAt); err != nil {
+		t.Fatalf("MarkDone: %v", err)
+	}
+	got, _ := store.ByID(ctx, id)
+	if got.Status != jobs.StatusDone {
+		t.Errorf("Status = %q, want done", got.Status)
+	}
+	if got.FinishedAt == nil || !got.FinishedAt.Equal(finishedAt) {
+		t.Errorf("FinishedAt = %v, want %v", got.FinishedAt, finishedAt)
+	}
+}
+
+func TestMarkFailedStoresBothMessages(t *testing.T) {
+	ctx, db, controlID := migrated(t)
+	store := jobstore.New(db)
+
+	id, _ := store.Insert(ctx, jobs.NewJob{
+		ControlID: controlID, Kind: jobs.KindAnalyse, Payload: []byte(`{}`),
+	})
+	_ = store.MarkRunning(ctx, id, time.Unix(1_735_000_000, 0))
+
+	finishedAt := time.Unix(1_735_000_010, 0)
+	if err := store.MarkFailed(ctx, id, "worker rechazó el escaneo",
+		"ERR: /work/… scan not recognized\nMore lines\n", finishedAt); err != nil {
+		t.Fatalf("MarkFailed: %v", err)
+	}
+	got, _ := store.ByID(ctx, id)
+	if got.Status != jobs.StatusFailed {
+		t.Errorf("Status = %q, want failed", got.Status)
+	}
+	if got.Error != "worker rechazó el escaneo" {
+		t.Errorf("Error = %q, want the short message", got.Error)
+	}
+	if got.Detail == "" {
+		t.Errorf("Detail is empty, want the long context")
+	}
+	if got.FinishedAt == nil || !got.FinishedAt.Equal(finishedAt) {
+		t.Errorf("FinishedAt = %v, want %v", got.FinishedAt, finishedAt)
+	}
+}
+
+func TestMarkDismissedStampsViewedAt(t *testing.T) {
+	ctx, db, controlID := migrated(t)
+	store := jobstore.New(db)
+
+	id, _ := store.Insert(ctx, jobs.NewJob{
+		ControlID: controlID, Kind: jobs.KindReanalyse, Payload: []byte(`{}`),
+	})
+	_ = store.MarkRunning(ctx, id, time.Unix(1_735_000_000, 0))
+	_ = store.MarkDone(ctx, id, time.Unix(1_735_000_030, 0))
+
+	viewedAt := time.Unix(1_735_000_500, 0)
+	if err := store.MarkDismissed(ctx, id, viewedAt); err != nil {
+		t.Fatalf("MarkDismissed: %v", err)
+	}
+	got, _ := store.ByID(ctx, id)
+	if got.ViewedAt == nil || !got.ViewedAt.Equal(viewedAt) {
+		t.Errorf("ViewedAt = %v, want %v", got.ViewedAt, viewedAt)
+	}
+}
+
+func TestLatestForControlReturnsTheMostRecentJob(t *testing.T) {
+	ctx, db, controlID := migrated(t)
+	store := jobstore.New(db)
+
+	first, _ := store.Insert(ctx, jobs.NewJob{
+		ControlID: controlID, Kind: jobs.KindGenerate, Payload: []byte(`{}`),
+	})
+	// SQLite created_at is unixepoch() at INSERT — bump a second so ordering
+	// is unambiguous; two INSERTs in the same second would tie.
+	time.Sleep(1100 * time.Millisecond)
+	second, _ := store.Insert(ctx, jobs.NewJob{
+		ControlID: controlID, Kind: jobs.KindReanalyse, Payload: []byte(`{}`),
+	})
+
+	got, err := store.LatestForControl(ctx, controlID)
+	if err != nil {
+		t.Fatalf("LatestForControl: %v", err)
+	}
+	if got.ID != second {
+		t.Errorf("LatestForControl.ID = %d, want the most recent (%d), got the earlier (%d)",
+			got.ID, second, first)
+	}
+}
+
+func TestLatestForControlReturnsErrJobNotFoundWhenTheControlHasNoJobs(t *testing.T) {
+	ctx, db, controlID := migrated(t)
+	store := jobstore.New(db)
+
+	if _, err := store.LatestForControl(ctx, controlID); !errors.Is(err, jobs.ErrJobNotFound) {
+		t.Errorf("LatestForControl on a control with no jobs = %v, want ErrJobNotFound", err)
+	}
+}
+
+func TestQueuedIDsListsEveryQueuedJobOldestFirst(t *testing.T) {
+	ctx, db, controlID := migrated(t)
+	store := jobstore.New(db)
+
+	first, _ := store.Insert(ctx, jobs.NewJob{
+		ControlID: controlID, Kind: jobs.KindGenerate, Payload: []byte(`{}`),
+	})
+	second, _ := store.Insert(ctx, jobs.NewJob{
+		ControlID: controlID, Kind: jobs.KindReanalyse, Payload: []byte(`{}`),
+	})
+	third, _ := store.Insert(ctx, jobs.NewJob{
+		ControlID: controlID, Kind: jobs.KindAnnotate, Payload: []byte(`{}`),
+	})
+	// Move `second` to `done`, so it drops out of QueuedIDs.
+	_ = store.MarkRunning(ctx, second, time.Unix(1_735_000_000, 0))
+	_ = store.MarkDone(ctx, second, time.Unix(1_735_000_030, 0))
+
+	ids, err := store.QueuedIDs(ctx)
+	if err != nil {
+		t.Fatalf("QueuedIDs: %v", err)
+	}
+	if len(ids) != 2 || ids[0] != first || ids[1] != third {
+		t.Errorf("QueuedIDs = %v, want [%d %d] (oldest first, skipping done)",
+			ids, first, third)
+	}
+}
+
+func TestFailRunningWithMessageFlipsEveryRunningRow(t *testing.T) {
+	ctx, db, controlID := migrated(t)
+	store := jobstore.New(db)
+
+	// Two `running` rows, one `queued` (untouched), one `done` (untouched).
+	running1, _ := store.Insert(ctx, jobs.NewJob{
+		ControlID: controlID, Kind: jobs.KindAnalyse, Payload: []byte(`{}`),
+	})
+	_ = store.MarkRunning(ctx, running1, time.Unix(1_735_000_000, 0))
+	running2, _ := store.Insert(ctx, jobs.NewJob{
+		ControlID: controlID, Kind: jobs.KindReanalyse, Payload: []byte(`{}`),
+	})
+	_ = store.MarkRunning(ctx, running2, time.Unix(1_735_000_000, 0))
+	queued, _ := store.Insert(ctx, jobs.NewJob{
+		ControlID: controlID, Kind: jobs.KindGenerate, Payload: []byte(`{}`),
+	})
+	done, _ := store.Insert(ctx, jobs.NewJob{
+		ControlID: controlID, Kind: jobs.KindAnnotate, Payload: []byte(`{}`),
+	})
+	_ = store.MarkRunning(ctx, done, time.Unix(1_735_000_000, 0))
+	_ = store.MarkDone(ctx, done, time.Unix(1_735_000_030, 0))
+
+	finishedAt := time.Unix(1_735_100_000, 0)
+	n, err := store.FailRunningWithMessage(ctx, jobs.RestartMidJobError, finishedAt)
+	if err != nil {
+		t.Fatalf("FailRunningWithMessage: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("FailRunningWithMessage flipped %d rows, want 2", n)
+	}
+
+	got1, _ := store.ByID(ctx, running1)
+	if got1.Status != jobs.StatusFailed || got1.Error != jobs.RestartMidJobError {
+		t.Errorf("running1 = {%q, %q}, want {failed, %q}",
+			got1.Status, got1.Error, jobs.RestartMidJobError)
+	}
+	if got1.FinishedAt == nil || !got1.FinishedAt.Equal(finishedAt) {
+		t.Errorf("running1.FinishedAt = %v, want %v", got1.FinishedAt, finishedAt)
+	}
+	gotQueued, _ := store.ByID(ctx, queued)
+	if gotQueued.Status != jobs.StatusQueued {
+		t.Errorf("queued row moved to %q, want it untouched", gotQueued.Status)
+	}
+	gotDone, _ := store.ByID(ctx, done)
+	if gotDone.Status != jobs.StatusDone {
+		t.Errorf("done row moved to %q, want it untouched", gotDone.Status)
+	}
+}

--- a/apps/server/migrations/00012_jobs.sql
+++ b/apps/server/migrations/00012_jobs.sql
@@ -11,8 +11,11 @@
 --
 -- payload_json holds the runner's inputs verbatim so a Sweep-requeued
 -- job can be re-executed by the runner without hitting anything else in
--- the schema. The shape is kind-specific (generate carries a CreateRequest,
--- reanalyse carries thresholds, etc.); the runner unmarshals against the
+-- the schema. The shape is kind-specific: analyse carries a batch name +
+-- thresholds (controls.AnalysePayload); reanalyse carries thresholds
+-- (controls.ReanalysePayload); generate and annotate carry the empty
+-- object `{}` (controls.EmptyPayload) because their async methods read
+-- the control row for what they need. The runner unmarshals against the
 -- kind stored on the row.
 --
 -- error is the short one-line message the banner renders (typically

--- a/apps/server/migrations/00012_jobs.sql
+++ b/apps/server/migrations/00012_jobs.sql
@@ -1,0 +1,45 @@
+-- Issue #249: async job runner for the four minutes-class AMC operations
+-- (generate, analyse, reanalyse, annotate batch). One row per submission,
+-- persisted so the queue survives Watchtower restarts (ADR-0038) and the
+-- server sweeps `running` rows into `failed` at boot rather than leaving
+-- them dangling.
+--
+-- Times are unix seconds in INTEGER columns, matching every other table
+-- (job.created_at, started_at, finished_at, viewed_at). Nullable
+-- started_at/finished_at carry "not started yet / not finished yet";
+-- nullable viewed_at is "the banner has not been dismissed".
+--
+-- payload_json holds the runner's inputs verbatim so a Sweep-requeued
+-- job can be re-executed by the runner without hitting anything else in
+-- the schema. The shape is kind-specific (generate carries a CreateRequest,
+-- reanalyse carries thresholds, etc.); the runner unmarshals against the
+-- kind stored on the row.
+--
+-- error is the short one-line message the banner renders (typically
+-- AnalyzerRefusedError.Message); detail carries the long context for
+-- future debugging (AnalyzerRefusedError.Detail — the same distinction the
+-- flash cookie already draws in refusedFlash, scans.go). Same
+-- shape-of-two-fields as the wrapped error the amcworker client returns.
+
+-- +goose Up
+CREATE TABLE job (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    control_id    TEXT    NOT NULL REFERENCES control(id) ON DELETE CASCADE,
+    kind          TEXT    NOT NULL CHECK (kind IN ('generate', 'analyse', 'reanalyse', 'annotate')),
+    status        TEXT    NOT NULL CHECK (status IN ('queued', 'running', 'done', 'failed')),
+    error         TEXT,
+    detail        TEXT,
+    payload_json  TEXT    NOT NULL,
+    created_at    INTEGER NOT NULL,
+    started_at    INTEGER,
+    finished_at   INTEGER,
+    viewed_at     INTEGER
+);
+
+-- The Detail handler asks for "the most recent job on this control" —
+-- (control_id, created_at DESC) covers it.
+CREATE INDEX idx_job_by_control ON job (control_id, created_at DESC);
+
+-- +goose Down
+
+DROP TABLE job;

--- a/apps/server/migrations/00012_jobs.sql
+++ b/apps/server/migrations/00012_jobs.sql
@@ -17,8 +17,7 @@
 --
 -- error is the short one-line message the banner renders (typically
 -- AnalyzerRefusedError.Message); detail carries the long context for
--- future debugging (AnalyzerRefusedError.Detail — the same distinction the
--- flash cookie already draws in refusedFlash, scans.go). Same
+-- future debugging (AnalyzerRefusedError.Detail). Same
 -- shape-of-two-fields as the wrapped error the amcworker client returns.
 
 -- +goose Up

--- a/docs/decisions/0034-the-backend-is-born-with-the-controls.md
+++ b/docs/decisions/0034-the-backend-is-born-with-the-controls.md
@@ -3,7 +3,7 @@
 **Status:** Accepted
 **Date:** 2026-08-16
 **Decision-makers:** Miguel Rodriguez
-**Amended by:** #150 (2026-08-16) — the empty `00001_init.sql` was deleted and the auth schema numbered `00002`; the image measured 12.2 MB after the port · #166 (2026-08-17) — WP-E landed and the server now shares the `amc-work` named volume with `apps/amc-worker`; the two-container seeding-order rule is recorded in §Consequences
+**Amended by:** #150 (2026-08-16) — the empty `00001_init.sql` was deleted and the auth schema numbered `00002`; the image measured 12.2 MB after the port · #166 (2026-08-17) — WP-E landed and the server now shares the `amc-work` named volume with `apps/amc-worker`; the two-container seeding-order rule is recorded in §Consequences · #249 (2026-08-27) — the "row is committed AND files are on disk, or neither" atomicity of `Service.Create` and `Service.UploadScan` is now bounded to their SYNC halves (`Service.PrepareControl`, `Service.SaveUploadedBatch`); the async halves (`Service.GenerateAssets`, `Service.AnalyzeBatch`) deliberately preserve the row + files on worker refusal so the professor does not lose the pool snapshot to a transient outage. The full runner design lives in ADR-0050.
 **Source:** #149 (WP-C1), design `docs/design/2026-08-controles.md` §C10, §C11
 
 ## Context

--- a/docs/decisions/0048-the-corrected-pdf-is-drawn-by-amc.md
+++ b/docs/decisions/0048-the-corrected-pdf-is-drawn-by-amc.md
@@ -3,6 +3,7 @@
 **Status:** Accepted
 **Date:** 2026-08-19
 **Decision-makers:** Miguel Rodriguez
+**Amended by:** #249 (2026-08-27) — the per-copy `amc annotate` call moved off the HTTP goroutine into the async job runner (`KindAnnotate`, `controls.NewAnnotateHandler`, `Service.AnnotateAllCleanCopies`), discharging §Consequences "async is a follow-up if courses grow". The runner is documented in ADR-0050.
 **Source:** #190 (every copy ends the control cycle with an annotated PDF),
 conversation 2026-08-19 after the first real production control (#186–#189).
 

--- a/docs/decisions/0050-the-controls-runner-is-in-process-single-goroutine.md
+++ b/docs/decisions/0050-the-controls-runner-is-in-process-single-goroutine.md
@@ -1,0 +1,233 @@
+# ADR-0050: The controls runner is in-process, single-goroutine, and does not retry
+
+**Status:** Accepted
+**Date:** 2026-08-27
+**Decision-makers:** Miguel Rodriguez
+**Source:** #249 (async job runner for the four minutes-class AMC operations),
+prompted by the 2026-08-27 incident where a `/reanalyse` on Control 2 took 83 s
+and Tailscale funnel returned 502 to the browser before the server finished
+successfully (`project_issue243_shipped.md` §"502 en Tailscale funnel").
+
+## Context
+
+Every operation `apps/server` runs against `apps/amc-worker` is minutes-class.
+`/generate` takes 10–30 seconds. `/analyse` is minutes for a real batch.
+`/reanalyse` is 10–90 seconds and the 83-second case above tripped the
+Tailscale funnel's proxy timeout — the server finished the work, but the
+professor saw a 502 and did not know if it worked. The per-copy `/annotate`
+loop runs seconds–minutes and ADR-0048 §Consequences explicitly deferred an
+async version to a follow-up.
+
+Before this WP the four operations blocked the HTTP request. The professor
+watched a white progress bar for the duration; a proxy timeout looked like a
+failure that was actually a success; the annotate loop after `/analyse` ran
+in a bare goroutine detached from any DB representation, so a server
+restart mid-batch left the professor with no signal of what got done. The
+UX cost is real (spurious 502s, no visible state) and the operational cost
+compounds it: on the Jetson (ADR-0038) Watchtower restarts on every CD
+push, several times a week, and any in-flight work at the moment of that
+restart vanishes without a trace.
+
+The question this ADR answers is what a durable async shape looks like on a
+server that ADR-0034 committed to running as a single instance with no
+outside dependencies.
+
+## Decision
+
+An in-process job runner, wired at `cmd/server/main.go` between the
+controls service and the HTTP surface, with SQLite as the durability
+substrate.
+
+### 1. One goroutine, one queue, one job at a time
+
+`internal/domain/jobs.Runner` reads from a buffered channel and dispatches
+one handler at a time. Not a worker pool, not a per-Kind queue: one
+goroutine. The point is the single-writer invariant against AMC — its
+project state is a SQLite file the worker container mutates, and running
+two `/analyse` calls against the same project would corrupt it. The mutex
+inside `amcworker.Client` (`generateLock`) already provided this at a
+lower level; the runner promotes it to the level above so any future sync
+caller that skips the runner still has the mutex as belt-and-braces.
+
+The buffered channel (`runnerBuffer = 256`) absorbs bursts of submissions
+without blocking the HTTP handler. Overflow does not lose work: the row
+is `queued` in the DB and `drainStore` after every completed job re-scans
+for stragglers.
+
+### 2. Every job is a persisted row before it runs
+
+Migration `00012_jobs.sql` creates the `job` table. `Runner.Submit`
+INSERTs the row with `status = 'queued'` BEFORE pushing to the channel.
+Handlers move it through `running` → `done` | `failed` with explicit
+`WHERE status = ?` guards (see §5). The `payload_json` column carries
+whatever the handler needs; two of the four kinds (`generate`,
+`annotate`) carry `{}` because their async methods re-read the control
+row for what they need.
+
+The set of Kind values is closed: `generate`, `analyse`, `reanalyse`,
+`annotate`. The set is enforced twice — the SQLite `CHECK (kind IN
+(...))` on the column, and the `jobs.ValidKinds` slice in Go — because a
+runtime typo satisfying one side without the other silently drops a
+whole class of work. Adding a Kind requires a paired migration.
+
+### 3. Boot-time Sweep, not retry
+
+`Runner.Sweep` runs ONCE from `main.go`, BEFORE `go runner.Start(ctx)`.
+Two passes:
+
+1. Every row in `status = 'running'` is flipped to `failed` with
+   `error = 'server_restart_mid_job'`. The previous server died before it
+   could mark the row terminal; automatic retry would silently redo work
+   the professor cannot see, and the failure surface (the banner) is
+   where a human decides what to do.
+2. Every row in `status = 'queued'` is re-pushed to the channel. Those
+   rows were committed but never picked up, so the runner picks up where
+   it left off.
+
+No automatic retry of `failed` rows. The professor dismisses via `POST
+/jobs/{id}/dismiss` and re-submits from the form; a future WP may add an
+explicit "Regenerate" button.
+
+### 4. Handlers register at boot, panic on missing
+
+`jobs.NewRunner` demands a handler for every entry in `ValidKinds`. A
+missing or `nil` entry panics at boot, matching the rest of the app's
+`NewService` / `NewControls` / `NewAuth` "wiring mistake is a boot
+panic" rule (`backend-code-style.md` §Errors). Adding a Kind therefore
+lands in four coordinated places:
+
+1. A new `jobs.Kind` constant + `ValidKinds` entry
+   (`internal/domain/jobs/jobs.go`)
+2. A migration extending the `job.kind` CHECK enum
+3. A `controls.NewXHandler` factory
+   (`internal/domain/controls/jobhandlers.go`)
+4. Its registration in `cmd/server/main.go`'s `jobs.Handlers` map
+
+The panic-at-boot catches any of the four being missing.
+
+### 5. `WHERE status = ?` guards on Mark\*
+
+`jobstore.MarkRunning` / `MarkDone` / `MarkFailed` each guard the FROM
+state in the WHERE clause (`queued` → `running`, `running` → `done`,
+`running` → `failed`). The single-goroutine invariant makes concurrent
+transitions impossible today, but the guard turns any future accident
+(a second `go Start`, an ops tooling call) into a loud
+`ErrJobNotFound` instead of silent status corruption. The next
+`Mark*` variant copies this shape.
+
+### 6. Row + files survive a worker refusal (atomicity reversal)
+
+ADR-0034 §Failure modes described `Service.Create` as all-or-nothing:
+"the row is committed AND the files are on disk, or neither". This WP
+splits `Create` into `PrepareControl` (sync, atomic) + `GenerateAssets`
+(async, worker call), and `UploadScan` into `SaveUploadedBatch` (sync,
+atomic file write) + `AnalyzeBatch` (async, worker call). The atomicity
+promise still holds on the SYNC halves. On the ASYNC halves,
+`GenerateAssets` and `AnalyzeBatch` deliberately leave the row and files
+intact on any refusal. The reasoning: `source.tex` and `pool.json` are
+the professor's authored artefacts, and rolling them back on a transient
+outage would force the professor to re-choose the pool.
+
+ADR-0034 is `Amended by:` this ADR for the atomicity clause. `apps/server/CLAUDE.md`
+carries the operating rule so an agent editing the runner doesn't paper over it.
+
+## Alternatives
+
+**Worker pool of N goroutines.** Rejected because AMC's per-project
+SQLite state is a single-writer resource and N > 1 would need a
+per-project mutex to stay correct — the same lock we already have inside
+`amcworker.Client`, just further out. N = 1 is the honest name for what
+the single-writer invariant requires.
+
+**External queue (Redis, RabbitMQ, Cloud Tasks).** Rejected on
+dependency ceilings. `go.mod`'s direct set is `modernc.org/sqlite` and
+`github.com/pressly/goose/v3` on purpose (ADR-0034). Redis adds a
+second stateful process to a Jetson we already keep austere; RabbitMQ
+adds one more thing that can be down when Watchtower restarts the
+compose stack. Neither buys anything a durable SQLite queue does not.
+
+**Cron-poll the DB without a channel.** Rejected because it trades a
+notification (`ch <- id` after INSERT) for a poll interval, and any
+polling interval is either latency or wasted work. The channel + drain
+combination gets the latency of the notification for the happy path and
+the durability of the poll for the recovery path.
+
+**Automatic retry of `failed` rows.** Rejected because AMC failures are
+mostly professor-visible (a bad scan, an inverted threshold, a paper
+size mismatch), not transient. Silent retry of a failed job would repeat
+the same failure at cadence with no signal until the professor visits.
+The banner is where a human decides what to do next.
+
+**Retry `running` rows on boot instead of failing them.** Rejected for
+the same reason and one more: two-phase commit between "start the
+handler" and "confirm we started it" is fragile against Watchtower's
+container kill window. A "was running, now failed with
+server_restart_mid_job" state is honest about the ambiguity.
+
+## Consequences
+
+**Atomicity boundary moves.** The sync halves are atomic; the async
+halves preserve state on refusal. ADR-0034 §Failure modes' `Create`
+promise is now scoped to `PrepareControl`. The reversal is in
+`apps/server/CLAUDE.md` §Rules for Claude and in each Service method's
+docstring.
+
+**Single-instance operational constraint compounds.** ADR-0034 already
+required a single server instance (migrations at boot, no lock table).
+The runner adds a second reason: two runners over one SQLite would race
+on `MarkRunning` (the WHERE guard catches it, but the loser would burn
+the handler's work). Adding a replica is now a decision that reopens
+BOTH constraints.
+
+**Watchtower restart is visible.** A restart mid-`analyse` leaves the
+job `failed` with `error = 'server_restart_mid_job'` on the banner. The
+professor decides whether to re-upload; the operator sees the marker in
+`job.error` for post-mortem.
+
+**No new dependency, no new port, no new container.** `go.mod` is
+unchanged and no service was added to `infra/local/docker-compose.yml`.
+The Jetson deploy shape (ADR-0038) does not change.
+
+**Buffer size 256 is a magic value with a comment.** The buffer sits
+between Submit and Start. If it fills, `drainStore` after every
+completed job picks up the queued rows. 256 is comfortably above any
+realistic teacher-burst (a class of 30 copies produces ONE upload, not
+30 jobs). The rejected alternative (unbuffered channel) makes Submit
+block on runner idleness, coupling the HTTP handler to it.
+
+**The `WHERE status = ?` guard is the pattern the next Mark\* copies.**
+Any future async subsystem in this app (a Canvas grade poster in WP-G,
+an email reminder queue) inherits: closed-set Kind + CHECK enum + typed
+Payload + panic-at-boot registry + `WHERE status = ?` on state
+transitions.
+
+## Review triggers
+
+Revisit this ADR when:
+
+- A second async subsystem lands. If the shape stabilises, promote it
+  into `docs/standards/backend-code-style.md` §Queue-persisted
+  subsystems (currently pattern-only; see #249 review DCO-6).
+- A course scales past what one runner can chew through. The 30-copy
+  batches this ADR sizes for are far from the runner's ceiling; if a
+  class grows to hundreds, N > 1 needs a real answer.
+- Watchtower churn forces a rethink of `server_restart_mid_job`. If a
+  common restart is minutes rather than seconds, an explicit retry
+  policy or a state-machine step may become worth the complexity.
+- The `apps/amc-worker` mutex is removed. Belt-and-braces at two levels
+  makes sense as long as both are cheap; if the worker layer changes,
+  the runner's single-writer invariant becomes the only one holding.
+
+## References
+
+- Issue #249 §Design, §Problem, §Non-goals
+- ADR-0034 (backend born) — the atomicity clause this ADR amends
+- ADR-0048 (annotate PDF) — §Consequences "async is a follow-up if
+  courses grow" is what this ADR discharges
+- ADR-0038 (Jetson + Watchtower) — the operational surface that made
+  Sweep-on-boot necessary
+- `apps/server/internal/domain/jobs/{jobs.go,runner.go}`
+- `apps/server/internal/infra/storage/jobstore/jobstore.go`
+- `apps/server/migrations/00012_jobs.sql`
+- `apps/server/internal/domain/controls/jobhandlers.go`
+- `apps/server/cmd/server/main.go` §"the async job runner"


### PR DESCRIPTION
Closes #249.

## Summary

An in-process async job runner for the four minutes-class AMC operations (generate, analyse, reanalyse, close-annotate). HTTP handlers now enqueue a job and return `303` in <1 ms; a single-goroutine runner picks it up, the detail page's `JobBanner` surfaces the running / done / failed state, and a Watchtower restart mid-job flips the row to `failed` with `server_restart_mid_job` for the professor to see. No new dependency, no new container. Full design in ADR-0050.

## Slices

- [x] **S1** — Migration `00012_jobs.sql` + `internal/domain/jobs` types + `internal/infra/storage/jobstore` adapter with round-trip tests.
- [x] **S2** — Runner core (`Runner.Submit`, `Runner.Start`, `Runner.Sweep`) with in-memory fake store for the domain-side tests.
- [x] **S3** — Migrate `POST /controls/{id}/reanalyze` to the runner + banner in Detail + `POST /jobs/{id}/dismiss`. First end-to-end slice.
- [x] **S4** — Migrate `POST /controls/{id}/scans` (analyse). `Service.UploadScan` splits into `SaveUploadedBatch` (sync, file write) + `AnalyzeBatch` (async, worker + persist + annotate).
- [x] **S5** — Migrate `POST /controls` (generate). `Service.Create` splits into `PrepareControl` (sync) + `GenerateAssets` (async).
- [x] **S6** — Migrate "Cerrar corrección" annotate batch. `Service.AnnotateAllCleanCopies` runs through the runner as `KindAnnotate`.
- [ ] **S7** — Manual E2E on the Jetson: dispatch `/reanalyse` on Control 2, see banner cycle running → done, refresh shows updated results, no 502 from Tailscale funnel. **Blocker for Miguel.**
- [x] **S8** — Review pipeline (Round A + Round B) + PR.

## Acceptance criteria + evidence

- [x] `/reanalyse` on Control 2 returns `303` in <200 ms; banner shows "Procesando re-lectura…" while the runner processes; refresh after the banner changes to "re-lectura lista" shows updated results — `TestReanalyzeReturns303ImmediatelyAndCreatesAJobRow`, `TestDetailRendersTheJobBannerAfterAReanalyzeIsEnqueued` (`apps/server/internal/app/web/handler/scans_test.go`)
- [x] `/analyse` on a new batch goes through the runner; handler test confirms a `job` row with `kind='analyse'` — `TestUploadScanCallsAnalyzerAndFlashesSuccess` uses `uploadOnce` which waits on the job (`waitLatestJobTerminal` in `controls_test.go`)
- [x] Kill container mid-`/analyse` and restart: `Sweep` marks the row as `failed` with `error='server_restart_mid_job'` — `TestSweepFailsRunningRowsFromABeforeCrashAsRestartMidJob` (`internal/domain/jobs/runner_test.go`), `TestFailRunningWithMessageFlipsEveryRunningRow` (`internal/infra/storage/jobstore/jobstore_test.go`)
- [x] A queued job (INSERT before the runner starts) gets processed by Sweep at boot — `TestSweepRePushesQueuedRowsToTheRunner`
- [x] `annotate/copy` (single copy from SaveReview) stays sync — grep confirms `save_review.go` has no `Runner.Submit`; `Service.Annotate` is still called synchronously from `SaveReview`
- [x] Two concurrent `/reanalyze` requests → two `job` rows, the second waits for the first — `TestTwoConcurrentReanalyzesProduceTwoJobs`
- [x] `AnalyzerRefusedError` is persisted in `job.error` (short) and `job.detail` (long); banner shows the short — `TestReanalyzeRefusalRecordsMessageAndDetailOnTheJobRow`, `TestUploadScanRefusalRecordsMessageAndDetailOnTheJobRow`, `TestUploadScanRefusalWithoutDetailStillRecordsTheShortMessage`
- [x] `apps/server` per-commit + pre-PR green — `gofmt -l .` clean, `go vet ./...` clean, `go test -race -count=1 ./...` green across the whole module, `go build ./...` clean, `govulncheck` "No vulnerabilities found"
- [ ] **Miguel manual on the Jetson**: dispatch `/reanalyse` on Control 2, see banner without a 502. See §Manual verification below.

## Tests

- **New**: `internal/domain/jobs/{jobs.go,runner.go}` + `runner_test.go` (in-memory fakeStore covering queued→running→done/failed, panic-at-boot on missing handler, Sweep re-push, boot-time RestartMidJob marker, handler panic recovery, plus a Detail test asserting the banner renders after Submit).
- **New**: `internal/infra/storage/jobstore/jobstore_test.go` (round-trip Insert/ByID, MarkRunning/Done/Failed with the `WHERE status = ?` guards, MarkDismissed, LatestForControl ordering with distinct timestamps — no `time.Sleep`, QueuedIDs oldest-first, FailRunningWithMessage buckets by status).
- **Extended**: `internal/app/web/handler/scans_test.go` — three new tests (`TestReanalyzeReturns303ImmediatelyAndCreatesAJobRow`, `TestTwoConcurrentReanalyzesProduceTwoJobs`, `TestDismissJobStampsViewedAtAndRedirects`), refusal tests rewritten to check `job.error`/`job.detail` instead of the flash cookie, `uploadOnce` waits on the async job.
- **Extended**: `internal/domain/controls/service_test.go` — three UploadScan cases and every Create setup migrated to two-step composition helpers (`createControlSync` = `PrepareControl` + `GenerateAssets`; `uploadScanSync` = `SaveUploadedBatch` + `AnalyzeBatch`), matching the runner's exact composition. Rollback tests renamed to `TestGenerateAssetsRefusalLeavesTheRowAndFilesIntact` + sujet-missing sibling to reflect the new atomicity contract.
- **Deleted**: `Service.Create`, `Service.UploadScan`, and `UploadResult` — zero non-test callers after the runner landed; kept them was an invitation to drift (Round A ARQ-1).

## Reviews run

Two rounds via the `agentic-workflow:review-pipeline` skill over `92f961d..HEAD` (merge-base with `origin/main`):

**Round A — code**
- Panel A: `lens-correctness-tests`, `lens-arch-simplicity`, `lens-security` (worktree-isolated, parallel). `lens-performance` skipped — the diff is HTTP handlers + a single-goroutine runner + SQLite CRUD; no hot path.
- Verifier: `review-verifier` over ARQ-1 (the one important finding); confirmed.
- Findings: 8 total (1 important + 7 suggestions).
  - **Accepted**: ARQ-1 (delete Service.Create + Service.UploadScan + UploadResult), ARQ-2 (drop empty payload structs, use `controls.EmptyPayload`), ARQ-3 (NewRunner demands all four kinds, panic on missing), COR-2 (Store.Insert accepts injected clock; delete `time.Sleep(1.1s)` in the test), COR-3 (`WHERE status = ?` guards on Mark*).
  - **Deferred**: ARQ-4 (split `jobs.Store` into RunnerStore/BannerStore), COR-1 (drainStore SQLITE_BUSY backoff), COR-4 (slog-capture test for the Detail-never-logged invariant).
- Per-fix recheck (arch-simplicity + correctness-tests lenses): all five accepted findings verified `fixed`. One new suggestion surfaced: four stale doc-comments pointing at the deleted `Service.Create` — cleaned up in `docs(issue-249): retarget stale Service.Create references`.
- Zero security findings.

**Round B — documentation**
- Panel B: `lens-docs-completeness`, `lens-docs-accuracy`, `lens-adr-hunter`, `lens-agent-readability` (worktree-isolated, parallel).
- Findings: 24 total (2 critical + 15 important + 6 suggestions/patterns; after dedup: 12 unique).
  - **Accepted**: ADR-1/2/DCO-1 (write ADR-0050 + amend ADR-0034), ADR-3 (amend ADR-0040), AGR-1/DCO-2 (three new bullets in apps/server/CLAUDE.md: new-Kind lands in four places, worker-refusal-leaves-row-and-files, uploaded-batch-survives updated for sync/async split), AGR-3 (peer-domain import worked case), AGR-5 (§Description reworded), AGR-6 (README §Layout tree), DAC-1..7 (all the stale doc-comments and README labels), and post-recheck DAC-8/9 (two more stale banner/refusedFlash references).
  - **Deferred**: DCO-3 (register "add a job kind" in integration-guides.md), ADR-4 (promote `WHERE status = ?` pattern), AGR-7/DCO-4 (minutes-class pattern in add-a-backend-endpoint.md), DCO-5 (design/2026-08-controles.md), DCO-6 (queue-persisted subsystem pattern).
- Per-fix recheck (docs-accuracy + adr-hunter + agent-readability): all accepted findings verified `fixed`. DAC-8/9 (two more stale references, same class as DAC-1..7) surfaced during the recheck and were applied in `docs(issue-249): DAC-8/9 stale banner + refusedFlash sweep`.

## Manual verification (Miguel, on the Jetson)

Blocking S7 + AC-9:

1. `ssh jetson` (`ref_jetson_access.md`)
2. Watchtower auto-pulls the merged image (~5 min). Confirm the running image is the merged one: `cd /opt/nalanda/repo/infra/local && docker-compose logs server --tail=20 | grep 'jobs: sweep'` — you should see the Sweep log line at boot ("jobs: sweep marked running jobs as failed" or "jobs: sweep re-pushed queued jobs" if there were any pre-existing rows, or nothing if empty).
3. Open a control in the browser. If any existing running/queued jobs are on the DB from before the deploy, they should show as `failed` with `server_restart_mid_job` on their banner.
4. Pick Control 2 (~30 copies). Dispatch `/reanalyse`.
    - Expected: HTTP `303` returns in <200 ms (no 502 from Tailscale funnel).
    - Expected: detail page shows "**Procesando re-lectura…** (hace 0 s). Refrescá la página cuando el aviso cambie." with a **Refrescar** button.
5. Wait a bit and refresh. Expected: banner changes to "**re-lectura lista.**" with a **Refrescar** button. Click it — banner disappears (viewed_at stamped).
6. If anything looks wrong, screenshot + `docker-compose logs server --tail=200 | grep -E 'jobs:|controls:'`.

## Notes

- The four AMC operations are now async, but `annotate/copy` (single-copy annotate from SaveReview) stays sync on purpose — it's sub-second and complicating it wins nothing (issue #249 §Non-goals).
- `amcworker.Client.generateLock` (the pre-existing per-client mutex) stays as belt-and-braces — the runner's single-goroutine invariant makes it redundant today, but it survives to cover any future sync caller that skips the runner.
- Follow-ups explicitly deferred (each may become its own WP if demand appears):
  - Explicit "Regenerate" button for a failed generate job.
  - Progress bar with a copy counter (`progress_current` / `progress_total`).
  - SSE / WebSockets for real-time push instead of manual refresh.
  - Per-control queues for concurrency between controls (the Jetson is single-professor so no demand today).
  - Automatic retry of transient failures.
  - Split `jobs.Store` into RunnerStore + BannerStore (Round A ARQ-4).
  - `WHERE status = ?` promoted to backend-code-style.md (Round A COR-1 + Round B ADR-4).
  - Documentation: add a "job kind" extension-point guide + a "minutes-class handler" pattern in add-a-backend-endpoint.md (Round B DCO-3 + AGR-7).
- **Squash-merge**, not rebase-merge — the slice-per-commit history is for the reviewer, not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
