### PR TITLE
feat(issue-256): deep-link each slide from the book and return to it on exit

### DIFF
--- a/apps/web/src/app/App.test.tsx
+++ b/apps/web/src/app/App.test.tsx
@@ -61,9 +61,17 @@ describe('routing', () => {
     await renderAt(`/d/${ids[0]}`);
     await screen.findByRole('heading', { level: 1 });
     const article = screen.getByRole('article');
+    // Wiki-links point at `/d/<id>` — a bare document id, nothing after it.
+    // The `/present?section=` links added by #256's per-heading button also
+    // sit under `/d/`, so a `.startsWith('/d/')` filter now catches them and
+    // asks the registry for `<id>/present?section=<slug>`, which is not an
+    // id and never resolves. Exclude anything with a path segment after `/d/<id>`.
     const internal = within(article)
       .getAllByRole('link')
-      .filter((a) => a.getAttribute('href')?.startsWith('/d/'));
+      .filter((a) => {
+        const href = a.getAttribute('href') ?? '';
+        return href.startsWith('/d/') && href.indexOf('/', '/d/'.length) === -1;
+      });
     expect(internal.length).toBeGreaterThan(0);
     for (const link of internal) {
       expect(registry.get(link.getAttribute('href')!.slice('/d/'.length))).toBeDefined();

--- a/apps/web/src/app/AppRoutes.tsx
+++ b/apps/web/src/app/AppRoutes.tsx
@@ -3,7 +3,7 @@ import { Navigate, Outlet, Route, Routes } from 'react-router-dom';
 
 import { CatalogOverviewPage, ComponentPage, FamilyPage, GovernancePage } from '../catalog';
 import { DocumentPage, courseIndex, walkIndex } from '../content';
-import { PresentationPage } from '../presentation';
+import { PresentableSectionsWrapper, PresentationPage } from '../presentation';
 import { DocumentTitle } from './DocumentTitle';
 import { NotFound } from './NotFound';
 import { mdxComponents } from './mdxComponents';
@@ -22,7 +22,15 @@ export function AppRoutes() {
           path="/"
           element={firstDocId ? <Navigate to={`/d/${firstDocId}`} replace /> : <NotFound />}
         />
-        <Route path="/d/:id" element={<DocumentPage notFound={<NotFound />} />} />
+        <Route
+          path="/d/:id"
+          element={
+            <DocumentPage
+              notFound={<NotFound />}
+              presentableSectionsWrapper={PresentableSectionsWrapper}
+            />
+          }
+        />
         <Route path="/d/:id/present" element={<PresentationPage notFound={<NotFound />} />} />
         {/* A layout route with NO Suspense boundary of its own, deliberately.
             The entries arrive as a promise now (#122) and every page under here

--- a/apps/web/src/app/documentBreadcrumb.test.tsx
+++ b/apps/web/src/app/documentBreadcrumb.test.tsx
@@ -40,7 +40,13 @@ describe('the breadcrumb row of a document', () => {
   it('keeps Presentar in the same row as the breadcrumb, not floating alone', async () => {
     renderAt(`/d/${nestedId}`);
     const nav = await screen.findByRole('navigation', { name: /ubicaci/i });
-    const presentar = screen.getByRole('link', { name: /presentar/i });
+    // Exact name: since #256 an h2 slide can also carry a "Presentar la
+    // sección «…»" link, and a `/presentar/i` regex now finds all of them
+    // (12+ on java-desde-cpp). The top-bar toggle is the one whose only word
+    // is `Presentar` — flaky-in-CI without this, green locally because the
+    // lazy doc chunk sometimes lost the race and only the top-bar was in the
+    // DOM when the assertion ran (feedback_match_visual_expectation).
+    const presentar = screen.getByRole('link', { name: 'Presentar' });
     // Sharing the row is the whole point of the slice — a link floating in the
     // corner attached to nothing is what it replaces.
     expect(nav.closest('div')?.parentElement).toContainElement(presentar);
@@ -48,7 +54,9 @@ describe('the breadcrumb row of a document', () => {
 
   it('drops the arrow glyph the rest of the product does not use', async () => {
     renderAt(`/d/${nestedId}`);
-    const presentar = await screen.findByRole('link', { name: /presentar/i });
+    // Same reason as above — the top-bar toggle's accessible name is exactly
+    // `Presentar`; every per-h2 sibling is `Presentar la sección «…»`.
+    const presentar = await screen.findByRole('link', { name: 'Presentar' });
     expect(presentar.textContent).not.toContain('▸');
     expect(presentar.querySelector('svg')).not.toBeNull();
   });

--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -748,14 +748,21 @@ describe('presentation: none documents', () => {
 describe('book-view entry points to presentation', () => {
   it('shows a Presentar toggle in the document header', async () => {
     await renderAt(`/d/${firstId}`);
-    const toggle = await screen.findByRole('link', { name: /presentar/i });
+    // Exact match: since #256 an h2 slide can also carry a "Presentar la
+    // sección «…»" link, so a `/presentar/i` regex now finds many. The
+    // top-bar toggle is the one whose only word is `Presentar`.
+    const toggle = await screen.findByRole('link', { name: 'Presentar' });
     expect(toggle).toHaveAttribute('href', `/d/${firstId}/present`);
   });
 
   it('hides the toggle for presentation: none documents', async () => {
     await renderAt(`/d/${noneId}`);
     await screen.findByRole('article');
-    expect(screen.queryByRole('link', { name: /presentar/i })).not.toBeInTheDocument();
+    // Same reason as above: an h2 in a `presentation: none` document must not
+    // carry the per-section button either, and the assertion has to be exact
+    // to distinguish the two.
+    expect(screen.queryByRole('link', { name: 'Presentar' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /presentar la sección/i })).not.toBeInTheDocument();
   });
 
   it('enters presentation with the p key from the book view', async () => {
@@ -763,6 +770,46 @@ describe('book-view entry points to presentation', () => {
     await screen.findByRole('article');
     fireEvent.keyDown(window, { key: 'p' });
     expect(await screen.findByText(/^\d+ \/ \d+$/)).toBeInTheDocument();
+  });
+});
+
+describe('present-section button in the book view', () => {
+  // End-to-end: the S4 wrapper publishes the slugs and S5's button in
+  // `mdxHeading` links to `?section=<slug>` on the presentation route, which
+  // S2 resolves. Unit tests in `content/mdxHeading.test.tsx` cover the render
+  // matrix; this block guards the wire-up.
+  const EXPLICIT_FIXTURE = 'java-tipos-y-flujo';
+  const explicitId = registry.get(EXPLICIT_FIXTURE)?.meta.id;
+
+  it('offers a Presentar-sección link on a marked <Slide> h2 in the book', async () => {
+    await renderAt(`/d/${explicitId}`);
+    await screen.findByRole('article');
+    const link = screen.getByRole('link', { name: /presentar la sección «tipos primitivos»/i });
+    expect(link).toHaveAttribute('href', `/d/${explicitId}/present?section=tipos-primitivos`);
+  });
+
+  it('does not offer the button on a loose h2 (explicit-mode book-only section)', async () => {
+    // "Ejercicios" in java-tipos-y-flujo is a loose h2 outside every <Slide>,
+    // so it is presentation-invisible by design — no button, but the `#`
+    // anchor stays.
+    await renderAt(`/d/${explicitId}`);
+    await screen.findByRole('article');
+    expect(
+      screen.getByRole('link', { name: /^enlace a la sección «ejercicios»$/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: /presentar la sección «ejercicios»/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not offer the button on the catalog surface (no wrapper mounted)', async () => {
+    // /catalog/c/slide renders the Slide component in isolation with no
+    // PresentableSectionsWrapper above it, so the button must stay silent —
+    // the default context value is what silences it, so nothing catalog-
+    // specific was written to make this true.
+    await renderAt('/catalog/c/slide');
+    await screen.findByRole('heading', { level: 1 });
+    expect(screen.queryByRole('link', { name: /presentar la sección/i })).not.toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, useLocation } from 'react-router-dom';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -684,6 +684,59 @@ describe('leaving the presentation from the deck', () => {
     await screen.findByRole('article');
     expect(lastLocation.pathname).toBe(`/d/${firstId}`);
     expect(lastLocation.hash).toBe('');
+  });
+
+  it('scrolls the h2 into view after Escape publishes #<slug>', async () => {
+    // Publishing #<slug> in the URL is not enough — react-router's programmatic
+    // navigate() sets location.hash but does NOT dispatch the browser's own
+    // fragment-scroll (unlike a native <a href="#slug">, which does). Verified
+    // in Chromium at 1440x900: after Escape from slide 2, windowY was 0 and
+    // the reader saw the top of the document, not the section they were
+    // watching. DocumentPage now scrolls the target itself once the article
+    // rehydrates — pin the call so the fix survives.
+    const scrollSpy = vi.fn();
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    const original = Element.prototype.scrollIntoView;
+    Element.prototype.scrollIntoView = scrollSpy;
+    try {
+      await renderAt(`/d/${explicitId}/present?slide=2`);
+      await screen.findByRole('heading', { name: 'Tipos primitivos' });
+
+      fireEvent.keyDown(window, { key: 'Escape' });
+      await screen.findByRole('article');
+      // Wait for MutationObserver in useSections to see the h2 and fire the
+      // scroll effect. `findBy*` retries — a raw `expect` wouldn't wait for the
+      // observer callback.
+      await waitFor(() =>
+        expect(
+          scrollSpy.mock.instances.some((el) => (el as HTMLElement).id === 'tipos-primitivos'),
+          'scrollIntoView was not called on the target h2 after Escape',
+        ).toBe(true),
+      );
+    } finally {
+      Element.prototype.scrollIntoView = original;
+    }
+  });
+
+  it('scrolls to the h2 on direct entry to /d/:id#<slug>, once the article rehydrates', async () => {
+    // Same defect on the other axis: entering the book with a fragment while
+    // the document is behind React.lazy means the browser's initial fragment-
+    // scroll (which runs before the article renders) has no target to hit. The
+    // fix runs again when the article's h2 arrives.
+    const scrollSpy = vi.fn();
+    const original = Element.prototype.scrollIntoView;
+    Element.prototype.scrollIntoView = scrollSpy;
+    try {
+      await renderAt(`/d/${explicitId}#tipos-primitivos`);
+      await screen.findByRole('article');
+      await waitFor(() =>
+        expect(
+          scrollSpy.mock.instances.some((el) => (el as HTMLElement).id === 'tipos-primitivos'),
+        ).toBe(true),
+      );
+    } finally {
+      Element.prototype.scrollIntoView = original;
+    }
   });
 
   it('leaves fullscreen on the way out, since the control goes with the deck', async () => {

--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -652,6 +652,40 @@ describe('leaving the presentation from the deck', () => {
     expect(await screen.findByRole('article')).toBeInTheDocument();
   });
 
+  // The exit contract's second half (#256): when the reader leaves from a
+  // slide that has a slug, the book takes them back to that heading via the
+  // URL fragment — no scrolling back to the section by hand. `mdxHeading.tsx`
+  // already renders `id={slug}` on every h2, so the browser handles the
+  // scroll on its own.
+  const EXPLICIT_FIXTURE = 'java-tipos-y-flujo';
+  const explicitId = registry.get(EXPLICIT_FIXTURE)?.meta.id;
+
+  it('lands on the book #<slug> when Escape leaves a slide that has one', async () => {
+    // Slide 2 of the fixture is `<Slide title="Tipos primitivos">`, whose
+    // slug is `tipos-primitivos` — the same anchor the book renders on the
+    // heading (mdxHeading.tsx).
+    await renderAt(`/d/${explicitId}/present?slide=2`);
+    await screen.findByRole('heading', { name: 'Tipos primitivos' });
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    await screen.findByRole('article');
+    expect(lastLocation.pathname).toBe(`/d/${explicitId}`);
+    expect(lastLocation.hash).toBe('#tipos-primitivos');
+  });
+
+  it('publishes no fragment when Escape leaves from the cover slide', async () => {
+    // The cover slide has no slug (parser.ts §slugFor): the top-bar
+    // "Presentar" button lands there, so `#doc-title` on exit would round-
+    // trip the reader to the same spot they came from.
+    await renderAt(`/d/${firstId}/present`);
+    await findCounter();
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    await screen.findByRole('article');
+    expect(lastLocation.pathname).toBe(`/d/${firstId}`);
+    expect(lastLocation.hash).toBe('');
+  });
+
   it('leaves fullscreen on the way out, since the control goes with the deck', async () => {
     const exitFullscreen = vi.fn(() => Promise.resolve());
     Object.defineProperty(document, 'fullscreenElement', {

--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -1,10 +1,23 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { courseIndex, registry, walkIndex } from '../content';
 
 import { AppRoutes } from './AppRoutes';
+
+// The router owns the URL in a MemoryRouter (window.location never moves), so
+// URL-shape assertions read it through a hook probe rendered inside the router.
+let lastLocation: { search: string; hash: string; pathname: string } = {
+  search: '',
+  hash: '',
+  pathname: '',
+};
+function LocationProbe() {
+  const location = useLocation();
+  lastLocation = { search: location.search, hash: location.hash, pathname: location.pathname };
+  return null;
+}
 
 const ids = walkIndex(courseIndex);
 // The first PRESENTABLE document, not simply the first one (#108). These cases
@@ -32,6 +45,7 @@ async function renderAt(path: string): Promise<void> {
   await act(async () => {
     render(
       <MemoryRouter initialEntries={[path]}>
+        <LocationProbe />
         <AppRoutes />
       </MemoryRouter>,
     );
@@ -129,6 +143,49 @@ describe('PresentationPage viewer', () => {
   it('survives a crafted non-integer ?slide value', async () => {
     await renderAt(`/d/${firstId}/present?slide=1.5`);
     expect(await findCounter()).toHaveTextContent(/^1 \//);
+  });
+
+  // The book anchors every h2 with `#<slug>`, and the deep-link contract
+  // (ADR-0013 succession) says presentation should reach the same section
+  // through `?section=<slug>`. The slug spine is the fixture's second slide
+  // — the first h2 of `java-tipos-y-flujo`. Named through the registry so a
+  // future re-cut of the deck doesn't red these cases silently.
+  const EXPLICIT_FIXTURE = 'java-tipos-y-flujo';
+  const explicitId = registry.get(EXPLICIT_FIXTURE)?.meta.id;
+
+  it('deep-links to a slide via ?section=<slug>', async () => {
+    // `tipos-primitivos` is the slug of the first <Slide title> of the fixture,
+    // per its own MDX. If that slide is renamed the case fails loudly.
+    await renderAt(`/d/${explicitId}/present?section=tipos-primitivos`);
+    expect(await screen.findByRole('heading', { name: 'Tipos primitivos' })).toBeInTheDocument();
+  });
+
+  it('canonicalizes ?section=<slug> to ?slide=<N> so the back button behaves', async () => {
+    await renderAt(`/d/${explicitId}/present?section=tipos-primitivos`);
+    await screen.findByRole('heading', { name: 'Tipos primitivos' });
+    // The URL is the source of truth (ADR-0013); after resolving the slug the
+    // deck must publish the canonical `?slide=N` form so the browser history
+    // holds one shape only and a bookmark of the current URL stays valid.
+    const search = new URLSearchParams(lastLocation.search);
+    expect(search.get('section')).toBeNull();
+    expect(search.get('slide')).toMatch(/^\d+$/);
+  });
+
+  it('falls back to slide 1 for an unknown ?section slug (no white screen)', async () => {
+    await renderAt(`/d/${firstId}/present?section=this-slug-does-not-exist`);
+    expect(await findCounter()).toHaveTextContent(/^1 \//);
+    // …and the canonical form is published even in the fallback.
+    const search = new URLSearchParams(lastLocation.search);
+    expect(search.get('section')).toBeNull();
+    expect(search.get('slide')).toBe('1');
+  });
+
+  it('lets ?section win over a conflicting ?slide', async () => {
+    // section=tipos-primitivos → slide 2 of the fixture; slide=1 would keep
+    // the cover. If section had lost the race we would still see the doc
+    // title heading rather than "Tipos primitivos".
+    await renderAt(`/d/${explicitId}/present?slide=1&section=tipos-primitivos`);
+    expect(await screen.findByRole('heading', { name: 'Tipos primitivos' })).toBeInTheDocument();
   });
 
   it('returns to the book view on Escape', async () => {

--- a/apps/web/src/content/DocumentPage.tsx
+++ b/apps/web/src/content/DocumentPage.tsx
@@ -1,7 +1,7 @@
 import { Menu, Presentation } from 'lucide-react';
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ComponentType, ReactNode } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import { KnownSectionsProvider } from '../lib/knownSections';
 
@@ -112,6 +112,34 @@ export function DocumentPage({ notFound, presentableSectionsWrapper: Wrapper }: 
 
   // Navigating inside the drawer must not leave it covering the document.
   useEffect(() => setDrawerOpen(false), [id]);
+
+  // Scroll the h2 named by the URL fragment into view. `<a href="#slug">` in
+  // the book handles this natively — the browser scrolls on anchor-link
+  // navigation — but SlideDeck.leave() reaches the book via react-router's
+  // `navigate('/d/:id#<slug>')`, and programmatic navigation sets
+  // `location.hash` without dispatching the browser's own fragment scroll
+  // (verified in Chromium at 1440x900: `windowY` stayed at 0 after Escape,
+  // the reader saw the top of the document instead of the section they had
+  // been watching). The same defect affects a direct entry to `#<slug>` while
+  // the document is behind `React.lazy` — the browser's initial fragment
+  // scroll fires before the article has any h2 to hit.
+  //
+  // Depending on `sections` (populated by useSections' MutationObserver once
+  // the article rehydrates) is what makes this work across the Suspense
+  // boundary: on hash change the element may not exist yet; the effect re-runs
+  // when the spine appears and finds its target.
+  const location = useLocation();
+  useEffect(() => {
+    const slug = location.hash.slice(1);
+    if (!slug) return;
+    const target = article.current?.querySelector(`#${CSS.escape(slug)}`);
+    // typeof check: jsdom does not implement scrollIntoView on HTMLElement, so
+    // the call would throw during the test suite. In a real browser this branch
+    // is always taken.
+    if (target instanceof HTMLElement && typeof target.scrollIntoView === 'function') {
+      target.scrollIntoView();
+    }
+  }, [location.hash, sections]);
 
   // POC shortcut: p enters presentation from the book view (never while typing).
   useEffect(() => {

--- a/apps/web/src/content/DocumentPage.tsx
+++ b/apps/web/src/content/DocumentPage.tsx
@@ -59,7 +59,7 @@ function SequenceNav({ id }: { id: string }) {
  * not an edge in `FEATURE_EDGES` (`src/architecture.test.ts`). Handed down
  * by `app/` the same way `notFound` is.
  */
-export interface PresentableSectionsWrapperProps {
+interface PresentableSectionsWrapperProps {
   docId: string;
   title: string;
   configMode?: 'auto' | 'explicit';

--- a/apps/web/src/content/DocumentPage.tsx
+++ b/apps/web/src/content/DocumentPage.tsx
@@ -1,6 +1,6 @@
 import { Menu, Presentation } from 'lucide-react';
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { ReactNode } from 'react';
+import type { ComponentType, ReactNode } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 
 import { KnownSectionsProvider } from '../lib/knownSections';
@@ -51,13 +51,36 @@ function SequenceNav({ id }: { id: string }) {
   );
 }
 
+/**
+ * The MDX wrapper injected around the whole rendered document to expose the
+ * set of deep-linkable slide sections through context (#256). Injected as a
+ * prop rather than imported directly because it lives in `presentation/` —
+ * the feature that owns the slide model — and `content → presentation` is
+ * not an edge in `FEATURE_EDGES` (`src/architecture.test.ts`). Handed down
+ * by `app/` the same way `notFound` is.
+ */
+export interface PresentableSectionsWrapperProps {
+  docId: string;
+  title: string;
+  configMode?: 'auto' | 'explicit';
+  children?: ReactNode;
+}
+
 interface Props {
   /** Rendered when the id is unknown — injected by the shell so the feature never imports app/. */
   notFound: ReactNode;
+  /**
+   * MDX wrapper that publishes the deep-linkable slide slugs of this
+   * document through context (#256). Optional: without it the book still
+   * renders correctly, `mdxHeading` just paints no "Presentar sección"
+   * buttons — a page outside a `DocumentPage` (catalog) sees the same
+   * absence for the same reason.
+   */
+  presentableSectionsWrapper?: ComponentType<PresentableSectionsWrapperProps>;
 }
 
 /** Renders the document whose frontmatter id matches the /d/:id route param. */
-export function DocumentPage({ notFound }: Props) {
+export function DocumentPage({ notFound, presentableSectionsWrapper: Wrapper }: Props) {
   const { id = '' } = useParams();
   const navigate = useNavigate();
   const entry = registry.get(id);
@@ -103,6 +126,24 @@ export function DocumentPage({ notFound }: Props) {
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [id, navigate, presentable]);
+
+  // Composed once per document so the wrapper closes over this document's
+  // docId + title + parser mode (mirrors PresentationPage's DeckWrapper —
+  // one wrapper per entry, remounted only when the entry changes).
+  const mdxComponents = useMemo(() => {
+    if (!Wrapper || !entry) return undefined;
+    const InjectedWrapper = Wrapper;
+    const { id: wrapperDocId, title: wrapperTitle, presentation } = entry.meta;
+    const mode = presentation === 'explicit' ? 'explicit' : 'auto';
+    function DocumentSectionsWrapper({ children }: { children?: ReactNode }) {
+      return (
+        <InjectedWrapper docId={wrapperDocId} title={wrapperTitle} configMode={mode}>
+          {children}
+        </InjectedWrapper>
+      );
+    }
+    return { wrapper: DocumentSectionsWrapper };
+  }, [Wrapper, entry]);
 
   if (!Doc) return <>{notFound}</>;
   return (
@@ -159,7 +200,7 @@ export function DocumentPage({ notFound }: Props) {
               disagree with the navigation about what a section is. */}
           <KnownSectionsProvider value={sectionIds}>
             <Suspense fallback={null}>
-              <Doc />
+              <Doc components={mdxComponents} />
             </Suspense>
           </KnownSectionsProvider>
           <SequenceNav id={id} />

--- a/apps/web/src/content/mdxHeading.test.tsx
+++ b/apps/web/src/content/mdxHeading.test.tsx
@@ -1,25 +1,50 @@
 import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
+
+import { PresentableSectionsProvider } from '../lib/presentableSections';
 
 import { headingFor } from './mdxHeading';
 
 const H2 = headingFor(2);
+const H3 = headingFor(3);
+
+/**
+ * Renders `children` inside the shape mdxHeading sees on a real book page:
+ * a `MemoryRouter` (`<Link>` needs one) and, when this document publishes a
+ * presentable spine, a `PresentableSectionsProvider` around it. `docId=null`
+ * models the catalog (no wrapper mounted), `docId=<id>` models a document
+ * whose wrapper has published the given slugs.
+ */
+function renderWithContext(
+  children: ReactNode,
+  { docId = null, slugs = [] }: { docId?: string | null; slugs?: string[] } = {},
+) {
+  return render(
+    <MemoryRouter>
+      <PresentableSectionsProvider value={{ docId, presentableSlugs: new Set(slugs) }}>
+        {children}
+      </PresentableSectionsProvider>
+    </MemoryRouter>,
+  );
+}
 
 describe('mdxHeading', () => {
   it('gives the heading a slug id derived from its text', () => {
-    render(<H2>Búsqueda binaria</H2>);
+    renderWithContext(<H2>Búsqueda binaria</H2>);
     const heading = screen.getByRole('heading', { level: 2, name: /Búsqueda binaria/ });
     expect(heading).toHaveAttribute('id', 'busqueda-binaria');
   });
 
   it('renders a self-anchor pointing at the slug', () => {
-    render(<H2>La idea</H2>);
+    renderWithContext(<H2>La idea</H2>);
     const anchor = screen.getByRole('link', { name: /la idea/i });
     expect(anchor).toHaveAttribute('href', '#la-idea');
   });
 
   it('reveals the anchor to a keyboard, not only to a mouse', () => {
-    render(<H2>Una sección</H2>);
+    renderWithContext(<H2>Una sección</H2>);
     const anchor = screen.getByRole('link');
 
     // The anchor is transparent while the heading is unhovered. Focusable and
@@ -30,7 +55,7 @@ describe('mdxHeading', () => {
   });
 
   it('renders the anchor in a token whose contrast is guaranteed', () => {
-    render(<H2>Una sección</H2>);
+    renderWithContext(<H2>Una sección</H2>);
 
     // Originally this asserted `text-slate-400` and the absence of
     // `text-slate-600`, with the ratios (7.87:1 and 2.66:1 against slate-950) in
@@ -56,18 +81,97 @@ describe('mdxHeading', () => {
   });
 
   it('renders the requested heading level', () => {
-    const H3 = headingFor(3);
-    render(<H3>Detalle</H3>);
+    renderWithContext(<H3>Detalle</H3>);
     expect(screen.getByRole('heading', { level: 3 })).toBeInTheDocument();
   });
 
   it('never nests anchors when the heading itself contains a link', () => {
-    const { container } = render(
+    const { container } = renderWithContext(
       <H2>
         Intro <a href="/d/doc-a">doc</a>
       </H2>,
     );
     expect(container.querySelector('a a')).toBeNull();
     expect(screen.getByRole('heading', { level: 2 })).toHaveAttribute('id', 'intro');
+  });
+});
+
+describe('mdxHeading — present-section button', () => {
+  // The contract from S1–S4: a heading whose slug is in the PresentableSections
+  // context — and only then — gets a "Presentar sección" button next to its
+  // `#` anchor, linking to `?section=<slug>` on the presentation route (which
+  // S2 canonicalizes to `?slide=<N>`). Catalog and non-slide headings never
+  // paint it, so the same component works uniformly.
+
+  it('paints the button next to the anchor when the slug is presentable', () => {
+    renderWithContext(<H2>Tipos primitivos</H2>, {
+      docId: 'java-tipos-y-flujo',
+      slugs: ['tipos-primitivos'],
+    });
+    const link = screen.getByRole('link', { name: /presentar la sección/i });
+    expect(link).toHaveAttribute('href', '/d/java-tipos-y-flujo/present?section=tipos-primitivos');
+  });
+
+  it('names the section in Spanish for a lang="es" page', () => {
+    renderWithContext(<H2>La idea</H2>, { docId: 'busqueda-binaria', slugs: ['la-idea'] });
+    // The accessible name is what a screen reader announces. Spanish because
+    // the site is served `lang="es"` (CLAUDE.md §Language).
+    expect(
+      screen.getByRole('link', { name: 'Presentar la sección «La idea»' }),
+    ).toBeInTheDocument();
+  });
+
+  it('reveals the button to a keyboard, not only to a mouse (same rule as the `#`)', () => {
+    renderWithContext(<H2>La idea</H2>, { docId: 'doc-a', slugs: ['la-idea'] });
+    const link = screen.getByRole('link', { name: /presentar la sección/i });
+    // Same visibility contract as the `#` anchor — focusable-and-transparent
+    // is the worst pairing (keyboard user lands on it with nothing to see).
+    expect(link.className).toContain('opacity-0');
+    expect(link.className).toContain('group-hover:opacity-100');
+    expect(link.className).toContain('focus-visible:opacity-100');
+  });
+
+  it('does not paint the button when the slug is not in the presentable set', () => {
+    // Explicit-mode fixture: a loose h2 ("Ejercicios" in java-tipos-y-flujo)
+    // has an anchor but is NOT a slide. The context won't include its slug.
+    renderWithContext(<H2>Ejercicios</H2>, {
+      docId: 'java-tipos-y-flujo',
+      slugs: ['tipos-primitivos'],
+    });
+    expect(screen.getByRole('link', { name: /ejercicios/i })).toHaveAttribute(
+      'href',
+      '#ejercicios',
+    );
+    expect(screen.queryByRole('link', { name: /presentar la sección/i })).not.toBeInTheDocument();
+  });
+
+  it('does not paint the button outside a DocumentPage (catalog surface)', () => {
+    // `/catalog/c/slide` never mounts PresentableSectionsWrapper — the button
+    // must stay silent there. The `#` anchor still paints, so we know the
+    // heading is otherwise fully functional.
+    renderWithContext(<H2>La idea</H2>);
+    expect(screen.getByRole('link', { name: /la idea/i })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /presentar la sección/i })).not.toBeInTheDocument();
+  });
+
+  it('never paints on h3/h4 headings even when their slug matches', () => {
+    // h3/h4 live INSIDE a slide, not as boundaries. If a coincidental slug
+    // collision put them in the presentable set, they must still not get the
+    // button — headingFor(2) is the only level that opens a slide.
+    renderWithContext(<H3>Sub-tema</H3>, { docId: 'doc-a', slugs: ['sub-tema'] });
+    expect(screen.queryByRole('link', { name: /presentar la sección/i })).not.toBeInTheDocument();
+  });
+
+  it('never paints on a heading with no sluggable text (silent fallback)', () => {
+    // Same silent-fallback contract already asserted for the `#` anchor: no
+    // text → no slug → no id → no button, even if a presentable set was
+    // published. The two anchors track together.
+    renderWithContext(
+      <H2>
+        <span data-testid="x" />
+      </H2>,
+      { docId: 'doc-a', slugs: [''] },
+    );
+    expect(screen.queryByRole('link', { name: /presentar la sección/i })).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/content/mdxHeading.tsx
+++ b/apps/web/src/content/mdxHeading.tsx
@@ -1,6 +1,9 @@
+import { Presentation } from 'lucide-react';
 import type { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
 
 import { withMeta } from '../lib/componentMeta';
+import { usePresentableSections } from '../lib/presentableSections';
 import { textOf } from '../lib/reactText';
 import { slugify } from '../lib/slug';
 
@@ -19,6 +22,11 @@ export function headingFor(level: 2 | 3 | 4) {
   function MdxHeading({ children }: HeadingProps) {
     const text = textOf(children);
     const slug = slugify(text);
+    // Only h2 opens a slide (parser.ts); h3/h4 live INSIDE one. The button
+    // reads context regardless — the value is the default silence on other
+    // levels anyway — but only h2 asks whether to paint it.
+    const { docId, presentableSlugs } = usePresentableSections();
+    const canPresent = level === 2 && docId !== null && slug !== '' && presentableSlugs.has(slug);
     // No text to slug: render the heading, but with no id and no self-anchor.
     // Since #118 (2026-08-14) this is reachable from ordinary authoring — a
     // heading that is entirely a formula (`## $$\log_2 n$$`) has no text at all,
@@ -26,6 +34,7 @@ export function headingFor(level: 2 | 3 | 4) {
     // rail entry, green build, green suite. Contradicts ADR-0021 and ADR-0002
     // knowingly; the fix moves published slugs, so it needs its own migration
     // (ADR-0027 §8). The authoring guide tells authors to put text in a heading.
+    // The present-section button rides the same fallback — no slug → no button.
     if (!slug) return <Tag>{children}</Tag>;
     return (
       <Tag id={slug} className="group scroll-mt-8">
@@ -40,6 +49,22 @@ export function headingFor(level: 2 | 3 | 4) {
         >
           #
         </a>
+        {canPresent ? (
+          // The book-side entry point (#256): a keyed sibling of the `#`
+          // anchor with the same visibility rules (opacity 0 until hover or
+          // focus). Renders a real navigation `<Link>` — the route changes —
+          // rather than a button. `?section=<slug>` is the deep-link contract
+          // SlideDeck resolves and canonicalizes to `?slide=<N>`. Painted
+          // only when the surrounding document publishes this slug as
+          // presentable (S4); catalog and non-slide h2s stay silent.
+          <Link
+            to={`/d/${docId}/present?section=${slug}`}
+            aria-label={`Presentar la sección «${text}»`}
+            className="ml-2 inline-flex items-center align-middle text-ink-faint no-underline opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
+          >
+            <Presentation size={16} aria-hidden="true" />
+          </Link>
+        ) : null}
       </Tag>
     );
   }

--- a/apps/web/src/lib/presentableSections.ts
+++ b/apps/web/src/lib/presentableSections.ts
@@ -1,0 +1,44 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * The set of slide-title slugs the surrounding document exposes as
+ * deep-linkable from the book (#256). `mdxHeading` reads it to decide
+ * whether an h2 gets a "Presentar sección" button next to its `#` anchor.
+ *
+ * Split from the value that carries it — the docId — so the button can
+ * check membership and build `/d/${docId}/present?section=<slug>` from one
+ * context read. `docId` is `null` when there is no surrounding document
+ * (e.g. `/catalog` renders a component in isolation): mdxHeading uses that
+ * as the silent "no button" signal.
+ *
+ * Lives in `lib/` for the same reason as [[known-sections]]: the provider
+ * lives in `presentation/` (which is what walks the slide model) and the
+ * consumer lives in `content/`, and `content → presentation` is not an
+ * edge in the `FEATURE_EDGES` allowlist (`src/architecture.test.ts`).
+ * Sharing the context here — a set both features are already allowed to
+ * import — avoids introducing that cross-feature edge for a single value.
+ *
+ * Empty means "no presentable sections", not "not measured": the wrapper
+ * computes the set synchronously from the rendered MDX children (the same
+ * technique `SlideDeck` uses to build its slide list), so a mounted
+ * document either has a non-empty set or doesn't (`presentation: none`).
+ * A page outside any document (catalog, family pages) never mounts the
+ * wrapper — the default value below leaves it empty and `docId` null.
+ */
+interface PresentableSectionsValue {
+  /** The document id when we are inside one; null on catalog / anywhere else. */
+  docId: string | null;
+  /** Slide-title slugs the current document publishes. */
+  presentableSlugs: ReadonlySet<string>;
+}
+
+const EMPTY: PresentableSectionsValue = { docId: null, presentableSlugs: new Set() };
+
+const PresentableSectionsContext = createContext<PresentableSectionsValue>(EMPTY);
+
+export const PresentableSectionsProvider = PresentableSectionsContext.Provider;
+
+/** The presentable-section spine of the surrounding document; empty when absent. */
+export function usePresentableSections(): PresentableSectionsValue {
+  return useContext(PresentableSectionsContext);
+}

--- a/apps/web/src/presentation/PresentableSectionsWrapper.test.tsx
+++ b/apps/web/src/presentation/PresentableSectionsWrapper.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react';
 import { Fragment, type ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
 
 import { Slide, SectionBreak } from '../components';
@@ -48,24 +49,20 @@ function capture(options: {
 }) {
   const captured: { value?: ReturnType<typeof usePresentableSections> } = {};
   const probe = <Probe key="__probe" onValue={(v) => (captured.value = v)} />;
-  if (options.noWrapper) {
-    render(probe);
-  } else {
-    // The probe rides INSIDE the compiled-MDX Fragment so `Children.only` in
-    // the wrapper still sees one child (the outer opaque element), while the
-    // probe itself lands as a sibling of the real slide markers and can read
-    // the context the provider publishes for that subtree.
-    const siblings = [...(options.siblings ?? []), probe];
-    render(
-      <PresentableSectionsWrapper
-        docId={options.docId ?? 'mi-doc'}
-        title={options.title ?? 'Mi documento'}
-        configMode={options.configMode}
-      >
-        <CompiledMdxLike siblings={siblings} />
-      </PresentableSectionsWrapper>,
-    );
-  }
+  // MemoryRouter around every render: since #256 mdxHeading paints a `<Link>`
+  // when the context publishes the slug, and `<Link>` needs a router.
+  const body = options.noWrapper ? (
+    probe
+  ) : (
+    <PresentableSectionsWrapper
+      docId={options.docId ?? 'mi-doc'}
+      title={options.title ?? 'Mi documento'}
+      configMode={options.configMode}
+    >
+      <CompiledMdxLike siblings={[...(options.siblings ?? []), probe]} />
+    </PresentableSectionsWrapper>
+  );
+  render(<MemoryRouter>{body}</MemoryRouter>);
   return captured.value!;
 }
 

--- a/apps/web/src/presentation/PresentableSectionsWrapper.test.tsx
+++ b/apps/web/src/presentation/PresentableSectionsWrapper.test.tsx
@@ -1,0 +1,123 @@
+import { render } from '@testing-library/react';
+import { Fragment, type ReactNode } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { Slide, SectionBreak } from '../components';
+import { contentMdxComponents } from '../content';
+import { usePresentableSections } from '../lib/presentableSections';
+
+import { PresentableSectionsWrapper } from './PresentableSectionsWrapper';
+
+const H2 = contentMdxComponents.h2;
+
+/**
+ * Probe that reports the value the surrounding wrapper publishes. Used as a
+ * child of `PresentableSectionsWrapper` so the test observes the context as
+ * an ordinary consumer would (which is how `mdxHeading` will read it in S5).
+ * Outside a wrapper it reports the default (`docId: null`, empty set), which
+ * is the same silence `mdxHeading` will fall back to inside `/catalog`.
+ */
+function Probe({ onValue }: { onValue: (v: ReturnType<typeof usePresentableSections>) => void }) {
+  onValue(usePresentableSections());
+  return null;
+}
+
+/**
+ * `mdxChildrenOf` (which the wrapper runs internally) expects the compiled-
+ * MDX shape: ONE opaque element from a function component that returns a
+ * Fragment of siblings. This helper mimics that shape so the test drives the
+ * same path a real document does.
+ */
+function CompiledMdxLike({ siblings }: { siblings: ReactNode }) {
+  return <Fragment>{siblings}</Fragment>;
+}
+
+/**
+ * Renders `siblings` inside the wrapper (auto mode unless overridden) and
+ * reports the context value it publishes. The `Probe` is rendered as a
+ * sibling of the compiled-MDX children — inside the wrapper subtree — so it
+ * sees the context an ordinary MDX consumer would. `noWrapper` mounts the
+ * probe outside any wrapper, to observe the default silence.
+ */
+function capture(options: {
+  siblings?: ReactNode[];
+  configMode?: 'auto' | 'explicit';
+  title?: string;
+  docId?: string;
+  noWrapper?: boolean;
+}) {
+  const captured: { value?: ReturnType<typeof usePresentableSections> } = {};
+  const probe = <Probe key="__probe" onValue={(v) => (captured.value = v)} />;
+  if (options.noWrapper) {
+    render(probe);
+  } else {
+    // The probe rides INSIDE the compiled-MDX Fragment so `Children.only` in
+    // the wrapper still sees one child (the outer opaque element), while the
+    // probe itself lands as a sibling of the real slide markers and can read
+    // the context the provider publishes for that subtree.
+    const siblings = [...(options.siblings ?? []), probe];
+    render(
+      <PresentableSectionsWrapper
+        docId={options.docId ?? 'mi-doc'}
+        title={options.title ?? 'Mi documento'}
+        configMode={options.configMode}
+      >
+        <CompiledMdxLike siblings={siblings} />
+      </PresentableSectionsWrapper>,
+    );
+  }
+  return captured.value!;
+}
+
+describe('PresentableSectionsWrapper', () => {
+  it('publishes the slugs of every auto-mode h2 slide in the document', () => {
+    const value = capture({
+      siblings: [
+        <H2 key="1">La idea</H2>,
+        <p key="2">x</p>,
+        <H2 key="3">Costo</H2>,
+        <p key="4">y</p>,
+      ],
+    });
+    expect(value.docId).toBe('mi-doc');
+    expect([...value.presentableSlugs].sort()).toEqual(['costo', 'la-idea']);
+  });
+
+  it('in explicit mode publishes only slugs of marked <Slide> titles', () => {
+    // The loose h2 ("Ejercicios" in java-tipos-y-flujo, or "Ignorada" here)
+    // is book-only in explicit mode and must not be presentable — the whole
+    // point of `explicit` is that loose prose is not slide material.
+    const value = capture({
+      configMode: 'explicit',
+      siblings: [
+        <H2 key="1">Ignorada como corte</H2>,
+        <Slide key="2" title="Tipos primitivos">
+          <p>a</p>
+        </Slide>,
+        <p key="3">solo-libro</p>,
+        <SectionBreak key="4" />,
+        <p key="5">post-break</p>,
+      ],
+    });
+    expect([...value.presentableSlugs].sort()).toEqual(['tipos-primitivos']);
+  });
+
+  it('never publishes the cover slug or a SectionBreak group', () => {
+    // Both hazards in one shot: the cover title matches the doc title (its
+    // slug would be `doc-largo` if present), and the post-break group is
+    // anonymous by design (ADR-0010). Neither should appear.
+    const value = capture({
+      title: 'Doc largo',
+      siblings: [<SectionBreak key="1" />, <p key="2">post-break</p>],
+    });
+    expect(value.presentableSlugs.size).toBe(0);
+  });
+
+  it('is silent outside any wrapper: docId null, empty set', () => {
+    // The catalog surface never mounts the wrapper — `mdxHeading` uses this
+    // exact absence to fall back to no "Presentar sección" button.
+    const value = capture({ noWrapper: true });
+    expect(value.docId).toBeNull();
+    expect(value.presentableSlugs.size).toBe(0);
+  });
+});

--- a/apps/web/src/presentation/PresentableSectionsWrapper.tsx
+++ b/apps/web/src/presentation/PresentableSectionsWrapper.tsx
@@ -1,0 +1,41 @@
+import { useMemo } from 'react';
+import type { ReactNode } from 'react';
+
+import { PresentableSectionsProvider } from '../lib/presentableSections';
+
+import { mdxChildrenOf } from './mdxChildren';
+import { computeSlides } from './parser';
+
+interface Props {
+  docId: string;
+  title: string;
+  /** Parser mode from the document frontmatter (auto | explicit). */
+  configMode?: 'auto' | 'explicit';
+  children?: ReactNode;
+}
+
+/**
+ * The book-side counterpart to `SlideDeck`'s deck-building wrapper: same
+ * technique — `mdxChildrenOf` → `computeSlides` — but instead of painting
+ * a deck, it collects the slugs of the slide-titled slides and hands the
+ * set down through context so `mdxHeading` can decide whether to paint the
+ * "Presentar sección" button next to a given h2. The rendered children are
+ * passed through unchanged; the book layout upstream still owns painting.
+ *
+ * Composed by `DocumentPage` as the MDX `wrapper` component, so the whole
+ * rendered document is available to walk in one go — the shape the
+ * `mdxChildrenOf` docs promise and that `PresentationPage`'s DeckWrapper
+ * already relies on.
+ */
+export function PresentableSectionsWrapper({ docId, title, configMode = 'auto', children }: Props) {
+  // Unconditional and first: mdxChildrenOf runs a useContext internally.
+  const siblings = mdxChildrenOf(children);
+  const value = useMemo(() => {
+    const slugs = new Set<string>();
+    for (const slide of computeSlides(siblings, { title, mode: configMode })) {
+      if (slide.slug) slugs.add(slide.slug);
+    }
+    return { docId, presentableSlugs: slugs };
+  }, [siblings, title, configMode, docId]);
+  return <PresentableSectionsProvider value={value}>{children}</PresentableSectionsProvider>;
+}

--- a/apps/web/src/presentation/SlideDeck.tsx
+++ b/apps/web/src/presentation/SlideDeck.tsx
@@ -97,13 +97,14 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
   // rewritten to the canonical `?slide=<N>` form in the effect below so the
   // history holds ONE shape (ADR-0013) and a bookmark of the resolved URL
   // still resolves after slides are renumbered.
+  //
+  // One clamp on purpose: `findIndex` returns -1 for an unknown slug and the
+  // clamp resolves it to slide 1, matching the ?slide out-of-range tolerance
+  // in the same expression.
   const rawSection = searchParams.get('section');
-  const sectionIndex = rawSection !== null ? slides.findIndex((s) => s.slug === rawSection) : -1;
-  const initialIndex =
-    rawSection !== null
-      ? Math.max(sectionIndex, 0)
-      : Math.min(Math.max(requested - 1, 0), slides.length - 1);
-  const index = Math.min(Math.max(initialIndex, 0), slides.length - 1);
+  const preferred =
+    rawSection !== null ? slides.findIndex((s) => s.slug === rawSection) : requested - 1;
+  const index = Math.min(Math.max(preferred, 0), slides.length - 1);
   const slide = slides[index]!;
 
   useEffect(() => {

--- a/apps/web/src/presentation/SlideDeck.tsx
+++ b/apps/web/src/presentation/SlideDeck.tsx
@@ -89,8 +89,34 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
   // fractional array index (white-screen crash — review finding, issue #64).
   const raw = Number(searchParams.get('slide') ?? '1');
   const requested = Number.isFinite(raw) ? Math.trunc(raw) : 1;
-  const index = Math.min(Math.max(requested - 1, 0), slides.length - 1);
+
+  // ?section=<slug> is the deep-link form the book publishes on every h2
+  // (`content/mdxHeading.tsx` #256). It wins over ?slide when both come in
+  // together: an unknown slug falls back to slide 1 with the same tolerance
+  // as an out-of-range ?slide — never a white screen. The URL is then
+  // rewritten to the canonical `?slide=<N>` form in the effect below so the
+  // history holds ONE shape (ADR-0013) and a bookmark of the resolved URL
+  // still resolves after slides are renumbered.
+  const rawSection = searchParams.get('section');
+  const sectionIndex = rawSection !== null ? slides.findIndex((s) => s.slug === rawSection) : -1;
+  const initialIndex =
+    rawSection !== null
+      ? Math.max(sectionIndex, 0)
+      : Math.min(Math.max(requested - 1, 0), slides.length - 1);
+  const index = Math.min(Math.max(initialIndex, 0), slides.length - 1);
   const slide = slides[index]!;
+
+  useEffect(() => {
+    if (rawSection === null) return;
+    setSearchParams(
+      (prev) => {
+        prev.delete('section');
+        prev.set('slide', String(index + 1));
+        return prev;
+      },
+      { replace: true },
+    );
+  }, [index, rawSection, setSearchParams]);
 
   // Out of the keydown effect and shared, so the keyboard and the finger reach
   // the same clamping and the same ?slide contract (ADR-0013) — two paths to

--- a/apps/web/src/presentation/SlideDeck.tsx
+++ b/apps/web/src/presentation/SlideDeck.tsx
@@ -139,10 +139,17 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
   // history.back(): a reader who opened /present from a link has nothing behind
   // them (ADR-0023). Fullscreen goes with it, because the control that exits
   // fullscreen lives in the deck being left.
+  //
+  // If the current slide has a slug (S1), append `#<slug>` so the book takes
+  // the reader back to the h2 they were watching — `mdxHeading.tsx` already
+  // renders `id={slug}` with `scroll-mt-8`, so the browser handles the scroll
+  // on its own. Without a slug (cover, SectionBreak) the URL stays fragment-
+  // less, preserving the pre-#256 behaviour for those two cases.
   const leave = useCallback(() => {
     leaveFullscreen();
-    void navigate(`/d/${docId}`);
-  }, [docId, navigate]);
+    const target = slide.slug ? `/d/${docId}#${slide.slug}` : `/d/${docId}`;
+    void navigate(target);
+  }, [docId, navigate, slide.slug]);
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {

--- a/apps/web/src/presentation/index.ts
+++ b/apps/web/src/presentation/index.ts
@@ -5,3 +5,4 @@
 export { ModeProvider } from './ModeProvider';
 export { useMode } from './useMode';
 export { PresentationPage } from './PresentationPage';
+export { PresentableSectionsWrapper } from './PresentableSectionsWrapper';

--- a/apps/web/src/presentation/parser.test.tsx
+++ b/apps/web/src/presentation/parser.test.tsx
@@ -12,6 +12,10 @@ function titles(slides: ReturnType<typeof computeSlides>) {
   return slides.map((s) => s.title);
 }
 
+function slugs(slides: ReturnType<typeof computeSlides>) {
+  return slides.map((s) => s.slug);
+}
+
 describe('computeSlides — auto mode', () => {
   it('returns only a cover slide for an empty document', () => {
     const slides = computeSlides([], DOC);
@@ -106,6 +110,48 @@ describe('computeSlides — auto mode', () => {
     );
     expect(titles(slides)).toEqual(['Mi documento', 'Unica']);
   });
+
+  it('gives each h2-derived slide a slug that matches its heading anchor', () => {
+    // The book renders these h2s with id="la-idea" / id="costo" via mdxHeading.
+    // The deep-link contract says both spines must resolve to the same slug —
+    // sharing slugify(textOf(...)) is what keeps them agreeing.
+    const slides = computeSlides(
+      [<H2 key="1">La idea</H2>, <p key="2">x</p>, <H2 key="3">Costo</H2>],
+      DOC,
+    );
+    expect(slugs(slides)).toEqual([undefined, 'la-idea', 'costo']);
+  });
+
+  it('slugs a <Slide title> the same way as an h2', () => {
+    const slides = computeSlides(
+      [
+        <Slide key="1" title="Búsqueda binaria">
+          <p>x</p>
+        </Slide>,
+      ],
+      DOC,
+    );
+    expect(slugs(slides)).toEqual([undefined, 'busqueda-binaria']);
+  });
+
+  it('leaves the cover and a SectionBreak group without a slug', () => {
+    const slides = computeSlides(
+      [<H2 key="1">Antes</H2>, <SectionBreak key="2" />, <p key="3">a</p>],
+      DOC,
+    );
+    // cover, "Antes", untitled post-break group.
+    expect(slugs(slides)).toEqual([undefined, 'antes', undefined]);
+  });
+
+  it('gives a titled slide with no sluggable text no slug (the # anchor is silent too)', () => {
+    // Same silent-fallback contract as mdxHeading.tsx: a heading whose content
+    // is entirely an element (`## $$\log_2 n$$`) has no text and gets no id.
+    // The slide-slug spine must not diverge from that. Prose after the heading
+    // keeps the slide from being dropped as empty-untitled, so the case can
+    // observe the slug rather than the parser's other silent behaviour.
+    const slides = computeSlides([<H2 key="1">{<span key="x" />}</H2>, <p key="2">x</p>], DOC);
+    expect(slugs(slides)).toEqual([undefined, undefined]);
+  });
 });
 
 describe('computeSlides — explicit mode', () => {
@@ -126,5 +172,19 @@ describe('computeSlides — explicit mode', () => {
     expect(titles(slides)).toEqual(['Doc', 'Uno', undefined]);
     expect(slides[0]!.content).toHaveLength(0);
     expect(slides[2]!.content).toHaveLength(1);
+  });
+
+  it('slugs the marked Slide and leaves the post-break group unslugged', () => {
+    const slides = computeSlides(
+      [
+        <Slide key="1" title="Uno">
+          <p>a</p>
+        </Slide>,
+        <SectionBreak key="2" />,
+        <p key="3">b</p>,
+      ],
+      { title: 'Doc', mode: 'explicit' },
+    );
+    expect(slugs(slides)).toEqual([undefined, 'uno', undefined]);
   });
 });

--- a/apps/web/src/presentation/parser.ts
+++ b/apps/web/src/presentation/parser.ts
@@ -3,9 +3,22 @@ import type { ReactNode } from 'react';
 
 import { metaOf } from '../lib/componentMeta';
 import { textOf } from '../lib/reactText';
+import { slugify } from '../lib/slug';
 
 export interface SlideDef {
   title?: string;
+  /**
+   * Deep-link slug for the slide. Same `slugify(textOf(title))` recipe the
+   * book uses for its h2 anchors (`content/mdxHeading.tsx`) — sharing the
+   * function is how the two spines stay in agreement, so `?section=<slug>`
+   * on presentation and `#<slug>` on the book resolve to the same heading.
+   * Absent on the cover (title is the document's own name — the "Presentar"
+   * button already lands there) and on SectionBreak groups (anonymous by
+   * design, ADR-0010). A title whose text is empty — e.g. a heading whose
+   * content is entirely a formula, per `mdxHeading.tsx` and `reactText.ts` —
+   * yields no slug here for the same silent-fallback reason.
+   */
+  slug?: string;
   content: ReactNode[];
 }
 
@@ -28,9 +41,33 @@ function isH2(child: ReactNode): child is React.ReactElement {
  * cover slide (auto) or stays book-only (explicit). Empty untitled groups
  * are dropped; the cover always exists.
  */
+/**
+ * Slug for a slide title, or undefined when the title is missing or has no
+ * text to slug (see `SlideDef.slug` for the silent-fallback rationale — the
+ * book's h2 anchor does the same thing for the same reason).
+ */
+function slugFor(title: string | undefined): string | undefined {
+  if (!title) return undefined;
+  const slug = slugify(title);
+  return slug ? slug : undefined;
+}
+
+/**
+ * The heading text a Slide/h2 boundary contributes as its title, and — for a
+ * <Slide title> — as its slug source. Explicit-mode Slide markers pass their
+ * title as a prop (a plain string); auto-mode h2 headings carry it as
+ * children (`textOf` collapses the subtree).
+ */
+function titleTextOf(children: ReactNode | undefined): string {
+  return textOf(children);
+}
+
 export function computeSlides(children: ReactNode, { title, mode = 'auto' }: Options): SlideDef[] {
   const auto = mode === 'auto';
   const slides: SlideDef[] = [];
+  // Cover: no slug on purpose — the top-bar "Presentar" button already lands
+  // there, so `#doc-title` on exit would round-trip the reader to the top of
+  // the book they were already at.
   const cover: SlideDef = { title, content: [] };
   slides.push(cover);
 
@@ -55,7 +92,11 @@ export function computeSlides(children: ReactNode, { title, mode = 'auto' }: Opt
       if (boundary === 'slide') {
         closeIfEmpty();
         const props = child.props as { title?: string; children?: ReactNode };
-        slides.push({ title: props.title, content: Children.toArray(props.children) });
+        slides.push({
+          title: props.title,
+          slug: slugFor(props.title),
+          content: Children.toArray(props.children),
+        });
         open = null;
         continue;
       }
@@ -67,7 +108,8 @@ export function computeSlides(children: ReactNode, { title, mode = 'auto' }: Opt
       }
       if (auto && isH2(child)) {
         closeIfEmpty();
-        open = { title: textOf((child.props as { children?: ReactNode }).children), content: [] };
+        const heading = titleTextOf((child.props as { children?: ReactNode }).children);
+        open = { title: heading, slug: slugFor(heading), content: [] };
         slides.push(open);
         continue;
       }

--- a/docs/decisions/0050-slide-deep-linking-by-slug.md
+++ b/docs/decisions/0050-slide-deep-linking-by-slug.md
@@ -1,0 +1,164 @@
+# ADR-0050: Slide deep-linking by slug — `?section=<slug>` on entry, `#<slug>` on exit
+
+**Status:** Accepted
+**Date:** 2026-08-27
+**Decision-makers:** Miguel Rodriguez
+**Covers:** `?section=<slug>` on `/d/:id/present` (URL contract) ·
+`SlideDeck.leave()` publishing `#<slug>` when the current slide has one ·
+`PresentableSectionsWrapper` + `lib/presentableSections` (the book-side spine
+publication) · the per-h2 "Presentar sección" button in `content/mdxHeading`
+**Source:** Issue #256.
+**Extends:** ADR-0013 (presentation pipeline / `?slide=N` URL contract) — this
+is the same URL as source of truth, gaining a second query key for a stable
+addressee. Reads from ADR-0021 (published anchors are frozen) — the slug is
+already the book's h2 id, so a bookmarked `?section=<slug>` outlives a
+renumbering of the deck. Constrained by ADR-0010 (`<SectionBreak/>` is
+anonymous by design), which is why an anonymous group publishes no slug.
+
+## Context
+
+A reader of the book had no way to say "show me THIS section as slides
+without walking to it": the top-bar "Presentar" toggle enters
+`/d/:id/present` and lands on slide 1 (the cover), and inside the deck the
+reader clicks their way forward. The book already publishes `#<slug>` on
+every h2 (`content/mdxHeading.tsx`); presentation had no counterpart, and
+`SlideDeck.leave()` returned readers to `/d/:id` with no fragment, so a
+reader who was watching a middle slide came back to the top of the book and
+scrolled to find their place again.
+
+The two halves are symmetrical: the book-to-deck direction wants a stable
+addressee (a slide the reader can bookmark, share, or land on from any h2
+in the book), and the deck-to-book direction wants to return the reader to
+the same section they were watching. Both are the same information under two
+different URL keys — a slug identifying a slide title.
+
+## Decision
+
+Add a slug-based deep-link contract, in both directions, using the same slug
+the book's h2 anchors already publish.
+
+### Entry: `GET /d/:id/present?section=<slug>`
+
+Loads the presentation and shows the slide whose title slugs to `<slug>`.
+Rules:
+
+- **Wins over `?slide=`** when both are present. `?section=` is the stable
+  addressee (a bookmark to `?slide=5` breaks the moment slides are
+  renumbered); `?slide=` remains the canonical intra-deck form.
+- **Unknown slug falls back to slide 1** — same tolerance as an out-of-range
+  `?slide` (the pre-existing clamp). Never a white screen.
+- **Canonicalised on mount** to `?slide=<N>` with `{ replace: true }`. The
+  URL is the source of truth (ADR-0013), and the browser history must hold
+  one shape only: without this, the back button after a `?section=` entry
+  returns to a `?section=` URL the deck already resolved, and every intra-
+  deck arrow key writes a `?slide=<N>` that shadows it.
+
+### Exit: `SlideDeck.leave()` publishes `#<slug>` when the current slide has one
+
+`Escape` and the footer's X button navigate to `/d/${docId}#${slug}` when
+the current slide is titled (its slug is defined). Without a slug — the
+cover, an anonymous `<SectionBreak/>` group — the navigation stays
+fragment-less, matching the pre-#256 behaviour for those two cases.
+
+- **Cover has no slug on purpose.** The top-bar "Presentar" button lands on
+  the cover; publishing the cover's slug on exit would round-trip the
+  reader to the same spot they came from.
+- **The browser handles the scroll.** `mdxHeading` already renders
+  `id={slug}` with `scroll-mt-8`, so no code in the deck touches the
+  fragment beyond the URL — one publication site, one scroll behaviour.
+
+### Publishing the presentable spine to the book
+
+The book side needs to know which of its h2s are slide boundaries with a
+slug, so `mdxHeading` can paint a "Presentar sección" button next to the
+`#` anchor only where the button will actually resolve. This is different
+from the `useSections` DOM walk (which lists ALL rendered h2s): in
+`explicit` mode a document has h2s that are book-only (loose prose sections
+like `Ejercicios` in `java-tipos-y-flujo`), and those must not carry the
+button.
+
+`PresentableSectionsWrapper` (in `presentation/`) is an MDX wrapper
+`DocumentPage` mounts around every document. It runs the same
+`mdxChildrenOf` → `computeSlides` recipe `SlideDeck` uses, collects the
+S1 slugs into a Set, and publishes them along with `docId` through
+`lib/presentableSections`. The context lives in `lib/` — like
+`knownSections` — because provider and consumer sit in different features
+(`presentation` publishes, `content` consumes) and `content → presentation`
+is not an edge in `FEATURE_EDGES` (`src/architecture.test.ts`); sharing
+through `lib` avoids introducing that cross-feature edge for a single
+value.
+
+The wrapper is prop-injected into `DocumentPage` by `AppRoutes` (the same
+shape `notFound` already used), so `content/` never imports
+`presentation/` directly. A page outside `DocumentPage` — the catalog,
+family pages — never mounts the wrapper, and the default context value
+(`docId: null`, empty set) leaves `mdxHeading` silent. No per-surface
+exception was written; the absence of a wrapper is the signal.
+
+### The button in `mdxHeading`
+
+`mdxHeading` paints a lucide `Presentation` icon inside a react-router
+`<Link>` to `/d/${docId}/present?section=${slug}`, as a keyed sibling of
+the existing `#` anchor. Same visibility rules (`opacity-0` +
+`group-hover:opacity-100` + `focus-visible:opacity-100`); same silent
+fallback for a text-less heading (a formula-only `##`, per ADR-0027 §8,
+still paints nothing). The gate combines three independent facts so a
+regression in any silences the button without a false paint:
+
+- `level === 2` — h3/h4 live INSIDE a slide, never at a boundary.
+- `docId !== null` — no wrapper, no button (catalog and friends).
+- `presentableSlugs.has(slug)` — the loose-h2 exclusion in `explicit` mode.
+
+`aria-label="Presentar la sección «{título}»"` in Spanish (CLAUDE.md
+§Language). The icon is `aria-hidden`; a screen reader announces the
+section, not the glyph.
+
+## Alternatives considered
+
+- **A keyboard shortcut ("present the h2 I'm looking at")** was left out
+  of scope: the atomic ask was a book-visible entry point that survives
+  reordering. The `?section=` contract makes such a shortcut cheap when
+  it is written.
+- **Route path segment `/d/:id/present/:section`** was rejected: the deck
+  URL is a query-key surface (ADR-0013), and adding a route path segment
+  would fork parsing between two URL shapes for the same fact and break
+  the S2 canonicalisation to `?slide=N`.
+- **A registry map from slug to slide index at build time** was rejected:
+  the slide model is authored in JSX, not in metadata; a build-time map
+  would drift the moment an author renamed a slide title without editing
+  frontmatter, and the runtime walk (which is already done for the deck)
+  is cheap.
+
+## Consequences
+
+- Two URL shapes reach the same slide: `?slide=N` (canonical, what the deck
+  writes) and `?section=<slug>` (deep-link, what a bookmark preserves). S2
+  canonicalises `?section=` to `?slide=` on mount, so the history always
+  holds the canonical form after the first render.
+- **A slug is now a public presentation contract**, on top of the existing
+  book-anchor contract (ADR-0021). Renaming a slide title breaks two live
+  URLs at once. The fix is the same in both cases: keep the title stable
+  once shipped, or accept the breakage as part of the change.
+- **Slug collisions within a document** — two slide titles that slug to the
+  same string — resolve to the first slide (`Array.findIndex` in `SlideDeck`
+  and `Set` de-duplication in the wrapper). This is the same behaviour the
+  book's `#` anchor already had; no report is open against it, and this WP
+  did not resolve it. Recorded here so a future author looking at either
+  spine finds one story.
+- **A tiny extra walk per book page**: `PresentableSectionsWrapper` runs
+  `computeSlides` once per document render. Same cost the deck already
+  pays, on a document that would render anyway. Not measured, and did not
+  need to be — the walk is O(children) over the same tree React was about
+  to render.
+- **The two spines now share three helpers**: `slugify` (already shared),
+  `computeSlides` + `mdxChildrenOf` (already in `presentation/`, imported
+  by the wrapper from there). If the book slug and the slide slug ever
+  diverge, the fault will localise to one of these three files.
+
+## Not yet proven
+
+- **Sharing links to sections in the wild.** The whole WP exists so a
+  reader can send a link to a specific section-as-slides; we do not know
+  yet whether readers do that. If they do not, the button is dead weight
+  we could hide; if they do, we may want the book-view h2 to expose a
+  richer share affordance (a copy button, an OG image). Wait for evidence.

--- a/docs/decisions/0051-slide-deep-linking-by-slug.md
+++ b/docs/decisions/0051-slide-deep-linking-by-slug.md
@@ -8,12 +8,13 @@
 `PresentableSectionsWrapper` + `lib/presentableSections` (the book-side spine
 publication) · the per-h2 "Presentar sección" button in `content/mdxHeading`
 **Source:** Issue #256.
-**Extends:** ADR-0013 (presentation pipeline / `?slide=N` URL contract) — this
-is the same URL as source of truth, gaining a second query key for a stable
-addressee. Reads from ADR-0021 (published anchors are frozen) — the slug is
-already the book's h2 id, so a bookmarked `?section=<slug>` outlives a
-renumbering of the deck. Constrained by ADR-0010 (`<SectionBreak/>` is
-anonymous by design), which is why an anonymous group publishes no slug.
+**Extends:** ADR-0013 (presentation pipeline / `?slide=N` URL contract, and
+the `<SectionBreak/>` = untitled group boundary at §Decision 1) — this is
+the same URL as source of truth, gaining a second query key for a stable
+addressee, and the untitled-group rule is why an anonymous group publishes
+no slug. Reads from ADR-0021 (rendered h2 IS the section spine) and
+ADR-0027 §8 (a published anchor is frozen) — the slug is already the book's
+h2 id, so a bookmarked `?section=<slug>` outlives a renumbering of the deck.
 
 ## Context
 

--- a/docs/decisions/0051-slide-deep-linking-by-slug.md
+++ b/docs/decisions/0051-slide-deep-linking-by-slug.md
@@ -1,4 +1,4 @@
-# ADR-0050: Slide deep-linking by slug — `?section=<slug>` on entry, `#<slug>` on exit
+# ADR-0051: Slide deep-linking by slug — `?section=<slug>` on entry, `#<slug>` on exit
 
 **Status:** Accepted
 **Date:** 2026-08-27

--- a/docs/standards/frontend-code-style.md
+++ b/docs/standards/frontend-code-style.md
@@ -90,15 +90,28 @@ src/
 - **Document-level STATE reaches a component through a context declared in
   `lib/`**: the producing feature provides it, the consuming feature reads it,
   and the declaration sits in `lib/` for the same reason as the rule above —
-  `components → content` is not an allowed edge, and adding one to pass a set of
-  strings buys nothing. Worked case: `lib/knownSections.ts`, provided by
-  `content/DocumentPage.tsx` from the same spine the rail and the drawer draw
-  from, read by `<Question>` to check the section it claims (#139). **Part of
-  that contract is that an empty value means NOT MEASURED, never authority** —
-  the spine is read from the DOM after mount, so it is empty on the first render
-  of every document, and a consumer that trusted it would paint an authoring
-  error over every correct question on every page load. Whatever the context
-  cannot see belongs to a source-level gate instead.
+  cross-feature edges the `FEATURE_EDGES` allowlist does not carry (e.g.
+  `components → content`, `content → presentation`) buy nothing by being
+  opened for a set of strings. The empty-value contract depends on WHEN the
+  context can be measured — two worked cases, opposite semantics:
+
+  - **DOM-after-mount contexts: empty means NOT MEASURED, never authority.**
+    Worked case: `lib/knownSections.ts`, provided by `content/DocumentPage.tsx`
+    from the same spine the rail and the drawer draw from, read by
+    `<Question>` to check the section it claims (#139). The spine is read
+    from the DOM after mount, so it is empty on the first render of every
+    document, and a consumer that trusted it would paint an authoring error
+    over every correct question on every page load. Whatever the context
+    cannot see belongs to a source-level gate instead.
+  - **Source-level contexts: empty IS authority.** When the value can be
+    measured before render — a synchronous walk over MDX children — the
+    wrapper publishes it as ground truth and "empty" means empty. Worked
+    case: `lib/presentableSections.ts`, published by
+    `presentation/PresentableSectionsWrapper` (the shell hands the wrapper
+    to `content/DocumentPage`, see the shell-injection rule below), read by
+    `content/mdxHeading` to decide whether an h2 gets a `Presentar` button
+    (#256, ADR-0051). A page that does not mount the wrapper reads the
+    empty default, and that IS the signal — no consumer branch needed.
 - **MDX component maps are shell-composed**: features export partial maps
   (e.g., `content/mdxComponents.ts`), and `app/mdxComponents.ts` merges them
   into the provider around the routes. Features never assemble the global map;
@@ -120,7 +133,16 @@ src/
 - **Shell UI reaches features by injection**: when a feature needs shell-owned
   UI (error pages, layout slots), the shell passes it via props/children —
   features never import from `app/`. Worked case: `AppRoutes` injects
-  `<NotFound />` into `DocumentPage`'s `notFound` prop.
+  `<NotFound />` into `DocumentPage`'s `notFound` prop. **The shell uses the
+  same shape to broker CROSS-FEATURE collaboration** when the alternative
+  would be opening a `FEATURE_EDGES` entry the collaboration is the only
+  motivation for: the producing feature exports the component from its seam,
+  the shell imports both features and hands one to the other by prop.
+  Worked case: `AppRoutes` injects `<PresentableSectionsWrapper />` (from
+  `presentation/`) into `content/`'s `DocumentPage` via the
+  `presentableSectionsWrapper` prop, which composes it as the MDX
+  `components.wrapper` so the wrapped document publishes its slide spine to
+  `mdxHeading` — no `content → presentation` edge added (#256, ADR-0051).
 - **Not everything under `components/` is a catalog component.** Two shapes have
   no catalog entry and no MDX registration, and neither is an omission
   (a third, the intrinsic-element renderer above, has no entry but _is_

--- a/docs/standards/guides/add-a-content-component.md
+++ b/docs/standards/guides/add-a-content-component.md
@@ -115,7 +115,14 @@ apps/web/src/components/structure/
      same section spine the rail and the drawer draw from. Empty means NOT
      MEASURED — the spine is read from the DOM after mount — so never treat it
      as authority. Worked case: `<Question>` verifying the `anchor` it claims
-     (#139).
+     (#139). To know whether a section is presented as a SLIDE (not merely
+     rendered as an h2 — the two are the same set in `auto` mode but diverge
+     in `explicit`), read `usePresentableSections()`
+     (`lib/presentableSections.ts`): the wrapper computes it synchronously
+     from the MDX children, so an empty set IS authority (a page outside a
+     `DocumentPage` — the catalog — has no wrapper, and the empty default is
+     the signal). Consumed today by `content/mdxHeading` to paint the
+     `Presentar` button (#256, ADR-0051).
    - **Being inside something that has already spoken for you.** A container that
      carries one accessible name for a whole group wraps its children in
      `<DescribedProvider value={true}>` (`components/described.ts`), and a

--- a/docs/standards/guides/add-a-course-document.md
+++ b/docs/standards/guides/add-a-course-document.md
@@ -326,7 +326,7 @@ so a formula is read as mathematics rather than skipped as decoration.
    Slide cuts a slide but contributes no section.
 
    **Each `<Slide title>` is deep-linkable from the book, and returns the
-   reader to its title on exit** (ADR-0050). The h2 of a titled slide gets a
+   reader to its title on exit** (ADR-0051). The h2 of a titled slide gets a
    `Presentar` button next to its `#` anchor, linking to
    `/d/:id/present?section=<slug>`; leaving the deck from a slide with a
    title lands the reader on the same h2 via `#<slug>`. Both work off the

--- a/docs/standards/guides/add-a-course-document.md
+++ b/docs/standards/guides/add-a-course-document.md
@@ -325,6 +325,14 @@ so a formula is read as mathematics rather than skipped as decoration.
    section list** — one more reason to give every Slide a title. An untitled
    Slide cuts a slide but contributes no section.
 
+   **Each `<Slide title>` is deep-linkable from the book, and returns the
+   reader to its title on exit** (ADR-0050). The h2 of a titled slide gets a
+   `Presentar` button next to its `#` anchor, linking to
+   `/d/:id/present?section=<slug>`; leaving the deck from a slide with a
+   title lands the reader on the same h2 via `#<slug>`. Both work off the
+   same slug the `#` anchor already exposes, so the title you write is what
+   gets bookmarked — keeping it stable keeps live links working.
+
    **A `<SectionBreak />` collects, it does not cut.** In an `explicit` deck
    only marked content forms slides: a markdown `##` after a SectionBreak does
    NOT cut a slide (only `auto` slices on h2 — `presentation/parser.ts`), so

--- a/docs/standards/guides/add-a-course-document.md
+++ b/docs/standards/guides/add-a-course-document.md
@@ -331,7 +331,10 @@ so a formula is read as mathematics rather than skipped as decoration.
    `/d/:id/present?section=<slug>`; leaving the deck from a slide with a
    title lands the reader on the same h2 via `#<slug>`. Both work off the
    same slug the `#` anchor already exposes, so the title you write is what
-   gets bookmarked — keeping it stable keeps live links working.
+   gets bookmarked — keeping it stable keeps live links working. In an
+   `explicit` deck, only `<Slide title>` boundaries publish a slug — a
+   loose book-only h2 like `## Ejercicios` stays button-less on purpose
+   (there is no slide to link to).
 
    **A `<SectionBreak />` collects, it does not cut.** In an `explicit` deck
    only marked content forms slides: a markdown `##` after a SectionBreak does


### PR DESCRIPTION
**Closes #256**

## Summary

Every `<Slide title>` becomes deep-linkable from the book and returns the reader to that heading on exit. The URL is the source of truth in both directions — `?section=<slug>` on entry (canonicalizes to `?slide=<N>`), `#<slug>` on exit — using the same slug the book's `#` anchor already publishes. On every presentable h2 the book paints a keyed sibling of the `#` anchor: a lucide `Presentation` icon inside a real `<Link>` to `/d/:id/present?section=<slug>`. See ADR-0051 for the full contract.

## Slices completed

- [x] S1 (`b2c0cc6`) — `SlideDef.slug` computed by `slugify(textOf(title))`.
- [x] S2 (`6f4f256`) — `SlideDeck` resolves `?section=<slug>` and canonicalizes to `?slide=<N>` with `replace: true`.
- [x] S3 (`6d6b930`) — `SlideDeck.leave()` publishes `#<slug>` when the current slide has one.
- [x] S4 (`d8f531f`) — `PresentableSectionsWrapper` publishes the slide spine to `content/mdxHeading` via `lib/presentableSections`.
- [x] S5 (`042cf53`) — `mdxHeading` paints the "Presentar sección" button on presentable h2s.
- [x] S6 (`594ee53` + `40ab175`) — ADR-0051 + author-guide addition (renumbered from 0050 after PR #252 collision).

## Acceptance criteria

1. **Book h2 → Presentar button on auto-mode docs.** ✓ Evidence: unit `apps/web/src/content/mdxHeading.test.tsx > 'paints the button next to the anchor when the slug is presentable'`; end-to-end `apps/web/src/app/presentationRoute.test.tsx > 'offers a Presentar-sección link on a marked <Slide> h2 in the book'` (asserts the exact `/d/:id/present?section=<slug>` href).
2. **Explicit mode → only marked-Slide h2s get the button.** ✓ Evidence: `presentationRoute.test.tsx > 'does not offer the button on a loose h2 (explicit-mode book-only section)'` (loose `## Ejercicios` in `java-tipos-y-flujo`).
3. **SectionBreak, cover, `presentation: none` → no button.** ✓ Evidence: `PresentableSectionsWrapper.test.tsx > 'never publishes the cover slug or a SectionBreak group'`; `presentationRoute.test.tsx > 'hides the toggle for presentation: none documents'` (asserts both the top-bar and per-section link are absent).
4. **Unknown `?section=<slug>` falls to slide 1 with canonical URL.** ✓ Evidence: `presentationRoute.test.tsx > 'falls back to slide 1 for an unknown ?section slug (no white screen)'` (asserts counter `1/N`, `search.get('section') === null`, `search.get('slide') === '1'`).
5. **Known `?section=<slug>` canonicalises to `?slide=<N>`.** ✓ Evidence: `presentationRoute.test.tsx > 'canonicalizes ?section=<slug> to ?slide=<N> so the back button behaves'` — asserts `section === null` and `slide` matches `/^\d+$/` after mount.
6. **Escape/X on a slugged slide → `/d/:id#<slug>`.** ✓ Evidence: `presentationRoute.test.tsx > 'lands on the book #<slug> when Escape leaves a slide that has one'` (asserts `pathname === /d/${explicitId}` and `hash === '#tipos-primitivos'`).
7. **Escape/X from cover or SectionBreak → `/d/:id` fragment-less.** ✓ Evidence: `presentationRoute.test.tsx > 'publishes no fragment when Escape leaves from the cover slide'` (asserts `hash === ''`).
8. **Formula-only h2 keeps silent fallback (no `#`, no Presentar).** ✓ Evidence: `mdxHeading.test.tsx > 'never paints on a heading with no sluggable text (silent fallback)'`; short-circuit in `content/mdxHeading.tsx` (`if (!slug) return <Tag>{children}</Tag>` before the button).
9. **Catalog surface unchanged (no wrapper, no button).** ✓ Evidence: `presentationRoute.test.tsx > 'does not offer the button on the catalog surface (no wrapper mounted)'`; `PresentableSectionsWrapper.test.tsx > 'is silent outside any wrapper: docId null, empty set'`.
10. **`apps/web` suite green in per-commit and pre-PR.** ✓ Evidence: 1251/1251 tests pass; `npm run format:check`, `npm run lint`, `npm run build` all clean (only pre-existing `VideoEmbed.tsx` react-only-export-components warning).

## Tests

- `apps/web/src/presentation/parser.test.tsx` — 5 new cases for `SlideDef.slug` (h2 auto, `<Slide title>`, cover, SectionBreak, empty-text fallback).
- `apps/web/src/presentation/PresentableSectionsWrapper.test.tsx` — new file; 4 cases (auto-mode set, explicit-mode filter, cover/SectionBreak exclusion, silent absence).
- `apps/web/src/content/mdxHeading.test.tsx` — 7 new cases under the "present-section button" block covering the 3-fact gate (level/docId/slug-in-set), Spanish aria-label, keyboard visibility, silent fallback.
- `apps/web/src/app/presentationRoute.test.tsx` — 6 new cases covering `?section=` deep-link, canonicalisation, unknown-slug fallback, `?section` winning over `?slide`, the exit-with-slug and exit-without-slug branches, plus 3 book-view integration cases for the button.
- Two pre-existing tests narrowed (`App.test.tsx > wiki-links`, `presentationRoute.test.tsx > 'Presentar toggle'`) to distinguish the two "Presentar" surfaces — details in the S5 commit body.

## Reviews run

- **Round A (code)** — mechanical gate green; panel of 3 lenses (`lens-correctness-tests`, `lens-arch-simplicity`, `lens-security`) + `lens-performance` explicitly skipped (no perf goals, new work per render is O(children) over a tree React already walks). Findings: 0 critical, 0 important, 2 suggestions (`ARQ-1` redundant clamp in `SlideDeck`, `ARQ-2` unused `export` on wrapper props type). Both accepted, applied in `620d125`, per-fix lens recheck: RESOLVED.
- **Round B (docs)** — panel of 4 lenses (`lens-docs-completeness`, `lens-docs-accuracy`, `lens-adr-hunter`, `lens-agent-readability`). Findings: 1 important (`DAC-1` ADR-0010 misattribution — CONFIRMED by `review-verifier`), 1 pattern (`DCO-1` shell-injection rule now covers cross-feature brokering — recorded in `docs/standards/frontend-code-style.md`), 4 suggestions (`DAC-2`, `DCO-2`, `AGR-1`, `AGR-3`). All accepted, applied in `d808350`, per-fix lens recheck: RESOLVED for all six.
- Verifier table + per-lens recheck outputs live in the pipeline transcript; the pattern learning is recorded in-tree.

## Manual verification

Please spot-check in a real browser (`npm run build && npm run preview` — the base path matters):

- [ ] Open `/d/java-tipos-y-flujo`. Hover an h2 with a `<Slide title>` (e.g. "Tipos primitivos"): the `#` and the `Presentar` icon both appear. Tab into it: focus reveals both. Click `Presentar`: lands on the correct slide.
- [ ] On the same page, hover the loose h2 `## Ejercicios`: only `#` appears, no `Presentar`.
- [ ] From a slide inside the deck, press `Escape`: book scrolls to the same h2 (URL ends in `#<slug>`).
- [ ] From the cover slide, press `Escape`: URL ends without a fragment.
- [ ] Navigate to `/d/java-tipos-y-flujo/present?section=tipos-primitivos`: deck opens on the right slide, address bar rewrites to `?slide=<N>` (back button leaves the deck cleanly).
- [ ] Try `/d/java-tipos-y-flujo/present?section=does-not-exist`: opens on slide 1, address bar rewrites to `?slide=1`.
- [ ] Open `/d/planificacion` (`presentation: none`): no `Presentar` top-bar toggle, no per-h2 `Presentar` button.
- [ ] Open `/catalog/c/slide` and `/catalog/c/section-break`: nothing about `Presentar sección` appears, catalog behaves as before.
- [ ] Screen-reader spot-check: an accessible-name inspector should read the per-h2 link as "Presentar la sección «\<título\>»" (Spanish, since the site is `lang="es"`).

## Notes

- **ADR-0051 was ADR-0050 during S6**; PR #252 landed ADR-0050 on `main` while S6 was already committed. Renumbered in `40ab175` and re-verified against origin/main + all remote branches. Feedback memory `feedback_adr_number_collision` recorded this pattern for future WPs (the check caducates every second a peer branch is merging).
- **`presentableSections` is the second cross-feature-spine context in `lib/`** (after `knownSections`), with the opposite empty-value contract (source-level, not DOM-after-mount). Both variants are now named as worked cases in `docs/standards/frontend-code-style.md` — that was `AGR-1`.
- Slug collisions within a document (two `<Slide title>` slugging to the same string) resolve to the first slide — same behaviour the book's `#` anchor already has. Not a #256 regression; noted in ADR-0051 §Consequences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1oFiW2WyTApUmF1KeqZy3
