### PR TITLE
fix(presentation): keep deck shortcuts off while the reader is typing (#262)

### DIFF
--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -462,6 +462,12 @@ describe('presentation while the reader is typing in a slide', () => {
     } finally {
       editor.remove();
     }
+
+    // Same positive control the <input> case above carries: without a key that
+    // still moves the deck once the editable is gone, a listener that no-op'd
+    // outright would satisfy the assertion above.
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    expect(counter).toHaveTextContent(/^2 \//);
   });
 
   it('still leaves the deck on Escape from an editable target', async () => {

--- a/apps/web/src/app/presentationRoute.test.tsx
+++ b/apps/web/src/app/presentationRoute.test.tsx
@@ -409,6 +409,79 @@ describe('presentation on a phone held in portrait', () => {
   });
 });
 
+// The deck's window-level keydown listener sees keystrokes that originate in
+// editable regions inside a slide — the code widget on Class 0, any runtime
+// <MdxPre> fence — because they bubble up to window. Before the guard, Space
+// and ArrowRight cancelled the character AND advanced ?slide; ArrowLeft
+// rewound it (issue #262). The predicate is unit-tested in
+// presentation/typingTarget.test.ts; this block pins the WIRING through the
+// real route, over the same document the viewer cases use.
+describe('presentation while the reader is typing in a slide', () => {
+  it('ignores slide keys that come from an <input> in the page', async () => {
+    await renderAt(`/d/${firstId}/present`);
+    const counter = await findCounter();
+    const input = document.createElement('input');
+    document.body.append(input);
+
+    try {
+      // Every navigation key the deck listens to: without the guard, ArrowRight
+      // and Space each advance and ArrowLeft rewinds — three chances for the
+      // counter to move if the guard is off.
+      fireEvent.keyDown(input, { key: 'ArrowRight' });
+      fireEvent.keyDown(input, { key: ' ' });
+      fireEvent.keyDown(input, { key: 'ArrowLeft' });
+      expect(counter).toHaveTextContent(/^1 \//);
+    } finally {
+      input.remove();
+    }
+
+    // Positive control: with the editable gone, the SAME key fired at window
+    // moves the deck. Without this, a listener that stopped working entirely
+    // would satisfy the assertion above.
+    fireEvent.keyDown(window, { key: 'ArrowRight' });
+    expect(counter).toHaveTextContent(/^2 \//);
+  });
+
+  it('ignores slide keys that come from inside a contenteditable region', async () => {
+    // The shape a rich editor produces: the real keydown target is a
+    // descendant of the contenteditable root, not the root itself. CodeMirror
+    // fires at an inner <span class="cm-line">; the predicate walks up.
+    await renderAt(`/d/${firstId}/present`);
+    const counter = await findCounter();
+    const editor = document.createElement('div');
+    editor.setAttribute('contenteditable', 'true');
+    const line = document.createElement('span');
+    editor.append(line);
+    document.body.append(editor);
+
+    try {
+      fireEvent.keyDown(line, { key: 'ArrowRight' });
+      fireEvent.keyDown(line, { key: ' ' });
+      fireEvent.keyDown(line, { key: 'ArrowLeft' });
+      expect(counter).toHaveTextContent(/^1 \//);
+    } finally {
+      editor.remove();
+    }
+  });
+
+  it('still leaves the deck on Escape from an editable target', async () => {
+    // The one shortcut the guard deliberately lets through, matching the
+    // portrait branch above it (SlideDeck.tsx §portrait short-circuit): a
+    // modal has to have a way out, and the editor is one.
+    await renderAt(`/d/${firstId}/present`);
+    await findCounter();
+    const input = document.createElement('input');
+    document.body.append(input);
+
+    try {
+      fireEvent.keyDown(input, { key: 'Escape' });
+      expect(await screen.findByRole('article')).toBeInTheDocument();
+    } finally {
+      input.remove();
+    }
+  });
+});
+
 describe('advancing the deck by touch', () => {
   function swipe(from: number, to: number, y = 200, endY = 205) {
     const stage = screen.getByTestId('slide-stage');

--- a/apps/web/src/presentation/SlideDeck.tsx
+++ b/apps/web/src/presentation/SlideDeck.tsx
@@ -18,6 +18,7 @@ import { fitScale } from './fit';
 import { startsInsideHorizontalScroller, swipeDirection } from './swipe';
 import type { Point } from './swipe';
 import { RotateNotice } from './RotateNotice';
+import { isTypingTarget } from './typingTarget';
 import { usePortraitPhone } from './usePortraitPhone';
 
 // Exiting is guarded everywhere it happens: exitFullscreen() REJECTS when
@@ -161,6 +162,13 @@ export function SlideDeck({ docId, title, configMode = 'auto', children }: Props
       // wrong slide (#91 review). Escape is deliberately still live: it is the
       // way out of a modal, and the panel is one.
       if (portraitPhone && event.key !== 'Escape') return;
+      // A slide can host an editable region (the code widget on Class 0, any
+      // runtime <MdxPre>): the reader typing there sees Space and ArrowRight
+      // cancel the character AND advance ?slide, ArrowLeft rewind mid-edit
+      // (#262). Escape stays live for the same reason it does through the
+      // portrait branch above: a modal has to have a way out, and the editor
+      // is one.
+      if (event.key !== 'Escape' && isTypingTarget(event.target)) return;
       switch (event.key) {
         case 'ArrowRight':
         case ' ':

--- a/apps/web/src/presentation/typingTarget.test.ts
+++ b/apps/web/src/presentation/typingTarget.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+
+import { isTypingTarget } from './typingTarget';
+
+// The whole point of the predicate is to answer, at the deck's keydown
+// listener, "is the reader typing?". Every case here is one node shape that
+// listener actually meets. jsdom cannot execute CodeMirror, so the descendant
+// case builds by hand the tree the browser produces (`.cm-editor > .cm-content
+// > .cm-line`) — what matters is the ancestor walk, which the suite can judge.
+describe('isTypingTarget', () => {
+  it('is true for an <input>', () => {
+    const input = document.createElement('input');
+    expect(isTypingTarget(input)).toBe(true);
+  });
+
+  it('is true for a <textarea>', () => {
+    const textarea = document.createElement('textarea');
+    expect(isTypingTarget(textarea)).toBe(true);
+  });
+
+  it('is true for a <select>', () => {
+    const select = document.createElement('select');
+    expect(isTypingTarget(select)).toBe(true);
+  });
+
+  it('is true for an element with contenteditable="true"', () => {
+    const editable = document.createElement('div');
+    editable.setAttribute('contenteditable', 'true');
+    expect(isTypingTarget(editable)).toBe(true);
+  });
+
+  it('is true for an element with a bare contenteditable attribute', () => {
+    // `<div contenteditable>` — the empty-string form the HTML spec treats the
+    // same as "true". A predicate that only matched `="true"` missed it.
+    const editable = document.createElement('div');
+    editable.setAttribute('contenteditable', '');
+    expect(isTypingTarget(editable)).toBe(true);
+  });
+
+  it('is true for a descendant of a contenteditable ancestor', () => {
+    // The shape CodeMirror produces: the real keydown target is an inner
+    // <span class="cm-line">, not the .cm-content wrapper that carries the
+    // attribute. A predicate that only looked at the target itself missed it.
+    const editor = document.createElement('div');
+    editor.className = 'cm-editor';
+    const content = document.createElement('div');
+    content.className = 'cm-content';
+    content.setAttribute('contenteditable', 'true');
+    const line = document.createElement('span');
+    line.className = 'cm-line';
+    content.append(line);
+    editor.append(content);
+    document.body.append(editor);
+
+    expect(isTypingTarget(line)).toBe(true);
+
+    editor.remove();
+  });
+
+  it('is false for a plain <div>', () => {
+    const div = document.createElement('div');
+    expect(isTypingTarget(div)).toBe(false);
+  });
+
+  it('is false for null', () => {
+    expect(isTypingTarget(null)).toBe(false);
+  });
+
+  it('is false for a target that is not an Element (like window)', () => {
+    // The other presentation-route cases fire keydown at `window`, which is not
+    // an Element. If the predicate said `true` for that, EVERY existing case
+    // would see the guard swallow the key and go red.
+    expect(isTypingTarget(window)).toBe(false);
+  });
+
+  it('is false for a descendant of a contenteditable="false" ancestor', () => {
+    // The negative form of contenteditable — an author disabling editing on a
+    // subtree. Not something the deck cares about in practice, but the
+    // predicate must not confuse it with an enabled region.
+    const outer = document.createElement('div');
+    outer.setAttribute('contenteditable', 'false');
+    const inner = document.createElement('span');
+    outer.append(inner);
+    document.body.append(outer);
+
+    expect(isTypingTarget(inner)).toBe(false);
+
+    outer.remove();
+  });
+});

--- a/apps/web/src/presentation/typingTarget.ts
+++ b/apps/web/src/presentation/typingTarget.ts
@@ -1,0 +1,24 @@
+// Standard form fields the browser sends every keystroke to before we see it.
+const FORM_FIELD_TAGS = new Set(['INPUT', 'TEXTAREA', 'SELECT']);
+
+// Both spellings the HTML spec accepts for "editing on": `contenteditable="true"`
+// and the empty-string form `<div contenteditable>`. `false` deliberately isn't
+// here — an author disabling editing on a subtree is not typing.
+const CONTENTEDITABLE_ON_SELECTOR = '[contenteditable="true"], [contenteditable=""]';
+
+/**
+ * Whether a keydown originated somewhere the reader is composing text — a form
+ * field, or anywhere inside a contenteditable region. `.closest` walks up
+ * because a rich editor's real target is a descendant of the editable root:
+ * CodeMirror fires at an inner `<span class="cm-line">`, not at the
+ * `.cm-content` node that carries the `contenteditable` attribute.
+ *
+ * Returns `false` for anything that is not an Element (null, `window`) — the
+ * deck's existing keydown cases fire at `window`, and a `true` there would make
+ * the guard swallow every key on every slide.
+ */
+export function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  if (FORM_FIELD_TAGS.has(target.tagName)) return true;
+  return target.closest(CONTENTEDITABLE_ON_SELECTOR) !== null;
+}


### PR DESCRIPTION
Closes #262

## Summary

In presentation mode, the deck's window-level keydown listener
(`apps/web/src/presentation/SlideDeck.tsx`) was advancing `?slide` even when
the reader was typing inside an editor rendered in a slide — the
`<CodeEditor>` on Class 0 and every runtime `<MdxPre>` fence. `Space` and
`ArrowRight` cancelled the character AND advanced the deck; `ArrowLeft`
rewound mid-edit.

Adds a tiny predicate `isTypingTarget(target)` (input/textarea/select or
anywhere inside a `contenteditable` region, walked via `.closest` because
CodeMirror fires at an inner `<span class="cm-line">`, not the `.cm-content`
node that carries the attribute) and one guarded line in the existing
keydown handler:

```ts
if (event.key !== 'Escape' && isTypingTarget(event.target)) return;
```

`Escape` stays live for the same reason it does through the portrait branch
immediately above (`SlideDeck.tsx:129`): a modal has to have a way out, and
the editor is one.

## Slices

- [x] S1 — `typingTarget.ts` + unit tests (`5417d5f`)
- [x] S2 — wire the guard, integration cases, browser check (`33f62f9`)
- Review fixes (`19a2ccb`) — COR-3 (add own positive control to the CE case)

## Acceptance criteria + evidence

- **AC1**: `isTypingTarget` returns `true` for `<input>`, `<textarea>`,
  `<select>`, `contenteditable="true"`, `contenteditable=""`, and a
  descendant shaped like `.cm-editor > .cm-content > .cm-line`. `false` for
  `<div>`, `null`, and `window` (which the pre-existing suite fires most of
  its keydowns at, so this is what keeps them green). Covered by
  `apps/web/src/presentation/typingTarget.test.ts` — 10 cases.
- **AC2**: Integration case proves ArrowRight/Space/ArrowLeft from an
  `<input>` and from a descendant of a contenteditable div do NOT change
  `?slide`, both with a local positive control (`fireEvent.keyDown(window,
  ...)` after the editable is removed still advances the counter). See
  `apps/web/src/app/presentationRoute.test.tsx` §"presentation while the
  reader is typing in a slide".
- **AC3**: All pre-existing presentation-route cases green (`window` is not
  an `Element`, so the predicate returns `false` and the guard is inert for
  them). Full suite: `1239 passed`.
- **AC4**: `apps/web` per-commit protocol green (`format:check` + `lint` +
  `build` + `test` all exit 0).
- **AC5**: Browser check in Chromium at 1440×900 against `npm run build &&
  npm run preview`, on `/d/java-tipos-y-flujo/present?slide=4` (the "El
  desborde, en vivo" slide, which carries a `<CodeEditor>`):

  | case | before guard | after guard |
  |------|--------------|-------------|
  | Space while focused in editor | char dropped + `?slide` → `5` | char inserted, `?slide` stays `4` ✅ |
  | ArrowRight while focused | `?slide` → `5` | cursor moves in editor, `?slide` stays `4` ✅ |
  | ArrowLeft while focused | `?slide` → `3` | `?slide` stays `4` ✅ |
  | ArrowRight after blur | `?slide` → `5` | `?slide` → `5` ✅ |
  | Escape while focused | leaves presentation | leaves presentation ✅ |

  Screenshot of the focused editor at slide 4/13 with the cursor sitting on
  the freshly-typed empty line: saved in the reviewer's scratchpad
  (`02-focused-editor.png`).

## Reviews run (pre-PR pipeline)

Two rounds, `main...HEAD`.

**Round A — code** (`lens-correctness-tests`, `lens-arch-simplicity`,
`lens-security`; `lens-performance` skipped — one boolean check per keydown
is not a hot path, no perf goal in the WP):
- security: 0 findings
- arch/simplicity: 0 findings
- correctness/tests: 3 findings (1 important, 2 suggestions)

Verifier (only critical/important sent):
- **COR-1** *important* — "Load-bearing CodeMirror premise unverified in the
  suite; needs a browser check per apps/web/CLAUDE.md Class 2 doctrine."
  → verifier verdict: `confirmed`, recommendation: `act`.
  Decision: **act** — browser-check note in this PR body (§AC5).

Suggestions:
- **COR-3** — CE integration case lacked its own positive control.
  Decision: **act** — added the `fireEvent.keyDown(window,...)` after the
  editor is removed. Commit `19a2ccb`.
- **COR-2** — selector misses `contenteditable="plaintext-only"`.
  Decision: **defer** — not used anywhere in the repo; adding branches for
  hypothetical future widgets goes against the repo's no-future-proofing
  rule. Watch-item if a plaintext-only widget ever ships.

**Round B — documentation** (`lens-docs-completeness`,
`lens-docs-accuracy`, `lens-adr-hunter`, `lens-agent-readability`): 0
findings across all four. No ADR owed (the "Escape stays live in modal
contexts" pattern is still at n=2 in the same handler, both instances
cross-referenced inline — a watch-item at n=3).

## Manual verification

- [ ] Open the built site (`npm run build && npm run preview`, base
      `/nalanda/`).
- [ ] Navigate to `/d/java-tipos-y-flujo/present?slide=4` (the "El
      desborde, en vivo" slide with the CodeEditor). Click into the code
      editor, then:
      - Press `Space` → a character appears in the code; the counter stays
        at `4 / 13`.
      - Press `ArrowRight` → cursor moves inside the editor; counter stays.
      - Press `ArrowLeft` → cursor moves back inside the editor; counter
        stays.
      - Press `Escape` → deck exits to the book view (`/d/java-tipos-y-flujo`).
- [ ] Blur the editor (click elsewhere) and press `ArrowRight` → counter
      advances to `5 / 13`.
- [ ] Any other slide without an editor: `ArrowRight`/`Space` still advance
      as before.

## Notes

- No ADR owed (issue §Notes + ADR-hunter concurred).
- No dependency-manifest changes. No changes under `content/`. No new
  design-token usage.
- Extends the existing "Escape stays live in modal contexts" pattern from
  the portrait short-circuit; the new comment cross-references it.
