### PR TITLE
refactor(issue-254): put Controles in the navbar, move Recargar banco to /controls

### DIFF
--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -255,7 +255,7 @@ Routes today:
 | `GET /professors/{id}/edit` · `POST /professors/{id}` | Rename. The address is not editable |
 | `POST /professors/{id}/deactivate` | Flips `is_active=0` and ends every session that professor holds |
 | `POST /professors/{id}/reactivate` | Flips `is_active=1` and clears `deactivated_at` |
-| `POST /admin/bank/refresh` | Reloads the in-memory question bank from `NALANDA_QUESTIONS_JSON_URL` and redirects back to `Referer` (or `/controls` on empty / off-origin / scheme-relative-path). Session-gated + CSRF. The "Recargar banco" button in the top bar posts to it (issue #230, ADR-0032 §Addendum) |
+| `POST /admin/bank/refresh` | Reloads the in-memory question bank from `NALANDA_QUESTIONS_JSON_URL` and redirects back to `Referer` (or `/controls` on empty / off-origin / scheme-relative-path). Session-gated + CSRF. The "Recargar banco" button on the `/controls` index posts to it (issue #230, ADR-0032 §Addendum; issue #254 moved the button out of the navbar) |
 | `GET /login` · `GET /login/google` · `GET /login/google/callback` · `POST /logout` | The login round trip — see §Signing in |
 
 Every state-changing route sits behind `middleware.RequireProfessor` AND

--- a/apps/server/internal/app/web/handler/admin_bank.go
+++ b/apps/server/internal/app/web/handler/admin_bank.go
@@ -48,9 +48,11 @@ func NewAdminBank(deps AdminBank) *AdminBank {
 // off-origin.
 //
 // The redirect target is Referer-derived rather than a fixed constant
-// because the button appears in the top bar on every backoffice page,
-// and losing the professor's context (which control they were looking at)
-// on every refresh is a small paper cut with no upside. The
+// so the professor keeps their context (which control they were looking
+// at) after every refresh. The button lives on the /controls index
+// (issue #254 moved it there from the top bar) but the endpoint stays
+// generic — a future caller from a detail page still redirects back
+// where they came from. The
 // same-origin guard below is why an evil Referer can never become an
 // open redirect: PublicURL is the deployed origin (host + optional port,
 // no path — see config.Load's validation), and only a Referer whose

--- a/apps/server/internal/app/web/handler/controls_test.go
+++ b/apps/server/internal/app/web/handler/controls_test.go
@@ -674,6 +674,30 @@ func TestListRendersEveryControl(t *testing.T) {
 	}
 }
 
+// Issue #254: the "Recargar banco" button moved from the navbar to the
+// /controls index — refreshing the bank is what precedes creating a control,
+// so the button lives where the professor actually reaches for it.
+func TestListCarriesTheBankRefreshFormWithItsCSRFToken(t *testing.T) {
+	f := newControlsFixture(t)
+
+	rec := httptest.NewRecorder()
+	f.handler.List(rec, f.authedRequest(t, http.MethodGet, handler.ControlsPath, nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("List status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		`action="/admin/bank/refresh"`,
+		`method="post"`,
+		`name="csrf_token"`,
+		`Recargar banco`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("list body missing %q\n---\n%s", want, body)
+		}
+	}
+}
+
 func TestRootRedirectsToControls(t *testing.T) {
 	f := newControlsFixture(t)
 	rec := httptest.NewRecorder()

--- a/apps/server/internal/app/web/handler/controls_test.go
+++ b/apps/server/internal/app/web/handler/controls_test.go
@@ -689,11 +689,28 @@ func TestListCarriesTheBankRefreshFormWithItsCSRFToken(t *testing.T) {
 	for _, want := range []string{
 		`action="/admin/bank/refresh"`,
 		`method="post"`,
-		`name="csrf_token"`,
+		// The full pair — a bare `name="csrf_token"` with an empty value
+		// would still pass a name-only assertion. Same guard shape as
+		// TestNewFormRendersCSRFToken above.
+		`name="csrf_token" value="csrf-1"`,
 		`Recargar banco`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("list body missing %q\n---\n%s", want, body)
+		}
+	}
+	// The form must sit inside a flow-content parent — a <p> would be
+	// invalid HTML5 (browsers auto-close the <p> before the <form>) and
+	// the raw-substring assertions above cannot see the DOM mismatch.
+	// The template wraps the actions row in <div class="acciones">.
+	if idx := strings.Index(body, `<form method="post" action="/admin/bank/refresh"`); idx >= 0 {
+		prefix := body[:idx]
+		lastDiv := strings.LastIndex(prefix, "<div")
+		lastP := strings.LastIndex(prefix, "<p")
+		lastClose := strings.LastIndex(prefix, "</p>")
+		// The last <p opened before the form must have been closed before it.
+		if lastP > lastDiv && lastP > lastClose {
+			t.Errorf("bank-refresh <form> nested in a <p> — invalid HTML5, DOM will not match the template")
 		}
 	}
 }

--- a/apps/server/internal/app/web/view/templates/layout.html
+++ b/apps/server/internal/app/web/view/templates/layout.html
@@ -43,14 +43,6 @@
         padding: 0.25rem 0.5rem;
         border-radius: 0.375rem;
       }
-      /* The bank-refresh button (issue #230, ADR-0032 §Addendum) sits beside the section
-         links in the top bar and needs to READ as one — a button that
-         opens a form flash message, not a page. The `form` is inline so
-         the layout stays a single row; the `button` inherits color and
-         font from currentColor so it lands in both themes without a
-         second palette. The hover/focus rule is shared with .sections a
-         (below) so a future palette tweak on the anchor version cannot
-         drift from the button. */
       .sections a:hover, .sections a:focus-visible {
         background: color-mix(in srgb, currentColor 12%, transparent);
       }

--- a/apps/server/internal/app/web/view/templates/layout.html
+++ b/apps/server/internal/app/web/view/templates/layout.html
@@ -253,6 +253,7 @@
         <nav class="sections" aria-label="Secciones">
           <span class="brand">Nalanda · administración</span>
           <a href="/professors">Profesores</a>
+          <a href="/controls">Controles</a>
           <form method="post" action="/admin/bank/refresh" class="section-action">
             <input type="hidden" name="csrf_token" value="{{ .CSRFToken }}" />
             <button type="submit" title="Vuelve a leer questions.json publicado en apps/web">Recargar banco</button>

--- a/apps/server/internal/app/web/view/templates/layout.html
+++ b/apps/server/internal/app/web/view/templates/layout.html
@@ -51,22 +51,7 @@
          second palette. The hover/focus rule is shared with .sections a
          (below) so a future palette tweak on the anchor version cannot
          drift from the button. */
-      .sections form.section-action {
-        display: inline;
-        margin: 0;
-      }
-      .sections form.section-action button {
-        font: inherit;
-        color: inherit;
-        background: transparent;
-        border: none;
-        padding: 0.25rem 0.5rem;
-        border-radius: 0.375rem;
-        cursor: pointer;
-      }
-      .sections a:hover, .sections a:focus-visible,
-      .sections form.section-action button:hover,
-      .sections form.section-action button:focus-visible {
+      .sections a:hover, .sections a:focus-visible {
         background: color-mix(in srgb, currentColor 12%, transparent);
       }
 
@@ -254,10 +239,6 @@
           <span class="brand">Nalanda · administración</span>
           <a href="/professors">Profesores</a>
           <a href="/controls">Controles</a>
-          <form method="post" action="/admin/bank/refresh" class="section-action">
-            <input type="hidden" name="csrf_token" value="{{ .CSRFToken }}" />
-            <button type="submit" title="Vuelve a leer questions.json publicado en apps/web">Recargar banco</button>
-          </form>
         </nav>
         <details class="menu">
           <summary>{{ .Professor.Email }}</summary>

--- a/apps/server/internal/app/web/view/templates/pages/controls_list.html
+++ b/apps/server/internal/app/web/view/templates/pages/controls_list.html
@@ -4,13 +4,13 @@
   <p>Cada control se imprime en papel y se lee al inicio de la clase; están
     ordenados por fecha de aplicación, de más reciente a más antigua.</p>
 
-  <p>
+  <div class="acciones">
     <a class="boton" href="/controls/new">Nuevo control</a>
     <form method="post" action="/admin/bank/refresh" class="inline">
       <input type="hidden" name="csrf_token" value="{{ .CSRFToken }}" />
       <button type="submit" title="Vuelve a leer questions.json publicado en apps/web">Recargar banco</button>
     </form>
-  </p>
+  </div>
 
   {{ if .Controls }}
     <table class="lista">

--- a/apps/server/internal/app/web/view/templates/pages/controls_list.html
+++ b/apps/server/internal/app/web/view/templates/pages/controls_list.html
@@ -4,7 +4,13 @@
   <p>Cada control se imprime en papel y se lee al inicio de la clase; están
     ordenados por fecha de aplicación, de más reciente a más antigua.</p>
 
-  <p><a class="boton" href="/controls/new">Nuevo control</a></p>
+  <p>
+    <a class="boton" href="/controls/new">Nuevo control</a>
+    <form method="post" action="/admin/bank/refresh" class="inline">
+      <input type="hidden" name="csrf_token" value="{{ .CSRFToken }}" />
+      <button type="submit" title="Vuelve a leer questions.json publicado en apps/web">Recargar banco</button>
+    </form>
+  </p>
 
   {{ if .Controls }}
     <table class="lista">

--- a/apps/server/internal/app/web/view/view_test.go
+++ b/apps/server/internal/app/web/view/view_test.go
@@ -37,9 +37,11 @@ func TestTheLayoutRendersTheBarForASignedInProfessor(t *testing.T) {
 	})
 
 	for _, want := range []string{
-		// The sections half, with the one entry the shell already has room for.
+		// The sections half, with the entries the shell now has room for.
 		`class="sections"`,
 		`href="/professors"`,
+		// Issue #254: the most-used CRUD is one click away.
+		`href="/controls"`,
 		// The professor's menu, opened by <details>/<summary> so JavaScript is
 		// not required.
 		`<details class="menu"`,
@@ -52,6 +54,13 @@ func TestTheLayoutRendersTheBarForASignedInProfessor(t *testing.T) {
 		if !strings.Contains(body, want) {
 			t.Errorf("body missing %q\n---\n%s", want, body)
 		}
+	}
+
+	// The order matters: Profesores first, Controles second (issue #254 AC-1).
+	profesores := strings.Index(body, `href="/professors"`)
+	controles := strings.Index(body, `href="/controls"`)
+	if profesores < 0 || controles < 0 || controles < profesores {
+		t.Errorf("navbar order wrong: /professors at %d, /controls at %d — want Profesores before Controles", profesores, controles)
 	}
 }
 

--- a/apps/server/internal/app/web/view/view_test.go
+++ b/apps/server/internal/app/web/view/view_test.go
@@ -64,6 +64,27 @@ func TestTheLayoutRendersTheBarForASignedInProfessor(t *testing.T) {
 	}
 }
 
+// Issue #254: the "Recargar banco" button was in the navbar; the WP moves it
+// to /controls (its natural home — refreshing the bank is what precedes creating
+// a control). The layout must no longer carry the form.
+func TestTheLayoutDoesNotCarryTheBankRefreshForm(t *testing.T) {
+	body := renderLogin(t, view.LoginPage{
+		Page: view.Page{
+			Professor: &auth.User{Email: "profesora@example.com"},
+			CSRFToken: "csrf-here",
+		},
+	})
+
+	for _, unwanted := range []string{
+		`action="/admin/bank/refresh"`,
+		`Recargar banco`,
+	} {
+		if strings.Contains(body, unwanted) {
+			t.Errorf("layout carries %q — the bank-refresh form belongs on /controls now (issue #254)\n---\n%s", unwanted, body)
+		}
+	}
+}
+
 // A page rendered for an anonymous visitor does NOT carry the bar: nobody is
 // signed in, and a menu naming "" as the professor would be a menu the login
 // page ships with no owner.

--- a/docs/decisions/0032-the-published-question-bank-is-the-contract.md
+++ b/docs/decisions/0032-the-published-question-bank-is-the-contract.md
@@ -159,8 +159,10 @@ read path.
   the same reason.
 - **Manual escape hatch.** `POST /admin/bank/refresh` (session-gated, CSRF-
   verified) triggers an immediate `Reload` and flashes the outcome in
-  Spanish. A "Recargar banco" button in the backoffice top bar posts to it;
-  the professor stays on the page they clicked from when the `Referer` shares
+  Spanish. A "Recargar banco" button on the `/controls` index posts to it
+  (issue #254 moved it out of the navbar — refreshing the bank belongs to
+  the controls flow, not to a global backoffice action); the professor
+  stays on the page they clicked from when the `Referer` shares
   scheme+host with `NALANDA_PUBLIC_URL`, or lands on `/controls` otherwise
   (an off-origin Referer never steers the redirect).
 
@@ -205,8 +207,9 @@ read path.
   actually moved and a `question bank refresh failed` when a cycle fails —
   the last one is the signal an operator watches for.
 - **The manual endpoint sits inside `/admin/`.** Session-gated + CSRF-verified
-  like every other state-changing route on this surface; the button's
-  visibility follows the top bar's `.Professor` guard. Neither an anonymous
+  like every other state-changing route on this surface; the button lives on
+  the `/controls` index (issue #254) whose visibility follows the same
+  `.Professor` guard the whole backoffice does. Neither an anonymous
   visitor nor a signed-out browser tab can trigger a refresh.
 
 ## Amendment — 2026-08-25 (page-only annotations)

--- a/docs/decisions/0032-the-published-question-bank-is-the-contract.md
+++ b/docs/decisions/0032-the-published-question-bank-is-the-contract.md
@@ -3,6 +3,7 @@
 **Status:** Accepted
 **Date:** 2026-08-16
 **Amended:** 2026-08-25 — page-only annotations (`<Explanation>`) are permitted authored content that deliberately does NOT enter the bank; see §Amendment.
+**Amended:** 2026-08-27 — the "Recargar banco" button moves from the backoffice top bar to the `/controls` index; the endpoint is unchanged; see §Amendment — 2026-08-27.
 **Decision-makers:** Miguel Rodriguez
 **Covers:** the shape of `questions.json` as the `apps/web` → `apps/server`
 contract · the join key from a printed sheet to a grade · why one authored
@@ -159,12 +160,11 @@ read path.
   the same reason.
 - **Manual escape hatch.** `POST /admin/bank/refresh` (session-gated, CSRF-
   verified) triggers an immediate `Reload` and flashes the outcome in
-  Spanish. A "Recargar banco" button on the `/controls` index posts to it
-  (issue #254 moved it out of the navbar — refreshing the bank belongs to
-  the controls flow, not to a global backoffice action); the professor
-  stays on the page they clicked from when the `Referer` shares
+  Spanish. A "Recargar banco" button in the backoffice top bar posts to it;
+  the professor stays on the page they clicked from when the `Referer` shares
   scheme+host with `NALANDA_PUBLIC_URL`, or lands on `/controls` otherwise
-  (an off-origin Referer never steers the redirect).
+  (an off-origin Referer never steers the redirect). *(Amended 2026-08-27 —
+  the button moved to the `/controls` index; see §Amendment — 2026-08-27.)*
 
 ### Alternatives considered
 
@@ -207,10 +207,12 @@ read path.
   actually moved and a `question bank refresh failed` when a cycle fails —
   the last one is the signal an operator watches for.
 - **The manual endpoint sits inside `/admin/`.** Session-gated + CSRF-verified
-  like every other state-changing route on this surface; the button lives on
-  the `/controls` index (issue #254) whose visibility follows the same
-  `.Professor` guard the whole backoffice does. Neither an anonymous
-  visitor nor a signed-out browser tab can trigger a refresh.
+  like every other state-changing route on this surface; the button's
+  visibility follows the top bar's `.Professor` guard. Neither an anonymous
+  visitor nor a signed-out browser tab can trigger a refresh. *(Amended
+  2026-08-27 — the button moved to the `/controls` index; the same
+  `.Professor` gate covers it because `/controls` sits behind
+  `RequireProfessor`. See §Amendment — 2026-08-27.)*
 
 ## Amendment — 2026-08-25 (page-only annotations)
 
@@ -232,3 +234,39 @@ deliberately unaware" is now a first-class pattern of the question
 subsystem; any future annotator that follows the same shape (declared via a
 `questionRole` value, dropped by the source parser, unwrapped by the
 rendered-tree parser) inherits this ADR without needing its own.
+
+## Amendment — 2026-08-27 — the "Recargar banco" button lives on `/controls`, not in the navbar (issue #254)
+
+**Context.** §Addendum (2026-08-26) placed the manual escape hatch's button
+"in the backoffice top bar" so it was one click away from every backoffice
+page. Two weeks of using it argued the placement was misjudged: the
+backoffice grew a second CRUD ("Controles"), and the top bar had space for
+one section link at most before the row got busy. Adding `href="/controls"`
+next to `href="/professors"` made the "Recargar banco" `<form>` the third
+occupant of a bar meant for navigation, and the button's own semantics —
+"refresh the bank before creating a control" — placed it inside the
+controls flow, not on top of every unrelated backoffice screen.
+
+**Decision.** The `<form action="/admin/bank/refresh">` moves from
+`layout.html` to the `/controls` index page (`pages/controls_list.html`),
+next to the "Nuevo control" anchor. Nothing else changes: the route is
+still `POST /admin/bank/refresh`, session-gated + CSRF-verified, and its
+Referer-derived redirect is unchanged (the docstring on `AdminBank.Refresh`
+now explains the same-origin guard survives a future caller from another
+page). The `.Professor` gate that ADR-0032 §Addendum §Consequences named
+"the top bar's" is now "the `/controls` list's" — same gate shape (the
+whole backoffice sits behind `RequireProfessor`), different template.
+
+**Why an amendment and not a new ADR.** The endpoint's contract is
+unchanged, the atomicity guarantee is unchanged, the failure semantics
+are unchanged. What moved is one HTML surface. `documentation.md` §Rule 4
+grows standards from recorded cases (plural); a single button moving out
+of a two-item navbar does not yet justify a repo-wide "action buttons
+live on their page, not in the global nav" rule. If a second global
+action ever moves the same way, promote the rule then.
+
+**Preserved wording.** The pre-#254 Addendum text is kept verbatim in the
+"Manual escape hatch" bullet above and in the "The manual endpoint sits
+inside `/admin/`" Consequences bullet, each with a trailing italic
+pointer to this amendment — per `documentation.md` §Reviews falsify
+claims ("it does not quietly replace the sentence").


### PR DESCRIPTION
Closes #254

## Summary

Refactors the backoffice navbar: adds a `Controles → /controls` link
between `Profesores` and the right edge, and moves the `Recargar banco`
button out of the top bar into the `/controls` index page (next to
`Nuevo control`). The endpoint `POST /admin/bank/refresh` is unchanged —
same session gate, same CSRF, same Referer-derived redirect. The `.section-action`
CSS block and its rationale comment (which existed only for the moved button) are
removed with the button.

## Slices

- **S1** — Add `<a href="/controls">Controles</a>` to `layout.html` `.sections`, between `Profesores` and the (still-present) Recargar banco form. Test pins presence AND ordering.
- **S2** — Move the `<form action="/admin/bank/refresh">` from `layout.html` to `pages/controls_list.html`, remove the dead `.section-action` CSS rules. New test in the view package pins the layout no longer carries the form; new test in the handler package pins the `/controls` page does carry it with its CSRF token.
- **S3** — Sweep the "top bar" claim across every surface — the CSS comment in `layout.html`, `apps/server/README.md` routes table, `docs/decisions/0032-*.md` §Addendum (two bullets), and the `AdminBank.Refresh` docstring in `handler/admin_bank.go`. The issue guessed the third surface was `apps/server/CLAUDE.md`; the sweep found it was actually README.md + the handler comment.

## Acceptance criteria — evidence

| AC | Evidence |
|----|----------|
| 1 · Controles link between Profesores and the right edge | `apps/server/internal/app/web/view/templates/layout.html:227`; test `TestTheLayoutRendersTheBarForASignedInProfessor` (`view_test.go:31`) pins presence AND order (Profesores before Controles) |
| 2 · Same style as Profesores (inherits `.sections a`) | No class added on the `<a>`; inherits `.sections a` (`layout.html:40`) |
| 3 · `layout.html` no longer contains the `<form>` | `layout.html` after S2 has no `/admin/bank/refresh`; new test `TestTheLayoutDoesNotCarryTheBankRefreshForm` (`view_test.go:67`) pins absence |
| 4 · `controls_list.html` contains the form with CSRF hidden input and button | `pages/controls_list.html:9-14`; test `TestListCarriesTheBankRefreshFormWithItsCSRFToken` (`controls_test.go:677`) pins the full pair `name="csrf_token" value="csrf-1"` plus a structural guard that the form is NOT a child of `<p>` (invalid HTML5 caught in review — see Reviews run) |
| 5 · Route `POST /admin/bank/refresh` unchanged; session + CSRF middleware still applies | `router.go` unchanged in this diff; verified by the security lens (Round A) |
| 6 · CSS comment in `layout.html` AND `docs/decisions/0032-*.md` §Addendum updated to the new location | `layout.html`: the CSS block and its rationale comment removed together (S2); `docs/decisions/0032-*.md`: updated as a dated `## Amendment — 2026-08-27` block that preserves the pre-#254 wording of the two edited bullets (Round B fix) and adds the standard-prescribed `**Amended:**` header line; also swept `apps/server/README.md:258` and the `AdminBank.Refresh` docstring |
| 7 · `apps/server` per-commit protocol green | `test -z "$(gofmt -l .)"` clean, `go vet ./...` clean, `go build ./...` clean, `go test -race -count=1 ./...` clean on every commit |

## Tests

New:
- `TestTheLayoutRendersTheBarForASignedInProfessor` extended with the `href="/controls"` + Profesores-then-Controles ordering assertion.
- `TestTheLayoutDoesNotCarryTheBankRefreshForm` — a signed-in professor's page must not carry the moved form/button.
- `TestListCarriesTheBankRefreshFormWithItsCSRFToken` — the `/controls` list carries the form, the full CSRF token pair (`name="csrf_token" value="csrf-1"`), and the form is NOT a child of `<p>` (structural guard from Round A review — see below).

## Reviews run

- **Round A** (code): mechanical gate (gofmt/vet/build/race) green; parallel lens panel: `lens-correctness-tests`, `lens-arch-simplicity`, `lens-security` (perf skipped — no hot-path or perf goal). Cross-lens finding **F1** (important, arch + correctness): the moved `<form>` was nested inside `<p>`, which HTML5 forbids — browsers auto-close the `<p>` before the `<form>`, so the DOM would not match the template's structure. Fixed by wrapping in `<div class="acciones">`. Suggestion **F2** (correctness): the new test asserted `name="csrf_token"` alone; strengthened to the full `name="csrf_token" value="csrf-1"` pair, matching the sibling `TestNewFormRendersCSRFToken`. Applied in commit `refactor(issue-254): review fixes`.
- **Round B** (docs, over post-fix state): 4-lens panel (`lens-docs-completeness`, `lens-docs-accuracy`, `lens-adr-hunter`, `lens-agent-readability`). ADR-hunter **ADR-1** (important): the ADR-0032 update was an in-place rewrite of a Decision bullet, which `documentation.md` §Reviews-falsify-claims explicitly refuses ("it does not quietly replace the sentence") — the standard prescribes a dated `## Amendment` block preserving older text. Fixed by restoring the pre-#254 wording of the two bullets, adding italic pointers to a new dated `## Amendment — 2026-08-27` block that keeps the reasoning intact, and adding the standard-prescribed `**Amended:**` header line. Applied in commit `docs(issue-254): reframe the ADR-0032 update as a dated amendment block`.

Other lenses in both rounds returned 0 findings.

## Manual verification

- [ ] Sign in as a professor. Confirm the navbar shows `Nalanda · administración`, `Profesores`, `Controles` — in that order — and no bank-refresh button.
- [ ] Click `Controles`. Confirm the page header shows `Nuevo control` + `Recargar banco` side by side.
- [ ] Click `Recargar banco`. Confirm the flash message names the outcome (either "Banco recargado: N documentos, M preguntas.", "El banco ya estaba al día.", or the failure message).
- [ ] Click `Recargar banco` again from a detail page (`/controls/<id>`) if the button is added there in the future — for now, verify from `/controls` that the redirect lands back on `/controls`.
- [ ] Confirm both themes render correctly (light and dark) — no palette drift from the removed `.section-action` block.
- [ ] Confirm that from an anonymous /login page, no navbar appears (no accidental Controles link exposure).

## Notes

- The endpoint `POST /admin/bank/refresh` and its Referer-derived redirect are deliberately unchanged. The docstring on `AdminBank.Refresh` was updated to explain why the endpoint stays generic (future callers from other pages still redirect back where they came from). The same-origin guard on `safeRedirect` is untouched.
- The dead `.section-action` CSS block (30 lines) and its rationale comment were both removed in this PR — the class is not referenced anywhere else in the repo.
- The ADR-0032 update follows `documentation.md`'s "amendments preserve the older claim" rule: the pre-#254 wording is kept verbatim in the two bullets, each with a trailing italic pointer to the new dated Amendment block at the end of the file.
- No new ADR (Round B ADR-2 confirmed this): a single button relocation within a two-item navbar does not yet justify a repo-wide "action buttons live on their page" rule. §Amendment on ADR-0032 is the right home.
